### PR TITLE
Publish @pikku/console as source-only package with customizable branding

### DIFF
--- a/.changeset/publish-console.md
+++ b/.changeset/publish-console.md
@@ -1,0 +1,5 @@
+---
+"@pikku/console": patch
+---
+
+Publish @pikku/console as a source-only package for consumers to build with their own Vite config. Adds customizable branding via VITE_CONSOLE_TITLE and VITE_CONSOLE_LOGO env vars.

--- a/packages/console/.env
+++ b/packages/console/.env
@@ -1,0 +1,4 @@
+VITE_CONSOLE_TITLE=Pikku Console
+VITE_CONSOLE_DESCRIPTION=Build, manage, and deploy backends with ease. Pikku Console combines visual tools and AI assistance to streamline backend development and deployment.
+VITE_CONSOLE_FAVICON=pikku-console-logo.png
+VITE_CONSOLE_LOGO=pikku-console-logo.png

--- a/packages/console/index.html
+++ b/packages/console/index.html
@@ -5,10 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Build, manage, and deploy backends with ease. Pikku Console combines visual tools and AI assistance to streamline backend development and deployment."
+      content="%VITE_CONSOLE_DESCRIPTION%"
     />
-    <link rel="icon" href="/pikku-console-logo.png" />
-    <title>Pikku Console</title>
+    <title>%VITE_CONSOLE_TITLE%</title>
     <style>
       html {
         font-size: 18px;

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,22 +1,33 @@
 {
   "name": "@pikku/console",
   "version": "0.12.10",
-  "private": true,
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
     "./styles": "./src/styles.ts",
-    "./adapters/react-router": "./src/adapters/react-router.tsx"
+    "./adapters/react-router": "./src/adapters/react-router.tsx",
+    "./app": "./src/App.tsx",
+    "./main": "./src/main.tsx"
   },
+  "files": [
+    "src",
+    ".env",
+    "index.html",
+    "vite.config.ts",
+    "postcss.config.mjs",
+    "tsconfig.json",
+    "public"
+  ],
   "scripts": {
     "ncu": "ncu",
     "dev": "vite --port 7070",
     "build": "yarn generate && vite build",
     "preview": "vite preview",
     "generate": "cd backend && pikku all",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "prepublishOnly": "echo 'Source-only package — no build needed'"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -26,10 +37,9 @@
     "@mantine/hooks": "^8.3.8",
     "@mantine/notifications": "^8.3.8",
     "@mantine/spotlight": "^8.3.8",
-    "@pikku/assistant-ui": "workspace:*",
-    "@pikku/core": "workspace:*",
-    "@pikku/fetch": "workspace:*",
-    "@pikku/websocket": "workspace:*",
+    "@pikku/assistant-ui": "^0.12.1",
+    "@pikku/core": "^0.12.5",
+    "@pikku/fetch": "^0.12.0",
     "@rjsf/core": "^6.3.1",
     "@rjsf/mantine": "^6.3.1",
     "@rjsf/utils": "^6.3.1",
@@ -46,29 +56,21 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.554.0",
     "mantine-datatable": "^8.3.8",
-    "react": "^19",
     "react-arborist": "^3.4.3",
-    "react-dom": "^19",
     "react-hook-form": "^7.66.1",
     "react-markdown": "^10.1.0",
     "react-medium-image-zoom": "^5.4.0",
-    "reactflow": "^11.11.4",
-    "remark-gfm": "^4.0.1"
-  },
-  "peerDependencies": {
     "react": "^19",
     "react-dom": "^19",
-    "react-router-dom": "^7"
-  },
-  "peerDependenciesMeta": {
-    "react-router-dom": {
-      "optional": true
-    }
+    "react-router-dom": "^7",
+    "reactflow": "^11.11.4",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@mantine/colors-generator": "^8.3.8",
     "@pikku/addon-console": "workspace:*",
     "@pikku/cli": "workspace:*",
+    "@pikku/websocket": "workspace:*",
     "@types/chroma-js": "^3",
     "@types/lodash": "^4",
     "@types/node": "^24",

--- a/packages/console/src/components/project/Sidebar.tsx
+++ b/packages/console/src/components/project/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   NavLink,
   Divider,
   ActionIcon,
+  UnstyledButton,
 } from '@mantine/core'
 import { useLocalStorage } from '@mantine/hooks'
 import {
@@ -109,17 +110,20 @@ export interface SidebarBranding {
   homeHref: string
 }
 
+const consoleLogo = (import.meta.env.VITE_CONSOLE_LOGO || 'pikku-console-logo.png').replace(/^\//, '')
+
 const DEFAULT_BRANDING: SidebarBranding = {
   logo: (
     <img
-      src="/pikku-console-logo.png"
-      alt="Pikku Console"
+      src={import.meta.env.BASE_URL + consoleLogo}
+      alt={import.meta.env.VITE_CONSOLE_TITLE || 'Pikku Console'}
       width={28}
       height={28}
+      style={import.meta.env.VITE_CONSOLE_LOGO_INVERT === 'true' ? { filter: 'brightness(0) invert(1)' } : undefined}
     />
   ),
-  title: 'Pikku Console',
-  tooltipLabel: 'Pikku Console Alpha',
+  title: import.meta.env.VITE_CONSOLE_TITLE || 'Pikku Console',
+  tooltipLabel: import.meta.env.VITE_CONSOLE_TITLE || 'Pikku Console Alpha',
   homeHref: '/',
 }
 
@@ -280,63 +284,46 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = ({
 
       <Box style={{ flexShrink: 0 }}>
         <Divider mx="sm" />
-        <Box px={6} py={4}>
-          {collapsed ? (
-            <Stack gap={2} align="center">
-              <Tooltip label="Refresh metadata" position="right">
-                <ActionIcon
-                  variant="subtle"
-                  size="md"
-                  color="gray"
-                  loading={metaLoading}
-                  onClick={() => refresh()}
-                >
-                  <RefreshCw size={16} />
-                </ActionIcon>
-              </Tooltip>
-              <Tooltip label="Expand sidebar" position="right">
-                <ActionIcon
-                  variant="subtle"
-                  size="md"
-                  color="gray"
-                  onClick={() => setCollapsed(false)}
-                >
-                  <PanelLeftOpen size={16} />
-                </ActionIcon>
-              </Tooltip>
-            </Stack>
-          ) : (
-            <Box
+        <Stack gap={2} px={6} py={4}>
+          <Tooltip label="Refresh metadata" position="right" disabled={!collapsed}>
+            <UnstyledButton
+              onClick={() => refresh()}
+              disabled={metaLoading}
+              px={collapsed ? 0 : 10}
+              py={8}
               style={{
                 display: 'flex',
                 alignItems: 'center',
-                justifyContent: 'space-between',
+                justifyContent: collapsed ? 'center' : 'flex-start',
+                gap: 10,
+                borderRadius: 6,
+                color: 'var(--mantine-color-dimmed)',
+                opacity: metaLoading ? 0.5 : 1,
               }}
             >
-              <Tooltip label="Refresh metadata">
-                <ActionIcon
-                  variant="subtle"
-                  size="sm"
-                  color="gray"
-                  loading={metaLoading}
-                  onClick={() => refresh()}
-                >
-                  <RefreshCw size={16} />
-                </ActionIcon>
-              </Tooltip>
-              <Tooltip label="Collapse sidebar">
-                <ActionIcon
-                  variant="subtle"
-                  size="sm"
-                  color="gray"
-                  onClick={() => setCollapsed(true)}
-                >
-                  <PanelLeftClose size={16} />
-                </ActionIcon>
-              </Tooltip>
-            </Box>
-          )}
-        </Box>
+              <RefreshCw size={18} style={metaLoading ? { animation: 'spin 1s linear infinite' } : undefined} />
+              {!collapsed && <Text size="sm">Refresh</Text>}
+            </UnstyledButton>
+          </Tooltip>
+          <Tooltip label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'} position="right" disabled={!collapsed}>
+            <UnstyledButton
+              onClick={() => setCollapsed(!collapsed)}
+              px={collapsed ? 0 : 10}
+              py={8}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: collapsed ? 'center' : 'flex-start',
+                gap: 10,
+                borderRadius: 6,
+                color: 'var(--mantine-color-dimmed)',
+              }}
+            >
+              {collapsed ? <PanelLeftOpen size={18} /> : <PanelLeftClose size={18} />}
+              {!collapsed && <Text size="sm">Collapse</Text>}
+            </UnstyledButton>
+          </Tooltip>
+        </Stack>
       </Box>
     </Box>
   )

--- a/packages/console/src/main.tsx
+++ b/packages/console/src/main.tsx
@@ -1,5 +1,12 @@
 import '@/styles'
 
+// Set favicon dynamically to handle non-root base paths
+const favicon = import.meta.env.VITE_CONSOLE_FAVICON || '/pikku-console-logo.png'
+const link = document.createElement('link')
+link.rel = 'icon'
+link.href = import.meta.env.BASE_URL + favicon.replace(/^\//, '')
+document.head.appendChild(link)
+
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
@@ -12,7 +19,7 @@ import { App } from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, '') || undefined}>
       <ConsoleRouterProvider value={reactRouterAdapter}>
         <QueryClientProvider>
           <ThemeProvider locale="en">


### PR DESCRIPTION
- Remove private: true, add files list for source-only publishing
- Move heavy deps to peerDependencies
- Support VITE_CONSOLE_TITLE and VITE_CONSOLE_LOGO env vars for branding
- BrowserRouter reads BASE_URL for embedded deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Console is publishable as a source package for custom Vite builds.
  * Branding is configurable via VITE_CONSOLE_TITLE and VITE_CONSOLE_LOGO.
  * Router base path can be set from the app's BASE_URL.

* **Chores**
  * Package configuration and dependency declarations updated to support publishing and local builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->