### PR TITLE
refactor: rename pikkuWorkflowFunc to pikkuWorkflow and pikkuSimpleWo…

### DIFF
--- a/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.ts
+++ b/packages/cli/src/functions/wirings/workflow/serialize-workflow-types.ts
@@ -65,7 +65,7 @@ export type PikkuFunctionWorkflow<
  * @param func - Function definition, either direct function or configuration object
  * @returns The normalized configuration object
  */
-export const pikkuWorkflowFunc = <In, Out = unknown>(
+export const pikkuWorkflow = <In, Out = unknown>(
   func:
     | PikkuFunctionWorkflow<In, Out>
     | PikkuFunctionConfig<In, Out, 'workflow', PikkuFunctionWorkflow<In, Out>>
@@ -91,7 +91,7 @@ export const pikkuWorkflowFunc = <In, Out = unknown>(
  * @param func - Function definition, either direct function or configuration object
  * @returns The normalized configuration object
  */
-export const pikkuSimpleWorkflowFunc = <In, Out = unknown>(
+export const pikkuWorkflowDAG = <In, Out = unknown>(
   func:
     | PikkuFunctionWorkflow<In, Out>
     | PikkuFunctionConfig<In, Out, 'workflow', PikkuFunctionWorkflow<In, Out>>

--- a/packages/inspector/src/add/add-functions.ts
+++ b/packages/inspector/src/add/add-functions.ts
@@ -295,7 +295,7 @@ export const addFunctions: AddWiring = (logger, node, checker, state) => {
   }
 
   // Match identifiers that contain both "pikku" and "func" (case insensitive)
-  const pikkuFuncPattern = /pikku.*func/i
+  const pikkuFuncPattern = /pikku.*func|pikkuWorkflow|pikkuWorkflowDAG/i
   if (!pikkuFuncPattern.test(expression.text)) {
     return
   }

--- a/packages/inspector/src/add/add-workflow.ts
+++ b/packages/inspector/src/add/add-workflow.ts
@@ -144,9 +144,9 @@ export const addWorkflow: AddWiring = (logger, node, checker, state) => {
   }
 
   let wrapperType: 'simple' | 'regular' | null = null
-  if (expression.text === 'pikkuWorkflowFunc') {
+  if (expression.text === 'pikkuWorkflow') {
     wrapperType = 'regular'
-  } else if (expression.text === 'pikkuSimpleWorkflowFunc') {
+  } else if (expression.text === 'pikkuWorkflowDAG') {
     wrapperType = 'simple'
   } else {
     return
@@ -243,14 +243,14 @@ export const addWorkflow: AddWiring = (logger, node, checker, state) => {
   } else {
     // Simple extraction failed
     if (wrapperType === 'simple') {
-      // For pikkuSimpleWorkflowFunc, this is a critical error
+      // For pikkuWorkflowDAG, this is a critical error
       logger.critical(
         ErrorCode.INVALID_SIMPLE_WORKFLOW,
-        `Workflow '${workflowName}' uses pikkuSimpleWorkflowFunc but does not conform to simple workflow DSL:\n${result.reason || 'Unknown error'}`
+        `Workflow '${workflowName}' uses pikkuWorkflowDAG but does not conform to simple workflow DSL:\n${result.reason || 'Unknown error'}`
       )
       return
     } else {
-      // For pikkuWorkflowFunc, fall back to basic extraction
+      // For pikkuWorkflow, fall back to basic extraction
       logger.debug(
         `Workflow '${workflowName}' could not be extracted as simple workflow: ${result.reason || 'Unknown error'}. Falling back to basic extraction.`
       )

--- a/packages/inspector/src/utils/extract-function-node.ts
+++ b/packages/inspector/src/utils/extract-function-node.ts
@@ -5,7 +5,7 @@ import {
 } from './type-utils.js'
 
 /**
- * Extracts the actual function node from a pikkuFunc/pikkuWorkflowFunc call
+ * Extracts the actual function node from a pikkuFunc/pikkuWorkflow call
  * Handles both direct function form and config object form { func: ... }
  */
 export function extractFunctionNode(

--- a/packages/inspector/src/utils/type-utils.ts
+++ b/packages/inspector/src/utils/type-utils.ts
@@ -20,7 +20,7 @@ export function resolveFunctionDeclaration(
     return node
   }
 
-  // If it's a call expression (e.g., pikkuWorkflowFunc(...)), get its first argument
+  // If it's a call expression (e.g., pikkuWorkflow(...)), get its first argument
   if (ts.isCallExpression(node) && node.arguments.length > 0) {
     const firstArg = node.arguments[0]
     if (ts.isFunctionExpression(firstArg) || ts.isArrowFunction(firstArg)) {

--- a/packages/inspector/src/workflow/extract-simple-workflow.ts
+++ b/packages/inspector/src/workflow/extract-simple-workflow.ts
@@ -150,7 +150,7 @@ export function extractSimpleWorkflow(
  * Find the workflow function (async arrow function)
  */
 function findWorkflowFunction(node: ts.Node): ts.ArrowFunction | null {
-  // Handle pikkuSimpleWorkflowFunc(async () => {}) or pikkuWorkflowFunc(async () => {})
+  // Handle pikkuWorkflowDAG(async () => {}) or pikkuWorkflow(async () => {})
   if (ts.isCallExpression(node)) {
     const arg = node.arguments[0]
     if (arg && ts.isArrowFunction(arg)) {
@@ -172,7 +172,7 @@ function findWorkflowFunction(node: ts.Node): ts.ArrowFunction | null {
     }
   }
 
-  // Handle pikkuSimpleWorkflowFunc({ func: async () => {} })
+  // Handle pikkuWorkflowDAG({ func: async () => {} })
   if (ts.isObjectLiteralExpression(node)) {
     for (const prop of node.properties) {
       if (

--- a/templates/functions/src/workflow-happy.functions.ts
+++ b/templates/functions/src/workflow-happy.functions.ts
@@ -1,4 +1,4 @@
-import { pikkuWorkflowFunc } from '../.pikku/workflow/pikku-workflow-types.gen.js'
+import { pikkuWorkflow } from '../.pikku/workflow/pikku-workflow-types.gen.js'
 import { pikkuSessionlessFunc } from '../.pikku/pikku-types.gen.js'
 
 /**
@@ -33,7 +33,7 @@ export const flakyHappyRPC = pikkuSessionlessFunc<
 /**
  * HAPPY PATH: Workflow that fails once then succeeds on retry
  */
-export const happyRetryWorkflow = pikkuWorkflowFunc<
+export const happyRetryWorkflow = pikkuWorkflow<
   { value: number },
   { result: number; finalAttempt: number; message: string }
 >({

--- a/templates/functions/src/workflow-simple.functions.ts
+++ b/templates/functions/src/workflow-simple.functions.ts
@@ -1,5 +1,5 @@
 /**
- * Example of a Simple Workflow using pikkuSimpleWorkflowFunc
+ * Example of a DAG Workflow using pikkuWorkflowDAG
  *
  * Simple workflows must conform to a restricted DSL that enables:
  * - Static analysis and visualization
@@ -13,7 +13,7 @@
  * - All workflow calls must be awaited
  */
 
-import { pikkuSimpleWorkflowFunc } from '../.pikku/workflow/pikku-workflow-types.gen.js'
+import { pikkuWorkflowDAG } from '../.pikku/workflow/pikku-workflow-types.gen.js'
 import { pikkuSessionlessFunc } from '../.pikku/pikku-types.gen.js'
 
 // RPC function to create organization
@@ -70,7 +70,7 @@ export const sendWelcomeEmail = pikkuSessionlessFunc<
 /**
  * Organization onboarding workflow (simple DSL)
  */
-export const orgOnboardingSimpleWorkflow = pikkuSimpleWorkflowFunc<
+export const orgOnboardingSimpleWorkflow = pikkuWorkflowDAG<
   { email: string; name: string; plan: string; memberEmails: string[] },
   { orgId: string; ownerId?: string }
 >(async ({}, data, { workflow }) => {
@@ -169,7 +169,7 @@ export const orgOnboardingSimpleWorkflow = pikkuSimpleWorkflowFunc<
 /**
  * Sequential member invitation with delays (simple DSL)
  */
-export const sequentialInviteSimpleWorkflow = pikkuSimpleWorkflowFunc<
+export const sequentialInviteSimpleWorkflow = pikkuWorkflowDAG<
   { orgId: string; memberEmails: string[]; delayMs: number },
   { invitedCount: number }
 >(async ({}, data, { workflow }) => {

--- a/templates/functions/src/workflow-unhappy.functions.ts
+++ b/templates/functions/src/workflow-unhappy.functions.ts
@@ -1,4 +1,4 @@
-import { pikkuWorkflowFunc } from '../.pikku/workflow/pikku-workflow-types.gen.js'
+import { pikkuWorkflow } from '../.pikku/workflow/pikku-workflow-types.gen.js'
 import { pikkuSessionlessFunc } from '../.pikku/pikku-types.gen.js'
 
 /**
@@ -26,7 +26,7 @@ export const alwaysFailsRPC = pikkuSessionlessFunc<
 /**
  * UNHAPPY PATH: Workflow that exhausts retries and fails
  */
-export const unhappyRetryWorkflow = pikkuWorkflowFunc<
+export const unhappyRetryWorkflow = pikkuWorkflow<
   { value: number },
   { result: number }
 >({

--- a/templates/functions/src/workflow.functions.ts
+++ b/templates/functions/src/workflow.functions.ts
@@ -1,4 +1,4 @@
-import { pikkuWorkflowFunc } from '../.pikku/workflow/pikku-workflow-types.gen.js'
+import { pikkuWorkflow } from '../.pikku/workflow/pikku-workflow-types.gen.js'
 import { pikkuSessionlessFunc } from '../.pikku/pikku-types.gen.js'
 
 // Pikku function to create a user profile
@@ -38,7 +38,7 @@ export const sendEmail = pikkuSessionlessFunc<
 /**
  * User onboarding workflow with email and profile setup
  */
-export const onboardingWorkflow = pikkuWorkflowFunc<
+export const onboardingWorkflow = pikkuWorkflow<
   { email: string; userId: string },
   { userId: string; email: string }
 >({


### PR DESCRIPTION
…rkflowFunc to pikkuWorkflowDAG

Simplify workflow function naming for better clarity:
- pikkuWorkflowFunc → pikkuWorkflow
- pikkuSimpleWorkflowFunc → pikkuWorkflowDAG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Renamed workflow factory functions for improved clarity: `pikkuWorkflowFunc` is now `pikkuWorkflow`, and `pikkuSimpleWorkflowFunc` is now `pikkuWorkflowDAG`. Workflow functionality remains unchanged; update your code to use the new function names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->