### PR TITLE
Fix credentials crash and add --credential flag

### DIFF
--- a/.changeset/fix-credentials-and-add-credential-flag.md
+++ b/.changeset/fix-credentials-and-add-credential-flag.md
@@ -1,0 +1,6 @@
+---
+"@pikku/cli": patch
+"@pikku/openapi-parser": patch
+---
+
+Fix credentials command crash when state.credentials is undefined, and add --credential flag to `pikku new addon` for per-user credential wiring (apikey, bearer, oauth2).

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -288,6 +288,10 @@ wireCLI({
                 'Include OAuth2 credential wiring and OAuth2Client-based API service',
               default: false,
             },
+            credential: {
+              description:
+                'Include per-user credential wiring (apikey, bearer, or oauth2)',
+            },
             test: {
               description: 'Include test harness (default: true)',
               default: true,

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -37,7 +37,12 @@ interface AddonVars {
 
 function getAddonFiles(
   vars: AddonVars,
-  flags: { secret: boolean; variable: boolean; oauth: boolean }
+  flags: {
+    secret: boolean
+    variable: boolean
+    oauth: boolean
+    credential?: 'apikey' | 'bearer' | 'oauth2'
+  }
 ): Record<string, string> {
   const {
     name,
@@ -163,7 +168,27 @@ ${description}
 `
 
   // src/services.ts
-  if (flags.oauth) {
+  if (flags.credential && flags.credential !== 'oauth2') {
+    // Per-user credential: use createWireServices with wire.getCredentials()
+    const credField = flags.credential === 'bearer' ? 'token' : 'apiKey'
+    files['src/services.ts'] =
+      `import { ${pascalName}Service } from './${name}-api.service.js'
+import { pikkuAddonWireServices } from '#pikku'
+
+export const createWireServices = pikkuAddonWireServices(
+  async (_services, wire) => {
+    const credentials = wire.getCredentials()
+    const cred = credentials['${camelName}'] as { ${credField}: string } | undefined
+    if (!cred?.${credField}) {
+      throw new Error('Missing ${camelName} credential')
+    }
+    const ${camelName} = new ${pascalName}Service(cred)
+
+    return { ${camelName} }
+  }
+)
+`
+  } else if (flags.oauth || flags.credential === 'oauth2') {
     files['src/services.ts'] =
       `import { ${pascalName}Service } from './${name}-api.service.js'
 import { pikkuAddonServices } from '#pikku'
@@ -210,7 +235,62 @@ export const createSingletonServices = pikkuAddonServices(async (
   }
 
   // src/{name}-api.service.ts
-  if (flags.oauth) {
+  if (flags.credential && flags.credential !== 'oauth2') {
+    const credField = flags.credential === 'bearer' ? 'token' : 'apiKey'
+    const credType = `{ ${credField}: string }`
+    const authHeader =
+      flags.credential === 'bearer'
+        ? `\`Bearer \${this.creds.token}\``
+        : `this.creds.apiKey`
+    const authLine =
+      flags.credential === 'bearer'
+        ? `'Authorization': ${authHeader},`
+        : `'Authorization': \`Bearer \${this.creds.apiKey}\`,`
+    files[`src/${name}-api.service.ts`] =
+      `const BASE_URL = 'https://api.example.com/v1'
+
+export interface RequestOptions {
+  body?: unknown
+  qs?: Record<string, string | number | boolean | undefined>
+}
+
+export class ${pascalName}Service {
+  constructor(private creds: ${credType}) {}
+
+  async request<T>(
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
+    endpoint: string,
+    options?: RequestOptions
+  ): Promise<T> {
+    const url = new URL(endpoint, BASE_URL)
+
+    if (options?.qs) {
+      for (const [key, value] of Object.entries(options.qs)) {
+        if (value !== undefined) {
+          url.searchParams.set(key, String(value))
+        }
+      }
+    }
+
+    const response = await fetch(url.toString(), {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        ${authLine}
+      },
+      body: options?.body ? JSON.stringify(options.body) : undefined,
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(\`${displayName} API error (\${response.status}): \${errorText}\`)
+    }
+
+    return response.json() as Promise<T>
+  }
+}
+`
+  } else if (flags.oauth) {
     files[`src/${name}-api.service.ts`] =
       `import { OAuth2Client } from '@pikku/core/oauth2'
 import type { TypedSecretService } from '#pikku/secrets/pikku-secrets.gen.js'
@@ -401,8 +481,40 @@ export interface SingletonServices extends CoreSingletonServices<Config> {
 export interface Services extends CoreServices<SingletonServices> {}
 `
 
-  // Conditional: secret file
-  if (flags.oauth) {
+  // Conditional: credential / secret file
+  if (flags.credential === 'apikey') {
+    files[`src/${name}.credential.ts`] = `import { z } from 'zod'
+import { wireCredential } from '@pikku/core/credential'
+
+export const ${camelName}CredentialSchema = z.object({
+  apiKey: z.string().describe('${displayName} API key'),
+})
+
+wireCredential({
+  name: '${camelName}',
+  displayName: '${displayName}',
+  description: '${description}',
+  type: 'wire',
+  schema: ${camelName}CredentialSchema,
+})
+`
+  } else if (flags.credential === 'bearer') {
+    files[`src/${name}.credential.ts`] = `import { z } from 'zod'
+import { wireCredential } from '@pikku/core/credential'
+
+export const ${camelName}CredentialSchema = z.object({
+  token: z.string().describe('${displayName} bearer token'),
+})
+
+wireCredential({
+  name: '${camelName}',
+  displayName: '${displayName}',
+  description: '${description}',
+  type: 'wire',
+  schema: ${camelName}CredentialSchema,
+})
+`
+  } else if (flags.oauth || flags.credential === 'oauth2') {
     files[`src/${name}.credential.ts`] = `import { z } from 'zod'
 import { wireCredential } from '@pikku/core/credential'
 import { wireSecret } from '@pikku/core/secret'
@@ -682,6 +794,7 @@ export const pikkuNewAddon = pikkuSessionlessFunc<
     secret?: boolean
     variable?: boolean
     oauth?: boolean
+    credential?: string
     test?: boolean
     openapi?: string
     mcp?: boolean
@@ -699,6 +812,7 @@ export const pikkuNewAddon = pikkuSessionlessFunc<
       secret = false,
       variable = false,
       oauth = false,
+      credential,
       test = true,
       openapi,
       mcp = false,
@@ -735,19 +849,38 @@ export const pikkuNewAddon = pikkuSessionlessFunc<
       category,
     }
 
-    // oauth implies secret
+    // Validate credential type if provided
+    const credentialType = credential as
+      | 'apikey'
+      | 'bearer'
+      | 'oauth2'
+      | undefined
+    if (
+      credentialType &&
+      !['apikey', 'bearer', 'oauth2'].includes(credentialType)
+    ) {
+      logger.error(
+        `Invalid credential type "${credential}": must be one of apikey, bearer, oauth2`
+      )
+      process.exit(1)
+    }
+
+    // oauth implies secret (unless credential flag is used); credential oauth2 implies oauth
+    const effectiveOAuth = oauth || credentialType === 'oauth2'
     const addonFiles = getAddonFiles(vars, {
-      secret: secret || oauth,
+      secret: (secret || effectiveOAuth) && !credentialType,
       variable,
-      oauth,
+      oauth: effectiveOAuth,
+      credential: credentialType,
     })
 
     // If openapi spec provided, generate typed files and merge over scaffold
     if (openapi) {
       const spec = await parseOpenAPISpec(openapi)
       const openapiFiles = generateAddonFromOpenAPI(spec, vars, {
-        oauth,
-        secret: secret || oauth,
+        oauth: effectiveOAuth,
+        secret: (secret || effectiveOAuth) && !credentialType,
+        credential: credentialType,
         mcp,
       })
       Object.assign(addonFiles, openapiFiles)

--- a/packages/cli/src/functions/wirings/credentials/pikku-command-credentials.ts
+++ b/packages/cli/src/functions/wirings/credentials/pikku-command-credentials.ts
@@ -14,7 +14,7 @@ export const pikkuCredentials = pikkuSessionlessFunc<void, void>({
 
     const state = await getInspectorState()
 
-    if (state.credentials.definitions.length === 0) {
+    if (!state.credentials || state.credentials.definitions.length === 0) {
       return
     }
 

--- a/packages/cli/src/functions/wirings/functions/pikku-command-addon-types.ts
+++ b/packages/cli/src/functions/wirings/functions/pikku-command-addon-types.ts
@@ -43,7 +43,7 @@ export const pikkuAddonTypes = pikkuSessionlessFunc<void, void>({
       `import type { RequiredSingletonServices } from '${getFileImportRelativePath(addonTypesFile, servicesFile, packageMappings)}'`,
       `import { TypedSecretService } from '${getFileImportRelativePath(addonTypesFile, secretsFile, packageMappings)}'`,
       `import { TypedVariablesService } from '${getFileImportRelativePath(addonTypesFile, variablesFile, packageMappings)}'`,
-      visitState.credentials.definitions.length > 0
+      visitState.credentials?.definitions?.length > 0
         ? `import { TypedCredentialService } from '${getFileImportRelativePath(addonTypesFile, credentialsFile, packageMappings)}'`
         : null
     )

--- a/packages/openapi-parser/src/codegen.ts
+++ b/packages/openapi-parser/src/codegen.ts
@@ -32,6 +32,7 @@ interface AddonVars {
 interface CodegenFlags {
   oauth: boolean
   secret: boolean
+  credential?: 'apikey' | 'bearer' | 'oauth2'
   mcp?: boolean
 }
 
@@ -386,7 +387,9 @@ function generateServiceFile(
   // Always import all error classes used in the switch statement
   const allErrorClasses = new Set<string>(Object.values(STATUS_TO_ERROR))
 
-  if (flags.oauth) {
+  if (flags.credential && flags.credential !== 'oauth2') {
+    // Per-user credential: no special imports needed, creds passed via constructor
+  } else if (flags.oauth || flags.credential === 'oauth2') {
     lines.push("import { OAuth2Client } from '@pikku/core/oauth2'")
     lines.push(
       "import type { TypedSecretService } from '#pikku/secrets/pikku-secrets.gen.js'"
@@ -458,7 +461,17 @@ function generateServiceFile(
   lines.push(`export class ${pascalName}Service {`)
   lines.push('  private baseUrl: string')
 
-  if (flags.oauth) {
+  if (flags.credential && flags.credential !== 'oauth2') {
+    const credField = flags.credential === 'bearer' ? 'token' : 'apiKey'
+    lines.push('')
+    lines.push(
+      `  constructor(private creds: { ${credField}: string }, variables: TypedVariablesService) {`
+    )
+    lines.push(
+      `    this.baseUrl = variables.get('${screamingName}_BASE_URL') as string`
+    )
+    lines.push('  }')
+  } else if (flags.oauth || flags.credential === 'oauth2') {
     lines.push('  private oauth: OAuth2Client')
     lines.push('')
     lines.push(
@@ -548,7 +561,30 @@ function generateServiceFile(
   lines.push('    }')
   lines.push('')
 
-  if (flags.oauth) {
+  if (flags.credential && flags.credential !== 'oauth2') {
+    // Per-user credential: use creds from wire.getCredentials()
+    if (flags.credential === 'bearer') {
+      lines.push('    headers.Authorization = `Bearer ${this.creds.token}`')
+    } else {
+      // apikey: check spec for custom header name
+      const apiKeyScheme = Object.values(spec.securitySchemes).find(
+        (s) => s.type === 'apiKey'
+      )
+      if (apiKeyScheme?.name && apiKeyScheme?.in === 'header') {
+        lines.push(
+          `    headers[${JSON.stringify(apiKeyScheme.name)}] = this.creds.apiKey`
+        )
+      } else {
+        lines.push('    headers.Authorization = `Bearer ${this.creds.apiKey}`')
+      }
+    }
+    lines.push('')
+    lines.push('    const response = await fetch(url.toString(), {')
+    lines.push('      method,')
+    lines.push('      headers,')
+    lines.push('      body: body ? JSON.stringify(body) : undefined,')
+    lines.push('    })')
+  } else if (flags.oauth || flags.credential === 'oauth2') {
     lines.push(
       '    const response = await this.oauth.request(url.toString(), {'
     )


### PR DESCRIPTION
## Summary
- Fix `state.credentials.definitions` crash in `pikku-command-credentials.ts` and `pikku-command-addon-types.ts` when `state.credentials` is undefined (guard with early return / optional chaining)
- Add `--credential <type>` flag (`apikey`, `bearer`, `oauth2`) to `pikku new addon` for per-user credential wiring via `wireCredential({ type: 'wire' })`
- Generate `createWireServices` with `wire.getCredentials()` for credential types
- Update openapi-parser codegen to support credential flag in service generation
- Keep `--oauth` as backwards-compatible alias for `--credential oauth2`

## Test plan
- [x] `pikku new addon stripe --credential apikey` generates `.credential.ts` with `wireCredential` and `createWireServices`
- [x] `pikku new addon github --credential bearer` generates bearer token schema
- [x] `--credential oauth2` behaves same as `--oauth`
- [ ] Publish and verify makeanagent container builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the credentials command that occurred when credentials were not defined.

* **New Features**
  * Added `--credential` flag to `pikku new addon` command to configure per-user credential wiring. Supports API key, bearer token, and OAuth2 authentication methods, providing greater flexibility for securing addon credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->