### PR TITLE
Replace workspace:* with explicit npm version ranges

### DIFF
--- a/.changeset/fix-workspace-protocol.md
+++ b/.changeset/fix-workspace-protocol.md
@@ -1,0 +1,8 @@
+---
+"@pikku/cli": patch
+"@pikku/cloudflare": patch
+"pikku-vscode": patch
+"@pikku/kysely-mysql": patch
+---
+
+Replace workspace:* protocol with explicit npm version ranges in all package.json files. Fixes broken publishes where workspace:* was included literally in the npm registry.

--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -9,7 +9,7 @@ rm -rf -- .pikku dist
 
 # Bootstrap using the published CLI - generates all .pikku files
 echo "Bootstrapping with published @pikku/cli..."
-: "${PIKKU_CLI_VERSION:=latest}"
+: "${PIKKU_CLI_VERSION:=0.12.14}"
 npx -y "@pikku/cli@${PIKKU_CLI_VERSION}"
 
 # Patch stale forge references from published CLI (renamed to node/)

--- a/packages/runtimes/cloudflare/package.json
+++ b/packages/runtimes/cloudflare/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.12.18",
     "@cloudflare/workers-types": "^4.20260305.0",
-    "@pikku/kysely": "workspace:*",
+    "@pikku/kysely": "^0.12.9",
     "@vitest/runner": "^2.1.9",
     "@vitest/snapshot": "^2.1.9",
     "typescript": "^5.9.3",

--- a/packages/services/kysely-mysql/package.json
+++ b/packages/services/kysely-mysql/package.json
@@ -13,8 +13,8 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@pikku/core": "workspace:*",
-    "@pikku/kysely": "workspace:*",
+    "@pikku/core": "^0.12.15",
+    "@pikku/kysely": "^0.12.9",
     "kysely": "^0.28.12"
   },
   "devDependencies": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -95,8 +95,8 @@
     }
   },
   "dependencies": {
-    "@pikku/core": "workspace:*",
-    "@pikku/inspector": "workspace:*"
+    "@pikku/core": "^0.12.15",
+    "@pikku/inspector": "^0.12.8"
   },
   "devDependencies": {
     "@types/vscode": "^1.85.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5320,7 +5320,7 @@ __metadata:
   dependencies:
     "@cloudflare/vitest-pool-workers": "npm:^0.12.18"
     "@cloudflare/workers-types": "npm:^4.20260305.0"
-    "@pikku/kysely": "workspace:*"
+    "@pikku/kysely": "npm:^0.12.9"
     "@vitest/runner": "npm:^2.1.9"
     "@vitest/snapshot": "npm:^2.1.9"
     kysely-d1: "npm:^0.4.0"
@@ -5609,8 +5609,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/kysely-mysql@workspace:packages/services/kysely-mysql"
   dependencies:
-    "@pikku/core": "workspace:*"
-    "@pikku/kysely": "workspace:*"
+    "@pikku/core": "npm:^0.12.15"
+    "@pikku/kysely": "npm:^0.12.9"
     kysely: "npm:^0.28.12"
     typescript: "npm:^5.9"
   languageName: unknown
@@ -5641,7 +5641,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pikku/kysely@npm:^0.12.0, @pikku/kysely@npm:^0.12.5, @pikku/kysely@workspace:*, @pikku/kysely@workspace:packages/services/kysely":
+"@pikku/kysely@npm:^0.12.0, @pikku/kysely@npm:^0.12.5, @pikku/kysely@npm:^0.12.9, @pikku/kysely@workspace:*, @pikku/kysely@workspace:packages/services/kysely":
   version: 0.0.0-use.local
   resolution: "@pikku/kysely@workspace:packages/services/kysely"
   dependencies:
@@ -19448,8 +19448,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "pikku-vscode@workspace:packages/vscode-extension"
   dependencies:
-    "@pikku/core": "workspace:*"
-    "@pikku/inspector": "workspace:*"
+    "@pikku/core": "npm:^0.12.15"
+    "@pikku/inspector": "npm:^0.12.8"
     "@types/vscode": "npm:^1.85.0"
     esbuild: "npm:^0.24.0"
     typescript: "npm:^5.9.0"


### PR DESCRIPTION
## Summary
- Replaces all `workspace:*` protocol references with explicit npm version ranges across `@pikku/cli`, `@pikku/cloudflare`, `pikku-vscode`, and `@pikku/kysely-mysql`
- Fixes broken npm publishes where `workspace:*` was included literally in the registry, causing install failures for consumers
- Updates yarn.lock

## Changeset included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced workspace protocol references with explicit npm version ranges to prevent publish/install issues and improve package stability.
* **Chores**
  * Added a changeset to bump patch versions across packages.
  * Pinned the CLI bootstrap version to a specific release to stabilize build/bootstrap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->