### PR TITLE
React hooks

### DIFF
--- a/.changeset/react-query-hooks.md
+++ b/.changeset/react-query-hooks.md
@@ -1,0 +1,5 @@
+---
+"@pikku/cli": patch
+---
+
+Add React Query hooks generation from RPC map. New `reactQueryFile` option in `clientFiles` config generates typed `usePikkuQuery`, `usePikkuMutation`, and `usePikkuInfiniteQuery` hooks, plus workflow hooks (`useRunWorkflow`, `useStartWorkflow`, `useWorkflowStatus`). Infinite query is type-constrained to RPCs whose output includes `nextCursor`.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -147,14 +147,3 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SLS_TELEMETRY_DISABLED: 1
       SLS_NOTIFICATIONS_MODE: off
-
-  release-dry-run:
-    name: Release (dry run)
-    runs-on: ubuntu-latest
-    needs: [verifiers, templates, e2e]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/setup
-      - run: npx changeset status

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -2,6 +2,7 @@ import { pikkuSchemas } from './functions/wirings/functions/schemas.js'
 import { pikkuFetch } from './functions/runtimes/fetch/index.js'
 import { pikkuWebSocketTyped } from './functions/runtimes/websocket/pikku-command-websocket-typed.js'
 import { pikkuRPCClient } from './functions/wirings/rpc/pikku-command-rpc-client.js'
+import { pikkuReactQuery } from './functions/wirings/rpc/pikku-command-react-query.js'
 import { pikkuQueueService } from './functions/wirings/queue/pikku-command-queue-service.js'
 import { pikkuOpenAPI } from './functions/wirings/http/pikku-command-openapi.js'
 import { pikkuNext } from './functions/runtimes/nextjs/pikku-command-nextjs.js'
