### PR TITLE
Remove server/container deploy from OSS

### DIFF
--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -359,6 +359,10 @@ wireCLI({
               default: 'cloudflare',
               short: 'p',
             },
+            resultFile: {
+              description:
+                'Write structured JSON plan result to this file path',
+            },
           },
         }),
         apply: pikkuCLICommand({
@@ -369,6 +373,15 @@ wireCLI({
               description: 'Deployment provider (cloudflare, aws)',
               default: 'cloudflare',
               short: 'p',
+            },
+            fromPlan: {
+              description:
+                'Skip build pipeline, deploy from existing plan output',
+              default: false,
+            },
+            resultFile: {
+              description:
+                'Write structured JSON deploy result to this file path',
             },
           },
         }),

--- a/packages/cli/src/functions/commands/deploy-apply.ts
+++ b/packages/cli/src/functions/commands/deploy-apply.ts
@@ -1,14 +1,12 @@
 import { basename, join, relative } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-import { pikkuVoidFunc } from '#pikku'
+import { pikkuSessionlessFunc } from '#pikku'
 import type {
   ProviderAdapter,
   EntryGenerationContext,
 } from '../../deploy/provider-adapter.js'
-import type { PlanChange } from '../../deploy/plan/types.js'
 import type { InspectorState } from '@pikku/inspector'
