### PR TITLE
breaking: extract docs in the wiring meta

### DIFF
--- a/.changeset/fruity-mirrors-reply.md
+++ b/.changeset/fruity-mirrors-reply.md
@@ -1,0 +1,7 @@
+---
+'@pikku/inspector': patch
+'@pikku/core': patch
+'@pikku/cli': patch
+---
+
+breaking: extract docs in the wiring meta

--- a/packages/cli/src/functions/wirings/http/openapi-spec-generator.ts
+++ b/packages/cli/src/functions/wirings/http/openapi-spec-generator.ts
@@ -120,8 +120,17 @@ export async function generateOpenAPISpec(
 
   for (const routeMeta of Object.values(httpMeta)) {
     for (const meta of Object.values(routeMeta)) {
-      const { route, method, inputTypes, pikkuFuncName, params, query, docs } =
-        meta
+      const {
+        route,
+        method,
+        inputTypes,
+        pikkuFuncName,
+        params,
+        query,
+        errors,
+        description,
+        tags,
+      } = meta
       const functionMeta = functionsMeta[pikkuFuncName]
       if (!functionMeta) {
         logger.error(
@@ -139,7 +148,7 @@ export async function generateOpenAPISpec(
       }
 
       const responses = {}
-      docs?.errors?.forEach((error) => {
+      errors?.forEach((error) => {
         const errorResponse = getErrorResponseForConstructorName(error)
         if (errorResponse) {
           responses[errorResponse.status] = {
@@ -150,9 +159,9 @@ export async function generateOpenAPISpec(
 
       const operation: any = {
         description:
-          docs?.description ||
+          description ||
           `This endpoint handles the ${method.toUpperCase()} request for the route ${route}.`,
-        tags: docs?.tags || [route.split('/')[1] || 'default'],
+        tags: tags || [route.split('/')[1] || 'default'],
         parameters: [],
         responses: {
           ...responses,

--- a/packages/core/src/function/functions.types.ts
+++ b/packages/core/src/function/functions.types.ts
@@ -2,7 +2,6 @@ import type {
   CoreServices,
   CoreSingletonServices,
   CoreUserSession,
-  PikkuDocs,
   CorePikkuMiddleware,
   PikkuWire,
   PickRequired,
@@ -198,12 +197,11 @@ export type CorePikkuFunctionConfig<
   >,
 > = {
   name?: string
+  tags?: string[]
   expose?: boolean
   internal?: boolean
   func: PikkuFunction
   auth?: boolean
   permissions?: CorePermissionGroup<PikkuPermission>
   middleware?: PikkuMiddleware[]
-  tags?: string[]
-  docs?: PikkuDocs
 }

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -85,18 +85,18 @@ export type FunctionRuntimeMeta = {
 }
 
 export type FunctionMeta = FunctionRuntimeMeta &
-  Partial<{
-    name: string
-    services: FunctionServicesMeta
-    usedWires: string[]
-    inputs: string[] | null
-    outputs: string[] | null
-    tags: string[]
-    docs: PikkuDocs
-    middleware: MiddlewareMetadata[]
-    permissions: PermissionMetadata[]
-    isDirectFunction: boolean
-  }>
+  Partial<
+    {
+      name: string
+      services: FunctionServicesMeta
+      usedWires: string[]
+      inputs: string[] | null
+      outputs: string[] | null
+      middleware: MiddlewareMetadata[]
+      permissions: PermissionMetadata[]
+      isDirectFunction: boolean
+    } & CommonWireMeta
+  >
 
 export type FunctionsRuntimeMeta = Record<string, FunctionRuntimeMeta>
 export type FunctionsMeta = Record<string, FunctionMeta>
@@ -361,11 +361,16 @@ export type CreateConfig<
 /**
  * Represents the documentation for a route, including summary, description, tags, and errors.
  */
-export type PikkuDocs = {
+export type CommonWireMeta = {
+  pikkuFuncName: string
+
+  tags?: string[]
   summary?: string
   description?: string
-  tags?: string[]
   errors?: string[]
+
+  middleware?: MiddlewareMetadata[]
+  permissions?: PermissionMetadata[]
 }
 
 /**

--- a/packages/core/src/wirings/channel/channel.types.ts
+++ b/packages/core/src/wirings/channel/channel.types.ts
@@ -5,7 +5,6 @@ import {
   PikkuHTTPResponse,
 } from '../http/http.types.js'
 import {
-  PikkuDocs,
   CoreSingletonServices,
   CreateWireServices,
   CorePikkuMiddleware,
@@ -38,7 +37,10 @@ export type RunChannelParams<ChannelData> = {
 
 export interface ChannelMessageMeta {
   pikkuFuncName: string
-  docs?: PikkuDocs
+  summary?: string
+  description?: string
+  errors?: string[]
+  tags?: string[]
   middleware?: MiddlewareMetadata[]
   permissions?: PermissionMetadata[]
 }
@@ -54,7 +56,9 @@ export interface ChannelMeta {
   disconnect: ChannelMessageMeta | null
   message: ChannelMessageMeta | null
   messageWirings: Record<string, Record<string, ChannelMessageMeta>>
-  docs?: PikkuDocs
+  summary?: string
+  description?: string
+  errors?: string[]
   tags?: string[]
   middleware?: MiddlewareMetadata[] // Pre-resolved middleware chain (tag + explicit)
   permissions?: PermissionMetadata[] // Pre-resolved permission chain (tag + explicit)

--- a/packages/core/src/wirings/cli/cli.types.ts
+++ b/packages/core/src/wirings/cli/cli.types.ts
@@ -2,7 +2,6 @@ import {
   CorePikkuMiddleware,
   CoreSingletonServices,
   CoreUserSession,
-  PikkuDocs,
   CoreServices,
   MiddlewareMetadata,
   PermissionMetadata,
@@ -74,8 +73,9 @@ export interface CLICommandMeta {
   positionals: CLIPositional[]
   options: Record<string, CLIOption>
   renderName?: string
+  summary?: string
   description?: string
-  docs?: PikkuDocs
+  errors?: string[]
   tags?: string[]
   subcommands?: Record<string, CLICommandMeta>
   middleware?: MiddlewareMetadata[] // Pre-resolved middleware chain (tag + explicit)
@@ -267,7 +267,9 @@ export interface CoreCLICommand<
   middleware?: PikkuMiddleware[]
   permissions?: Record<string, PikkuPermission | PikkuPermission[]>
   auth?: boolean
-  docs?: PikkuDocs
+  summary?: string
+  errors?: string[]
+  tags?: string[]
   subcommands?: Subcommands
   isDefault?: boolean
 }
@@ -328,7 +330,8 @@ export interface CoreCLI<
   options?: CLIOptions<Options>
   middleware?: PikkuMiddleware[]
   render?: PikkuCLIRender
-  docs?: PikkuDocs
+  summary?: string
+  errors?: string[]
   tags?: string[]
 }
 

--- a/packages/core/src/wirings/http/http.types.ts
+++ b/packages/core/src/wirings/http/http.types.ts
@@ -1,14 +1,12 @@
 import type { SerializeOptions } from 'cookie'
 import type { PikkuError } from '../../errors/error-handler.js'
 import type {
-  PikkuDocs,
   CoreServices,
   CoreSingletonServices,
   CoreUserSession,
   CreateWireServices,
   CorePikkuMiddleware,
-  MiddlewareMetadata,
-  PermissionMetadata,
+  CommonWireMeta,
 } from '../../types/core.types.js'
 import type {
   CorePikkuFunction,
@@ -240,18 +238,13 @@ export type HTTPFunctionMetaInputTypes = {
 /**
  * Represents metadata for a set of HTTP wirings, including HTTP wiring details, methods, input/output types, and documentation.
  */
-export type HTTPWiringMeta = {
-  pikkuFuncName: string
+export type HTTPWiringMeta = CommonWireMeta & {
   route: string
   method: HTTPMethod
   params?: string[]
   query?: string[]
   inputTypes?: HTTPFunctionMetaInputTypes
-  docs?: PikkuDocs
-  tags?: string[]
   sse?: true
-  middleware?: MiddlewareMetadata[] // Pre-resolved middleware chain (global + route + tag + explicit)
-  permissions?: PermissionMetadata[] // Pre-resolved permission chain (global + route + tag + explicit)
 }
 export type HTTPWiringsMeta = Record<HTTPMethod, Record<string, HTTPWiringMeta>>
 

--- a/packages/core/src/wirings/mcp/mcp.types.ts
+++ b/packages/core/src/wirings/mcp/mcp.types.ts
@@ -104,6 +104,8 @@ export type CoreMCPResource<
   uri: string
   title: string
   description: string
+  summary?: string
+  errors?: string[]
   mimeType?: string
   size?: number
   streaming?: boolean
@@ -126,6 +128,8 @@ export type CoreMCPTool<
   name: string
   title?: string
   description: string
+  summary?: string
+  errors?: string[]
   func: PikkuFunctionConfig
   tags?: string[]
   streaming?: boolean
@@ -145,6 +149,8 @@ export type CoreMCPPrompt<
 > = {
   name: string
   description: string
+  summary?: string
+  errors?: string[]
   func: PikkuFunctionConfig
   tags?: string[]
   middleware?: PikkuMiddleware[]

--- a/packages/core/src/wirings/queue/queue-runner.ts
+++ b/packages/core/src/wirings/queue/queue-runner.ts
@@ -67,7 +67,6 @@ export const wireQueueWorker = <
     permissions: queueWorker.func.permissions,
     middleware: queueWorker.func.middleware as any,
     tags: queueWorker.func.tags,
-    docs: queueWorker.func.docs as any,
   })
 
   // Store processor definition in state - runtime adapters will pick this up

--- a/packages/core/src/wirings/queue/queue.types.ts
+++ b/packages/core/src/wirings/queue/queue.types.ts
@@ -1,4 +1,4 @@
-import { PikkuDocs, MiddlewareMetadata } from '../../types/core.types.js'
+import { CommonWireMeta } from '../../types/core.types.js'
 import { CorePikkuFunctionConfig } from '../../function/functions.types.js'
 import { QueueConfigMapping } from './validate-worker-config.js'
 
@@ -147,15 +147,9 @@ export interface QueueWorkers {
  */
 export type QueueWorkersMeta = Record<
   string,
-  {
-    pikkuFuncName: string
-    schemaName?: string
+  CommonWireMeta & {
     queueName: string
-    session?: undefined
-    docs?: PikkuDocs
-    tags?: string[]
     config?: PikkuWorkerConfig
-    middleware?: MiddlewareMetadata[] // Pre-resolved middleware chain (tag + explicit)
   }
 >
 
@@ -172,8 +166,7 @@ export type CoreQueueWorker<
   queueName: string
   func: PikkuFunctionConfig
   config?: PikkuWorkerConfig
-  docs?: PikkuDocs
-  session?: undefined
+  errors?: string[]
   tags?: string[]
   middleware?: PikkuFunctionConfig['middleware']
 }

--- a/packages/core/src/wirings/scheduler/scheduler-runner.test.ts
+++ b/packages/core/src/wirings/scheduler/scheduler-runner.test.ts
@@ -145,7 +145,6 @@ describe('runScheduledTask', () => {
       func: {
         func: async () => {
           taskExecuted = true
-          return 'success'
         },
         auth: false,
       },
@@ -165,13 +164,12 @@ describe('runScheduledTask', () => {
     wireScheduler(mockTask)
 
     const mockLogger = createMockLogger()
-    const result = await runScheduledTask({
+    await runScheduledTask({
       name: 'simple-task',
       singletonServices: { logger: mockLogger } as any,
     })
 
     assert.equal(taskExecuted, true)
-    assert.equal(result, 'success')
 
     const logs = mockLogger.getLogs()
     assert.equal(logs.length, 1)
@@ -188,7 +186,6 @@ describe('runScheduledTask', () => {
       func: {
         func: async (services: any, data: any, wire: any) => {
           receivedSession = await wire.session.get()
-          return 'ok'
         },
         auth: false,
       },
@@ -360,7 +357,6 @@ describe('runScheduledTask', () => {
       func: {
         func: async (services: any, data: any, wire: any) => {
           capturedWire = wire
-          return 'ok'
         },
         auth: false,
       },
@@ -399,7 +395,7 @@ describe('runScheduledTask', () => {
       name: 'session-services-task',
       schedule: '0 0 * * *',
       func: {
-        func: async () => 'ok',
+        func: async () => undefined,
         auth: false,
       },
     }
@@ -444,7 +440,7 @@ describe('runScheduledTask', () => {
       name: 'cleanup-task',
       schedule: '0 0 * * *',
       func: {
-        func: async () => 'ok',
+        func: async () => undefined,
         auth: false,
       },
     }
@@ -571,7 +567,6 @@ describe('runScheduledTask', () => {
       func: {
         func: async () => {
           executionOrder.push('task')
-          return 'ok'
         },
         auth: false,
       },

--- a/packages/core/src/wirings/scheduler/scheduler-runner.ts
+++ b/packages/core/src/wirings/scheduler/scheduler-runner.ts
@@ -44,9 +44,8 @@ export const wireScheduler = <
     func: scheduledTask.func.func,
     auth: scheduledTask.func.auth,
     permissions: scheduledTask.func.permissions,
-    middleware: scheduledTask.func.middleware as any,
+    middleware: scheduledTask.func.middleware,
     tags: scheduledTask.func.tags,
-    docs: scheduledTask.func.docs as any,
   })
 
   const tasks = pikkuState('scheduler', 'tasks')
@@ -113,7 +112,7 @@ export async function runScheduledTask({
       `Running schedule task: ${name} | schedule: ${task.schedule}`
     )
 
-    const result = await runPikkuFunc(
+    await runPikkuFunc(
       PikkuWiringTypes.scheduler,
       meta.name,
       meta.pikkuFuncName,
@@ -128,8 +127,6 @@ export async function runScheduledTask({
         wire,
       }
     )
-
-    return result
   } catch (e: any) {
     const errorResponse = getErrorResponse(e)
     if (errorResponse != null) {

--- a/packages/core/src/wirings/scheduler/scheduler.types.ts
+++ b/packages/core/src/wirings/scheduler/scheduler.types.ts
@@ -1,8 +1,7 @@
 import {
-  PikkuDocs,
   CoreUserSession,
   CorePikkuMiddleware,
-  MiddlewareMetadata,
+  CommonWireMeta,
 } from '../../types/core.types.js'
 import {
   CorePikkuFunctionConfig,
@@ -15,14 +14,10 @@ import {
 export type ScheduledTasksMeta<UserSession extends CoreUserSession = any> =
   Record<
     string,
-    {
-      pikkuFuncName: string
+    CommonWireMeta & {
       name: string
       schedule: string
       session?: UserSession
-      docs?: PikkuDocs
-      tags?: string[]
-      middleware?: MiddlewareMetadata[] // Pre-resolved middleware chain (tag + explicit)
     }
   >
 
@@ -38,7 +33,6 @@ export type CoreScheduledTask<
   name: string
   schedule: string
   func: PikkuFunctionConfig
-  docs?: PikkuDocs
   tags?: string[]
   middleware?: PikkuMiddleware[]
 }

--- a/packages/core/src/wirings/workflow/workflow.types.ts
+++ b/packages/core/src/wirings/workflow/workflow.types.ts
@@ -1,10 +1,9 @@
 import {
-  PikkuDocs,
-  MiddlewareMetadata,
   SerializedError,
   CoreSingletonServices,
   CreateWireServices,
   CoreConfig,
+  CommonWireMeta,
 } from '../../types/core.types.js'
 import { CorePikkuFunctionConfig } from '../../function/functions.types.js'
 
@@ -97,8 +96,6 @@ export type CoreWorkflow<
 > = {
   /** Unique workflow name */
   name: string
-  /** Description of the workflow */
-  description?: string
   /** The workflow function */
   func: PikkuFunctionConfig
   /** Middleware chain for this workflow */
@@ -107,8 +104,6 @@ export type CoreWorkflow<
   permissions?: PikkuFunctionConfig['permissions']
   /** Tags for organization and filtering */
   tags?: string[]
-  /** Documentation metadata */
-  docs?: PikkuDocs
 }
 
 /**
@@ -183,8 +178,6 @@ export interface RpcStepMeta {
   outputVar?: string
   /** Input source mappings */
   inputs?: Record<string, InputSource>
-  /** Display name */
-  description?: string
   /** Step options */
   options?: WorkflowStepOptions
 }
@@ -339,14 +332,8 @@ export interface PikkuWorkflow {
  */
 export type WorkflowsMeta = Record<
   string,
-  {
-    pikkuFuncName: string
+  CommonWireMeta & {
     workflowName: string
-    description?: string
-    session?: undefined
-    docs?: PikkuDocs
-    tags?: string[]
-    middleware?: MiddlewareMetadata[]
     steps: WorkflowStepMeta[]
     /** Whether this workflow conforms to simple workflow DSL */
     simple?: boolean

--- a/packages/inspector/src/add/add-channel.ts
+++ b/packages/inspector/src/add/add-channel.ts
@@ -2,10 +2,9 @@ import * as ts from 'typescript'
 import { ErrorCode } from '../error-codes.js'
 import {
   getPropertyValue,
-  getPropertyTags,
+  getCommonWireMetaData,
 } from '../utils/get-property-value.js'
 import { pathToRegexp } from 'path-to-regexp'
-import { PikkuDocs } from '@pikku/core'
 import { extractFunctionName } from '../utils/extract-function-name.js'
 import { getPropertyAssignmentInitializer } from '../utils/type-utils.js'
 import type { ChannelMessageMeta, ChannelMeta } from '@pikku/core/channel'
@@ -206,7 +205,12 @@ export function addMessagesRoutes(
                     if (fnMeta) {
                       // Resolve middleware for this route
                       const routeTags = ts.isObjectLiteralExpression(init)
-                        ? getPropertyTags(init, 'channel', channelKey, logger)
+                        ? getCommonWireMetaData(
+                            init,
+                            'Channel message',
+                            routeKey,
+                            logger
+                          ).tags
                         : undefined
                       const routeMiddleware = ts.isObjectLiteralExpression(init)
                         ? resolveMiddleware(state, init, routeTags, checker)
@@ -233,7 +237,12 @@ export function addMessagesRoutes(
                   if (fnMeta) {
                     // Resolve middleware for this route
                     const routeTags = ts.isObjectLiteralExpression(init)
-                      ? getPropertyTags(init, 'channel', channelKey, logger)
+                      ? getCommonWireMetaData(
+                          init,
+                          'Channel message',
+                          routeKey,
+                          logger
+                        ).tags
                       : undefined
                     const routeMiddleware = ts.isObjectLiteralExpression(init)
                       ? resolveMiddleware(state, init, routeTags, checker)
@@ -277,12 +286,12 @@ export function addMessagesRoutes(
                         if (fnMeta) {
                           // Resolve middleware for this route
                           const routeTags = ts.isObjectLiteralExpression(init)
-                            ? getPropertyTags(
+                            ? getCommonWireMetaData(
                                 init,
-                                'channel',
-                                channelKey,
+                                'Channel message',
+                                routeKey,
                                 logger
-                              )
+                              ).tags
                             : undefined
                           const routeMiddleware = ts.isObjectLiteralExpression(
                             init
@@ -308,12 +317,12 @@ export function addMessagesRoutes(
                         if (fnMeta) {
                           // Resolve middleware for this route
                           const routeTags = ts.isObjectLiteralExpression(init)
-                            ? getPropertyTags(
+                            ? getCommonWireMetaData(
                                 init,
-                                'channel',
-                                channelKey,
+                                'Channel message',
+                                routeKey,
                                 logger
-                              )
+                              ).tags
                             : undefined
                           const routeMiddleware = ts.isObjectLiteralExpression(
                             init
@@ -396,7 +405,12 @@ export function addMessagesRoutes(
               if (fnMeta) {
                 // Resolve middleware for this route
                 const routeTags = ts.isObjectLiteralExpression(init)
-                  ? getPropertyTags(init, 'channel', channelKey, logger)
+                  ? getCommonWireMetaData(
+                      init,
+                      'Channel message',
+                      routeKey,
+                      logger
+                    ).tags
                   : undefined
                 const routeMiddleware = ts.isObjectLiteralExpression(init)
                   ? resolveMiddleware(state, init, routeTags, checker)
@@ -438,7 +452,7 @@ export function addMessagesRoutes(
       // Resolve middleware and permissions for this route
       // Check if the route config is an object literal with middleware/permissions
       const routeTags = ts.isObjectLiteralExpression(init)
-        ? getPropertyTags(init, 'channel', channelKey, logger)
+        ? getCommonWireMetaData(init, 'Channel message', routeKey, logger).tags
         : undefined
       const routeMiddleware = ts.isObjectLiteralExpression(init)
         ? resolveMiddleware(state, init, routeTags, checker)
@@ -487,8 +501,12 @@ export const addChannel: AddWiring = (
         .map((k) => k.name)
     : []
 
-  const docs = getPropertyValue(obj, 'docs') as PikkuDocs | undefined
-  const tags = getPropertyTags(obj, 'Channel', route, logger)
+  const { tags, summary, description, errors } = getCommonWireMetaData(
+    obj,
+    'Channel',
+    name,
+    logger
+  )
   const query = getPropertyValue(obj, 'query') as string[] | []
 
   const connect = getPropertyAssignmentInitializer(
@@ -602,7 +620,9 @@ export const addChannel: AddWiring = (
       : null,
     message,
     messageWirings,
-    docs: docs ?? undefined,
+    summary,
+    description,
+    errors,
     tags: tags ?? undefined,
     middleware,
   }

--- a/packages/inspector/src/add/add-http-route.ts
+++ b/packages/inspector/src/add/add-http-route.ts
@@ -1,11 +1,10 @@
 import * as ts from 'typescript'
 import {
   getPropertyValue,
-  getPropertyTags,
+  getCommonWireMetaData,
 } from '../utils/get-property-value.js'
 import { pathToRegexp } from 'path-to-regexp'
 import { HTTPMethod } from '@pikku/core/http'
-import { PikkuDocs } from '@pikku/core'
 import { extractFunctionName } from '../utils/extract-function-name.js'
 import { getPropertyAssignmentInitializer } from '../utils/type-utils.js'
 import { AddWiring } from '../types.js'
@@ -71,8 +70,12 @@ export const addHTTPRoute: AddWiring = (
 
   const method =
     (getPropertyValue(obj, 'method') as string)?.toLowerCase() || 'get'
-  const docs = (getPropertyValue(obj, 'docs') as PikkuDocs) || undefined
-  const tags = getPropertyTags(obj, 'HTTP route', route, logger)
+  const { tags, summary, description, errors } = getCommonWireMetaData(
+    obj,
+    'HTTP route',
+    route,
+    logger
+  )
   const query = (getPropertyValue(obj, 'query') as string[]) || []
 
   // --- find the referenced function name first for filtering ---
@@ -155,7 +158,9 @@ export const addHTTPRoute: AddWiring = (
     params: params.length > 0 ? params : undefined,
     query: query.length > 0 ? query : undefined,
     inputTypes,
-    docs,
+    summary,
+    description,
+    errors,
     tags,
     middleware,
     permissions,

--- a/packages/inspector/src/add/add-mcp-prompt.ts
+++ b/packages/inspector/src/add/add-mcp-prompt.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript'
 import {
   getPropertyValue,
-  getPropertyTags,
+  getCommonWireMetaData,
 } from '../utils/get-property-value.js'
 import { extractWireNames } from '../utils/post-process.js'
 import { ensureFunctionMetadata } from '../utils/ensure-function-metadata.js'
@@ -40,10 +40,12 @@ export const addMCPPrompt: AddWiring = (
     const obj = firstArg
 
     const nameValue = getPropertyValue(obj, 'name') as string | null
-    const descriptionValue = getPropertyValue(obj, 'description') as
-      | string
-      | null
-    const tags = getPropertyTags(obj, 'MCP prompt', nameValue, logger)
+    const { tags, summary, description, errors } = getCommonWireMetaData(
+      obj,
+      'MCP prompt',
+      nameValue,
+      logger
+    )
 
     const funcInitializer = getPropertyAssignmentInitializer(
       obj,
@@ -76,7 +78,7 @@ export const addMCPPrompt: AddWiring = (
       return
     }
 
-    if (!descriptionValue) {
+    if (!description) {
       logger.critical(
         ErrorCode.MISSING_DESCRIPTION,
         `MCP prompt '${nameValue}' is missing a description.`
@@ -116,7 +118,9 @@ export const addMCPPrompt: AddWiring = (
     state.mcpEndpoints.promptsMeta[nameValue] = {
       pikkuFuncName,
       name: nameValue,
-      description: descriptionValue,
+      description,
+      summary,
+      errors,
       tags,
       inputSchema,
       outputSchema,

--- a/packages/inspector/src/add/add-mcp-resource.ts
+++ b/packages/inspector/src/add/add-mcp-resource.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript'
 import {
   getPropertyValue,
-  getPropertyTags,
+  getCommonWireMetaData,
 } from '../utils/get-property-value.js'
 import { extractWireNames } from '../utils/post-process.js'
 import { ensureFunctionMetadata } from '../utils/ensure-function-metadata.js'
@@ -41,11 +41,13 @@ export const addMCPResource: AddWiring = (
 
     const uriValue = getPropertyValue(obj, 'uri') as string | null
     const titleValue = getPropertyValue(obj, 'title') as string | null
-    const descriptionValue = getPropertyValue(obj, 'description') as
-      | string
-      | null
+    const { tags, summary, description, errors } = getCommonWireMetaData(
+      obj,
+      'MCP resource',
+      uriValue,
+      logger
+    )
     const streamingValue = getPropertyValue(obj, 'streaming') as boolean | null
-    const tags = getPropertyTags(obj, 'MCP resource', uriValue, logger)
 
     if (streamingValue === true) {
       logger.warn(
@@ -92,7 +94,7 @@ export const addMCPResource: AddWiring = (
       return
     }
 
-    if (!descriptionValue) {
+    if (!description) {
       logger.critical(
         ErrorCode.MISSING_DESCRIPTION,
         `MCP resource '${uriValue}' is missing a description.`
@@ -133,7 +135,9 @@ export const addMCPResource: AddWiring = (
       pikkuFuncName,
       uri: uriValue,
       title: titleValue,
-      description: descriptionValue,
+      description,
+      summary,
+      errors,
       ...(streamingValue !== null && { streaming: streamingValue }),
       tags,
       inputSchema,

--- a/packages/inspector/src/add/add-mcp-tool.ts
+++ b/packages/inspector/src/add/add-mcp-tool.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript'
 import {
   getPropertyValue,
-  getPropertyTags,
+  getCommonWireMetaData,
 } from '../utils/get-property-value.js'
 import { extractWireNames } from '../utils/post-process.js'
 import { ensureFunctionMetadata } from '../utils/ensure-function-metadata.js'
@@ -41,11 +41,13 @@ export const addMCPTool: AddWiring = (
 
     const nameValue = getPropertyValue(obj, 'name') as string | null
     const titleValue = getPropertyValue(obj, 'title') as string | null
-    const descriptionValue = getPropertyValue(obj, 'description') as
-      | string
-      | null
+    const { tags, summary, description, errors } = getCommonWireMetaData(
+      obj,
+      'MCP tool',
+      nameValue,
+      logger
+    )
     const streamingValue = getPropertyValue(obj, 'streaming') as boolean | null
-    const tags = getPropertyTags(obj, 'MCP tool', nameValue, logger)
 
     if (streamingValue === true) {
       logger.warn(
@@ -84,7 +86,7 @@ export const addMCPTool: AddWiring = (
       return
     }
 
-    if (!descriptionValue) {
+    if (!description) {
       logger.critical(
         ErrorCode.MISSING_DESCRIPTION,
         `MCP tool '${nameValue}' is missing a description.`
@@ -125,7 +127,9 @@ export const addMCPTool: AddWiring = (
       pikkuFuncName,
       name: nameValue,
       title: titleValue || undefined,
-      description: descriptionValue,
+      description,
+      summary,
+      errors,
       ...(streamingValue !== null && { streaming: streamingValue }),
       tags,
       inputSchema,

--- a/packages/inspector/src/add/add-queue-worker.ts
+++ b/packages/inspector/src/add/add-queue-worker.ts
@@ -1,9 +1,8 @@
 import * as ts from 'typescript'
 import {
   getPropertyValue,
-  getPropertyTags,
+  getCommonWireMetaData,
 } from '../utils/get-property-value.js'
-import { PikkuDocs } from '@pikku/core'
 import { AddWiring } from '../types.js'
 import { extractFunctionName } from '../utils/extract-function-name.js'
 import { getPropertyAssignmentInitializer } from '../utils/type-utils.js'
@@ -11,13 +10,7 @@ import { resolveMiddleware } from '../utils/middleware.js'
 import { extractWireNames } from '../utils/post-process.js'
 import { ErrorCode } from '../error-codes.js'
 
-export const addQueueWorker: AddWiring = (
-  logger,
-  node,
-  checker,
-  state,
-  options
-) => {
+export const addQueueWorker: AddWiring = (logger, node, checker, state) => {
   if (!ts.isCallExpression(node)) {
     return
   }
@@ -39,8 +32,12 @@ export const addQueueWorker: AddWiring = (
     const obj = firstArg
 
     const queueName = getPropertyValue(obj, 'queueName') as string | null
-    const docs = (getPropertyValue(obj, 'docs') as PikkuDocs) || undefined
-    const tags = getPropertyTags(obj, 'Queue worker', queueName, logger)
+    const { tags, summary, description, errors } = getCommonWireMetaData(
+      obj,
+      'Queue worker',
+      queueName,
+      logger
+    )
 
     // --- find the referenced function ---
     const funcInitializer = getPropertyAssignmentInitializer(
@@ -84,7 +81,9 @@ export const addQueueWorker: AddWiring = (
     state.queueWorkers.meta[queueName] = {
       pikkuFuncName,
       queueName,
-      docs,
+      summary,
+      description,
+      errors,
       tags,
       middleware,
     }

--- a/packages/inspector/src/add/add-schedule.ts
+++ b/packages/inspector/src/add/add-schedule.ts
@@ -1,9 +1,8 @@
 import * as ts from 'typescript'
 import {
   getPropertyValue,
-  getPropertyTags,
+  getCommonWireMetaData,
 } from '../utils/get-property-value.js'
-import { PikkuDocs } from '@pikku/core'
 import { AddWiring } from '../types.js'
 import { extractFunctionName } from '../utils/extract-function-name.js'
 import { getPropertyAssignmentInitializer } from '../utils/type-utils.js'
@@ -40,8 +39,12 @@ export const addSchedule: AddWiring = (
 
     const nameValue = getPropertyValue(obj, 'name') as string | null
     const scheduleValue = getPropertyValue(obj, 'schedule') as string | null
-    const docs = (getPropertyValue(obj, 'docs') as PikkuDocs) || undefined
-    const tags = getPropertyTags(obj, 'Scheduler', nameValue, logger)
+    const { tags, summary, description, errors } = getCommonWireMetaData(
+      obj,
+      'Scheduler',
+      nameValue,
+      logger
+    )
 
     const funcInitializer = getPropertyAssignmentInitializer(
       obj,
@@ -81,7 +84,9 @@ export const addSchedule: AddWiring = (
       pikkuFuncName,
       name: nameValue,
       schedule: scheduleValue,
-      docs,
+      summary,
+      description,
+      errors,
       tags,
       middleware,
     }

--- a/packages/inspector/src/utils/get-property-value.ts
+++ b/packages/inspector/src/utils/get-property-value.ts
@@ -1,11 +1,10 @@
-import { PikkuDocs } from '@pikku/core'
 import * as ts from 'typescript'
 import { ErrorCode } from '../error-codes.js'
 
 export const getPropertyValue = (
   obj: ts.ObjectLiteralExpression,
   propertyName: string
-): string | string[] | null | PikkuDocs | boolean => {
+): string | string[] | null | boolean => {
   const property = obj.properties.find(
     (p) =>
       ts.isPropertyAssignment(p) &&
@@ -33,42 +32,6 @@ export const getPropertyValue = (
       return stringArray.length > 0 ? stringArray : null
     }
 
-    // Special handling for 'docs' -> expect RouteDocs
-    if (propertyName === 'docs' && ts.isObjectLiteralExpression(initializer)) {
-      const docs: PikkuDocs = {}
-
-      initializer.properties.forEach((prop) => {
-        if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
-          const propName = prop.name.text
-
-          if (propName === 'summary' && ts.isStringLiteral(prop.initializer)) {
-            docs.summary = prop.initializer.text
-          } else if (
-            propName === 'description' &&
-            ts.isStringLiteral(prop.initializer)
-          ) {
-            docs.description = prop.initializer.text
-          } else if (
-            propName === 'tags' &&
-            ts.isArrayLiteralExpression(prop.initializer)
-          ) {
-            docs.tags = prop.initializer.elements
-              .filter(ts.isStringLiteral)
-              .map((element) => element.text)
-          } else if (
-            propName === 'errors' &&
-            ts.isArrayLiteralExpression(prop.initializer)
-          ) {
-            docs.errors = prop.initializer.elements
-              .filter(ts.isIdentifier)
-              .map((element) => element.text as unknown as string)
-          }
-        }
-      })
-
-      return docs
-    }
-
     // booleans -> true/false
     if (initializer.kind === ts.SyntaxKind.TrueKeyword) {
       return true
@@ -94,27 +57,71 @@ export const getPropertyValue = (
 }
 
 /**
- * Gets the 'tags' property from an object and validates it's an array.
- * Logs a critical error if tags is not an array but still returns the value.
+ * Extracts common wire metadata (tags, summary, description, errors) directly from an object
+ * @param obj - The TypeScript object literal expression to extract metadata from
+ * @param wiringType - The type of wiring (e.g., 'HTTP route', 'Channel', 'Queue worker')
+ * @param wiringName - The name/identifier of the wiring (e.g., route path, channel name)
  * @param logger - Optional logger instance; if not provided, uses console.error
+ * @returns Object containing the common wire metadata fields
  */
-export const getPropertyTags = (
+export const getCommonWireMetaData = (
   obj: ts.ObjectLiteralExpression,
   wiringType: string,
   wiringName: string | null,
   logger?: { critical: (code: ErrorCode, message: string) => void }
-): string[] | undefined => {
-  const tagsValue = getPropertyValue(obj, 'tags')
+): {
+  tags?: string[]
+  summary?: string
+  description?: string
+  errors?: string[]
+} => {
+  const metadata: {
+    tags?: string[]
+    summary?: string
+    description?: string
+    errors?: string[]
+  } = {}
 
-  if (tagsValue !== null && !Array.isArray(tagsValue)) {
-    const errorMsg = `${wiringType} '${wiringName}' has invalid 'tags' property - must be an array of strings.`
-    if (logger) {
-      logger.critical(ErrorCode.INVALID_TAGS_TYPE, errorMsg)
-    } else {
-      console.error(errorMsg)
+  obj.properties.forEach((prop) => {
+    if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
+      const propName = prop.name.text
+
+      if (propName === 'summary' && ts.isStringLiteral(prop.initializer)) {
+        metadata.summary = prop.initializer.text
+      } else if (
+        propName === 'description' &&
+        ts.isStringLiteral(prop.initializer)
+      ) {
+        metadata.description = prop.initializer.text
+      } else if (propName === 'tags') {
+        if (ts.isArrayLiteralExpression(prop.initializer)) {
+          metadata.tags = prop.initializer.elements
+            .filter(ts.isStringLiteral)
+            .map((element) => element.text)
+        } else {
+          const errorMsg = `${wiringType} '${wiringName}' has invalid 'tags' property - must be an array of strings.`
+          if (logger) {
+            logger.critical(ErrorCode.INVALID_TAGS_TYPE, errorMsg)
+          } else {
+            console.error(errorMsg)
+          }
+        }
+      } else if (propName === 'errors') {
+        if (ts.isArrayLiteralExpression(prop.initializer)) {
+          metadata.errors = prop.initializer.elements
+            .filter(ts.isIdentifier)
+            .map((element) => element.text as unknown as string)
+        } else {
+          const errorMsg = `${wiringType} '${wiringName}' has invalid 'errors' property - must be an array of error identifiers.`
+          if (logger) {
+            logger.critical(ErrorCode.INVALID_TAGS_TYPE, errorMsg)
+          } else {
+            console.error(errorMsg)
+          }
+        }
+      }
     }
-    // Return undefined but don't stop processing - error will be caught by the exit handler
-  }
+  })
 
-  return Array.isArray(tagsValue) ? tagsValue : undefined
+  return metadata
 }

--- a/verifiers/treeshaking/README.md
+++ b/verifiers/treeshaking/README.md
@@ -57,8 +57,8 @@ This project verifies that Pikku's tree-shaking functionality works correctly by
 
 ### Single Tag Filters
 
-| Filter                 | Expected Services                          | Rationale                                                                                                         |
-| ---------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| Filter                 | Expected Services                          | Rationale                                                                                                      |
+| ---------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
 | `--tags=notifications` | email, logger, sms                         | Email, sms, logger (middleware), and wire services should be included                                          |
 | `--tags=email`         | email, logger                              | Email (function + permissions), logger (middleware), and wire services                                         |
 | `--tags=sms`           | email, logger, sms                         | SMS (function), logger (middleware), and wire services (email, logger)                                         |
@@ -67,51 +67,51 @@ This project verifies that Pikku's tree-shaking functionality works correctly by
 
 ### Multiple Tag Filters (OR logic)
 
-| Filter                          | Expected Services                               | Rationale                                                  |
-| ------------------------------- | ----------------------------------------------- | ---------------------------------------------------------- |
+| Filter                          | Expected Services                               | Rationale                                               |
+| ------------------------------- | ----------------------------------------------- | ------------------------------------------------------- |
 | `--tags=notifications,payments` | analytics, email, logger, payment, sms, storage | All notification routes + payment route + wire services |
 | `--tags=email,sms`              | email, logger, sms                              | Both email and SMS routes + wire services               |
 | `--tags=notifications,storage`  | email, logger, sms, storage                     | All notification + storage routes + wire services       |
 
 ### Type Filters
 
-| Filter         | Expected Services                               | Rationale                                                                 |
-| -------------- | ----------------------------------------------- | ------------------------------------------------------------------------- |
+| Filter         | Expected Services                               | Rationale                                                              |
+| -------------- | ----------------------------------------------- | ---------------------------------------------------------------------- |
 | `--types=http` | analytics, email, logger, payment, sms, storage | All services should be included (all wirings are HTTP) + wire services |
 
 ### HTTP Method Filters
 
-| Filter               | Expected Services                               | Rationale                                                                |
-| -------------------- | ----------------------------------------------- | ------------------------------------------------------------------------ |
+| Filter               | Expected Services                               | Rationale                                                             |
+| -------------------- | ----------------------------------------------- | --------------------------------------------------------------------- |
 | `--httpMethods=POST` | analytics, email, logger, payment, sms, storage | All services should be included (all routes are POST) + wire services |
 | `--httpMethods=GET`  | email, logger                                   | No GET routes exist, only wire services                               |
 
 ### HTTP Route Filters
 
-| Filter                              | Expected Services                          | Rationale                                   |
-| ----------------------------------- | ------------------------------------------ | ------------------------------------------- |
+| Filter                              | Expected Services                          | Rationale                                |
+| ----------------------------------- | ------------------------------------------ | ---------------------------------------- |
 | `--httpRoutes=/api/notifications/*` | email, logger, sms                         | Only notification routes + wire services |
 | `--httpRoutes=/api/payments/*`      | analytics, email, logger, payment, storage | Only payment routes + wire services      |
 | `--httpRoutes=/api/storage/*`       | email, logger, storage                     | Only storage routes + wire services      |
 
 ### Directory Filters
 
-| Filter                          | Expected Services                               | Rationale                                                                             |
-| ------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Filter                          | Expected Services                               | Rationale                                                                          |
+| ------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------- |
 | `--directories=src/functions`   | analytics, email, logger, payment, sms, storage | All services should be included (all wirings are in src/functions) + wire services |
 | `--directories=src/nonexistent` | email, logger                                   | No wirings in nonexistent directory, only wire services                            |
 
 ### Combination Filters
 
-| Filter                                    | Expected Services                          | Rationale                                            |
-| ----------------------------------------- | ------------------------------------------ | ---------------------------------------------------- |
+| Filter                                    | Expected Services                          | Rationale                                         |
+| ----------------------------------------- | ------------------------------------------ | ------------------------------------------------- |
 | `--tags=notifications --httpMethods=POST` | email, logger, sms                         | Notification routes that are POST + wire services |
 | `--tags=payments --types=http`            | analytics, email, logger, payment, storage | Payment HTTP routes + wire services               |
 
 ### Wildcard Name Filters
 
-| Filter             | Expected Services                          | Rationale                                                                    |
-| ------------------ | ------------------------------------------ | ---------------------------------------------------------------------------- |
+| Filter             | Expected Services                          | Rationale                                                                 |
+| ------------------ | ------------------------------------------ | ------------------------------------------------------------------------- |
 | `--names=send*`    | email, logger, sms                         | Routes using sendEmail and sendSMS functions + middleware + wire services |
 | `--names=process*` | analytics, email, logger, payment, storage | Routes using processPayment function + middleware + wire services         |
 | `--names=*Payment` | analytics, email, logger, payment, storage | Routes using functions ending with "Payment" + middleware + wire services |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Migrated metadata structure from docs-based approach to semantic fields (summary, description, errors, tags) across functions, HTTP routes, workflows, scheduled tasks, and queue workers.

* **Improvements**
  * Standardized metadata handling for consistent documentation representation across all wiring types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->