@@ -150,6 +151,10 @@ wireCLI({
     rpc: pikkuCLICommand({
       func: pikkuRPCClient,
       description: 'Generate RPC client wrappers',
+    }),
+    'react-query': pikkuCLICommand({
+      func: pikkuReactQuery,
+      description: 'Generate React Query hooks from RPC map',
     }),
     'queue-service': pikkuCLICommand({
       func: pikkuQueueService,

--- a/packages/cli/src/functions/commands/all.ts
+++ b/packages/cli/src/functions/commands/all.ts
@@ -153,6 +153,7 @@ export const all = pikkuVoidFunc({
         await rpc.invoke('pikkuHTTPMap', null)
         await rpc.invoke('pikkuFetch', null)
         await rpc.invoke('pikkuRPCClient', null)
+        await rpc.invoke('pikkuReactQuery', null)
         allImports.push(config.httpWiringMetaFile, config.httpWiringsFile)
       }
 

--- a/packages/cli/src/functions/wirings/rpc/pikku-command-react-query.ts
+++ b/packages/cli/src/functions/wirings/rpc/pikku-command-react-query.ts
@@ -1,0 +1,52 @@
+import { pikkuSessionlessFunc } from '#pikku'
+import { getFileImportRelativePath } from '../../../utils/file-import-path.js'
+import { writeFileInDir } from '../../../utils/file-writer.js'
+import { logCommandInfoAndTime } from '../../../middleware/log-command-info-and-time.js'
+import { serializeReactQueryHooks } from './serialize-react-query-hooks.js'
+
+export const pikkuReactQuery = pikkuSessionlessFunc<void, void>({
+  func: async ({ logger, config, getInspectorState }) => {
+    const reactQueryFile = config.clientFiles?.reactQueryFile
+    const {
+      rpcMapDeclarationFile,
+      workflowMapDeclarationFile,
+      packageMappings,
+    } = config
+
+    if (!reactQueryFile) {
+      logger.debug({
+        message:
+          "Skipping generating React Query hooks since reactQueryFile isn't set in the pikku config.",
+        type: 'skip',
+      })
+      return
+    }
+
+    const { workflows } = await getInspectorState()
+    const hasWorkflows = Object.keys(workflows?.meta ?? {}).length > 0
+
+    const rpcMapPath = getFileImportRelativePath(
+      reactQueryFile,
+      rpcMapDeclarationFile,
+      packageMappings
+    )
+
+    let workflowMapPath: string | undefined
+    if (hasWorkflows) {
+      workflowMapPath = getFileImportRelativePath(
+        reactQueryFile,
+        workflowMapDeclarationFile,
+        packageMappings
+      )
+    }
+
+    const content = serializeReactQueryHooks(rpcMapPath, workflowMapPath)
+    await writeFileInDir(logger, reactQueryFile, content)
+  },
+  middleware: [
+    logCommandInfoAndTime({
+      commandStart: 'Generating React Query hooks',
+      commandEnd: 'Generated React Query hooks',
+    }),
+  ],
+})

--- a/packages/cli/src/functions/wirings/rpc/serialize-react-query-hooks.ts
+++ b/packages/cli/src/functions/wirings/rpc/serialize-react-query-hooks.ts
@@ -53,7 +53,7 @@ export const useWorkflowStatus = (
 `
     : ''
 
-  return `import { useQuery, useMutation, type UseQueryOptions, type UseMutationOptions } from '@tanstack/react-query'
+  return `import { useQuery, useInfiniteQuery, useMutation, type UseQueryOptions, type UseInfiniteQueryOptions, type UseMutationOptions, type InfiniteData } from '@tanstack/react-query'
 import { usePikkuRPC } from '@pikku/react'
 import type { FlattenedRPCMap } from '${rpcMapPath}'${workflowImport}
 
@@ -79,6 +79,30 @@ export const usePikkuMutation = <Name extends keyof FlattenedRPCMap>(
   const rpc = usePikkuRPC<{ invoke: RPCInvoke }>()
   return useMutation<FlattenedRPCMap[Name]['output'], Error, FlattenedRPCMap[Name]['input']>({
     mutationFn: (data) => rpc.invoke(name, data),
+    ...options,
+  })
+}
+
+type PaginatedKeys = {
+  [K in keyof FlattenedRPCMap]: FlattenedRPCMap[K]['output'] extends { nextCursor?: string | null } ? K : never
+}[keyof FlattenedRPCMap]
+
+type InfiniteOpts<Name extends PaginatedKeys> = Omit<
+  UseInfiniteQueryOptions<FlattenedRPCMap[Name]['output'], Error, InfiniteData<FlattenedRPCMap[Name]['output'], string | undefined>, readonly unknown[], string | undefined>,
+  'queryKey' | 'queryFn' | 'getNextPageParam' | 'initialPageParam'
+>
+
+export const usePikkuInfiniteQuery = <Name extends PaginatedKeys>(
+  name: Name,
+  data: Omit<FlattenedRPCMap[Name]['input'], 'nextCursor'>,
+  options?: InfiniteOpts<Name>
+) => {
+  const rpc = usePikkuRPC<{ invoke: RPCInvoke }>()
+  return useInfiniteQuery({
+    queryKey: [name, data] as const,
+    queryFn: ({ pageParam }: { pageParam: string | undefined }) => rpc.invoke(name, { ...data, nextCursor: pageParam } as FlattenedRPCMap[Name]['input']),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage: FlattenedRPCMap[Name]['output']) => (lastPage as { nextCursor?: string }).nextCursor ?? undefined,
     ...options,
   })
 }

--- a/packages/cli/src/functions/wirings/rpc/serialize-react-query-hooks.ts
+++ b/packages/cli/src/functions/wirings/rpc/serialize-react-query-hooks.ts
@@ -39,13 +39,16 @@ type WorkflowRunStatus = {
 
 export const useWorkflowStatus = (
   workflowName: keyof FlattenedWorkflowMap & string,
-  runId: string,
-  options?: Omit<UseQueryOptions<WorkflowRunStatus, Error>, 'queryKey' | 'queryFn'>
+  runId?: string,
+  options?: Omit<UseQueryOptions<WorkflowRunStatus, Error>, 'queryKey' | 'queryFn' | 'enabled'>
 ) => {
   const rpc = usePikkuRPC<{ workflowStatus: (name: string, runId: string) => Promise<WorkflowRunStatus> }>()
   return useQuery<WorkflowRunStatus, Error>({
     queryKey: ['workflowStatus', workflowName, runId],
-    queryFn: () => rpc.workflowStatus(workflowName, runId),
+    queryFn: () => {
+      if (!runId) throw new Error('runId is required')
+      return rpc.workflowStatus(workflowName, runId)
+    },
     enabled: !!runId,
     ...options,
   })

--- a/packages/cli/src/functions/wirings/rpc/serialize-react-query-hooks.ts
+++ b/packages/cli/src/functions/wirings/rpc/serialize-react-query-hooks.ts
@@ -1,0 +1,86 @@
+export const serializeReactQueryHooks = (
+  rpcMapPath: string,
+  workflowMapPath?: string
+) => {
+  const workflowImport = workflowMapPath
+    ? `\nimport type { FlattenedWorkflowMap } from '${workflowMapPath}'`
+    : ''
+
+  const workflowHooks = workflowMapPath
+    ? `
+export const useRunWorkflow = <Name extends keyof FlattenedWorkflowMap>(
+  name: Name,
+  options?: Omit<UseMutationOptions<FlattenedWorkflowMap[Name]['output'], Error, FlattenedWorkflowMap[Name]['input']>, 'mutationFn'>
+) => {
+  const rpc = usePikkuRPC<{ runWorkflow: <N extends keyof FlattenedWorkflowMap>(name: N, input: FlattenedWorkflowMap[N]['input']) => Promise<FlattenedWorkflowMap[N]['output']> }>()
+  return useMutation<FlattenedWorkflowMap[Name]['output'], Error, FlattenedWorkflowMap[Name]['input']>({
+    mutationFn: (input) => rpc.runWorkflow(name, input),
+    ...options,
+  })
+}
+
+export const useStartWorkflow = <Name extends keyof FlattenedWorkflowMap>(
+  name: Name,
+  options?: Omit<UseMutationOptions<{ runId: string }, Error, FlattenedWorkflowMap[Name]['input']>, 'mutationFn'>
+) => {
+  const rpc = usePikkuRPC<{ startWorkflow: <N extends keyof FlattenedWorkflowMap>(name: N, input: FlattenedWorkflowMap[N]['input']) => Promise<{ runId: string }> }>()
+  return useMutation<{ runId: string }, Error, FlattenedWorkflowMap[Name]['input']>({
+    mutationFn: (input) => rpc.startWorkflow(name, input),
+    ...options,
+  })
+}
+
+type WorkflowRunStatus = {
+  id: string
+  status: 'running' | 'suspended' | 'completed' | 'failed' | 'cancelled'
+  output?: unknown
+  error?: { message?: string }
+}
+
+export const useWorkflowStatus = (
+  workflowName: keyof FlattenedWorkflowMap & string,
+  runId: string,
+  options?: Omit<UseQueryOptions<WorkflowRunStatus, Error>, 'queryKey' | 'queryFn'>
+) => {
+  const rpc = usePikkuRPC<{ workflowStatus: (name: string, runId: string) => Promise<WorkflowRunStatus> }>()
+  return useQuery<WorkflowRunStatus, Error>({
+    queryKey: ['workflowStatus', workflowName, runId],
+    queryFn: () => rpc.workflowStatus(workflowName, runId),
+    enabled: !!runId,
+    ...options,
+  })
+}
+`
+    : ''
+
+  return `import { useQuery, useMutation, type UseQueryOptions, type UseMutationOptions } from '@tanstack/react-query'
+import { usePikkuRPC } from '@pikku/react'
+import type { FlattenedRPCMap } from '${rpcMapPath}'${workflowImport}
+
+type RPCInvoke = <Name extends keyof FlattenedRPCMap>(name: Name, data: FlattenedRPCMap[Name]['input']) => Promise<FlattenedRPCMap[Name]['output']>
+
+export const usePikkuQuery = <Name extends keyof FlattenedRPCMap>(
+  name: Name,
+  data: FlattenedRPCMap[Name]['input'],
+  options?: Omit<UseQueryOptions<FlattenedRPCMap[Name]['output'], Error>, 'queryKey' | 'queryFn'>
+) => {
+  const rpc = usePikkuRPC<{ invoke: RPCInvoke }>()
+  return useQuery<FlattenedRPCMap[Name]['output'], Error>({
+    queryKey: [name, data],
+    queryFn: () => rpc.invoke(name, data),
+    ...options,
+  })
+}
+
+export const usePikkuMutation = <Name extends keyof FlattenedRPCMap>(
+  name: Name,
+  options?: Omit<UseMutationOptions<FlattenedRPCMap[Name]['output'], Error, FlattenedRPCMap[Name]['input']>, 'mutationFn'>
+) => {
+  const rpc = usePikkuRPC<{ invoke: RPCInvoke }>()
+  return useMutation<FlattenedRPCMap[Name]['output'], Error, FlattenedRPCMap[Name]['input']>({
+    mutationFn: (data) => rpc.invoke(name, data),
+    ...options,
+  })
+}
+${workflowHooks}`
+}

--- a/packages/cli/src/utils/pikku-cli-config.ts
+++ b/packages/cli/src/utils/pikku-cli-config.ts
@@ -7,6 +7,7 @@ const CLIENT_FILE_KEYS = [
   'fetchFile',
   'websocketFile',
   'rpcWiringsFile',
+  'reactQueryFile',
   'queueWiringsFile',
   'mcpJsonFile',
   'nextBackendFile',

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -189,6 +189,7 @@ export type PikkuCLIInput = {
     fetchFile?: string
     websocketFile?: string
     rpcWiringsFile?: string
+    reactQueryFile?: string
     queueWiringsFile?: string
     mcpJsonFile?: string
     nextBackendFile?: string

--- a/verifiers/functions/package.json
+++ b/verifiers/functions/package.json
@@ -18,8 +18,11 @@
   "devDependencies": {
     "@pikku/cli": "workspace:*",
     "@pikku/fetch": "workspace:*",
+    "@pikku/react": "workspace:*",
     "@pikku/websocket": "workspace:*",
+    "@tanstack/react-query": "^5",
     "@types/node": "^24",
+    "@types/react": "^19",
     "@types/ws": "^8",
     "concurrently": "^9.2.1",
     "tsx": "^4.21.0",

--- a/verifiers/functions/pikku.config.json
+++ b/verifiers/functions/pikku.config.json
@@ -12,6 +12,7 @@
     "websocketFile": ".pikku/pikku-websocket.gen.ts",
     "rpcWiringsFile": ".pikku/pikku-rpc.gen.ts",
     "queueWiringsFile": ".pikku/pikku-queue.gen.ts",
-    "mcpJsonFile": ".pikku/mcp/mcp.gen.json"
+    "mcpJsonFile": ".pikku/mcp/mcp.gen.json",
+    "reactQueryFile": ".pikku/pikku-react-query.gen.ts"
   }
 }

--- a/verifiers/functions/src/functions/rpc/rpc.functions.ts
+++ b/verifiers/functions/src/functions/rpc/rpc.functions.ts
@@ -11,3 +11,16 @@ export const rpcTest = pikkuSessionlessFunc<{ in: number }>({
   },
   expose: true,
 })
+
+export const listItems = pikkuSessionlessFunc<
+  { limit: number; nextCursor?: string },
+  { items: string[]; nextCursor?: string }
+>({
+  func: async (_services, data) => {
+    return {
+      items: [`item-${data.limit}`],
+      nextCursor: data.nextCursor ? undefined : 'next',
+    }
+  },
+  expose: true,
+})

--- a/verifiers/functions/src/functions/rpc/rpc.react-query.verify.ts
+++ b/verifiers/functions/src/functions/rpc/rpc.react-query.verify.ts
@@ -1,0 +1,37 @@
+/**
+ * Type-level verification for generated React Query hooks.
+ * This file is checked by `tsc --noEmit` — it must compile without errors.
+ * It is NOT executed at runtime.
+ */
+
+import {
+  usePikkuQuery,
+  usePikkuMutation,
+} from '#pikku/pikku-react-query.gen.js'
+
+// --- usePikkuQuery ---
+
+// Valid: known RPC name with correct input
+void usePikkuQuery('rpcTest', { in: 1 })
+
+// Valid: with options
+void usePikkuQuery('rpcTest', { in: 1 }, { staleTime: 5000 })
+
+// @ts-expect-error — unknown RPC name must fail
+usePikkuQuery('doesNotExist', {})
+
+// @ts-expect-error — wrong input type must fail
+usePikkuQuery('rpcTest', { wrong: 'field' })
+
+// --- usePikkuMutation ---
+
+// Valid: known RPC name
+const mutation = usePikkuMutation('rpcTest')
+// mutate should accept the correct input type
+mutation.mutate({ in: 42 })
+
+// @ts-expect-error — unknown RPC name must fail
+usePikkuMutation('doesNotExist')
+
+// @ts-expect-error — wrong input type must fail
+mutation.mutate({ wrong: 'field' })

--- a/verifiers/functions/src/functions/rpc/rpc.react-query.verify.ts
+++ b/verifiers/functions/src/functions/rpc/rpc.react-query.verify.ts
@@ -7,6 +7,7 @@
 import {
   usePikkuQuery,
   usePikkuMutation,
+  usePikkuInfiniteQuery,
 } from '#pikku/pikku-react-query.gen.js'
 
 // --- usePikkuQuery ---
@@ -35,3 +36,17 @@ usePikkuMutation('doesNotExist')
 
 // @ts-expect-error — wrong input type must fail
 mutation.mutate({ wrong: 'field' })
+
+// --- usePikkuInfiniteQuery ---
+
+// Valid: listItems has nextCursor in output
+void usePikkuInfiniteQuery('listItems', { limit: 20 })
+
+// @ts-expect-error — rpcTest output has no nextCursor, must fail
+usePikkuInfiniteQuery('rpcTest', { in: 1 })
+
+// @ts-expect-error — unknown RPC name must fail
+usePikkuInfiniteQuery('doesNotExist', {})
+
+// @ts-expect-error — wrong input type must fail
+usePikkuInfiniteQuery('listItems', { wrong: 'field' })

--- a/verifiers/functions/src/functions/rpc/rpc.react-query.verify.ts
+++ b/verifiers/functions/src/functions/rpc/rpc.react-query.verify.ts
@@ -10,12 +10,7 @@ import {
   usePikkuInfiniteQuery,
 } from '#pikku/pikku-react-query.gen.js'
 
-// --- usePikkuQuery ---
-
-// Valid: known RPC name with correct input
 void usePikkuQuery('rpcTest', { in: 1 })
-
-// Valid: with options
 void usePikkuQuery('rpcTest', { in: 1 }, { staleTime: 5000 })
 
 // @ts-expect-error — unknown RPC name must fail
@@ -24,11 +19,7 @@ usePikkuQuery('doesNotExist', {})
 // @ts-expect-error — wrong input type must fail
 usePikkuQuery('rpcTest', { wrong: 'field' })
 
-// --- usePikkuMutation ---
-
-// Valid: known RPC name
 const mutation = usePikkuMutation('rpcTest')
-// mutate should accept the correct input type
 mutation.mutate({ in: 42 })
 
 // @ts-expect-error — unknown RPC name must fail
@@ -37,9 +28,6 @@ usePikkuMutation('doesNotExist')
 // @ts-expect-error — wrong input type must fail
 mutation.mutate({ wrong: 'field' })
 
-// --- usePikkuInfiniteQuery ---
-
-// Valid: listItems has nextCursor in output
 void usePikkuInfiniteQuery('listItems', { limit: 20 })
 
 // @ts-expect-error — rpcTest output has no nextCursor, must fail

--- a/verifiers/functions/tsconfig.json
+++ b/verifiers/functions/tsconfig.json
@@ -4,6 +4,7 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "module": "node18",
+    "jsx": "react-jsx",
     "types": ["node"]
   },
   "include": ["src/", ".pikku/*", "types/eventhub-topics.d.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5789,7 +5789,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pikku/react@workspace:packages/frontend/react":
+"@pikku/react@workspace:*, @pikku/react@workspace:packages/frontend/react":
   version: 0.0.0-use.local
   resolution: "@pikku/react@workspace:packages/frontend/react"
   dependencies:
@@ -6367,10 +6367,13 @@ __metadata:
     "@pikku/core": "workspace:*"
     "@pikku/fetch": "workspace:*"
     "@pikku/jose": "workspace:*"
+    "@pikku/react": "workspace:*"
     "@pikku/schema-cfworker": "workspace:*"
     "@pikku/templates-function-addon": "workspace:*"
     "@pikku/websocket": "workspace:*"
+    "@tanstack/react-query": "npm:^5"
     "@types/node": "npm:^24"
+    "@types/react": "npm:^19"
     "@types/ws": "npm:^8"
     concurrently: "npm:^9.2.1"
     eventsource: "npm:^4.1.0"
@@ -10233,6 +10236,24 @@ __metadata:
   version: 5.90.20
   resolution: "@tanstack/query-core@npm:5.90.20"
   checksum: 10/25e38f4382442bc15e0f6cce8d787e9df8d8822c61d3f3e9427e89e01b1e2506f848292e086dae29aeb55f8ce71b097c34221f3c5eda37fb4a688b5ceca5d1b3
+  languageName: node
+  linkType: hard
+
+"@tanstack/query-core@npm:5.99.0":
+  version: 5.99.0
+  resolution: "@tanstack/query-core@npm:5.99.0"
+  checksum: 10/752c38122c772a8c511ffd927e003282a23a3ab6979b066d1d8b100a2061a5448096fce4cfc9e2d93a2ef468ffac5440a6181203b1456d12f6e51f69bcdc1a4d
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query@npm:^5":
+  version: 5.99.0
+  resolution: "@tanstack/react-query@npm:5.99.0"
+  dependencies:
+    "@tanstack/query-core": "npm:5.99.0"
+  peerDependencies:
+    react: ^18 || ^19
+  checksum: 10/aafbc87fc9c6c01c8ac8229d42ab209273f39f8284a72b8917c5fab39722b949b8dff2cf3b28487b2ebcb286bb08a377a42ed8a56dabe7f1ac4681c5af338401
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added React Query hooks generation from RPC maps via a new `react-query` CLI command and `reactQueryFile` configuration option.
  * Generates typed hooks: `usePikkuQuery` for queries, `usePikkuMutation` for mutations, and `usePikkuInfiniteQuery` for paginated requests.
  * Added workflow-specific hooks: `useRunWorkflow`, `useStartWorkflow`, `useWorkflowStatus`.
  * `usePikkuInfiniteQuery` automatically supports cursor-based pagination for RPC entries with `nextCursor` output fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->