### PR TITLE
Fix: workflow inspector crash when data has 'description' property

### DIFF
--- a/.changeset/fix-434-workflow-description-crash.md
+++ b/.changeset/fix-434-workflow-description-crash.md
@@ -1,0 +1,5 @@
+---
+"@pikku/inspector": patch
+---
+
+Fix workflow inspector crash when workflow.do() data object has a 'description' property

--- a/packages/inspector/src/add/add-workflow.ts
+++ b/packages/inspector/src/add/add-workflow.ts
@@ -97,7 +97,7 @@ function getWorkflowInvocations(
           const stepNameArg = args[0]
           const secondArg = args[1]
           const optionsArg =
-            args.length >= 3 ? args[args.length - 1] : undefined
+            args.length >= 4 ? args[args.length - 1] : undefined
 
           const stepName = extractStringLiteral(stepNameArg, checker)
           const description =

--- a/packages/inspector/src/utils/extract-node-value.test.ts
+++ b/packages/inspector/src/utils/extract-node-value.test.ts
@@ -1,0 +1,67 @@
+import { test, describe } from 'node:test'
+import { strict as assert } from 'node:assert'
+import * as ts from 'typescript'
+import { extractDescription } from './extract-node-value'
+
+const createChecker = (source: string) => {
+  const sourceFile = ts.createSourceFile(
+    'test.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  )
+  const host = ts.createCompilerHost({})
+  const originalGetSourceFile = host.getSourceFile
+  host.getSourceFile = (fileName, target) => {
+    if (fileName === 'test.ts') return sourceFile
+    return originalGetSourceFile.call(host, fileName, target)
+  }
+  const program = ts.createProgram(['test.ts'], {}, host)
+  return { checker: program.getTypeChecker(), sourceFile }
+}
+
+const findObjectLiteral = (
+  node: ts.Node
+): ts.ObjectLiteralExpression | undefined => {
+  if (ts.isObjectLiteralExpression(node)) return node
+  let result: ts.ObjectLiteralExpression | undefined
+  ts.forEachChild(node, (child) => {
+    if (!result) result = findObjectLiteral(child)
+  })
+  return result
+}
+
+describe('extractDescription', () => {
+  test('returns null when node is undefined', () => {
+    const { checker } = createChecker('')
+    assert.equal(extractDescription(undefined, checker), null)
+  })
+
+  test('extracts string literal description', () => {
+    const { checker, sourceFile } = createChecker(
+      `const opts = { description: 'my step' }`
+    )
+    const obj = findObjectLiteral(sourceFile)!
+    assert.equal(extractDescription(obj, checker), 'my step')
+  })
+
+  test('returns null for non-literal description value without crashing', () => {
+    const { checker, sourceFile } = createChecker(
+      `const name = 'test'; const data = { description: name + ' addon' }`
+    )
+    const objs: ts.ObjectLiteralExpression[] = []
+    const visit = (node: ts.Node) => {
+      if (ts.isObjectLiteralExpression(node)) objs.push(node)
+      ts.forEachChild(node, visit)
+    }
+    ts.forEachChild(sourceFile, visit)
+    const dataObj = objs[objs.length - 1]!
+    assert.equal(extractDescription(dataObj, checker), null)
+  })
+
+  test('returns null for non-object node', () => {
+    const { checker, sourceFile } = createChecker(`const x = 42`)
+    assert.equal(extractDescription(sourceFile, checker), null)
+  })
+})

--- a/packages/inspector/src/utils/extract-node-value.ts
+++ b/packages/inspector/src/utils/extract-node-value.ts
@@ -110,7 +110,11 @@ export function extractDescription(
   if (!optionsNode || !ts.isObjectLiteralExpression(optionsNode)) {
     return null
   }
-  return extractPropertyString(optionsNode, 'description', checker)
+  try {
+    return extractPropertyString(optionsNode, 'description', checker)
+  } catch {
+    return null
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Only treat the last `workflow.do()` arg as options when there are 4+ args (3-arg form is `stepName, rpcName, data` — no options)
- Make `extractDescription` defensive with try/catch so non-literal values don't crash the inspector

Fixes #434

## Test plan
- [x] New test: `extractDescription` handles string literals, non-literal expressions, undefined, and non-object nodes
- [x] Inspector build passes
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)