### PR TITLE
refactor: removing wiring enum - turning into type

### DIFF
--- a/packages/core/src/function/function-runner.test.ts
+++ b/packages/core/src/function/function-runner.test.ts
@@ -3,11 +3,7 @@ import * as assert from 'node:assert'
 import { addFunction, runPikkuFunc } from './function-runner.js'
 import { addMiddleware, addPermission } from '../index.js'
 import { resetPikkuState, pikkuState } from '../pikku-state.js'
-import {
-  CoreServices,
-  CorePikkuMiddleware,
-  PikkuWiringTypes,
-} from '../types/core.types.js'
+import { CoreServices, CorePikkuMiddleware } from '../types/core.types.js'
 import { CorePermissionGroup } from './functions.types.js'
 
 beforeEach(() => {
@@ -71,7 +67,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     })
 
     const result = await runPikkuFunc(
-      PikkuWiringTypes.rpc,
+      'rpc',
       Math.random().toString(),
       'testFunc',
       {
@@ -141,7 +137,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     })
 
     const result = await runPikkuFunc(
-      PikkuWiringTypes.rpc,
+      'rpc',
       Math.random().toString(),
       'testFunc',
       {
@@ -176,7 +172,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     })
 
     await assert.rejects(
-      runPikkuFunc(PikkuWiringTypes.rpc, Math.random().toString(), 'testFunc', {
+      runPikkuFunc('rpc', Math.random().toString(), 'testFunc', {
         singletonServices: mockSingletonServices,
         getAllServices: () => mockServices,
         data: () => ({}),
@@ -200,7 +196,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     })
 
     await assert.rejects(
-      runPikkuFunc(PikkuWiringTypes.rpc, Math.random().toString(), 'testFunc', {
+      runPikkuFunc('rpc', Math.random().toString(), 'testFunc', {
         singletonServices: mockSingletonServices,
         getAllServices: () => mockServices,
         data: () => ({}),
@@ -225,7 +221,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     })
 
     await assert.rejects(
-      runPikkuFunc(PikkuWiringTypes.rpc, Math.random().toString(), 'testFunc', {
+      runPikkuFunc('rpc', Math.random().toString(), 'testFunc', {
         singletonServices: mockSingletonServices,
         getAllServices: () => mockServices,
         data: () => ({}),
@@ -249,7 +245,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     })
 
     await assert.rejects(
-      runPikkuFunc(PikkuWiringTypes.rpc, Math.random().toString(), 'testFunc', {
+      runPikkuFunc('rpc', Math.random().toString(), 'testFunc', {
         singletonServices: mockSingletonServices,
         getAllServices: () => mockServices,
         data: () => ({}),
@@ -283,18 +279,13 @@ describe('runPikkuFunc - Integration Tests', () => {
       tags: ['testTag'], // Same middleware via tag
     })
 
-    await runPikkuFunc(
-      PikkuWiringTypes.rpc,
-      Math.random().toString(),
-      'testFunc',
-      {
-        singletonServices: mockSingletonServices,
-        getAllServices: () => mockServices,
-        data: () => ({}),
-        auth: false,
-        wire: {},
-      }
-    )
+    await runPikkuFunc('rpc', Math.random().toString(), 'testFunc', {
+      singletonServices: mockSingletonServices,
+      getAllServices: () => mockServices,
+      data: () => ({}),
+      auth: false,
+      wire: {},
+    })
 
     // Should only execute once due to deduplication
     assert.equal(executionCount, 1)
@@ -336,7 +327,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     })
 
     const result = await runPikkuFunc(
-      PikkuWiringTypes.rpc,
+      'rpc',
       Math.random().toString(),
       'testFunc',
       {
@@ -364,7 +355,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     })
 
     const result = await runPikkuFunc(
-      PikkuWiringTypes.rpc,
+      'rpc',
       Math.random().toString(),
       'simpleFunc',
       {
@@ -408,7 +399,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     })
 
     const result = await runPikkuFunc(
-      PikkuWiringTypes.rpc,
+      'rpc',
       Math.random().toString(),
       'testFunc',
       {
@@ -462,7 +453,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     })
 
     const result = await runPikkuFunc(
-      PikkuWiringTypes.rpc,
+      'rpc',
       Math.random().toString(),
       'testFunc',
       {
@@ -499,17 +490,12 @@ describe('runPikkuFunc - Integration Tests', () => {
       },
     })
 
-    await runPikkuFunc(
-      PikkuWiringTypes.rpc,
-      Math.random().toString(),
-      'testFunc',
-      {
-        singletonServices: mockServices,
-        data: () => testData,
-        auth: false,
-        wire: { rpc: {} },
-      }
-    )
+    await runPikkuFunc('rpc', Math.random().toString(), 'testFunc', {
+      singletonServices: mockServices,
+      data: () => testData,
+      auth: false,
+      wire: { rpc: {} },
+    })
 
     assert.deepEqual(receivedServices, mockServices)
     assert.equal(receivedData, testData)
@@ -536,7 +522,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     }
 
     const result = await runPikkuFunc(
-      PikkuWiringTypes.rpc,
+      'rpc',
       Math.random().toString(),
       'testFunc',
       {

--- a/packages/core/src/middleware-runner.test.ts
+++ b/packages/core/src/middleware-runner.test.ts
@@ -6,7 +6,7 @@ import {
   runMiddleware,
 } from './middleware-runner.js'
 import { resetPikkuState } from './pikku-state.js'
-import { CorePikkuMiddleware, PikkuWiringTypes } from './types/core.types.js'
+import { CorePikkuMiddleware } from './types/core.types.js'
 
 beforeEach(() => {
   resetPikkuState()
@@ -14,24 +14,17 @@ beforeEach(() => {
 
 describe('combineMiddleware', () => {
   test('should return empty array when no parameters provided', () => {
-    const result = combineMiddleware(
-      PikkuWiringTypes.http,
-      Math.random().toString()
-    )
+    const result = combineMiddleware('http', Math.random().toString())
     assert.deepEqual(result, [])
   })
 
   test('should return empty array when all parameters are undefined', () => {
-    const result = combineMiddleware(
-      PikkuWiringTypes.http,
-      Math.random().toString(),
-      {
-        wiringMiddleware: undefined,
-        wiringTags: undefined,
-        funcMiddleware: undefined,
-        funcTags: undefined,
-      }
-    )
+    const result = combineMiddleware('http', Math.random().toString(), {
+      wiringMiddleware: undefined,
+      wiringTags: undefined,
+      funcMiddleware: undefined,
+      funcTags: undefined,
+    })
     assert.deepEqual(result, [])
   })
 
@@ -51,13 +44,9 @@ describe('combineMiddleware', () => {
       await next()
     }
 
-    const result = combineMiddleware(
-      PikkuWiringTypes.http,
-      Math.random().toString(),
-      {
-        wireMiddleware: [mockMiddleware1, mockMiddleware2],
-      }
-    )
+    const result = combineMiddleware('http', Math.random().toString(), {
+      wireMiddleware: [mockMiddleware1, mockMiddleware2],
+    })
 
     assert.equal(result.length, 2)
     assert.equal(result[0], mockMiddleware1)
@@ -80,13 +69,9 @@ describe('combineMiddleware', () => {
       await next()
     }
 
-    const result = combineMiddleware(
-      PikkuWiringTypes.http,
-      Math.random().toString(),
-      {
-        funcMiddleware: [mockMiddleware1, mockMiddleware2],
-      }
-    )
+    const result = combineMiddleware('http', Math.random().toString(), {
+      funcMiddleware: [mockMiddleware1, mockMiddleware2],
+    })
 
     assert.equal(result.length, 2)
     assert.equal(result[0], mockMiddleware1)
@@ -128,16 +113,12 @@ describe('combineMiddleware', () => {
       await next()
     }
 
-    const result = combineMiddleware(
-      PikkuWiringTypes.http,
-      Math.random().toString(),
-      {
-        wireInheritedMiddleware: [{ type: 'tag', tag: 'wiringTag' }],
-        wireMiddleware: [wiringMiddleware],
-        funcInheritedMiddleware: [{ type: 'tag', tag: 'funcTag' }],
-        funcMiddleware: [funcMiddleware],
-      }
-    )
+    const result = combineMiddleware('http', Math.random().toString(), {
+      wireInheritedMiddleware: [{ type: 'tag', tag: 'wiringTag' }],
+      wireMiddleware: [wiringMiddleware],
+      funcInheritedMiddleware: [{ type: 'tag', tag: 'funcTag' }],
+      funcMiddleware: [funcMiddleware],
+    })
 
     assert.equal(result.length, 4)
     // Order: wireInheritedMiddleware (tags), wireMiddleware, funcInheritedMiddleware (tags), funcMiddleware
@@ -158,13 +139,9 @@ describe('combineMiddleware', () => {
 
     addMiddleware('testTag', [taggedMiddleware])
 
-    const result = combineMiddleware(
-      PikkuWiringTypes.http,
-      Math.random().toString(),
-      {
-        wireInheritedMiddleware: [{ type: 'tag', tag: 'testTag' }],
-      }
-    )
+    const result = combineMiddleware('http', Math.random().toString(), {
+      wireInheritedMiddleware: [{ type: 'tag', tag: 'testTag' }],
+    })
 
     assert.equal(result.length, 1)
     assert.equal(result[0], taggedMiddleware)
@@ -181,13 +158,9 @@ describe('combineMiddleware', () => {
 
     addMiddleware('funcTestTag', [taggedMiddleware])
 
-    const result = combineMiddleware(
-      PikkuWiringTypes.http,
-      Math.random().toString(),
-      {
-        funcInheritedMiddleware: [{ type: 'tag', tag: 'funcTestTag' }],
-      }
-    )
+    const result = combineMiddleware('http', Math.random().toString(), {
+      funcInheritedMiddleware: [{ type: 'tag', tag: 'funcTestTag' }],
+    })
 
     assert.equal(result.length, 1)
     assert.equal(result[0], taggedMiddleware)
@@ -204,16 +177,12 @@ describe('combineMiddleware', () => {
     addMiddleware('tag1', [middleware1])
     addMiddleware('tag2', [middleware2])
 
-    const result = combineMiddleware(
-      PikkuWiringTypes.http,
-      Math.random().toString(),
-      {
-        wireInheritedMiddleware: [
-          { type: 'tag', tag: 'tag1' },
-          { type: 'tag', tag: 'tag2' },
-        ],
-      }
-    )
+    const result = combineMiddleware('http', Math.random().toString(), {
+      wireInheritedMiddleware: [
+        { type: 'tag', tag: 'tag1' },
+        { type: 'tag', tag: 'tag2' },
+      ],
+    })
 
     assert.equal(result.length, 2)
     assert.equal(result[0], middleware1)
@@ -227,19 +196,13 @@ describe('combineMiddleware', () => {
 
     addMiddleware('existingTag', [middleware])
 
-    const result = combineMiddleware(
-      PikkuWiringTypes.http,
-      Math.random().toString(),
-      {
-        wireInheritedMiddleware: [
-          { type: 'tag', tag: 'existingTag' },
-          { type: 'tag', tag: 'nonExistentTag' },
-        ],
-        funcInheritedMiddleware: [
-          { type: 'tag', tag: 'anotherNonExistentTag' },
-        ],
-      }
-    )
+    const result = combineMiddleware('http', Math.random().toString(), {
+      wireInheritedMiddleware: [
+        { type: 'tag', tag: 'existingTag' },
+        { type: 'tag', tag: 'nonExistentTag' },
+      ],
+      funcInheritedMiddleware: [{ type: 'tag', tag: 'anotherNonExistentTag' }],
+    })
 
     assert.equal(result.length, 1)
     assert.equal(result[0], middleware)
@@ -263,7 +226,7 @@ describe('runMiddleware', () => {
     await runMiddleware(
       {} as any,
       {} as any,
-      combineMiddleware(PikkuWiringTypes.rpc, Math.random().toString(), {
+      combineMiddleware('rpc', Math.random().toString(), {
         wireMiddleware: [middleware1, middleware2, middleware1, middleware2],
       }),
       async () => {

--- a/packages/core/src/middleware-runner.ts
+++ b/packages/core/src/middleware-runner.ts
@@ -112,14 +112,14 @@ const middlewareCache: Record<
   PikkuWiringTypes,
   Record<string, readonly CorePikkuMiddleware[]>
 > = {
-  [PikkuWiringTypes.http]: {},
-  [PikkuWiringTypes.rpc]: {},
-  [PikkuWiringTypes.channel]: {},
-  [PikkuWiringTypes.queue]: {},
-  [PikkuWiringTypes.scheduler]: {},
-  [PikkuWiringTypes.mcp]: {},
-  [PikkuWiringTypes.cli]: {},
-  [PikkuWiringTypes.workflow]: {},
+  http: {},
+  rpc: {},
+  channel: {},
+  queue: {},
+  scheduler: {},
+  mcp: {},
+  cli: {},
+  workflow: {},
 }
 
 /**

--- a/packages/core/src/permissions.test.ts
+++ b/packages/core/src/permissions.test.ts
@@ -6,11 +6,7 @@ import {
   runPermissions,
 } from './permissions.js'
 import { resetPikkuState } from './pikku-state.js'
-import {
-  CoreServices,
-  CoreUserSession,
-  PikkuWiringTypes,
-} from './types/core.types.js'
+import { CoreServices, CoreUserSession } from './types/core.types.js'
 import { CorePermissionGroup } from './function/functions.types.js'
 
 beforeEach(() => {
@@ -164,7 +160,7 @@ describe('getPermissionsForTags', () => {
 describe('runPermissions', () => {
   test('should pass when no permissions are defined', async () => {
     // Should not throw
-    await runPermissions(PikkuWiringTypes.rpc, Math.random().toString(), {
+    await runPermissions('rpc', Math.random().toString(), {
       services: mockServices,
       wire: {},
       data: {},
@@ -180,7 +176,7 @@ describe('runPermissions', () => {
 
     addPermission('wiringTag', [wiringTagPermission])
 
-    await runPermissions(PikkuWiringTypes.rpc, Math.random().toString(), {
+    await runPermissions('rpc', Math.random().toString(), {
       wireInheritedPermissions: [{ type: 'tag', tag: 'wiringTag' }],
       services: mockServices,
       wire: {},
@@ -223,7 +219,7 @@ describe('runPermissions', () => {
       ],
     }
 
-    await runPermissions(PikkuWiringTypes.rpc, Math.random().toString(), {
+    await runPermissions('rpc', Math.random().toString(), {
       wireInheritedPermissions: [{ type: 'tag', tag: 'wiringTag' }],
       wirePermissions,
       funcInheritedPermissions: [{ type: 'tag', tag: 'funcTag' }],
@@ -249,7 +245,7 @@ describe('runPermissions', () => {
     addPermission('atLeastOneTestTag', [failingPermission, passingPermission])
 
     // Should not throw because at least one permission passes
-    await runPermissions(PikkuWiringTypes.rpc, Math.random().toString(), {
+    await runPermissions('rpc', Math.random().toString(), {
       wireInheritedPermissions: [{ type: 'tag', tag: 'atLeastOneTestTag' }],
       services: mockServices,
       wire: {},
@@ -264,7 +260,7 @@ describe('runPermissions', () => {
     addPermission('allFailTestTag', [failingPermission1, failingPermission2])
 
     await assert.rejects(
-      runPermissions(PikkuWiringTypes.rpc, Math.random().toString(), {
+      runPermissions('rpc', Math.random().toString(), {
         wireInheritedPermissions: [{ type: 'tag', tag: 'allFailTestTag' }],
         services: mockServices,
         wire: {},
@@ -282,7 +278,7 @@ describe('runPermissions', () => {
     }
 
     await assert.rejects(
-      runPermissions(PikkuWiringTypes.rpc, Math.random().toString(), {
+      runPermissions('rpc', Math.random().toString(), {
         wirePermissions,
         services: mockServices,
         wire: {},
@@ -300,7 +296,7 @@ describe('runPermissions', () => {
     addPermission('funcTag', [failingPermission])
 
     await assert.rejects(
-      runPermissions(PikkuWiringTypes.rpc, Math.random().toString(), {
+      runPermissions('rpc', Math.random().toString(), {
         funcInheritedPermissions: [{ type: 'tag', tag: 'funcTag' }],
         services: mockServices,
         wire: {},
@@ -318,7 +314,7 @@ describe('runPermissions', () => {
     }
 
     await assert.rejects(
-      runPermissions(PikkuWiringTypes.rpc, Math.random().toString(), {
+      runPermissions('rpc', Math.random().toString(), {
         funcPermissions,
         services: mockServices,
         wire: {},
@@ -350,7 +346,7 @@ describe('runPermissions', () => {
     }
 
     // Should NOT throw because at least one permission (wirePermissions) passes
-    await runPermissions(PikkuWiringTypes.rpc, Math.random().toString(), {
+    await runPermissions('rpc', Math.random().toString(), {
       wireInheritedPermissions: [{ type: 'tag', tag: 'failingWiringTag' }],
       wirePermissions,
       services: mockServices,
@@ -368,7 +364,7 @@ describe('runPermissions', () => {
     addPermission('arrayTestTag', arrayPermission)
 
     // Should not throw because verifyPermissions handles array properly
-    await runPermissions(PikkuWiringTypes.rpc, Math.random().toString(), {
+    await runPermissions('rpc', Math.random().toString(), {
       wireInheritedPermissions: [{ type: 'tag', tag: 'arrayTestTag' }],
       services: mockServices,
       wire: {},
@@ -384,7 +380,7 @@ describe('runPermissions', () => {
     addPermission('objectTestTag', permissionGroup)
 
     // Should not throw because verifyPermissions handles objects properly
-    await runPermissions(PikkuWiringTypes.rpc, Math.random().toString(), {
+    await runPermissions('rpc', Math.random().toString(), {
       wireInheritedPermissions: [{ type: 'tag', tag: 'objectTestTag' }],
       services: mockServices,
       wire: {},
@@ -408,7 +404,7 @@ describe('runPermissions', () => {
 
     addPermission('paramTestTag', [testPermission])
 
-    await runPermissions(PikkuWiringTypes.rpc, Math.random().toString(), {
+    await runPermissions('rpc', Math.random().toString(), {
       wireInheritedPermissions: [{ type: 'tag', tag: 'paramTestTag' }],
       services: mockServices,
       wire: {},

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -190,14 +190,14 @@ const combinedPermissionsCache: Record<
   PikkuWiringTypes,
   Record<string, readonly (CorePermissionGroup | CorePikkuPermission)[]>
 > = {
-  [PikkuWiringTypes.http]: {},
-  [PikkuWiringTypes.rpc]: {},
-  [PikkuWiringTypes.channel]: {},
-  [PikkuWiringTypes.queue]: {},
-  [PikkuWiringTypes.scheduler]: {},
-  [PikkuWiringTypes.mcp]: {},
-  [PikkuWiringTypes.cli]: {},
-  [PikkuWiringTypes.workflow]: {},
+  http: {},
+  rpc: {},
+  channel: {},
+  queue: {},
+  scheduler: {},
+  mcp: {},
+  cli: {},
+  workflow: {},
 }
 
 /**

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -18,16 +18,15 @@ import {
 } from '../wirings/workflow/workflow.types.js'
 import { SchedulerService } from '../services/scheduler-service.js'
 
-export enum PikkuWiringTypes {
-  http = 'http',
-  scheduler = 'scheduler',
-  channel = 'channel',
-  rpc = 'rpc',
-  queue = 'queue',
-  mcp = 'mcp',
-  cli = 'cli',
-  workflow = 'workflow',
-}
+export type PikkuWiringTypes =
+  | 'http'
+  | 'scheduler'
+  | 'channel'
+  | 'rpc'
+  | 'queue'
+  | 'mcp'
+  | 'cli'
+  | 'workflow'
 
 export interface FunctionServicesMeta {
   optimized: boolean

--- a/packages/core/src/wirings/channel/channel-common.ts
+++ b/packages/core/src/wirings/channel/channel-common.ts
@@ -1,8 +1,4 @@
-import {
-  CoreServices,
-  PikkuWiringTypes,
-  CorePikkuMiddleware,
-} from '../../types/core.types.js'
+import { CoreServices, CorePikkuMiddleware } from '../../types/core.types.js'
 import { CoreChannel, ChannelMessageMeta } from './channel.types.js'
 import { combineMiddleware, runMiddleware } from '../../middleware-runner.js'
 import { runPikkuFuncDirectly } from '../../function/function-runner.js'
@@ -49,7 +45,7 @@ export const runChannelLifecycleWithMiddleware = async ({
 
   // Use combineMiddleware to properly resolve metadata + inline middleware
   const allMiddleware = combineMiddleware(
-    PikkuWiringTypes.channel,
+    'channel',
     `${channelConfig.name}:${lifecycleType}`,
     {
       wireInheritedMiddleware: meta.middleware,

--- a/packages/core/src/wirings/channel/channel-handler.ts
+++ b/packages/core/src/wirings/channel/channel-handler.ts
@@ -2,7 +2,6 @@ import {
   CoreServices,
   JSONValue,
   CoreUserSession,
-  PikkuWiringTypes,
 } from '../../types/core.types.js'
 import {
   ChannelMessageMeta,
@@ -123,24 +122,19 @@ export const processMessageHandlers = (
       ? `${channelConfig.name}:${routingProperty}:${routerValue}`
       : `${channelConfig.name}:default`
 
-    return await runPikkuFunc(
-      PikkuWiringTypes.channel,
-      cacheKey,
-      pikkuFuncName,
-      {
-        singletonServices: services,
-        data: () => data,
-        inheritedMiddleware,
-        wireMiddleware,
-        inheritedPermissions,
-        wirePermissions,
-        tags: channelConfig.tags,
-        wire: {
-          channel: channelHandler.getChannel(),
-          session: userSession,
-        },
-      }
-    )
+    return await runPikkuFunc('channel', cacheKey, pikkuFuncName, {
+      singletonServices: services,
+      data: () => data,
+      inheritedMiddleware,
+      wireMiddleware,
+      inheritedPermissions,
+      wirePermissions,
+      tags: channelConfig.tags,
+      wire: {
+        channel: channelHandler.getChannel(),
+        session: userSession,
+      },
+    })
   }
 
   return async (rawData): Promise<unknown> => {

--- a/packages/core/src/wirings/cli/cli-runner.ts
+++ b/packages/core/src/wirings/cli/cli-runner.ts
@@ -1,11 +1,7 @@
 import { NotFoundError } from '../../errors/errors.js'
 import { addFunction, runPikkuFunc } from '../../function/function-runner.js'
 import { pikkuState } from '../../pikku-state.js'
-import {
-  CorePikkuMiddleware,
-  CoreUserSession,
-  PikkuWiringTypes,
-} from '../../types/core.types.js'
+import { CorePikkuMiddleware, CoreUserSession } from '../../types/core.types.js'
 import {
   CoreCLI,
   CLICommandMeta,
@@ -339,23 +335,18 @@ export async function runCLICommand({
   }
 
   try {
-    const result = await runPikkuFunc(
-      PikkuWiringTypes.cli,
-      commandId,
-      funcName,
-      {
-        singletonServices,
-        createWireServices,
-        data: pluckedData,
-        auth: false,
-        inheritedMiddleware: currentCommand.middleware,
-        wireMiddleware: allWireMiddleware,
-        inheritedPermissions: currentCommand.permissions,
-        wirePermissions: undefined,
-        tags: programData?.tags,
-        wire,
-      }
-    )
+    const result = await runPikkuFunc('cli', commandId, funcName, {
+      singletonServices,
+      createWireServices,
+      data: pluckedData,
+      auth: false,
+      inheritedMiddleware: currentCommand.middleware,
+      wireMiddleware: allWireMiddleware,
+      inheritedPermissions: currentCommand.permissions,
+      wirePermissions: undefined,
+      tags: programData?.tags,
+      wire,
+    })
 
     // Apply renderer one final time with the final output (if renderer exists)
     if (renderer) {

--- a/packages/core/src/wirings/http/http-runner.ts
+++ b/packages/core/src/wirings/http/http-runner.ts
@@ -19,8 +19,8 @@ import {
   CorePikkuMiddleware,
   CorePikkuMiddlewareGroup,
   WireServices,
-  PikkuWiringTypes,
   PikkuWire,
+  PikkuWiringTypes,
 } from '../../types/core.types.js'
 import { NotFoundError } from '../../errors/errors.js'
 import {
@@ -322,7 +322,7 @@ const executeRoute = async (
   const wire: PikkuWire = { http, channel, session: userSession }
 
   result = await runPikkuFunc(
-    PikkuWiringTypes.http,
+    'http',
     `${meta.method}:${meta.route}`,
     meta.pikkuFuncName,
     {

--- a/packages/core/src/wirings/mcp/mcp-runner.ts
+++ b/packages/core/src/wirings/mcp/mcp-runner.ts
@@ -1,6 +1,5 @@
 import {
   PikkuWire,
-  PikkuWiringTypes,
   type CoreServices,
   type CoreSingletonServices,
   type CoreUserSession,
@@ -250,22 +249,17 @@ async function runMCPPikkuFunc(
       meta = pikkuState('mcp', 'promptsMeta')[name]
     }
 
-    const result = await runPikkuFunc(
-      PikkuWiringTypes.mcp,
-      `${type}:${name}`,
-      pikkuFuncName,
-      {
-        singletonServices,
-        createWireServices,
-        data: () => request.params,
-        inheritedMiddleware: meta?.middleware,
-        wireMiddleware: mcp.middleware,
-        inheritedPermissions: meta?.permissions,
-        wirePermissions: mcp.permissions,
-        tags: mcp.tags,
-        wire,
-      }
-    )
+    const result = await runPikkuFunc('mcp', `${type}:${name}`, pikkuFuncName, {
+      singletonServices,
+      createWireServices,
+      data: () => request.params,
+      inheritedMiddleware: meta?.middleware,
+      wireMiddleware: mcp.middleware,
+      inheritedPermissions: meta?.permissions,
+      wirePermissions: mcp.permissions,
+      tags: mcp.tags,
+      wire,
+    })
 
     return {
       id: request.id,

--- a/packages/core/src/wirings/queue/queue-runner.ts
+++ b/packages/core/src/wirings/queue/queue-runner.ts
@@ -7,7 +7,7 @@ import type {
 import { getErrorResponse, PikkuError } from '../../errors/error-handler.js'
 import { pikkuState } from '../../pikku-state.js'
 import { addFunction, runPikkuFunc } from '../../function/function-runner.js'
-import { CreateWireServices, PikkuWiringTypes } from '../../types/core.types.js'
+import { CreateWireServices } from '../../types/core.types.js'
 
 /**
  * Error class for queue processor not found
@@ -151,7 +151,7 @@ export async function runQueueJob({
 
     // Execute the pikku function with the job data
     const result = await runPikkuFunc(
-      PikkuWiringTypes.queue,
+      'queue',
       job.queueName,
       processorMeta.pikkuFuncName,
       {

--- a/packages/core/src/wirings/rpc/rpc-runner.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.ts
@@ -1,8 +1,4 @@
-import {
-  CoreServices,
-  PikkuWire,
-  PikkuWiringTypes,
-} from '../../types/core.types.js'
+import { CoreServices, PikkuWire } from '../../types/core.types.js'
 import { runPikkuFunc } from '../../function/function-runner.js'
 import { pikkuState } from '../../pikku-state.js'
 import { ForbiddenError } from '../../errors/errors.js'
@@ -60,7 +56,7 @@ export class ContextAwareRPCService {
         : undefined,
     }
     return runPikkuFunc<In, Out>(
-      PikkuWiringTypes.rpc,
+      'rpc',
       funcName,
       getPikkuFunctionName(funcName),
       {
@@ -93,7 +89,7 @@ export class ContextAwareRPCService {
         : undefined,
     }
     return runPikkuFunc<In, Out>(
-      PikkuWiringTypes.rpc,
+      'rpc',
       rpcName,
       getPikkuFunctionName(rpcName),
       {

--- a/packages/core/src/wirings/scheduler/scheduler-runner.ts
+++ b/packages/core/src/wirings/scheduler/scheduler-runner.ts
@@ -1,6 +1,5 @@
 import {
   PikkuWire,
-  PikkuWiringTypes,
   type CoreServices,
   type CoreSingletonServices,
   type CoreUserSession,
@@ -112,21 +111,16 @@ export async function runScheduledTask({
       `Running schedule task: ${name} | schedule: ${task.schedule}`
     )
 
-    await runPikkuFunc(
-      PikkuWiringTypes.scheduler,
-      meta.name,
-      meta.pikkuFuncName,
-      {
-        singletonServices,
-        createWireServices,
-        auth: false,
-        data: () => undefined,
-        inheritedMiddleware: meta.middleware,
-        wireMiddleware: task.middleware,
-        tags: task.tags,
-        wire,
-      }
-    )
+    await runPikkuFunc('scheduler', meta.name, meta.pikkuFuncName, {
+      singletonServices,
+      createWireServices,
+      auth: false,
+      data: () => undefined,
+      inheritedMiddleware: meta.middleware,
+      wireMiddleware: task.middleware,
+      tags: task.tags,
+      wire,
+    })
   } catch (e: any) {
     const errorResponse = getErrorResponse(e)
     if (errorResponse != null) {

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -6,7 +6,6 @@ import {
   CoreSingletonServices,
   CreateWireServices,
   PikkuWire,
-  PikkuWiringTypes,
   SerializedError,
 } from '../../types/core.types.js'
 import { QueueService } from '../queue/queue.types.js'
@@ -292,7 +291,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       const wire: PikkuWire = { workflow: workflowWire }
       try {
         const result = await runPikkuFunc(
-          PikkuWiringTypes.workflow,
+          'workflow',
           workflowMeta.workflowName,
           workflowMeta.pikkuFuncName,
           {

--- a/packages/inspector/src/utils/filter-utils.test.ts
+++ b/packages/inspector/src/utils/filter-utils.test.ts
@@ -1,6 +1,5 @@
 import { test, describe } from 'node:test'
 import { strict as assert } from 'node:assert'
-import { PikkuWiringTypes } from '@pikku/core'
 import { InspectorFilters } from '../types'
 import { matchesFilters, matchesWildcard } from './filter-utils'
 
@@ -11,6 +10,8 @@ describe('matchesFilters', () => {
     error: () => {},
     warn: () => {},
     debug: () => {},
+    critical: () => {},
+    hasCriticalErrors: () => false,
   }
 
   describe('Empty filters', () => {
@@ -20,7 +21,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: ['test'] },
-        { type: PikkuWiringTypes.http, name: 'test-route' },
+        { type: 'http', name: 'test-route' },
         mockLogger
       )
 
@@ -37,7 +38,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: ['test'] },
-        { type: PikkuWiringTypes.http, name: 'test-route' },
+        { type: 'http', name: 'test-route' },
         mockLogger
       )
 
@@ -54,7 +55,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: ['api', 'internal'] },
-        { type: PikkuWiringTypes.http, name: 'test-route' },
+        { type: 'http', name: 'test-route' },
         mockLogger
       )
 
@@ -69,7 +70,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: ['internal', 'private'] },
-        { type: PikkuWiringTypes.http, name: 'test-route' },
+        { type: 'http', name: 'test-route' },
         mockLogger
       )
 
@@ -84,7 +85,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: undefined },
-        { type: PikkuWiringTypes.http, name: 'test-route' },
+        { type: 'http', name: 'test-route' },
         mockLogger
       )
 
@@ -99,7 +100,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: [] },
-        { type: PikkuWiringTypes.http, name: 'test-route' },
+        { type: 'http', name: 'test-route' },
         mockLogger
       )
 
@@ -116,7 +117,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: ['test'] },
-        { type: PikkuWiringTypes.http, name: 'test-route' },
+        { type: 'http', name: 'test-route' },
         mockLogger
       )
 
@@ -131,7 +132,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: ['test'] },
-        { type: PikkuWiringTypes.http, name: 'test-route' },
+        { type: 'http', name: 'test-route' },
         mockLogger
       )
 
@@ -139,14 +140,7 @@ describe('matchesFilters', () => {
     })
 
     test('should handle all PikkuWiringTypes correctly', () => {
-      const eventTypes = [
-        PikkuWiringTypes.http,
-        PikkuWiringTypes.channel,
-        PikkuWiringTypes.queue,
-        PikkuWiringTypes.scheduler,
-        PikkuWiringTypes.rpc,
-        PikkuWiringTypes.mcp,
-      ]
+      const eventTypes = ['http', 'channel', 'queue', 'scheduler', 'rpc', 'mcp']
 
       eventTypes.forEach((eventType) => {
         const filters: InspectorFilters = {
@@ -175,7 +169,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['test'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'test-route',
           filePath: '/project/src/api/routes.ts',
         },
@@ -194,7 +188,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['test'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'test-route',
           filePath: '/project/src/public/routes.ts',
         },
@@ -213,7 +207,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['test'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'test-route',
           filePath: 'C:\\project\\src\\api\\routes.ts',
         },
@@ -232,7 +226,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['test'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'test-route',
           filePath: 'C:\\project\\src\\api\\routes.ts',
         },
@@ -250,7 +244,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: ['test'] },
-        { type: PikkuWiringTypes.http, name: 'test-route' }, // no filePath
+        { type: 'http', name: 'test-route' }, // no filePath
         mockLogger
       )
 
@@ -266,7 +260,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['test'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'test-route',
           filePath: '/project/src/api/v1/routes.ts',
         },
@@ -289,7 +283,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['api', 'public'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'test-route',
           filePath: '/project/src/api/routes.ts',
         },
@@ -310,7 +304,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['api', 'public'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'test-route',
           filePath: '/project/src/api/routes.ts',
         },
@@ -331,7 +325,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['api', 'public'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'test-route',
           filePath: '/project/src/api/routes.ts',
         },
@@ -352,7 +346,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['api', 'public'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'test-route',
           filePath: '/project/src/api/routes.ts',
         },
@@ -372,7 +366,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: undefined },
-        { type: PikkuWiringTypes.http, name: 'test-route' },
+        { type: 'http', name: 'test-route' },
         mockLogger
       )
 
@@ -387,7 +381,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: ['test'] },
-        { type: PikkuWiringTypes.http, name: '' },
+        { type: 'http', name: '' },
         mockLogger
       )
 
@@ -403,7 +397,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['test'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'test-route',
           filePath: '/project/src/api-v2/routes.ts',
         },
@@ -422,7 +416,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['test'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'test-route',
           filePath: '/project/src/api/routes.ts',
         },
@@ -440,7 +434,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: ['api', 'public', 'v1'] },
-        { type: PikkuWiringTypes.http, name: 'test-route' },
+        { type: 'http', name: 'test-route' },
         mockLogger
       )
 
@@ -455,7 +449,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { tags: ['test'] },
-        { type: PikkuWiringTypes.channel, name: 'test-channel' },
+        { type: 'channel', name: 'test-channel' },
         mockLogger
       )
 
@@ -471,7 +465,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['test'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'test-route',
           filePath: '/project/src/internal/routes.ts',
         },
@@ -491,7 +485,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { name: 'email-worker' },
-        { type: PikkuWiringTypes.queue, name: 'email-queue' },
+        { type: 'queue', name: 'email-queue' },
         mockLogger
       )
 
@@ -506,7 +500,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { name: 'email-worker' },
-        { type: PikkuWiringTypes.queue, name: 'email-queue' },
+        { type: 'queue', name: 'email-queue' },
         mockLogger
       )
 
@@ -521,7 +515,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { name: 'notification-worker' },
-        { type: PikkuWiringTypes.queue, name: 'notification-queue' },
+        { type: 'queue', name: 'notification-queue' },
         mockLogger
       )
 
@@ -536,7 +530,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         {},
-        { type: PikkuWiringTypes.http, name: 'test-route' },
+        { type: 'http', name: 'test-route' },
         mockLogger
       )
 
@@ -551,7 +545,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         { name: 'email-worker' },
-        { type: PikkuWiringTypes.queue, name: 'other-name' },
+        { type: 'queue', name: 'other-name' },
         mockLogger
       )
 
@@ -569,7 +563,7 @@ describe('matchesFilters', () => {
         filters,
         {},
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'users-route',
           httpRoute: '/api/users',
         },
@@ -588,7 +582,7 @@ describe('matchesFilters', () => {
         filters,
         {},
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'users-route',
           httpRoute: '/api/users',
         },
@@ -607,7 +601,7 @@ describe('matchesFilters', () => {
         filters,
         {},
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'webhook-route',
           httpRoute: '/webhooks/stripe',
         },
@@ -625,7 +619,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         {},
-        { type: PikkuWiringTypes.queue, name: 'worker' },
+        { type: 'queue', name: 'worker' },
         mockLogger
       )
 
@@ -641,7 +635,7 @@ describe('matchesFilters', () => {
         filters,
         {},
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'webhook-route',
           httpRoute: '/webhooks/stripe',
         },
@@ -662,7 +656,7 @@ describe('matchesFilters', () => {
         filters,
         {},
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'users-route',
           httpMethod: 'GET',
         },
@@ -681,7 +675,7 @@ describe('matchesFilters', () => {
         filters,
         {},
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'users-route',
           httpMethod: 'DELETE',
         },
@@ -700,7 +694,7 @@ describe('matchesFilters', () => {
         filters,
         {},
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'users-route',
           httpMethod: 'get',
         },
@@ -718,7 +712,7 @@ describe('matchesFilters', () => {
       const result = matchesFilters(
         filters,
         {},
-        { type: PikkuWiringTypes.queue, name: 'worker' },
+        { type: 'queue', name: 'worker' },
         mockLogger
       )
 
@@ -739,7 +733,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['api'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'users-route',
           httpRoute: '/api/users',
           httpMethod: 'GET',
@@ -760,7 +754,7 @@ describe('matchesFilters', () => {
         filters,
         { tags: ['api'] },
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'users-route',
           httpRoute: '/api/users',
         },
@@ -780,7 +774,7 @@ describe('matchesFilters', () => {
         filters,
         {},
         {
-          type: PikkuWiringTypes.http,
+          type: 'http',
           name: 'users-route',
           httpRoute: '/api/users',
           httpMethod: 'GET',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the wiring type system by transitioning from enum-based references to string literals across core services, resulting in more streamlined integration patterns.

* **New Features**
  * Added a `services` metadata field to function service configurations for enhanced service tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->