### PR TITLE
Remove server/container deploy 

### DIFF
--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -170,7 +170,7 @@ wireCLI({
           func: enableRpc,
           description: 'Enable public RPC endpoint',
           options: {
-            'no-auth': {
+            noAuth: {
               description: 'Disable auth requirement',
               default: false,
             },
@@ -180,7 +180,7 @@ wireCLI({
           func: enableConsole,
           description: 'Enable console functions',
           options: {
-            'no-auth': {
+            noAuth: {
               description: 'Disable auth requirement',
               default: false,
             },
@@ -190,7 +190,7 @@ wireCLI({
           func: enableAgent,
           description: 'Enable public agent endpoints',
           options: {
-            'no-auth': {
+            noAuth: {
               description: 'Disable auth requirement',
               default: false,
             },
@@ -200,7 +200,7 @@ wireCLI({
           func: enableWorkflow,
           description: 'Enable workflow workers',
           options: {
-            'no-auth': {
+            noAuth: {
               description: 'Disable auth requirement',
               default: false,
             },
@@ -359,6 +359,10 @@ wireCLI({
               default: 'cloudflare',
               short: 'p',
             },
+            resultFile: {
+              description:
+                'Write structured JSON plan result to this file path',
+            },
           },
         }),
         apply: pikkuCLICommand({
@@ -370,10 +374,14 @@ wireCLI({
               default: 'cloudflare',
               short: 'p',
             },
-            'from-plan': {
+            fromPlan: {
               description:
                 'Skip build pipeline, deploy from existing plan output',
               default: false,
+            },
+            resultFile: {
+              description:
+                'Write structured JSON deploy result to this file path',
             },
           },
         }),

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -370,6 +370,11 @@ wireCLI({
               default: 'cloudflare',
               short: 'p',
             },
+            'from-plan': {
+              description:
+                'Skip build pipeline, deploy from existing plan output',
+              default: false,
+            },
           },
         }),
         info: pikkuCLICommand({

--- a/packages/cli/src/functions/commands/deploy-apply.ts
+++ b/packages/cli/src/functions/commands/deploy-apply.ts
@@ -102,11 +102,7 @@ export async function resolveProvider(
   },
   providerName?: string
 ): Promise<ProviderAdapter> {
-  const name =
-    providerName ??
-    process.env.PIKKU_DEPLOY_PROVIDER ??
-    config?.deploy?.defaultProvider ??
-    'cloudflare'
+  const name = providerName ?? config?.deploy?.defaultProvider ?? 'cloudflare'
 
   const providers = config?.deploy?.providers ?? {
     cloudflare: '@pikku/deploy-cloudflare',
@@ -151,8 +147,10 @@ const ANSI = {
   reset: '\x1b[0m',
 }
 
-async function writeResultFile(result: Record<string, unknown>): Promise<void> {
-  const resultFile = process.env.PIKKU_RESULT_FILE
+async function writeResultFile(
+  resultFile: string | undefined,
+  result: Record<string, unknown>
+): Promise<void> {
   if (resultFile) {
     const { writeFile } = await import('node:fs/promises')
     await writeFile(resultFile, JSON.stringify(result, null, 2), 'utf-8')
@@ -162,11 +160,12 @@ async function writeResultFile(result: Record<string, unknown>): Promise<void> {
 async function runDeploy(
   provider: ProviderAdapter,
   providerDir: string,
-  logger: { info(msg: string): void; error(msg: string): void }
+  logger: { info(msg: string): void; error(msg: string): void },
+  resultFile?: string
 ): Promise<void> {
   if (typeof provider.deploy !== 'function') {
     logger.error(`Provider '${provider.name}' does not support deploy.`)
-    await writeResultFile({
+    await writeResultFile(resultFile, {
       success: false,
       errors: [{ step: 'provider', error: 'No deploy support' }],
     })
@@ -182,7 +181,7 @@ async function runDeploy(
     },
   })
 
-  await writeResultFile(deployResult)
+  await writeResultFile(resultFile, deployResult)
 
   console.log('')
   if (deployResult.success) {
@@ -201,13 +200,14 @@ async function runDeploy(
 }
 
 export const deployApply = pikkuSessionlessFunc<
-  { 'from-plan'?: boolean; provider?: string },
+  { fromPlan?: boolean; provider?: string; resultFile?: string },
   void
 >({
   func: async ({ logger, config, getInspectorState }, data) => {
     const projectDir = config.rootDir
     const provider = await resolveProvider(config, data?.provider)
-    const fromPlan = data?.['from-plan'] ?? false
+    const fromPlan = data?.fromPlan ?? false
+    const resultFile = data?.resultFile
 
     if (fromPlan) {
       // Skip build pipeline — deploy from existing plan output
@@ -221,14 +221,14 @@ export const deployApply = pikkuSessionlessFunc<
         logger.error(
           `No plan found at ${providerDir}. Run 'pikku deploy plan' first.`
         )
-        await writeResultFile({
+        await writeResultFile(resultFile, {
           success: false,
           errors: [{ step: 'plan', error: 'No plan found' }],
         })
         process.exit(1)
       }
 
-      await runDeploy(provider, providerDir, logger)
+      await runDeploy(provider, providerDir, logger, resultFile)
       return
     }
 
@@ -248,7 +248,7 @@ export const deployApply = pikkuSessionlessFunc<
 
     if (buildResult.manifest.units.length === 0) {
       logger.info('No deployment units found. Nothing to deploy.')
-      await writeResultFile({
+      await writeResultFile(resultFile, {
         success: true,
         workersDeployed: [],
         resourcesCreated: [],
@@ -260,13 +260,13 @@ export const deployApply = pikkuSessionlessFunc<
     const { providerDir, bundled } = buildResult
 
     if (typeof provider.deploy === 'function') {
-      await runDeploy(provider, providerDir, logger)
+      await runDeploy(provider, providerDir, logger, resultFile)
     } else {
       logger.info(`${ANSI.green}${ANSI.bold}Build complete.${ANSI.reset}`)
       logger.info(
         `  ${bundled.length} functions bundled to ${ANSI.bold}${providerDir}${ANSI.reset}`
       )
-      await writeResultFile({
+      await writeResultFile(resultFile, {
         success: true,
         buildOnly: true,
         unitCount: bundled.length,

--- a/packages/cli/src/functions/commands/deploy-apply.ts
+++ b/packages/cli/src/functions/commands/deploy-apply.ts
@@ -173,13 +173,29 @@ async function runDeploy(
   }
 
   logger.info(`Deploying via ${provider.name}...`)
-  const deployResult = await provider.deploy({
-    buildDir: providerDir,
-    logger,
-    onProgress: (_step: string, _detail: string) => {
-      process.stdout.write(` ${ANSI.green}done${ANSI.reset}\n`)
-    },
-  })
+
+  let deployResult: {
+    success: boolean
+    workersDeployed?: unknown[]
+    resourcesCreated?: unknown[]
+    errors: Array<{ step: string; error: string }>
+  }
+
+  try {
+    deployResult = await provider.deploy({
+      buildDir: providerDir,
+      logger,
+      onProgress: (_step: string, _detail: string) => {
+        process.stdout.write(` ${ANSI.green}done${ANSI.reset}\n`)
+      },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    deployResult = {
+      success: false,
+      errors: [{ step: 'deploy', error: message }],
+    }
+  }
 
   await writeResultFile(resultFile, deployResult)
 

--- a/packages/cli/src/functions/commands/deploy-apply.ts
+++ b/packages/cli/src/functions/commands/deploy-apply.ts
@@ -1,7 +1,7 @@
 import { basename, join, relative } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-import { pikkuVoidFunc } from '#pikku'
+import { pikkuSessionlessFunc } from '#pikku'
 import type {
   ProviderAdapter,
   EntryGenerationContext,
@@ -151,14 +151,91 @@ const ANSI = {
   reset: '\x1b[0m',
 }
 
-export const deployApply = pikkuVoidFunc({
-  func: async ({ logger, config, getInspectorState }) => {
+async function writeResultFile(result: Record<string, unknown>): Promise<void> {
+  const resultFile = process.env.PIKKU_RESULT_FILE
+  if (resultFile) {
+    const { writeFile } = await import('node:fs/promises')
+    await writeFile(resultFile, JSON.stringify(result, null, 2), 'utf-8')
+  }
+}
+
+async function runDeploy(
+  provider: ProviderAdapter,
+  providerDir: string,
+  logger: { info(msg: string): void; error(msg: string): void }
+): Promise<void> {
+  if (typeof provider.deploy !== 'function') {
+    logger.error(`Provider '${provider.name}' does not support deploy.`)
+    await writeResultFile({
+      success: false,
+      errors: [{ step: 'provider', error: 'No deploy support' }],
+    })
+    process.exit(1)
+  }
+
+  logger.info(`Deploying via ${provider.name}...`)
+  const deployResult = await provider.deploy({
+    buildDir: providerDir,
+    logger,
+    onProgress: (_step: string, _detail: string) => {
+      process.stdout.write(` ${ANSI.green}done${ANSI.reset}\n`)
+    },
+  })
+
+  await writeResultFile(deployResult)
+
+  console.log('')
+  if (deployResult.success) {
+    logger.info(`${ANSI.green}${ANSI.bold}Deployment complete.${ANSI.reset}`)
+    logger.info(
+      `  ${deployResult.workersDeployed?.length ?? 0} units deployed, ${deployResult.resourcesCreated?.length ?? 0} resources created`
+    )
+  } else {
+    logger.error(
+      `Deployment finished with ${deployResult.errors.length} error(s):`
+    )
+    for (const e of deployResult.errors) {
+      logger.error(`  ${e.step}: ${e.error}`)
+    }
+  }
+}
+
+export const deployApply = pikkuSessionlessFunc<
+  { 'from-plan'?: boolean; provider?: string },
+  void
+>({
+  func: async ({ logger, config, getInspectorState }, data) => {
     const projectDir = config.rootDir
+    const provider = await resolveProvider(config, data?.provider)
+    const fromPlan = data?.['from-plan'] ?? false
+
+    if (fromPlan) {
+      // Skip build pipeline — deploy from existing plan output
+      const { join } = await import('node:path')
+      const { existsSync } = await import('node:fs')
+
+      const providerDir = join(projectDir, '.deploy', provider.deployDirName)
+      const infraPath = join(providerDir, 'infra.json')
+
+      if (!existsSync(infraPath)) {
+        logger.error(
+          `No plan found at ${providerDir}. Run 'pikku deploy plan' first.`
+        )
+        await writeResultFile({
+          success: false,
+          errors: [{ step: 'plan', error: 'No plan found' }],
+        })
+        process.exit(1)
+      }
+
+      await runDeploy(provider, providerDir, logger)
+      return
+    }
+
+    // Full build + deploy pipeline
     const inspectorState = await getInspectorState(true)
     const projectId = await resolveProjectId(projectDir)
-    const provider = await resolveProvider(config)
 
-    // Build pipeline: analyze → codegen → bundle → configs
     const buildResult = await runBuildPipeline({
       projectDir,
       projectId,
@@ -171,43 +248,29 @@ export const deployApply = pikkuVoidFunc({
 
     if (buildResult.manifest.units.length === 0) {
       logger.info('No deployment units found. Nothing to deploy.')
+      await writeResultFile({
+        success: true,
+        workersDeployed: [],
+        resourcesCreated: [],
+        errors: [],
+      })
       return
     }
 
     const { providerDir, bundled } = buildResult
 
-    // Deploy via provider's deploy function
     if (typeof provider.deploy === 'function') {
-      logger.info(`Deploying via ${provider.name}...`)
-      const deployResult = await provider.deploy({
-        buildDir: providerDir,
-        logger,
-        onProgress: (_step: string, _detail: string) => {
-          process.stdout.write(` ${ANSI.green}done${ANSI.reset}\n`)
-        },
-      })
-
-      console.log('')
-      if (deployResult.success) {
-        logger.info(
-          `${ANSI.green}${ANSI.bold}Deployment complete.${ANSI.reset}`
-        )
-        logger.info(
-          `  ${deployResult.workersDeployed?.length ?? 0} units deployed, ${deployResult.resourcesCreated?.length ?? 0} resources created`
-        )
-      } else {
-        logger.error(
-          `Deployment finished with ${deployResult.errors.length} error(s):`
-        )
-        for (const e of deployResult.errors) {
-          logger.error(`  ${e.step}: ${e.error}`)
-        }
-      }
+      await runDeploy(provider, providerDir, logger)
     } else {
       logger.info(`${ANSI.green}${ANSI.bold}Build complete.${ANSI.reset}`)
       logger.info(
         `  ${bundled.length} functions bundled to ${ANSI.bold}${providerDir}${ANSI.reset}`
       )
+      await writeResultFile({
+        success: true,
+        buildOnly: true,
+        unitCount: bundled.length,
+      })
     }
   },
 })

--- a/packages/cli/src/functions/commands/deploy-plan.ts
+++ b/packages/cli/src/functions/commands/deploy-plan.ts
@@ -1,7 +1,7 @@
 import { basename, join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-import { pikkuVoidFunc } from '#pikku'
+import { pikkuSessionlessFunc } from '#pikku'
 import { generatePlan } from '../../deploy/plan/index.js'
 import { formatPlan } from '../../deploy/plan/formatter.js'
 import { runBuildPipeline } from '../../deploy/build-pipeline.js'
@@ -51,12 +51,15 @@ function createEmptyProvider(): DeployProvider {
   }
 }
 
-export const deployPlan = pikkuVoidFunc({
-  func: async ({ logger, config, getInspectorState }) => {
+export const deployPlan = pikkuSessionlessFunc<
+  { resultFile?: string; provider?: string },
+  void
+>({
+  func: async ({ logger, config, getInspectorState }, data) => {
     const projectDir = config.rootDir
     const inspectorState = await getInspectorState(true)
     const projectId = await resolveProjectId(projectDir)
-    const provider = await resolveProvider(config)
+    const provider = await resolveProvider(config, data?.provider)
 
     const result = await runBuildPipeline({
       projectDir,
@@ -103,8 +106,8 @@ export const deployPlan = pikkuVoidFunc({
     )
     logger.info(`Output: ${result.providerDir}`)
 
-    // Write result file if PIKKU_RESULT_FILE is set (used by Fabric build pipeline)
-    const resultFile = process.env.PIKKU_RESULT_FILE
+    // Write result file if --result-file is set (used by Fabric build pipeline)
+    const resultFile = data?.resultFile
     if (resultFile) {
       const { writeFile } = await import('node:fs/promises')
       await writeFile(

--- a/packages/cli/src/functions/commands/deploy-plan.ts
+++ b/packages/cli/src/functions/commands/deploy-plan.ts
@@ -102,5 +102,27 @@ export const deployPlan = pikkuVoidFunc({
       `${result.bundled.length} workers bundled (${formatBytes(totalSize)} total)`
     )
     logger.info(`Output: ${result.providerDir}`)
+
+    // Write result file if PIKKU_RESULT_FILE is set (used by Fabric build pipeline)
+    const resultFile = process.env.PIKKU_RESULT_FILE
+    if (resultFile) {
+      const { writeFile } = await import('node:fs/promises')
+      await writeFile(
+        resultFile,
+        JSON.stringify(
+          {
+            success: result.bundleErrors.length === 0,
+            providerDir: result.providerDir,
+            unitCount: result.bundled.length,
+            totalSizeBytes: totalSize,
+            errors: result.bundleErrors,
+            manifest: result.manifest,
+          },
+          null,
+          2
+        ),
+        'utf-8'
+      )
+    }
   },
 })

--- a/packages/cli/src/functions/commands/enable.ts
+++ b/packages/cli/src/functions/commands/enable.ts
@@ -18,7 +18,7 @@ async function enableFeature(
   config: { configDir: string },
   data: any
 ) {
-  const noAuth = data?.['no-auth'] ?? false
+  const noAuth = data?.noAuth ?? false
   const configPath = join(config.configDir, 'pikku.config.json')
   const raw = await readFile(configPath, 'utf-8')
   const json = JSON.parse(raw)

--- a/packages/core/src/wirings/cli/command-parser.ts
+++ b/packages/core/src/wirings/cli/command-parser.ts
@@ -6,6 +6,11 @@ import type {
   CLIOption,
 } from './cli.types.js'
 
+/** Convert kebab-case to camelCase: "from-plan" → "fromPlan" */
+function toCamelCase(str: string): string {
+  return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase())
+}
+
 /**
  * Result of parsing CLI arguments
  */
@@ -117,11 +122,11 @@ export function parseCLIArguments(
     const arg = args[currentIndex]
 
     if (arg.startsWith('--')) {
-      // Long option
+      // Long option (--from-plan → fromPlan)
       const equalIndex = arg.indexOf('=')
       if (equalIndex > 0) {
         // --option=value format
-        const key = arg.slice(2, equalIndex)
+        const key = toCamelCase(arg.slice(2, equalIndex))
         const optionDef = availableOptions[key]
 
         // Unknown options are allowed for forward compatibility
@@ -129,7 +134,7 @@ export function parseCLIArguments(
         optionArgs[key] = parseOptionValue(value, optionDef)
       } else {
         // --option value format
-        const key = arg.slice(2)
+        const key = toCamelCase(arg.slice(2))
         const optionDef = availableOptions[key]
 
         // Unknown options are allowed for forward compatibility

--- a/packages/deploy/deploy-cloudflare/src/adapter.ts
+++ b/packages/deploy/deploy-cloudflare/src/adapter.ts
@@ -10,7 +10,7 @@
 import { generateWranglerToml } from './wrangler-toml.js'
 import { generateInfraManifest } from './infra-manifest.js'
 
-type DeploymentHandler =
+export type DeploymentHandler =
   | {
       type: 'fetch'
       routes: Array<{ method: string; route: string; pikkuFuncId: string }>
@@ -18,7 +18,7 @@ type DeploymentHandler =
   | { type: 'queue'; queueName: string }
   | { type: 'scheduled'; schedule: string; taskName: string }
 
-interface DeploymentUnit {
+export interface DeploymentUnit {
   name: string
   role: string
   target: 'serverless' | 'server'
@@ -29,7 +29,7 @@ interface DeploymentUnit {
   tags: string[]
 }
 
-interface DeploymentManifest {
+export interface DeploymentManifest {
   projectId: string
   units: DeploymentUnit[]
   queues: Array<{
@@ -59,7 +59,7 @@ interface DeploymentManifest {
   }>
 }
 
-interface EntryGenerationContext {
+export interface EntryGenerationContext {
   unit: DeploymentUnit
   unitDir: string
   bootstrapPath: string
@@ -94,26 +94,42 @@ export class CloudflareProviderAdapter {
   private resolvePlatformImports(
     unit: DeploymentUnit,
     extraImports: string[] = []
-  ): { cfImports: string[]; needsD1: boolean; needsQueue: boolean; needsWorkflow: boolean; needsAI: boolean } {
+  ): {
+    cfImports: string[]
+    needsD1: boolean
+    needsQueue: boolean
+    needsWorkflow: boolean
+    needsAI: boolean
+  } {
     const needsQueue = unit.services.some((s) => s.capability === 'queue')
-    const needsWorkflow = unit.services.some((s) => s.capability === 'workflow-state')
-    const needsAI = unit.services.some((s) => s.capability === 'ai-storage' || s.capability === 'ai-model')
+    const needsWorkflow = unit.services.some(
+      (s) => s.capability === 'workflow-state'
+    )
+    const needsAI = unit.services.some(
+      (s) => s.capability === 'ai-storage' || s.capability === 'ai-model'
+    )
 
     const cfImports = [...extraImports]
     if (needsQueue) cfImports.push('CloudflareQueueService')
     if (needsWorkflow) cfImports.push('CloudflareWorkflowService')
-    if (needsAI) cfImports.push('CloudflareAIStorageService', 'CloudflareAgentRunService', 'CloudflareAIRunStateService')
+    if (needsAI)
+      cfImports.push(
+        'CloudflareAIStorageService',
+        'CloudflareAgentRunService',
+        'CloudflareAIRunStateService'
+      )
 
-    return { cfImports, needsD1: needsWorkflow || needsAI, needsQueue, needsWorkflow, needsAI }
+    return {
+      cfImports,
+      needsD1: needsWorkflow || needsAI,
+      needsQueue,
+      needsWorkflow,
+      needsAI,
+    }
   }
 
   generateEntrySource(ctx: EntryGenerationContext): string {
     const { unit } = ctx
-
-    // Server-target units get a uWS entry (container deployment)
-    if (unit.target === 'server') {
-      return this.generateServerEntry(ctx)
-    }
 
     // Gateway units use their own dedicated handler factories
     if (unit.role === 'channel') {
@@ -138,20 +154,32 @@ export class CloudflareProviderAdapter {
    */
   private generateCombinedHandlerEntry(ctx: EntryGenerationContext): string {
     const handlerTypes = getHandlerTypes(ctx.unit)
-    const platform = this.resolvePlatformImports(ctx.unit, ['createCloudflareHandler'])
+    const platform = this.resolvePlatformImports(ctx.unit, [
+      'createCloudflareHandler',
+    ])
 
     const lines: string[] = [
       `// Generated entry for "${ctx.unit.name}" (${ctx.unit.role})`,
       `import { createCloudflareHandler } from '@pikku/cloudflare/handler'`,
       `import type { CloudflareEnv } from '@pikku/cloudflare/handler'`,
-      ...(platform.needsQueue ? [`import { CloudflareQueueService } from '@pikku/cloudflare/queue'`] : []),
-      ...(platform.needsD1 ? [
-        `import { ${[
-          ...(platform.needsWorkflow ? ['CloudflareWorkflowService'] : []),
-          ...(platform.needsAI ? ['CloudflareAIStorageService', 'CloudflareAgentRunService', 'CloudflareAIRunStateService'] : []),
-        ].join(', ')} } from '@pikku/cloudflare/d1'`,
-        `import type { D1Database } from '@cloudflare/workers-types'`,
-      ] : []),
+      ...(platform.needsQueue
+        ? [`import { CloudflareQueueService } from '@pikku/cloudflare/queue'`]
+        : []),
+      ...(platform.needsD1
+        ? [
+            `import { ${[
+              ...(platform.needsWorkflow ? ['CloudflareWorkflowService'] : []),
+              ...(platform.needsAI
+                ? [
+                    'CloudflareAIStorageService',
+                    'CloudflareAgentRunService',
+                    'CloudflareAIRunStateService',
+                  ]
+                : []),
+            ].join(', ')} } from '@pikku/cloudflare/d1'`,
+            `import type { D1Database } from '@cloudflare/workers-types'`,
+          ]
+        : []),
       `import { CFWorkerSchemaService } from '@pikku/schema-cfworker'`,
       `import { JsonConsoleLogger } from '@pikku/core/services'`,
       ctx.configImport,
@@ -176,20 +204,32 @@ export class CloudflareProviderAdapter {
    * Uses the WebSocket handler factory and exports the DO class.
    */
   private generateChannelGatewayEntry(ctx: EntryGenerationContext): string {
-    const platform = this.resolvePlatformImports(ctx.unit, ['createCloudflareWebSocketHandler'])
+    const platform = this.resolvePlatformImports(ctx.unit, [
+      'createCloudflareWebSocketHandler',
+    ])
 
     const lines: string[] = [
       `// Generated entry for "${ctx.unit.name}" (${ctx.unit.role})`,
       `import { createCloudflareWebSocketHandler } from '@pikku/cloudflare/handler'`,
       `import type { CloudflareEnv } from '@pikku/cloudflare/handler'`,
-      ...(platform.needsQueue ? [`import { CloudflareQueueService } from '@pikku/cloudflare/queue'`] : []),
-      ...(platform.needsD1 ? [
-        `import { ${[
-          ...(platform.needsWorkflow ? ['CloudflareWorkflowService'] : []),
-          ...(platform.needsAI ? ['CloudflareAIStorageService', 'CloudflareAgentRunService', 'CloudflareAIRunStateService'] : []),
-        ].join(', ')} } from '@pikku/cloudflare/d1'`,
-        `import type { D1Database } from '@cloudflare/workers-types'`,
-      ] : []),
+      ...(platform.needsQueue
+        ? [`import { CloudflareQueueService } from '@pikku/cloudflare/queue'`]
+        : []),
+      ...(platform.needsD1
+        ? [
+            `import { ${[
+              ...(platform.needsWorkflow ? ['CloudflareWorkflowService'] : []),
+              ...(platform.needsAI
+                ? [
+                    'CloudflareAIStorageService',
+                    'CloudflareAgentRunService',
+                    'CloudflareAIRunStateService',
+                  ]
+                : []),
+            ].join(', ')} } from '@pikku/cloudflare/d1'`,
+            `import type { D1Database } from '@cloudflare/workers-types'`,
+          ]
+        : []),
       `import { CFWorkerSchemaService } from '@pikku/schema-cfworker'`,
       `import { JsonConsoleLogger } from '@pikku/core/services'`,
       ctx.configImport,
@@ -222,8 +262,13 @@ export class CloudflareProviderAdapter {
     })
     const bindingsMap = `{\n${bindingEntries.join(',\n')}\n  }`
 
-    const handlerName = includeQueueHandler ? 'createCloudflareHandler' : 'createCloudflareWorkerHandler'
-    const platform = this.resolvePlatformImports(ctx.unit, [handlerName, 'CloudflareDeploymentService'])
+    const handlerName = includeQueueHandler
+      ? 'createCloudflareHandler'
+      : 'createCloudflareWorkerHandler'
+    const platform = this.resolvePlatformImports(ctx.unit, [
+      handlerName,
+      'CloudflareDeploymentService',
+    ])
 
     const handlerTypes = includeQueueHandler ? `["fetch", "queue"]` : ''
 
@@ -240,14 +285,24 @@ export class CloudflareProviderAdapter {
       handlerImport,
       `import type { CloudflareEnv } from '@pikku/cloudflare/handler'`,
       `import { CloudflareDeploymentService } from '@pikku/cloudflare/deployment'`,
-      ...(platform.needsQueue ? [`import { CloudflareQueueService } from '@pikku/cloudflare/queue'`] : []),
-      ...(platform.needsD1 ? [
-        `import { ${[
-          ...(platform.needsWorkflow ? ['CloudflareWorkflowService'] : []),
-          ...(platform.needsAI ? ['CloudflareAIStorageService', 'CloudflareAgentRunService', 'CloudflareAIRunStateService'] : []),
-        ].join(', ')} } from '@pikku/cloudflare/d1'`,
-        `import type { D1Database } from '@cloudflare/workers-types'`,
-      ] : []),
+      ...(platform.needsQueue
+        ? [`import { CloudflareQueueService } from '@pikku/cloudflare/queue'`]
+        : []),
+      ...(platform.needsD1
+        ? [
+            `import { ${[
+              ...(platform.needsWorkflow ? ['CloudflareWorkflowService'] : []),
+              ...(platform.needsAI
+                ? [
+                    'CloudflareAIStorageService',
+                    'CloudflareAgentRunService',
+                    'CloudflareAIRunStateService',
+                  ]
+                : []),
+            ].join(', ')} } from '@pikku/cloudflare/d1'`,
+            `import type { D1Database } from '@cloudflare/workers-types'`,
+          ]
+        : []),
       `import { CFWorkerSchemaService } from '@pikku/schema-cfworker'`,
       `import { JsonConsoleLogger } from '@pikku/core/services'`,
       ctx.configImport,
@@ -287,7 +342,7 @@ export class CloudflareProviderAdapter {
         `    const workflowService = new CloudflareWorkflowService(env.WORKFLOW_DB as D1Database)`,
         `    await workflowService.init()`,
         `    services.workflowService = workflowService`,
-        `  }`,
+        `  }`
       )
     }
     if (platform.needsAI) {
@@ -301,7 +356,7 @@ export class CloudflareProviderAdapter {
         `    const aiRunState = new CloudflareAIRunStateService(db)`,
         `    await aiRunState.init()`,
         `    services.aiRunState = aiRunState`,
-        `  }`,
+        `  }`
       )
     }
     lines.push(`  return services`, `}`)
@@ -333,7 +388,7 @@ export class CloudflareProviderAdapter {
         `    const workflowService = new CloudflareWorkflowService(env.WORKFLOW_DB as D1Database)`,
         `    await workflowService.init()`,
         `    services.workflowService = workflowService`,
-        `  }`,
+        `  }`
       )
     }
     if (platform.needsAI) {
@@ -347,7 +402,7 @@ export class CloudflareProviderAdapter {
         `    const aiRunState = new CloudflareAIRunStateService(db)`,
         `    await aiRunState.init()`,
         `    services.aiRunState = aiRunState`,
-        `  }`,
+        `  }`
       )
     }
     lines.push(
@@ -358,73 +413,9 @@ export class CloudflareProviderAdapter {
       `    ${bindingsMap}`,
       `  )`,
       `  return services`,
-      `}`,
+      `}`
     )
     return lines
-  }
-
-  /**
-   * Generates entry for server-target units (CF Container).
-   * Uses PikkuUWSServer — same pattern as standalone adapter.
-   */
-  private generateServerEntry(ctx: EntryGenerationContext): string {
-    return [
-      `// Generated server entry for "${ctx.unit.name}" (container)`,
-      `import { stopSingletonServices } from '@pikku/core'`,
-      `import { ConsoleLogger } from '@pikku/core/services'`,
-      `import { InMemorySchedulerService } from '@pikku/schedule'`,
-      `import { PikkuUWSServer } from '@pikku/uws'`,
-      ``,
-      ctx.configImport,
-      ctx.servicesImport,
-      ctx.singletonServicesImport,
-      `import '${ctx.bootstrapPath}'`,
-      ``,
-      `const logger = new ConsoleLogger()`,
-      `const port = parseInt(process.env.PORT || '8080', 10)`,
-      `const hostname = process.env.HOST || '0.0.0.0'`,
-      ``,
-      `async function main() {`,
-      `  const config = await ${ctx.configVar}()`,
-      `  const schedulerService = new InMemorySchedulerService()`,
-      `  const singletonServices = await ${ctx.servicesVar}(config, {`,
-      `    logger,`,
-      `    schedulerService,`,
-      `  })`,
-      ``,
-      `  const server = new PikkuUWSServer(`,
-      `    { ...config, port, hostname },`,
-      `    logger,`,
-      `  )`,
-      `  await server.init({ respondWith404: true })`,
-      `  await schedulerService.start()`,
-      `  await server.start()`,
-      `  await server.enableExitOnSigInt()`,
-      `  logger.info('Server container ready on port ' + port)`,
-      `}`,
-      ``,
-      `main().catch((err) => {`,
-      `  logger.error('Fatal: ' + err.message)`,
-      `  process.exit(1)`,
-      `})`,
-      ``,
-    ].join('\n')
-  }
-
-  /**
-   * Generates a Dockerfile for server-target units.
-   */
-  private generateDockerfile(): string {
-    return [
-      `FROM node:22-slim`,
-      `WORKDIR /app`,
-      `COPY bundle.js .`,
-      `COPY package.json .`,
-      `RUN npm install --production 2>/dev/null || true`,
-      `ENV NODE_ENV=production`,
-      `EXPOSE 8080`,
-      `CMD ["node", "bundle.js"]`,
-    ].join('\n')
   }
 
   generateUnitConfigs(
@@ -433,9 +424,6 @@ export class CloudflareProviderAdapter {
     projectId: string
   ): Map<string, string> {
     const configs = new Map<string, string>()
-    if (unit.target === 'server') {
-      configs.set('Dockerfile', this.generateDockerfile())
-    }
     configs.set(
       'wrangler.toml',
       generateWranglerToml(unit, manifest, projectId)
@@ -443,171 +431,8 @@ export class CloudflareProviderAdapter {
     return configs
   }
 
-  generateProviderConfigs(manifest: DeploymentManifest): Map<string, string> {
-    const configs = new Map<string, string>()
-    const serverUnits = manifest.units.filter((u) => u.target === 'server')
-
-    if (serverUnits.length > 0) {
-      // Generate proxy Worker that routes to the container
-      configs.set(
-        'server-proxy/entry.ts',
-        this.generateProxyWorkerEntry(serverUnits, manifest)
-      )
-      configs.set(
-        'server-proxy/wrangler.toml',
-        this.generateProxyWranglerToml(serverUnits, manifest)
-      )
-      configs.set(
-        'server-proxy/package.json',
-        JSON.stringify({
-          name: `${manifest.projectId}-server-proxy`,
-          private: true,
-          type: 'module',
-          dependencies: {
-            '@cloudflare/containers': '^0.0.1',
-          },
-        }, null, 2)
-      )
-    }
-
-    return configs
-  }
-
-  /**
-   * Proxy Worker entry: extends Container, forwards HTTP/queue/cron to it.
-   */
-  private generateProxyWorkerEntry(
-    serverUnits: DeploymentUnit[],
-    manifest: DeploymentManifest
-  ): string {
-    // Collect all routes from server units
-    const serverRoutes: Array<{ method: string; route: string }> = []
-    for (const unit of serverUnits) {
-      for (const handler of unit.handlers) {
-        if (handler.type === 'fetch') {
-          for (const route of handler.routes) {
-            serverRoutes.push({ method: route.method, route: route.route })
-          }
-        }
-      }
-    }
-
-    // Collect queue names consumed by server units
-    const serverQueueNames = manifest.queues
-      .filter((q) => serverUnits.some((u) => u.name === q.consumerUnit))
-      .map((q) => q.name)
-
-    // Collect cron schedules for server units
-    const serverCrons = manifest.scheduledTasks
-      .filter((t) => serverUnits.some((u) => u.name === t.unitName))
-
-    return [
-      `// Generated proxy Worker — routes traffic to CF Container`,
-      `import { Container, getContainer } from "@cloudflare/containers"`,
-      ``,
-      `class PikkuServer extends Container {`,
-      `  defaultPort = 8080`,
-      `  sleepAfter = "2h"`,
-      `}`,
-      ``,
-      `interface Env {`,
-      `  PIKKU_SERVER: DurableObjectNamespace<PikkuServer>`,
-      `}`,
-      ``,
-      `export { PikkuServer }`,
-      ``,
-      `export default {`,
-      `  async fetch(request: Request, env: Env) {`,
-      `    const container = getContainer(env.PIKKU_SERVER)`,
-      `    return container.fetch(request)`,
-      `  },`,
-      ...(serverQueueNames.length > 0
-        ? [
-            `  async queue(batch: MessageBatch, env: Env) {`,
-            `    const container = getContainer(env.PIKKU_SERVER)`,
-            `    await container.fetch(new Request("http://internal/__pikku/queue", {`,
-            `      method: "POST",`,
-            `      headers: { "Content-Type": "application/json" },`,
-            `      body: JSON.stringify({ queue: batch.queue, messages: batch.messages.map(m => ({ id: m.id, body: m.body })) }),`,
-            `    }))`,
-            `  },`,
-          ]
-        : []),
-      ...(serverCrons.length > 0
-        ? [
-            `  async scheduled(controller: ScheduledController, env: Env) {`,
-            `    const container = getContainer(env.PIKKU_SERVER)`,
-            `    await container.fetch(new Request("http://internal/__pikku/scheduled", {`,
-            `      method: "POST",`,
-            `      headers: { "Content-Type": "application/json" },`,
-            `      body: JSON.stringify({ cron: controller.cron, scheduledTime: controller.scheduledTime }),`,
-            `    }))`,
-            `  },`,
-          ]
-        : []),
-      `}`,
-      ``,
-    ].join('\n')
-  }
-
-  /**
-   * Proxy Worker wrangler.toml with container binding + queue consumers + crons.
-   */
-  private generateProxyWranglerToml(
-    serverUnits: DeploymentUnit[],
-    manifest: DeploymentManifest
-  ): string {
-    const projectId = manifest.projectId
-    const lines: string[] = [
-      `name = "${projectId}-server-proxy"`,
-      `main = "entry.ts"`,
-      `compatibility_date = "2024-12-18"`,
-      `compatibility_flags = ["nodejs_compat_v2"]`,
-      ``,
-      `[observability]`,
-      `enabled = true`,
-      ``,
-      `[[containers]]`,
-      `class_name = "PikkuServer"`,
-      `image = "../server/Dockerfile"`,
-      `max_instances = 3`,
-      ``,
-      `[[durable_objects.bindings]]`,
-      `class_name = "PikkuServer"`,
-      `name = "PIKKU_SERVER"`,
-      ``,
-      `[[migrations]]`,
-      `new_sqlite_classes = ["PikkuServer"]`,
-      `tag = "v1"`,
-    ]
-
-    // Queue consumers for server functions
-    const serverQueueNames = manifest.queues
-      .filter((q) => serverUnits.some((u) => u.name === q.consumerUnit))
-
-    for (const queue of serverQueueNames) {
-      lines.push(
-        ``,
-        `[[queues.consumers]]`,
-        `queue = "${projectId}-${queue.name}"`,
-        `max_batch_size = 10`,
-        `max_batch_timeout = 5`,
-      )
-    }
-
-    // Cron triggers for server functions
-    const serverCrons = manifest.scheduledTasks
-      .filter((t) => serverUnits.some((u) => u.name === t.unitName))
-
-    if (serverCrons.length > 0) {
-      lines.push(``, `[triggers]`, `crons = [`)
-      for (const cron of serverCrons) {
-        lines.push(`  "${cron.schedule}",`)
-      }
-      lines.push(`]`)
-    }
-
-    return lines.join('\n')
+  generateProviderConfigs(_manifest: DeploymentManifest): Map<string, string> {
+    return new Map()
   }
 
   generateInfraManifest(manifest: DeploymentManifest): string | null {
@@ -659,12 +484,28 @@ export class CloudflareProviderAdapter {
       await readFile(join(options.buildDir, 'infra.json'), 'utf-8')
     )
 
+    // Error if any server-target units exist — container deploy requires Fabric
+    const serverUnits = Object.entries(infraJson.units || {}).filter(
+      ([_, u]) => (u as Record<string, unknown>).target === 'server'
+    )
+    if (serverUnits.length > 0) {
+      const names = serverUnits.map(([name]) => name).join(', ')
+      return {
+        success: false,
+        errors: [
+          {
+            step: 'validation',
+            error: `Project contains server-target functions (${names}) which require a container runtime. Server deploy is available via Pikku Fabric (https://pikku.dev/fabric).`,
+          },
+        ],
+      }
+    }
+
     return deploy({
       accountId,
       apiToken,
       buildDir: options.buildDir,
       manifest: infraJson,
-      dispatchNamespace: process.env.CF_DISPATCH_NAMESPACE,
       onProgress: options.onProgress,
     })
   }

--- a/packages/deploy/deploy-cloudflare/src/deploy.ts
+++ b/packages/deploy/deploy-cloudflare/src/deploy.ts
@@ -29,8 +29,6 @@ export interface DeployOptions {
   apiToken: string
   buildDir: string
   manifest: CloudflareInfraManifest
-  /** Workers for Platforms dispatch namespace. When set, workers are deployed into this namespace. */
-  dispatchNamespace?: string
   onProgress?: (step: string, detail: string) => void
 }
 
@@ -62,7 +60,7 @@ function toWorkerName(projectId: string, unitName: string): string {
 }
 
 export async function deploy(options: DeployOptions): Promise<DeployResult> {
-  const { accountId, apiToken, buildDir, manifest, dispatchNamespace, onProgress } = options
+  const { accountId, apiToken, buildDir, manifest, onProgress } = options
   const client = new CloudflareClient({ accountId, apiToken })
   const log = onProgress ?? (() => {})
   const projectId = manifest.projectId
@@ -111,15 +109,6 @@ export async function deploy(options: DeployOptions): Promise<DeployResult> {
   // Step 5: Enable workers.dev routes
   log('routes', 'Enabling workers.dev routes...')
   await enableWorkersDevRoutes(client, projectId, manifest, result, log)
-
-  // Step 6: Deploy server container via wrangler (if any server units exist)
-  const hasServerUnits = Object.values(manifest.units).some(
-    (u) => u.target === 'server'
-  )
-  if (hasServerUnits) {
-    log('container', 'Deploying server container via wrangler...')
-    await deployServerContainer(buildDir, result, log)
-  }
 
   result.success = result.errors.length === 0
   return result
@@ -300,13 +289,8 @@ async function uploadWorkersInOrder(
   log: (step: string, detail: string) => void
 ): Promise<void> {
   // Build dependency graph: unit -> set of service binding targets
-  // Skip server-target units — they're deployed as containers, not Workers
   const deps = new Map<string, Set<string>>()
   for (const [unitName, unitManifest] of Object.entries(manifest.units)) {
-    if (unitManifest.target === 'server') {
-      log('workers', `Skipping ${unitName} (server container — deploy via wrangler)`)
-      continue
-    }
     const serviceDeps = new Set<string>()
     for (const b of unitManifest.bindings) {
       if (b.startsWith('service:')) {
@@ -335,7 +319,10 @@ async function uploadWorkersInOrder(
     }
 
     if (ready.length === 0) {
-      log('workers', `Circular dependency detected among: ${[...remaining].join(', ')}`)
+      log(
+        'workers',
+        `Circular dependency detected among: ${[...remaining].join(', ')}`
+      )
       for (const unitName of remaining) {
         ready.push([unitName, manifest.units[unitName]])
       }
@@ -381,7 +368,7 @@ async function deployWorkerBatch(
         projectId
       )
 
-      await createWorker(client, workerName, script, bindings, [], undefined, dispatchNamespace)
+      await createWorker(client, workerName, script, bindings)
       result.workersDeployed.push(workerName)
       log('workers', `Deployed "${workerName}"`)
     } catch (err) {
@@ -438,10 +425,8 @@ async function wireConsumersAndTriggers(
     )
   }
 
-  // Set cron triggers (skip server-target units — their crons go through the proxy)
+  // Set cron triggers
   for (const cron of manifest.resources.cronTriggers) {
-    const unitManifest = manifest.units[cron.worker]
-    if (unitManifest?.target === 'server') continue
     const workerName = toWorkerName(projectId, cron.worker)
     tasks.push(
       (async () => {
@@ -488,71 +473,4 @@ async function enableWorkersDevRoutes(
     'routes',
     `Enabled workers.dev for ${Object.keys(manifest.units).length} workers`
   )
-}
-
-/**
- * Deploy the server container + proxy Worker via wrangler.
- * CF Containers can't be deployed via REST API — they require `wrangler deploy`
- * to build the Docker image and push it to CF's container registry.
- */
-async function deployServerContainer(
-  buildDir: string,
-  result: DeployResult,
-  log: (step: string, detail: string) => void
-): Promise<void> {
-  const { join } = await import('node:path')
-  const { existsSync } = await import('node:fs')
-  const { execSync } = await import('node:child_process')
-
-  const proxyDir = join(buildDir, 'server-proxy')
-  if (!existsSync(proxyDir)) {
-    log('container', 'No server-proxy directory found — skipping container deploy')
-    return
-  }
-
-  if (!existsSync(join(proxyDir, 'wrangler.toml'))) {
-    result.errors.push({
-      step: 'container',
-      error: 'server-proxy/wrangler.toml not found',
-    })
-    return
-  }
-
-  try {
-    // Install @cloudflare/containers dependency
-    log('container', 'Installing container dependencies...')
-    execSync('npm install --production', {
-      cwd: proxyDir,
-      timeout: 60_000,
-      stdio: 'pipe',
-    })
-
-    log('container', 'Running wrangler deploy for server container...')
-    const output = execSync('npx wrangler deploy', {
-      cwd: proxyDir,
-      timeout: 300_000,
-      env: {
-        ...process.env,
-        CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID,
-        CLOUDFLARE_API_TOKEN: process.env.CLOUDFLARE_API_TOKEN,
-        // Support Podman/Docker alternative
-        ...(process.env.WRANGLER_DOCKER_BIN
-          ? { WRANGLER_DOCKER_BIN: process.env.WRANGLER_DOCKER_BIN }
-          : {}),
-        // Disable buildkit provenance (not supported by Podman)
-        DOCKER_BUILDKIT: process.env.DOCKER_BUILDKIT ?? '0',
-      },
-      stdio: 'pipe',
-    })
-    log('container', `Container deployed: ${output.toString().trim().split('\n').pop()}`)
-    result.resourcesCreated.push('container:server')
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    // Extract useful error from wrangler output
-    const stderr = (err as { stderr?: Buffer })?.stderr?.toString() ?? ''
-    result.errors.push({
-      step: 'container',
-      error: stderr || message,
-    })
-  }
 }

--- a/packages/deploy/deploy-cloudflare/src/index.ts
+++ b/packages/deploy/deploy-cloudflare/src/index.ts
@@ -51,6 +51,12 @@ export type { DeployOptions, DeployResult } from './deploy.js'
 // Provider adapter
 import { CloudflareProviderAdapter } from './adapter.js'
 export { CloudflareProviderAdapter }
+export type {
+  DeploymentUnit,
+  DeploymentManifest,
+  DeploymentHandler,
+  EntryGenerationContext,
+} from './adapter.js'
 export const createAdapter = () => new CloudflareProviderAdapter()
 
 // Wrangler TOML generator


### PR DESCRIPTION
## Summary

- Server-target function deployment (CF Containers) removed from OSS adapter — now errors with a message directing users to Pikku Fabric
- Removed `deployServerContainer()`, proxy Worker generation, Dockerfile generation, server entry generation
- Removed `dispatchNamespace` from deploy path (Workers for Platforms is Fabric-only)
- Exported adapter types (`DeploymentUnit`, `DeploymentManifest`, `EntryGenerationContext`, `DeploymentHandler`) so Fabric can extend the class

## Test plan

- [x] CI passes — all verifiers green including `deploy-cloudflare`
- [x] Type-check clean across CLI and deploy-cloudflare packages
- [ ] Serverless-only project deploys as before
- [ ] Project with `deploy: 'server'` function → adapter errors with Fabric link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `from-plan` option to deploy apply command to skip build pipeline and deploy from existing plan output.
  * Added result file output capability for plan and deploy operations.

* **Breaking Changes**
  * Removed support for server-target unit deployments on Cloudflare.
  * Removed dispatch namespace configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->