-import type { CloudflareInfraManifest } from '@pikku/deploy-cloudflare'
 import { runBuildPipeline } from '../../deploy/build-pipeline.js'
 
 function toRelativeImport(fromDir: string, toFile: string): string {
@@ -104,11 +102,7 @@ export async function resolveProvider(
   },
   providerName?: string
 ): Promise<ProviderAdapter> {
-  const name =
-    providerName ??
-    process.env.PIKKU_DEPLOY_PROVIDER ??
-    config?.deploy?.defaultProvider ??
-    'cloudflare'
+  const name = providerName ?? config?.deploy?.defaultProvider ?? 'cloudflare'
 
   const providers = config?.deploy?.providers ?? {
     cloudflare: '@pikku/deploy-cloudflare',
@@ -159,27 +153,112 @@ const ANSI = {
   reset: '\x1b[0m',
 }
 
-function logProgress(
-  change: PlanChange,
-  _status: 'start' | 'done' | 'error',
-  error?: string
-) {
-  if (_status === 'done') {
-    process.stdout.write(` ${ANSI.green}done${ANSI.reset}\n`)
-  } else if (_status === 'error') {
-    process.stdout.write(` ${ANSI.red}error: ${error}${ANSI.reset}\n`)
+async function writeResultFile(
+  resultFile: string | undefined,
+  result: Record<string, unknown>
+): Promise<void> {
+  if (resultFile) {
+    const { writeFile } = await import('node:fs/promises')
+    await writeFile(resultFile, JSON.stringify(result, null, 2), 'utf-8')
   }
 }
 
-export const deployApply = pikkuVoidFunc({
-  func: async ({ logger, config, getInspectorState }) => {
+async function runDeploy(
+  provider: ProviderAdapter,
+  providerDir: string,
+  logger: { info(msg: string): void; error(msg: string): void },
+  resultFile?: string
+): Promise<void> {
+  if (typeof provider.deploy !== 'function') {
+    logger.error(`Provider '${provider.name}' does not support deploy.`)
+    await writeResultFile(resultFile, {
+      success: false,
+      errors: [{ step: 'provider', error: 'No deploy support' }],
+    })
+    process.exit(1)
+  }
+
+  logger.info(`Deploying via ${provider.name}...`)
+
+  let deployResult: {
+    success: boolean
+    workersDeployed?: unknown[]
+    resourcesCreated?: unknown[]
+    errors: Array<{ step: string; error: string }>
+  }
+
+  try {
+    deployResult = await provider.deploy({
+      buildDir: providerDir,
+      logger,
+      onProgress: (_step: string, _detail: string) => {
+        process.stdout.write(` ${ANSI.green}done${ANSI.reset}\n`)
+      },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    deployResult = {
+      success: false,
+      errors: [{ step: 'deploy', error: message }],
+    }
+  }
+
+  await writeResultFile(resultFile, deployResult)
+
+  console.log('')
+  if (deployResult.success) {
+    logger.info(`${ANSI.green}${ANSI.bold}Deployment complete.${ANSI.reset}`)
+    logger.info(
+      `  ${deployResult.workersDeployed?.length ?? 0} units deployed, ${deployResult.resourcesCreated?.length ?? 0} resources created`
+    )
+  } else {
+    logger.error(
+      `Deployment finished with ${deployResult.errors.length} error(s):`
+    )
+    for (const e of deployResult.errors) {
+      logger.error(`  ${e.step}: ${e.error}`)
+    }
+  }
+}
+
+export const deployApply = pikkuSessionlessFunc<
+  { fromPlan?: boolean; provider?: string; resultFile?: string },
+  void
+>({
+  func: async ({ logger, config, getInspectorState }, data) => {
     const projectDir = config.rootDir
+    const provider = await resolveProvider(config, data?.provider)
+    const fromPlan = data?.fromPlan ?? false
+    const resultFile = data?.resultFile
+
+    if (fromPlan) {
+      // Skip build pipeline — deploy from existing plan output
+      const { join } = await import('node:path')
+      const { existsSync } = await import('node:fs')
+
+      const providerDir = join(projectDir, '.deploy', provider.deployDirName)
+      const infraPath = join(providerDir, 'infra.json')
+
+      if (!existsSync(infraPath)) {
+        logger.error(
+          `No plan found at ${providerDir}. Run 'pikku deploy plan' first.`
+        )
+        await writeResultFile(resultFile, {
+          success: false,
+          errors: [{ step: 'plan', error: 'No plan found' }],
+        })
+        process.exit(1)
+      }
+
+      await runDeploy(provider, providerDir, logger, resultFile)
+      return
+    }
+
+    // Full build + deploy pipeline
     const inspectorState = await getInspectorState(true)
     const projectId = await resolveProjectId(projectDir)
-    const provider = await resolveProvider(config)
 
-    // Build pipeline: analyze → codegen → bundle → configs
-    const result = await runBuildPipeline({
+    const buildResult = await runBuildPipeline({
       projectDir,
       projectId,
       provider,
@@ -189,77 +268,31 @@ export const deployApply = pikkuVoidFunc({
       logger,
     })
 
-    if (result.manifest.units.length === 0) {
+    if (buildResult.manifest.units.length === 0) {
       logger.info('No deployment units found. Nothing to deploy.')
+      await writeResultFile(resultFile, {
+        success: true,
+        workersDeployed: [],
+        resourcesCreated: [],
+        errors: [],
+      })
       return
     }
 
-    const { providerDir, bundled } = result
+    const { providerDir, bundled } = buildResult
 
-    // Deploy (provider-specific)
-    if (provider.name === 'cloudflare') {
-      const accountId = process.env.CLOUDFLARE_ACCOUNT_ID
-      const apiToken = process.env.CLOUDFLARE_API_TOKEN
-
-      if (!accountId || !apiToken) {
-        logger.error(
-          'Missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_API_TOKEN environment variables.'
-        )
-        return
-      }
-
-      const infraJson = JSON.parse(
-        await readFile(join(providerDir, 'infra.json'), 'utf-8')
-      ) as CloudflareInfraManifest
-
-      logger.info('Deploying to Cloudflare...')
-      const { deploy: cfDeploy } = await import('@pikku/deploy-cloudflare')
-      const deployResult = await cfDeploy({
-        accountId,
-        apiToken,
-        buildDir: providerDir,
-        manifest: infraJson,
-        onProgress: (step, detail) => {
-          logProgress(
-            {
-              action: 'create',
-              resourceType: step as PlanChange['resourceType'],
-              name: detail,
-              reason: '',
-            },
-            'done'
-          )
-        },
-      })
-
-      console.log('')
-      if (deployResult.success) {
-        logger.info(
-          `${ANSI.green}${ANSI.bold}Deployment complete.${ANSI.reset}`
-        )
-        logger.info(
-          `  ${deployResult.workersDeployed.length} workers deployed, ${deployResult.resourcesCreated.length} resources created`
-        )
-      } else {
-        logger.error(
-          `Deployment finished with ${deployResult.errors.length} error(s):`
-        )
-        for (const e of deployResult.errors) {
-          logger.error(`  ${e.step}: ${e.error}`)
-        }
-      }
+    if (typeof provider.deploy === 'function') {
+      await runDeploy(provider, providerDir, logger, resultFile)
     } else {
       logger.info(`${ANSI.green}${ANSI.bold}Build complete.${ANSI.reset}`)
       logger.info(
         `  ${bundled.length} functions bundled to ${ANSI.bold}${providerDir}${ANSI.reset}`
       )
-      if (provider.name === 'serverless') {
-        logger.info(`\nTo deploy: cd ${providerDir} && npx serverless deploy`)
-      } else if (provider.name === 'azure') {
-        logger.info(
-          `\nTo deploy: cd ${providerDir} && func azure functionapp publish <app-name>`
-        )
-      }
+      await writeResultFile(resultFile, {
+        success: true,
+        buildOnly: true,
+        unitCount: bundled.length,
+      })
     }
   },
 })

--- a/packages/cli/src/functions/commands/deploy-plan.ts
+++ b/packages/cli/src/functions/commands/deploy-plan.ts
@@ -1,7 +1,7 @@
 import { basename, join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-import { pikkuVoidFunc } from '#pikku'
+import { pikkuSessionlessFunc } from '#pikku'
 import { generatePlan } from '../../deploy/plan/index.js'
 import { formatPlan } from '../../deploy/plan/formatter.js'
 import { runBuildPipeline } from '../../deploy/build-pipeline.js'
@@ -51,12 +51,15 @@ function createEmptyProvider(): DeployProvider {
   }
 }
 
-export const deployPlan = pikkuVoidFunc({
-  func: async ({ logger, config, getInspectorState }) => {
+export const deployPlan = pikkuSessionlessFunc<
+  { resultFile?: string; provider?: string },
+  void
+>({
+  func: async ({ logger, config, getInspectorState }, data) => {
     const projectDir = config.rootDir
     const inspectorState = await getInspectorState(true)
     const projectId = await resolveProjectId(projectDir)
-    const provider = await resolveProvider(config)
+    const provider = await resolveProvider(config, data?.provider)
 
     const result = await runBuildPipeline({
       projectDir,
@@ -102,5 +105,27 @@ export const deployPlan = pikkuVoidFunc({
       `${result.bundled.length} workers bundled (${formatBytes(totalSize)} total)`
     )
     logger.info(`Output: ${result.providerDir}`)
+
+    // Write result file if --result-file is set (used by Fabric build pipeline)
+    const resultFile = data?.resultFile
+    if (resultFile) {
+      const { writeFile } = await import('node:fs/promises')
+      await writeFile(
+        resultFile,
+        JSON.stringify(
+          {
+            success: result.bundleErrors.length === 0,
+            providerDir: result.providerDir,
+            unitCount: result.bundled.length,
+            totalSizeBytes: totalSize,
+            errors: result.bundleErrors,
+            manifest: result.manifest,
+          },
+          null,
+          2
+        ),
+        'utf-8'
+      )
+    }
   },
 })

--- a/packages/deploy/deploy-cloudflare/src/adapter.ts
+++ b/packages/deploy/deploy-cloudflare/src/adapter.ts
@@ -10,7 +10,7 @@
 import { generateWranglerToml } from './wrangler-toml.js'
 import { generateInfraManifest } from './infra-manifest.js'
 
-type DeploymentHandler =
+export type DeploymentHandler =
   | {
       type: 'fetch'
       routes: Array<{ method: string; route: string; pikkuFuncId: string }>
@@ -18,7 +18,7 @@ type DeploymentHandler =
   | { type: 'queue'; queueName: string }
   | { type: 'scheduled'; schedule: string; taskName: string }
 
-interface DeploymentUnit {
+export interface DeploymentUnit {
   name: string
   role: string
   target: 'serverless' | 'server'
@@ -29,7 +29,7 @@ interface DeploymentUnit {
   tags: string[]
 }
 
-interface DeploymentManifest {
+export interface DeploymentManifest {
   projectId: string
   units: DeploymentUnit[]
   queues: Array<{
@@ -59,7 +59,7 @@ interface DeploymentManifest {
   }>
 }
 
-interface EntryGenerationContext {
+export interface EntryGenerationContext {
   unit: DeploymentUnit
   unitDir: string
   bootstrapPath: string
@@ -94,26 +94,42 @@ export class CloudflareProviderAdapter {
   private resolvePlatformImports(
     unit: DeploymentUnit,
     extraImports: string[] = []
-  ): { cfImports: string[]; needsD1: boolean; needsQueue: boolean; needsWorkflow: boolean; needsAI: boolean } {
+  ): {
+    cfImports: string[]
+    needsD1: boolean
+    needsQueue: boolean
+    needsWorkflow: boolean
+    needsAI: boolean
+  } {
     const needsQueue = unit.services.some((s) => s.capability === 'queue')
-    const needsWorkflow = unit.services.some((s) => s.capability === 'workflow-state')
-    const needsAI = unit.services.some((s) => s.capability === 'ai-storage' || s.capability === 'ai-model')
+    const needsWorkflow = unit.services.some(
+      (s) => s.capability === 'workflow-state'
+    )
+    const needsAI = unit.services.some(
+      (s) => s.capability === 'ai-storage' || s.capability === 'ai-model'
+    )
 
     const cfImports = [...extraImports]
     if (needsQueue) cfImports.push('CloudflareQueueService')
     if (needsWorkflow) cfImports.push('CloudflareWorkflowService')
-    if (needsAI) cfImports.push('CloudflareAIStorageService', 'CloudflareAgentRunService', 'CloudflareAIRunStateService')
+    if (needsAI)
+      cfImports.push(
+        'CloudflareAIStorageService',
+        'CloudflareAgentRunService',
+        'CloudflareAIRunStateService'
+      )
 
-    return { cfImports, needsD1: needsWorkflow || needsAI, needsQueue, needsWorkflow, needsAI }
+    return {
+      cfImports,
+      needsD1: needsWorkflow || needsAI,
+      needsQueue,
+      needsWorkflow,
+      needsAI,
+    }
   }
 
   generateEntrySource(ctx: EntryGenerationContext): string {
     const { unit } = ctx
-
-    // Server-target units get a uWS entry (container deployment)
-    if (unit.target === 'server') {
-      return this.generateServerEntry(ctx)
-    }
 
     // Gateway units use their own dedicated handler factories
     if (unit.role === 'channel') {
@@ -138,20 +154,32 @@ export class CloudflareProviderAdapter {
    */
   private generateCombinedHandlerEntry(ctx: EntryGenerationContext): string {
     const handlerTypes = getHandlerTypes(ctx.unit)
-    const platform = this.resolvePlatformImports(ctx.unit, ['createCloudflareHandler'])
+    const platform = this.resolvePlatformImports(ctx.unit, [
+      'createCloudflareHandler',
+    ])
 
     const lines: string[] = [
       `// Generated entry for "${ctx.unit.name}" (${ctx.unit.role})`,
       `import { createCloudflareHandler } from '@pikku/cloudflare/handler'`,
       `import type { CloudflareEnv } from '@pikku/cloudflare/handler'`,
-      ...(platform.needsQueue ? [`import { CloudflareQueueService } from '@pikku/cloudflare/queue'`] : []),
-      ...(platform.needsD1 ? [
-        `import { ${[
-          ...(platform.needsWorkflow ? ['CloudflareWorkflowService'] : []),
-          ...(platform.needsAI ? ['CloudflareAIStorageService', 'CloudflareAgentRunService', 'CloudflareAIRunStateService'] : []),
-        ].join(', ')} } from '@pikku/cloudflare/d1'`,
-        `import type { D1Database } from '@cloudflare/workers-types'`,
-      ] : []),
+      ...(platform.needsQueue
+        ? [`import { CloudflareQueueService } from '@pikku/cloudflare/queue'`]
+        : []),
+      ...(platform.needsD1
+        ? [
+            `import { ${[
+              ...(platform.needsWorkflow ? ['CloudflareWorkflowService'] : []),
+              ...(platform.needsAI
+                ? [
+                    'CloudflareAIStorageService',
+                    'CloudflareAgentRunService',
+                    'CloudflareAIRunStateService',
+                  ]
+                : []),
+            ].join(', ')} } from '@pikku/cloudflare/d1'`,
+            `import type { D1Database } from '@cloudflare/workers-types'`,
+          ]
+        : []),
       `import { CFWorkerSchemaService } from '@pikku/schema-cfworker'`,
       `import { JsonConsoleLogger } from '@pikku/core/services'`,
       ctx.configImport,
@@ -176,20 +204,32 @@ export class CloudflareProviderAdapter {
    * Uses the WebSocket handler factory and exports the DO class.
    */
   private generateChannelGatewayEntry(ctx: EntryGenerationContext): string {
-    const platform = this.resolvePlatformImports(ctx.unit, ['createCloudflareWebSocketHandler'])
+    const platform = this.resolvePlatformImports(ctx.unit, [
+      'createCloudflareWebSocketHandler',
+    ])
 
     const lines: string[] = [
       `// Generated entry for "${ctx.unit.name}" (${ctx.unit.role})`,
       `import { createCloudflareWebSocketHandler } from '@pikku/cloudflare/handler'`,
       `import type { CloudflareEnv } from '@pikku/cloudflare/handler'`,
-      ...(platform.needsQueue ? [`import { CloudflareQueueService } from '@pikku/cloudflare/queue'`] : []),
-      ...(platform.needsD1 ? [
-        `import { ${[
-          ...(platform.needsWorkflow ? ['CloudflareWorkflowService'] : []),
-          ...(platform.needsAI ? ['CloudflareAIStorageService', 'CloudflareAgentRunService', 'CloudflareAIRunStateService'] : []),
-        ].join(', ')} } from '@pikku/cloudflare/d1'`,
-        `import type { D1Database } from '@cloudflare/workers-types'`,
-      ] : []),
+      ...(platform.needsQueue
+        ? [`import { CloudflareQueueService } from '@pikku/cloudflare/queue'`]
+        : []),
+      ...(platform.needsD1
+        ? [
+            `import { ${[
+              ...(platform.needsWorkflow ? ['CloudflareWorkflowService'] : []),
+              ...(platform.needsAI
+                ? [
+                    'CloudflareAIStorageService',
+                    'CloudflareAgentRunService',
+                    'CloudflareAIRunStateService',
+                  ]
+                : []),
+            ].join(', ')} } from '@pikku/cloudflare/d1'`,
+            `import type { D1Database } from '@cloudflare/workers-types'`,
+          ]
+        : []),
       `import { CFWorkerSchemaService } from '@pikku/schema-cfworker'`,
       `import { JsonConsoleLogger } from '@pikku/core/services'`,
       ctx.configImport,
@@ -222,8 +262,13 @@ export class CloudflareProviderAdapter {
     })
     const bindingsMap = `{\n${bindingEntries.join(',\n')}\n  }`
 
-    const handlerName = includeQueueHandler ? 'createCloudflareHandler' : 'createCloudflareWorkerHandler'
-    const platform = this.resolvePlatformImports(ctx.unit, [handlerName, 'CloudflareDeploymentService'])
+    const handlerName = includeQueueHandler
+      ? 'createCloudflareHandler'
+      : 'createCloudflareWorkerHandler'
+    const platform = this.resolvePlatformImports(ctx.unit, [
+      handlerName,
+      'CloudflareDeploymentService',
+    ])
 
     const handlerTypes = includeQueueHandler ? `["fetch", "queue"]` : ''
 
@@ -240,14 +285,24 @@ export class CloudflareProviderAdapter {
       handlerImport,
       `import type { CloudflareEnv } from '@pikku/cloudflare/handler'`,
       `import { CloudflareDeploymentService } from '@pikku/cloudflare/deployment'`,
-      ...(platform.needsQueue ? [`import { CloudflareQueueService } from '@pikku/cloudflare/queue'`] : []),
-      ...(platform.needsD1 ? [
-        `import { ${[
-          ...(platform.needsWorkflow ? ['CloudflareWorkflowService'] : []),
-          ...(platform.needsAI ? ['CloudflareAIStorageService', 'CloudflareAgentRunService', 'CloudflareAIRunStateService'] : []),
-        ].join(', ')} } from '@pikku/cloudflare/d1'`,
-        `import type { D1Database } from '@cloudflare/workers-types'`,
-      ] : []),
+      ...(platform.needsQueue
+        ? [`import { CloudflareQueueService } from '@pikku/cloudflare/queue'`]
+        : []),
+      ...(platform.needsD1
+        ? [
+            `import { ${[
+              ...(platform.needsWorkflow ? ['CloudflareWorkflowService'] : []),
+              ...(platform.needsAI
+                ? [
+                    'CloudflareAIStorageService',
+                    'CloudflareAgentRunService',
+                    'CloudflareAIRunStateService',
+                  ]
+                : []),
+            ].join(', ')} } from '@pikku/cloudflare/d1'`,
+            `import type { D1Database } from '@cloudflare/workers-types'`,
+          ]
+        : []),
       `import { CFWorkerSchemaService } from '@pikku/schema-cfworker'`,
       `import { JsonConsoleLogger } from '@pikku/core/services'`,
       ctx.configImport,
@@ -287,7 +342,7 @@ export class CloudflareProviderAdapter {
         `    const workflowService = new CloudflareWorkflowService(env.WORKFLOW_DB as D1Database)`,
         `    await workflowService.init()`,
         `    services.workflowService = workflowService`,
-        `  }`,
+        `  }`
       )
     }
     if (platform.needsAI) {
@@ -301,7 +356,7 @@ export class CloudflareProviderAdapter {
         `    const aiRunState = new CloudflareAIRunStateService(db)`,
         `    await aiRunState.init()`,
         `    services.aiRunState = aiRunState`,
-        `  }`,
+        `  }`
       )
     }
     lines.push(`  return services`, `}`)
@@ -333,7 +388,7 @@ export class CloudflareProviderAdapter {
         `    const workflowService = new CloudflareWorkflowService(env.WORKFLOW_DB as D1Database)`,
         `    await workflowService.init()`,
         `    services.workflowService = workflowService`,
-        `  }`,
+        `  }`
       )
     }
     if (platform.needsAI) {
@@ -347,7 +402,7 @@ export class CloudflareProviderAdapter {
         `    const aiRunState = new CloudflareAIRunStateService(db)`,
         `    await aiRunState.init()`,
         `    services.aiRunState = aiRunState`,
-        `  }`,
+        `  }`
       )
     }
     lines.push(
@@ -358,73 +413,9 @@ export class CloudflareProviderAdapter {
       `    ${bindingsMap}`,
       `  )`,
       `  return services`,
-      `}`,
+      `}`
     )
     return lines
-  }
-
-  /**
-   * Generates entry for server-target units (CF Container).
-   * Uses PikkuUWSServer — same pattern as standalone adapter.
-   */
-  private generateServerEntry(ctx: EntryGenerationContext): string {
-    return [
-      `// Generated server entry for "${ctx.unit.name}" (container)`,
-      `import { stopSingletonServices } from '@pikku/core'`,
-      `import { ConsoleLogger } from '@pikku/core/services'`,
-      `import { InMemorySchedulerService } from '@pikku/schedule'`,
-      `import { PikkuUWSServer } from '@pikku/uws'`,
-      ``,
-      ctx.configImport,
-      ctx.servicesImport,
-      ctx.singletonServicesImport,
-      `import '${ctx.bootstrapPath}'`,
-      ``,
-      `const logger = new ConsoleLogger()`,
-      `const port = parseInt(process.env.PORT || '8080', 10)`,
-      `const hostname = process.env.HOST || '0.0.0.0'`,
-      ``,
-      `async function main() {`,
-      `  const config = await ${ctx.configVar}()`,
-      `  const schedulerService = new InMemorySchedulerService()`,
-      `  const singletonServices = await ${ctx.servicesVar}(config, {`,
-      `    logger,`,
-      `    schedulerService,`,
-      `  })`,
-      ``,
-      `  const server = new PikkuUWSServer(`,
-      `    { ...config, port, hostname },`,
-      `    logger,`,
-      `  )`,
-      `  await server.init({ respondWith404: true })`,
-      `  await schedulerService.start()`,
-      `  await server.start()`,
-      `  await server.enableExitOnSigInt()`,
-      `  logger.info('Server container ready on port ' + port)`,
-      `}`,
-      ``,
-      `main().catch((err) => {`,
-      `  logger.error('Fatal: ' + err.message)`,
-      `  process.exit(1)`,
-      `})`,
-      ``,
-    ].join('\n')
-  }
-
-  /**
-   * Generates a Dockerfile for server-target units.
-   */
-  private generateDockerfile(): string {
-    return [
-      `FROM node:22-slim`,
-      `WORKDIR /app`,
-      `COPY bundle.js .`,
-      `COPY package.json .`,
-      `RUN npm install --production 2>/dev/null || true`,
-      `ENV NODE_ENV=production`,
-      `EXPOSE 8080`,
-      `CMD ["node", "bundle.js"]`,
-    ].join('\n')
   }
 
   generateUnitConfigs(
@@ -433,9 +424,6 @@ export class CloudflareProviderAdapter {
     projectId: string
   ): Map<string, string> {
     const configs = new Map<string, string>()
-    if (unit.target === 'server') {
-      configs.set('Dockerfile', this.generateDockerfile())
-    }
     configs.set(
       'wrangler.toml',
       generateWranglerToml(unit, manifest, projectId)
@@ -443,171 +431,8 @@ export class CloudflareProviderAdapter {
     return configs
   }
 
-  generateProviderConfigs(manifest: DeploymentManifest): Map<string, string> {
-    const configs = new Map<string, string>()
-    const serverUnits = manifest.units.filter((u) => u.target === 'server')
-
-    if (serverUnits.length > 0) {
-      // Generate proxy Worker that routes to the container
-      configs.set(
-        'server-proxy/entry.ts',
-        this.generateProxyWorkerEntry(serverUnits, manifest)
-      )
-      configs.set(
-        'server-proxy/wrangler.toml',
-        this.generateProxyWranglerToml(serverUnits, manifest)
-      )
-      configs.set(
-        'server-proxy/package.json',
-        JSON.stringify({
-          name: `${manifest.projectId}-server-proxy`,
-          private: true,
-          type: 'module',
-          dependencies: {
-            '@cloudflare/containers': '^0.0.1',
-          },
-        }, null, 2)
-      )
-    }
-
-    return configs
-  }
-
-  /**
-   * Proxy Worker entry: extends Container, forwards HTTP/queue/cron to it.
-   */
-  private generateProxyWorkerEntry(
-    serverUnits: DeploymentUnit[],
-    manifest: DeploymentManifest
-  ): string {
-    // Collect all routes from server units
-    const serverRoutes: Array<{ method: string; route: string }> = []
-    for (const unit of serverUnits) {
-      for (const handler of unit.handlers) {
-        if (handler.type === 'fetch') {
-          for (const route of handler.routes) {
-            serverRoutes.push({ method: route.method, route: route.route })
-          }
-        }
-      }
-    }
-
-    // Collect queue names consumed by server units
-    const serverQueueNames = manifest.queues
-      .filter((q) => serverUnits.some((u) => u.name === q.consumerUnit))
-      .map((q) => q.name)
-
-    // Collect cron schedules for server units
-    const serverCrons = manifest.scheduledTasks
-      .filter((t) => serverUnits.some((u) => u.name === t.unitName))
-
-    return [
-      `// Generated proxy Worker — routes traffic to CF Container`,
-      `import { Container, getContainer } from "@cloudflare/containers"`,
-      ``,
-      `class PikkuServer extends Container {`,
-      `  defaultPort = 8080`,
-      `  sleepAfter = "2h"`,
-      `}`,
-      ``,
-      `interface Env {`,
-      `  PIKKU_SERVER: DurableObjectNamespace<PikkuServer>`,
-      `}`,
-      ``,
-      `export { PikkuServer }`,
-      ``,
-      `export default {`,
-      `  async fetch(request: Request, env: Env) {`,
-      `    const container = getContainer(env.PIKKU_SERVER)`,
-      `    return container.fetch(request)`,
-      `  },`,
-      ...(serverQueueNames.length > 0
-        ? [
-            `  async queue(batch: MessageBatch, env: Env) {`,
-            `    const container = getContainer(env.PIKKU_SERVER)`,
-            `    await container.fetch(new Request("http://internal/__pikku/queue", {`,
-            `      method: "POST",`,
-            `      headers: { "Content-Type": "application/json" },`,
-            `      body: JSON.stringify({ queue: batch.queue, messages: batch.messages.map(m => ({ id: m.id, body: m.body })) }),`,
-            `    }))`,
-            `  },`,
-          ]
-        : []),
-      ...(serverCrons.length > 0
-        ? [
-            `  async scheduled(controller: ScheduledController, env: Env) {`,
-            `    const container = getContainer(env.PIKKU_SERVER)`,
-            `    await container.fetch(new Request("http://internal/__pikku/scheduled", {`,
-            `      method: "POST",`,
-            `      headers: { "Content-Type": "application/json" },`,
-            `      body: JSON.stringify({ cron: controller.cron, scheduledTime: controller.scheduledTime }),`,
-            `    }))`,
-            `  },`,
-          ]
-        : []),
-      `}`,
-      ``,
-    ].join('\n')
-  }
-
-  /**
-   * Proxy Worker wrangler.toml with container binding + queue consumers + crons.
-   */
-  private generateProxyWranglerToml(
-    serverUnits: DeploymentUnit[],
-    manifest: DeploymentManifest
-  ): string {
-    const projectId = manifest.projectId
-    const lines: string[] = [
-      `name = "${projectId}-server-proxy"`,
-      `main = "entry.ts"`,
-      `compatibility_date = "2024-12-18"`,
-      `compatibility_flags = ["nodejs_compat_v2"]`,
-      ``,
-      `[observability]`,
-      `enabled = true`,
-      ``,
-      `[[containers]]`,
-      `class_name = "PikkuServer"`,
-      `image = "../server/Dockerfile"`,
-      `max_instances = 3`,
-      ``,
-      `[[durable_objects.bindings]]`,
-      `class_name = "PikkuServer"`,
-      `name = "PIKKU_SERVER"`,
-      ``,
-      `[[migrations]]`,
-      `new_sqlite_classes = ["PikkuServer"]`,
-      `tag = "v1"`,
-    ]
-
-    // Queue consumers for server functions
-    const serverQueueNames = manifest.queues
-      .filter((q) => serverUnits.some((u) => u.name === q.consumerUnit))
-
-    for (const queue of serverQueueNames) {
-      lines.push(
-        ``,
-        `[[queues.consumers]]`,
-        `queue = "${projectId}-${queue.name}"`,
-        `max_batch_size = 10`,
-        `max_batch_timeout = 5`,
-      )
-    }
-
-    // Cron triggers for server functions
-    const serverCrons = manifest.scheduledTasks
-      .filter((t) => serverUnits.some((u) => u.name === t.unitName))
-
-    if (serverCrons.length > 0) {
-      lines.push(``, `[triggers]`, `crons = [`)
-      for (const cron of serverCrons) {
-        lines.push(`  "${cron.schedule}",`)
-      }
-      lines.push(`]`)
-    }
-
-    return lines.join('\n')
+  generateProviderConfigs(_manifest: DeploymentManifest): Map<string, string> {
+    return new Map()
   }
 
   generateInfraManifest(manifest: DeploymentManifest): string | null {
@@ -659,12 +484,28 @@ export class CloudflareProviderAdapter {
       await readFile(join(options.buildDir, 'infra.json'), 'utf-8')
     )
 
+    // Error if any server-target units exist — container deploy requires Fabric
+    const serverUnits = Object.entries(infraJson.units || {}).filter(
+      ([_, u]) => (u as Record<string, unknown>).target === 'server'
+    )
+    if (serverUnits.length > 0) {
+      const names = serverUnits.map(([name]) => name).join(', ')
+      return {
+        success: false,
+        errors: [
+          {
+            step: 'validation',
+            error: `Project contains server-target functions (${names}) which require a container runtime. Server deploy is available via Pikku Fabric (https://pikku.dev/fabric).`,
+          },
+        ],
+      }
+    }
+
     return deploy({
       accountId,
       apiToken,
       buildDir: options.buildDir,
       manifest: infraJson,
-      dispatchNamespace: process.env.CF_DISPATCH_NAMESPACE,
       onProgress: options.onProgress,
     })
   }

--- a/packages/deploy/deploy-cloudflare/src/deploy.ts
+++ b/packages/deploy/deploy-cloudflare/src/deploy.ts
@@ -29,8 +29,6 @@ export interface DeployOptions {
   apiToken: string
   buildDir: string
   manifest: CloudflareInfraManifest
-  /** Workers for Platforms dispatch namespace. When set, workers are deployed into this namespace. */
-  dispatchNamespace?: string
   onProgress?: (step: string, detail: string) => void
 }
 
@@ -62,7 +60,7 @@ function toWorkerName(projectId: string, unitName: string): string {
 }
 
 export async function deploy(options: DeployOptions): Promise<DeployResult> {
-  const { accountId, apiToken, buildDir, manifest, dispatchNamespace, onProgress } = options
+  const { accountId, apiToken, buildDir, manifest, onProgress } = options
   const client = new CloudflareClient({ accountId, apiToken })
   const log = onProgress ?? (() => {})
   const projectId = manifest.projectId
@@ -94,8 +92,7 @@ export async function deploy(options: DeployOptions): Promise<DeployResult> {
     manifest,
     resourceIds,
     result,
-    log,
-    dispatchNamespace
+    log
   )
 
   // Step 4: Wire consumers and cron triggers
@@ -112,15 +109,6 @@ export async function deploy(options: DeployOptions): Promise<DeployResult> {
   // Step 5: Enable workers.dev routes
   log('routes', 'Enabling workers.dev routes...')
   await enableWorkersDevRoutes(client, projectId, manifest, result, log)
-
-  // Step 6: Deploy server container via wrangler (if any server units exist)
-  const hasServerUnits = Object.values(manifest.units).some(
-    (u) => u.target === 'server'
-  )
-  if (hasServerUnits) {
-    log('container', 'Deploying server container via wrangler...')
-    await deployServerContainer(buildDir, result, log)
-  }
 
   result.success = result.errors.length === 0
   return result
@@ -298,17 +286,11 @@ async function uploadWorkersInOrder(
   manifest: CloudflareInfraManifest,
   resourceIds: ResourceIds,
   result: DeployResult,
-  log: (step: string, detail: string) => void,
-  dispatchNamespace?: string
+  log: (step: string, detail: string) => void
 ): Promise<void> {
   // Build dependency graph: unit -> set of service binding targets
-  // Skip server-target units — they're deployed as containers, not Workers
   const deps = new Map<string, Set<string>>()
   for (const [unitName, unitManifest] of Object.entries(manifest.units)) {
-    if (unitManifest.target === 'server') {
-      log('workers', `Skipping ${unitName} (server container — deploy via wrangler)`)
-      continue
-    }
     const serviceDeps = new Set<string>()
     for (const b of unitManifest.bindings) {
       if (b.startsWith('service:')) {
@@ -337,7 +319,10 @@ async function uploadWorkersInOrder(
     }
 
     if (ready.length === 0) {
-      log('workers', `Circular dependency detected among: ${[...remaining].join(', ')}`)
+      log(
+        'workers',
+        `Circular dependency detected among: ${[...remaining].join(', ')}`
+      )
       for (const unitName of remaining) {
         ready.push([unitName, manifest.units[unitName]])
       }
@@ -351,8 +336,7 @@ async function uploadWorkersInOrder(
       ready,
       resourceIds,
       result,
-      log,
-      dispatchNamespace
+      log
     )
 
     for (const [unitName] of ready) {
@@ -370,8 +354,7 @@ async function deployWorkerBatch(
   units: Array<[string, { bindings: string[]; role: string }]>,
   resourceIds: ResourceIds,
   result: DeployResult,
-  log: (step: string, detail: string) => void,
-  dispatchNamespace?: string
+  log: (step: string, detail: string) => void
 ): Promise<void> {
   const tasks = units.map(async ([unitName, unitManifest]) => {
     const workerName = toWorkerName(projectId, unitName)
@@ -385,7 +368,7 @@ async function deployWorkerBatch(
         projectId
       )
 
-      await createWorker(client, workerName, script, bindings, [], undefined, dispatchNamespace)
+      await createWorker(client, workerName, script, bindings)
       result.workersDeployed.push(workerName)
       log('workers', `Deployed "${workerName}"`)
     } catch (err) {
@@ -442,10 +425,8 @@ async function wireConsumersAndTriggers(
     )
   }
 
-  // Set cron triggers (skip server-target units — their crons go through the proxy)
+  // Set cron triggers
   for (const cron of manifest.resources.cronTriggers) {
-    const unitManifest = manifest.units[cron.worker]
-    if (unitManifest?.target === 'server') continue
     const workerName = toWorkerName(projectId, cron.worker)
     tasks.push(
       (async () => {
@@ -492,71 +473,4 @@ async function enableWorkersDevRoutes(
     'routes',
     `Enabled workers.dev for ${Object.keys(manifest.units).length} workers`
   )
-}
-
-/**
- * Deploy the server container + proxy Worker via wrangler.
- * CF Containers can't be deployed via REST API — they require `wrangler deploy`
- * to build the Docker image and push it to CF's container registry.
- */
-async function deployServerContainer(
-  buildDir: string,
-  result: DeployResult,
-  log: (step: string, detail: string) => void
-): Promise<void> {
-  const { join } = await import('node:path')
-  const { existsSync } = await import('node:fs')
-  const { execSync } = await import('node:child_process')
-
-  const proxyDir = join(buildDir, 'server-proxy')
-  if (!existsSync(proxyDir)) {
-    log('container', 'No server-proxy directory found — skipping container deploy')
-    return
-  }
-
-  if (!existsSync(join(proxyDir, 'wrangler.toml'))) {
-    result.errors.push({
-      step: 'container',
-      error: 'server-proxy/wrangler.toml not found',
-    })
-    return
-  }
-
-  try {
-    // Install @cloudflare/containers dependency
-    log('container', 'Installing container dependencies...')
-    execSync('npm install --production', {
-      cwd: proxyDir,
-      timeout: 60_000,
-      stdio: 'pipe',
-    })
-
-    log('container', 'Running wrangler deploy for server container...')
-    const output = execSync('npx wrangler deploy', {
-      cwd: proxyDir,
-      timeout: 300_000,
-      env: {
-        ...process.env,
-        CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID,
-        CLOUDFLARE_API_TOKEN: process.env.CLOUDFLARE_API_TOKEN,
-        // Support Podman/Docker alternative
-        ...(process.env.WRANGLER_DOCKER_BIN
-          ? { WRANGLER_DOCKER_BIN: process.env.WRANGLER_DOCKER_BIN }
-          : {}),
-        // Disable buildkit provenance (not supported by Podman)
-        DOCKER_BUILDKIT: process.env.DOCKER_BUILDKIT ?? '0',
-      },
-      stdio: 'pipe',
-    })
-    log('container', `Container deployed: ${output.toString().trim().split('\n').pop()}`)
-    result.resourcesCreated.push('container:server')
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    // Extract useful error from wrangler output
-    const stderr = (err as { stderr?: Buffer })?.stderr?.toString() ?? ''
-    result.errors.push({
-      step: 'container',
-      error: stderr || message,
-    })
-  }
 }

--- a/packages/deploy/deploy-cloudflare/src/index.ts
+++ b/packages/deploy/deploy-cloudflare/src/index.ts
@@ -51,6 +51,12 @@ export type { DeployOptions, DeployResult } from './deploy.js'
 // Provider adapter
 import { CloudflareProviderAdapter } from './adapter.js'
 export { CloudflareProviderAdapter }
+export type {
+  DeploymentUnit,
+  DeploymentManifest,
+  DeploymentHandler,
+  EntryGenerationContext,
+} from './adapter.js'
 export const createAdapter = () => new CloudflareProviderAdapter()
 
 // Wrangler TOML generator

--- a/verifiers/addon/package.json
+++ b/verifiers/addon/package.json
@@ -8,11 +8,11 @@
     "#pikku/*": "./.pikku/*"
   },
   "dependencies": {
-    "@pikku/core": "^0.12.14",
+    "@pikku/core": "workspace:*",
     "@pikku/templates-function-addon": "workspace:*"
   },
   "devDependencies": {
-    "@pikku/cli": "^0.12.15",
+    "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "typescript": "^5.9"
   },

--- a/verifiers/deploy-azure/package.json
+++ b/verifiers/deploy-azure/package.json
@@ -9,7 +9,7 @@
     "test": "npx tsx test-deploy.ts"
   },
   "devDependencies": {
-    "@pikku/cli": "^0.12.15",
+    "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "typescript": "^5.9"
   }

--- a/verifiers/deploy-azure/test-deploy.ts
+++ b/verifiers/deploy-azure/test-deploy.ts
@@ -15,9 +15,8 @@ const DEPLOY_DIR = join(FUNCTIONS_DIR, '.deploy', 'azure')
 console.log('Setting up: running pikku codegen + deploy plan (azure)...')
 execSync('rm -rf .deploy src/scaffold', { cwd: FUNCTIONS_DIR, stdio: 'pipe' })
 execSync('yarn pikku', { cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 60_000 })
-execSync('yarn pikku deploy plan', {
+execSync('yarn pikku deploy plan --provider azure', {
   cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 300_000,
-  env: { ...process.env, PIKKU_DEPLOY_PROVIDER: 'azure' },
 })
 console.log('Setup complete.\n')
 

--- a/verifiers/deploy-cloudflare/package.json
+++ b/verifiers/deploy-cloudflare/package.json
@@ -9,7 +9,7 @@
     "test": "npx tsx test-deploy.ts"
   },
   "devDependencies": {
-    "@pikku/cli": "^0.12.15",
+    "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "typescript": "^5.9"
   }

--- a/verifiers/deploy-cloudflare/test-deploy.ts
+++ b/verifiers/deploy-cloudflare/test-deploy.ts
@@ -15,11 +15,8 @@ const DEPLOY_DIR = join(FUNCTIONS_DIR, '.deploy', 'cloudflare')
 console.log('Setting up: running pikku codegen + deploy plan (cloudflare)...')
 execSync('rm -rf .deploy src/scaffold', { cwd: FUNCTIONS_DIR, stdio: 'pipe' })
 execSync('yarn pikku', { cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 60_000 })
-execSync('yarn pikku deploy plan', {
-  cwd: FUNCTIONS_DIR,
-  stdio: 'pipe',
-  timeout: 300_000,
-  env: { ...process.env, PIKKU_DEPLOY_PROVIDER: 'cloudflare' },
+execSync('yarn pikku deploy plan --provider cloudflare', {
+  cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 300_000,
 })
 console.log('Setup complete.\n')
 

--- a/verifiers/deploy-serverless/package.json
+++ b/verifiers/deploy-serverless/package.json
@@ -9,7 +9,7 @@
     "test": "npx tsx test-deploy.ts"
   },
   "devDependencies": {
-    "@pikku/cli": "^0.12.15",
+    "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "typescript": "^5.9"
   }

--- a/verifiers/deploy-serverless/test-deploy.ts
+++ b/verifiers/deploy-serverless/test-deploy.ts
@@ -15,9 +15,8 @@ const DEPLOY_DIR = join(FUNCTIONS_DIR, '.deploy', 'serverless')
 console.log('Setting up: running pikku codegen + deploy plan (serverless)...')
 execSync('rm -rf .deploy src/scaffold', { cwd: FUNCTIONS_DIR, stdio: 'pipe' })
 execSync('yarn pikku', { cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 60_000 })
-execSync('yarn pikku deploy plan', {
+execSync('yarn pikku deploy plan --provider serverless', {
   cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 300_000,
-  env: { ...process.env, PIKKU_DEPLOY_PROVIDER: 'serverless' },
 })
 console.log('Setup complete.\n')
 

--- a/verifiers/deploy-standalone/package.json
+++ b/verifiers/deploy-standalone/package.json
@@ -9,7 +9,7 @@
     "test": "npx tsx test-deploy.ts"
   },
   "devDependencies": {
-    "@pikku/cli": "^0.12.15",
+    "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "typescript": "^5.9"
   }

--- a/verifiers/deploy-standalone/test-deploy.ts
+++ b/verifiers/deploy-standalone/test-deploy.ts
@@ -15,9 +15,8 @@ const DEPLOY_DIR = join(FUNCTIONS_DIR, '.deploy', 'standalone')
 console.log('Setting up: running pikku codegen + deploy plan (standalone)...')
 execSync('rm -rf .deploy src/scaffold', { cwd: FUNCTIONS_DIR, stdio: 'pipe' })
 execSync('yarn pikku', { cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 60_000 })
-execSync('yarn pikku deploy plan', {
+execSync('yarn pikku deploy plan --provider standalone', {
   cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 300_000,
-  env: { ...process.env, PIKKU_DEPLOY_PROVIDER: 'standalone' },
 })
 console.log('Setup complete.\n')
 

--- a/verifiers/functions/package.json
+++ b/verifiers/functions/package.json
@@ -7,18 +7,18 @@
     "#pikku/*": "./.pikku/*"
   },
   "dependencies": {
-    "@pikku/core": "^0.12.14",
-    "@pikku/jose": "^0.12.3",
-    "@pikku/schema-cfworker": "^0.12.2",
+    "@pikku/core": "workspace:*",
+    "@pikku/jose": "workspace:*",
+    "@pikku/schema-cfworker": "workspace:*",
     "@pikku/templates-function-addon": "workspace:*",
     "eventsource": "^4.1.0",
     "ws": "^8.19.0",
     "zod": "^4"
   },
   "devDependencies": {
-    "@pikku/cli": "^0.12.15",
-    "@pikku/fetch": "^0.12.1",
-    "@pikku/websocket": "^0.12.1",
+    "@pikku/cli": "workspace:*",
+    "@pikku/fetch": "workspace:*",
+    "@pikku/websocket": "workspace:*",
     "@types/node": "^24",
     "@types/ws": "^8",
     "concurrently": "^9.2.1",

--- a/verifiers/gateway/package.json
+++ b/verifiers/gateway/package.json
@@ -12,10 +12,10 @@
     "test": "pikku && tsc && npx tsx src/start.ts"
   },
   "dependencies": {
-    "@pikku/core": "^0.12.14"
+    "@pikku/core": "workspace:*"
   },
   "devDependencies": {
-    "@pikku/cli": "^0.12.15",
+    "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "typescript": "^5.9"
   }

--- a/verifiers/hmr/package.json
+++ b/verifiers/hmr/package.json
@@ -7,11 +7,11 @@
     "#pikku/*": "./.pikku/*"
   },
   "dependencies": {
-    "@pikku/core": "^0.12.14",
-    "@pikku/schema-cfworker": "^0.12.2"
+    "@pikku/core": "workspace:*",
+    "@pikku/schema-cfworker": "workspace:*"
   },
   "devDependencies": {
-    "@pikku/cli": "^0.12.15",
+    "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "tsx": "^4.21.0",
     "typescript": "^5.9"

--- a/verifiers/middleware-and-permissions/package.json
+++ b/verifiers/middleware-and-permissions/package.json
@@ -14,11 +14,11 @@
     "test": "pikku && tsc && npx tsx src/start.ts"
   },
   "dependencies": {
-    "@pikku/core": "^0.12.14",
+    "@pikku/core": "workspace:*",
     "@pikku/templates-function-addon": "workspace:*"
   },
   "devDependencies": {
-    "@pikku/cli": "^0.12.15",
+    "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "typescript": "^5.9"
   }

--- a/verifiers/treeshaking/package.json
+++ b/verifiers/treeshaking/package.json
@@ -15,11 +15,11 @@
     "prebuild": "npm run generate:readme"
   },
   "dependencies": {
-    "@pikku/core": "^0.12.14",
+    "@pikku/core": "workspace:*",
     "@pikku/templates-function-addon": "workspace:*"
   },
   "devDependencies": {
-    "@pikku/cli": "^0.12.15",
+    "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "typescript": "^5.9"
   }

--- a/verifiers/types/package.json
+++ b/verifiers/types/package.json
@@ -8,7 +8,7 @@
     "#pikku/*": "./.pikku/*"
   },
   "dependencies": {
-    "@pikku/core": "^0.12.14",
+    "@pikku/core": "workspace:*",
     "@pikku/templates-function-addon": "workspace:*"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5561,7 +5561,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pikku/fetch@npm:^0.12.0, @pikku/fetch@npm:^0.12.1, @pikku/fetch@workspace:packages/client-fetch":
+"@pikku/fetch@npm:^0.12.0, @pikku/fetch@npm:^0.12.1, @pikku/fetch@workspace:*, @pikku/fetch@workspace:packages/client-fetch":
   version: 0.0.0-use.local
   resolution: "@pikku/fetch@workspace:packages/client-fetch"
   dependencies:
@@ -6313,8 +6313,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-addon@workspace:verifiers/addon"
   dependencies:
-    "@pikku/cli": "npm:^0.12.15"
-    "@pikku/core": "npm:^0.12.14"
+    "@pikku/cli": "workspace:*"
+    "@pikku/core": "workspace:*"
     "@pikku/templates-function-addon": "workspace:*"
     "@types/node": "npm:^24"
     typescript: "npm:^5.9"
@@ -6325,7 +6325,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-deploy-azure@workspace:verifiers/deploy-azure"
   dependencies:
-    "@pikku/cli": "npm:^0.12.15"
+    "@pikku/cli": "workspace:*"
     "@types/node": "npm:^24"
     typescript: "npm:^5.9"
   languageName: unknown
@@ -6335,7 +6335,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-deploy-cloudflare@workspace:verifiers/deploy-cloudflare"
   dependencies:
-    "@pikku/cli": "npm:^0.12.15"
+    "@pikku/cli": "workspace:*"
     "@types/node": "npm:^24"
     typescript: "npm:^5.9"
   languageName: unknown
@@ -6345,7 +6345,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-deploy-serverless@workspace:verifiers/deploy-serverless"
   dependencies:
-    "@pikku/cli": "npm:^0.12.15"
+    "@pikku/cli": "workspace:*"
     "@types/node": "npm:^24"
     typescript: "npm:^5.9"
   languageName: unknown
@@ -6355,7 +6355,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-deploy-standalone@workspace:verifiers/deploy-standalone"
   dependencies:
-    "@pikku/cli": "npm:^0.12.15"
+    "@pikku/cli": "workspace:*"
     "@types/node": "npm:^24"
     typescript: "npm:^5.9"
   languageName: unknown
@@ -6365,13 +6365,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-functions@workspace:verifiers/functions"
   dependencies:
-    "@pikku/cli": "npm:^0.12.15"
-    "@pikku/core": "npm:^0.12.14"
-    "@pikku/fetch": "npm:^0.12.1"
-    "@pikku/jose": "npm:^0.12.3"
-    "@pikku/schema-cfworker": "npm:^0.12.2"
+    "@pikku/cli": "workspace:*"
+    "@pikku/core": "workspace:*"
+    "@pikku/fetch": "workspace:*"
+    "@pikku/jose": "workspace:*"
+    "@pikku/schema-cfworker": "workspace:*"
     "@pikku/templates-function-addon": "workspace:*"
-    "@pikku/websocket": "npm:^0.12.1"
+    "@pikku/websocket": "workspace:*"
     "@types/node": "npm:^24"
     "@types/ws": "npm:^8"
     concurrently: "npm:^9.2.1"
@@ -6387,8 +6387,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-gateway@workspace:verifiers/gateway"
   dependencies:
-    "@pikku/cli": "npm:^0.12.15"
-    "@pikku/core": "npm:^0.12.14"
+    "@pikku/cli": "workspace:*"
+    "@pikku/core": "workspace:*"
     "@types/node": "npm:^24"
     typescript: "npm:^5.9"
   languageName: unknown
@@ -6398,9 +6398,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-hmr@workspace:verifiers/hmr"
   dependencies:
-    "@pikku/cli": "npm:^0.12.15"
-    "@pikku/core": "npm:^0.12.14"
-    "@pikku/schema-cfworker": "npm:^0.12.2"
+    "@pikku/cli": "workspace:*"
+    "@pikku/core": "workspace:*"
+    "@pikku/schema-cfworker": "workspace:*"
     "@types/node": "npm:^24"
     tsx: "npm:^4.21.0"
     typescript: "npm:^5.9"
@@ -6411,8 +6411,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-middleware-and-permissions@workspace:verifiers/middleware-and-permissions"
   dependencies:
-    "@pikku/cli": "npm:^0.12.15"
-    "@pikku/core": "npm:^0.12.14"
+    "@pikku/cli": "workspace:*"
+    "@pikku/core": "workspace:*"
     "@pikku/templates-function-addon": "workspace:*"
     "@types/node": "npm:^24"
     typescript: "npm:^5.9"
@@ -6437,8 +6437,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-treeshaking@workspace:verifiers/treeshaking"
   dependencies:
-    "@pikku/cli": "npm:^0.12.15"
-    "@pikku/core": "npm:^0.12.14"
+    "@pikku/cli": "workspace:*"
+    "@pikku/core": "workspace:*"
     "@pikku/templates-function-addon": "workspace:*"
     "@types/node": "npm:^24"
     typescript: "npm:^5.9"
@@ -6450,7 +6450,7 @@ __metadata:
   resolution: "@pikku/verifiers-types@workspace:verifiers/types"
   dependencies:
     "@pikku/cli": "workspace:*"
-    "@pikku/core": "npm:^0.12.14"
+    "@pikku/core": "workspace:*"
     "@pikku/templates-function-addon": "workspace:*"
     "@types/node": "npm:^24"
     typescript: "npm:^5.9"
@@ -6491,7 +6491,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pikku/websocket@npm:^0.12.1, @pikku/websocket@workspace:packages/client-websocket":
+"@pikku/websocket@npm:^0.12.1, @pikku/websocket@workspace:*, @pikku/websocket@workspace:packages/client-websocket":
   version: 0.0.0-use.local
   resolution: "@pikku/websocket@workspace:packages/client-websocket"
   dependencies:


### PR DESCRIPTION
Move server-target deployment (CF Containers, Dockerfile generation, proxy worker) behind Pikku Fabric. OSS deploy now validates and rejects server-target units with a clear error pointing to Fabric.

Also adds --from-plan and --result-file CLI options to deploy commands for Fabric's plan/apply pipeline integration, and refactors deploy-apply to use provider.deploy() instead of inline Cloudflare logic.