### PR TITLE
fix: align @types/* package versions when using yarn link

### DIFF
--- a/packages/create/src/utils.ts
+++ b/packages/create/src/utils.ts
@@ -452,14 +452,14 @@ export function updatePackageJSONScripts(
 }
 
 /**
- * Removes version constraints from @pikku/* packages when using yarn link.
- * This prevents yarn from trying to fetch unreleased versions from npm.
+ * Removes version constraints from @pikku/* and @types/* packages when using yarn link.
+ * This prevents yarn from trying to fetch unreleased versions from npm and avoids
+ * type library version conflicts with linked packages.
  */
 export function preparePackageJsonForYarnLink(targetPath: string): void {
   const packageFilePath = path.join(targetPath, 'package.json')
   const packageJson = JSON.parse(fs.readFileSync(packageFilePath, 'utf-8'))
 
-  // Remove version constraints from all @pikku/* packages
   const deps = ['dependencies', 'devDependencies', 'peerDependencies'] as const
   for (const depType of deps) {
     if (packageJson[depType]) {
@@ -467,7 +467,8 @@ export function preparePackageJsonForYarnLink(targetPath: string): void {
         if (
           pkg.startsWith('@pikku/') ||
           pkg === 'pikku' ||
-          pkg === 'create-pikku'
+          pkg === 'create-pikku' ||
+          pkg.startsWith('@types/')
         ) {
           packageJson[depType][pkg] = '*'
         }


### PR DESCRIPTION
Extend preparePackageJsonForYarnLink to set all @types/* packages to '*' version alongside @pikku/* packages. This prevents type library version conflicts when using yarn link for local development.

When create-pikku generates a project without a lockfile and uses yarn link, @types packages (like @types/aws-lambda) can resolve to different versions between the new project and linked @pikku packages, causing TypeScript type conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of type package dependencies during development setup to prevent version conflicts with linked packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->