### PR TITLE
Fix OpenAPI codegen bugs and make function input optional

### DIFF
--- a/.changeset/fix-openapi-codegen-bugs.md
+++ b/.changeset/fix-openapi-codegen-bugs.md
@@ -1,0 +1,6 @@
+---
+"@pikku/cli": patch
+"@pikku/openapi-to-zod-schema": patch
+---
+
+Fix OpenAPI codegen bugs: use operation description instead of response description, sanitize dots in type names, quote hyphenated property keys, make function input optional in types, and use pikkuServices() in test template.

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -527,24 +527,16 @@ wireAddon({ name: '${name}', package: '@pikku/addon-${name}' })
 `
 
   // test/src/services.ts
-  files['src/services.ts'] = `import type {
-  SingletonServices,
-} from '../types/application-types.js'
-import {
-  CreateSingletonServices,
-} from '@pikku/core'
-import {
+  files['src/services.ts'] = `import {
   ConsoleLogger,
   LocalVariablesService,
   LocalSecretService,
 } from '@pikku/core/services'
+import { pikkuServices } from '#pikku'
 
 import '../.pikku/pikku-bootstrap.gen.js'
 
-export const createSingletonServices: CreateSingletonServices<
-  {},
-  SingletonServices
-> = async (_config, existingServices) => {
+export const createSingletonServices = pikkuServices(async (_config, existingServices) => {
   const variables = existingServices?.variables ?? new LocalVariablesService(process.env)
   const secrets = existingServices?.secrets ?? new LocalSecretService(variables)
 
@@ -553,7 +545,7 @@ export const createSingletonServices: CreateSingletonServices<
     variables,
     secrets,
   }
-}
+})
 `
 
   // test/src/{name}-tests.function.ts

--- a/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
@@ -346,7 +346,7 @@ export type PikkuFunctionConfig<
  * Types are automatically inferred from the schemas.
  */
 export type PikkuFunctionConfigWithSchema<
-  InputSchema extends StandardSchemaV1,
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
   OutputSchema extends StandardSchemaV1 | undefined = undefined,
   RequiredWires extends keyof PikkuWire = never
 > = {
@@ -356,20 +356,20 @@ export type PikkuFunctionConfigWithSchema<
   mcp?: boolean
   internal?: boolean
   approvalRequired?: boolean
-  approvalDescription?: PikkuApprovalDescription<InferSchemaOutput<InputSchema>>
+  approvalDescription?: InputSchema extends StandardSchemaV1 ? PikkuApprovalDescription<InferSchemaOutput<InputSchema>> : never
   func: PikkuFunction<
-    InferSchemaOutput<InputSchema>,
+    InputSchema extends StandardSchemaV1 ? InferSchemaOutput<InputSchema> : unknown,
     OutputSchema extends StandardSchemaV1 ? InferSchemaOutput<OutputSchema> : unknown,
     RequiredWires
   > | PikkuFunctionSessionless<
-    InferSchemaOutput<InputSchema>,
+    InputSchema extends StandardSchemaV1 ? InferSchemaOutput<InputSchema> : unknown,
     OutputSchema extends StandardSchemaV1 ? InferSchemaOutput<OutputSchema> : unknown,
     RequiredWires
   >
   auth?: boolean
-  permissions?: CorePermissionGroup<PikkuPermission<InferSchemaOutput<InputSchema>>>
+  permissions?: InputSchema extends StandardSchemaV1 ? CorePermissionGroup<PikkuPermission<InferSchemaOutput<InputSchema>>> : undefined
   middleware?: PikkuMiddleware[]
-  input: InputSchema
+  input?: InputSchema
   output?: OutputSchema
   node?: NodeConfig
   errors?: Array<typeof PikkuError>
@@ -414,11 +414,11 @@ export type PikkuFunctionConfigWithSchema<
  * \`\`\`
  */
 export function pikkuFunc<
-  InputSchema extends StandardSchemaV1,
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
   OutputSchema extends StandardSchemaV1 | undefined = undefined
 >(
   config: PikkuFunctionConfigWithSchema<InputSchema, OutputSchema, 'session' | 'rpc'>
-): PikkuFunctionConfig<InferSchemaOutput<InputSchema>, OutputSchema extends StandardSchemaV1 ? InferSchemaOutput<OutputSchema> : unknown, 'session' | 'rpc'>
+): PikkuFunctionConfig<InputSchema extends StandardSchemaV1 ? InferSchemaOutput<InputSchema> : unknown, OutputSchema extends StandardSchemaV1 ? InferSchemaOutput<OutputSchema> : unknown, 'session' | 'rpc'>
 export function pikkuFunc<In, Out = unknown>(
   func:
     | PikkuFunction<In, Out, 'session' | 'rpc'>
@@ -432,7 +432,7 @@ export function pikkuFunc(func: any) {
  * Configuration object for sessionless Pikku functions with Zod schema validation.
  */
 export type PikkuFunctionSessionlessConfigWithSchema<
-  InputSchema extends StandardSchemaV1,
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
   OutputSchema extends StandardSchemaV1 | undefined = undefined,
   RequiredWires extends keyof PikkuWire = never
 > = {
@@ -444,16 +444,16 @@ export type PikkuFunctionSessionlessConfigWithSchema<
   internal?: boolean
   remote?: boolean
   approvalRequired?: boolean
-  approvalDescription?: PikkuApprovalDescription<InferSchemaOutput<InputSchema>>
+  approvalDescription?: InputSchema extends StandardSchemaV1 ? PikkuApprovalDescription<InferSchemaOutput<InputSchema>> : never
   func: PikkuFunctionSessionless<
-    InferSchemaOutput<InputSchema>,
+    InputSchema extends StandardSchemaV1 ? InferSchemaOutput<InputSchema> : unknown,
     OutputSchema extends StandardSchemaV1 ? InferSchemaOutput<OutputSchema> : unknown,
     RequiredWires
   >
   auth?: boolean
-  permissions?: CorePermissionGroup<PikkuPermission<InferSchemaOutput<InputSchema>>>
+  permissions?: InputSchema extends StandardSchemaV1 ? CorePermissionGroup<PikkuPermission<InferSchemaOutput<InputSchema>>> : undefined
   middleware?: PikkuMiddleware[]
-  input: InputSchema
+  input?: InputSchema
   output?: OutputSchema
   node?: NodeConfig
   errors?: Array<typeof PikkuError>
@@ -495,11 +495,11 @@ export type PikkuFunctionSessionlessConfigWithSchema<
  * \`\`\`
  */
 export function pikkuSessionlessFunc<
-  InputSchema extends StandardSchemaV1,
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
   OutputSchema extends StandardSchemaV1 | undefined = undefined
 >(
   config: PikkuFunctionSessionlessConfigWithSchema<InputSchema, OutputSchema, 'session' | 'rpc'>
-): PikkuFunctionConfig<InferSchemaOutput<InputSchema>, OutputSchema extends StandardSchemaV1 ? InferSchemaOutput<OutputSchema> : unknown, 'session' | 'rpc'>
+): PikkuFunctionConfig<InputSchema extends StandardSchemaV1 ? InferSchemaOutput<InputSchema> : unknown, OutputSchema extends StandardSchemaV1 ? InferSchemaOutput<OutputSchema> : unknown, 'session' | 'rpc'>
 export function pikkuSessionlessFunc<In, Out = unknown>(
   func:
     | PikkuFunctionSessionless<In, Out, 'session' | 'rpc'>

--- a/packages/cli/src/utils/openapi/codegen.ts
+++ b/packages/cli/src/utils/openapi/codegen.ts
@@ -10,6 +10,7 @@ import type {
 import {
   schemaToZod,
   schemaVarName,
+  sanitizeTypeName,
   createContext,
   type ZodCodegenContext,
 } from './zod-codegen.js'
@@ -32,6 +33,10 @@ interface CodegenFlags {
   oauth: boolean
   secret: boolean
   mcp?: boolean
+}
+
+function safeKey(key: string): string {
+  return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key) ? key : JSON.stringify(key)
 }
 
 const GENERIC_SUMMARIES = new Set([
@@ -61,40 +66,12 @@ function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
-function humanDescription(
-  named: NamedOperation,
-  parsed: ParsedOperation
-): string {
-  const summary = parsed.summary?.trim()
+function humanDescription(parsed: ParsedOperation): string | undefined {
   const description = parsed.description?.trim()
-
-  // Summary is preferred — it's the operation's intent
-  if (summary && !GENERIC_SUMMARIES.has(summary.toLowerCase())) {
-    // If description adds info beyond summary, combine them
-    if (
-      description &&
-      !GENERIC_SUMMARIES.has(description.toLowerCase()) &&
-      description.toLowerCase() !== summary.toLowerCase()
-    ) {
-      const sep = summary.endsWith('.') ? ' ' : '. '
-      return `${capitalize(summary)}${sep}${capitalize(description)}`
-    }
-    return capitalize(summary)
-  }
-
   if (description && !GENERIC_SUMMARIES.has(description.toLowerCase())) {
     return capitalize(description)
   }
-
-  if (parsed.responseDescription) {
-    return capitalize(parsed.responseDescription)
-  }
-
-  const words = named.functionName
-    .replace(/([A-Z])/g, ' $1')
-    .trim()
-    .toLowerCase()
-  return capitalize(words)
+  return undefined
 }
 
 function getErrorClassesForResponses(
@@ -190,7 +167,9 @@ function generateTypesFile(spec: ParsedSpec, ctx: ZodCodegenContext): string {
     const varName = schemaVarName(name)
     const zodCode = schemaToZod(schema, ctx)
     lines.push(`export const ${varName} = ${zodCode}`)
-    lines.push(`export type ${name} = z.infer<typeof ${varName}>`)
+    lines.push(
+      `export type ${sanitizeTypeName(name)} = z.infer<typeof ${varName}>`
+    )
     lines.push('')
   }
 
@@ -257,11 +236,13 @@ function generateFunctionFile(
     lines.push('')
   }
 
-  const description = humanDescription(named, parsed)
+  const description = humanDescription(parsed)
   const method = parsed.method.toUpperCase()
 
   const funcConfig: string[] = []
-  funcConfig.push(`  description: ${JSON.stringify(description)},`)
+  if (description) {
+    funcConfig.push(`  description: ${JSON.stringify(description)},`)
+  }
   if (hasInput) funcConfig.push(`  input: ${inputName},`)
   if (parsed.responseSchema) {
     funcConfig.push(`  output: ${outputName},`)
@@ -325,7 +306,7 @@ function buildInputSchema(
         const withDesc = propSchema.description
           ? `${zodCode}.describe(${JSON.stringify(propSchema.description)})`
           : zodCode
-        props.push(`  ${key}: ${withDesc},`)
+        props.push(`  ${safeKey(key)}: ${withDesc},`)
       }
     } else {
       const bodyZod = schemaToZod(parsed.requestBody, ctx)
@@ -358,7 +339,7 @@ function formatParamProp(
       ? `${zodCode}.describe(${JSON.stringify(descParts.join('. '))})`
       : zodCode
 
-  return `  ${param.name}: ${desc},`
+  return `  ${safeKey(param.name)}: ${desc},`
 }
 
 function buildOutputSchema(schema: any, ctx: ZodCodegenContext): string {

--- a/packages/cli/src/utils/openapi/zod-codegen.ts
+++ b/packages/cli/src/utils/openapi/zod-codegen.ts
@@ -4,4 +4,5 @@ export {
   createContext,
   schemaToZod,
   schemaVarName,
+  sanitizeTypeName,
 } from '@pikku/openapi-to-zod-schema'

--- a/packages/openapi-to-zod-schema/src/index.ts
+++ b/packages/openapi-to-zod-schema/src/index.ts
@@ -338,6 +338,11 @@ function safeKey(key: string): string {
  * Generate the Zod variable name for a component schema.
  * e.g. "PaginatedResponse" → "PaginatedResponseSchema"
  */
+export function sanitizeTypeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_$]/g, '')
+}
+
 export function schemaVarName(name: string): string {
-  return name.endsWith('Schema') ? name : `${name}Schema`
+  const sanitized = sanitizeTypeName(name)
+  return sanitized.endsWith('Schema') ? sanitized : `${sanitized}Schema`
 }


### PR DESCRIPTION
## Summary
- Use operation description instead of response description for function docs
- Sanitize dots in type names (e.g. `fly.MachineInit` → `flyMachineInit`)
- Quote hyphenated property keys in generated Zod schemas
- Make function `input` optional in types for output-only functions
- Use `pikkuServices()` instead of `CreateSingletonServices` in test template

## Test plan
- [x] Generated Fly.io addon from OpenAPI spec with all fixes applied
- [x] Addon builds with zero TypeScript errors
- [x] Published `@pikku/addon-flyio@0.1.0` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAPI code generation: fixed operation description usage and enhanced handling of special characters in property names and type names.
  * Better type name sanitization in generated code.

* **New Features**
  * Function schemas are now optional, enabling schema-less function configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->