### PR TITLE
Fix: sanitize function IDs for deploy directory names

### DIFF
--- a/.changeset/fix-430-function-id-sanitization.md
+++ b/.changeset/fix-430-function-id-sanitization.md
@@ -1,0 +1,5 @@
+---
+"@pikku/cli": patch
+---
+
+Sanitize function IDs with colons and slashes in deploy directory names

--- a/packages/cli/src/deploy/analyzer/analyzer.test.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.test.ts
@@ -1,0 +1,51 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { toKebab } from './analyzer.js'
+
+describe('toKebab', () => {
+  test('converts camelCase to kebab-case', () => {
+    assert.equal(toKebab('myFunction'), 'my-function')
+    assert.equal(toKebab('createUser'), 'create-user')
+  })
+
+  test('converts PascalCase to kebab-case', () => {
+    assert.equal(toKebab('CreateUser'), 'create-user')
+    assert.equal(toKebab('HTTPServer'), 'http-server')
+  })
+
+  test('sanitizes colons', () => {
+    assert.equal(
+      toKebab('workflowStart:myWorkflow'),
+      'workflow-start-my-workflow'
+    )
+    assert.equal(
+      toKebab('http:options:/rpc/:rpcName'),
+      'http-options-rpc-rpc-name'
+    )
+  })
+
+  test('sanitizes slashes', () => {
+    assert.equal(toKebab('http:get:/todos/:id'), 'http-get-todos-id')
+  })
+
+  test('collapses consecutive dashes', () => {
+    assert.equal(toKebab('a::b'), 'a-b')
+    assert.equal(toKebab('a://b'), 'a-b')
+  })
+
+  test('strips leading and trailing dashes', () => {
+    assert.equal(toKebab(':leadingColon'), 'leading-colon')
+    assert.equal(toKebab('/leadingSlash'), 'leading-slash')
+  })
+
+  test('handles already kebab-case', () => {
+    assert.equal(toKebab('my-function'), 'my-function')
+  })
+
+  test('handles graph function IDs', () => {
+    assert.equal(
+      toKebab('graphStart:todoReviewWorkflow:fetchOverdue'),
+      'graph-start-todo-review-workflow-fetch-overdue'
+    )
+  })
+})

--- a/packages/cli/src/deploy/analyzer/analyzer.test.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.test.ts
@@ -1,50 +1,50 @@
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { toKebab } from './analyzer.js'
+import { toSafeKebab } from './analyzer.js'
 
-describe('toKebab', () => {
+describe('toSafeKebab', () => {
   test('converts camelCase to kebab-case', () => {
-    assert.equal(toKebab('myFunction'), 'my-function')
-    assert.equal(toKebab('createUser'), 'create-user')
+    assert.equal(toSafeKebab('myFunction'), 'my-function')
+    assert.equal(toSafeKebab('createUser'), 'create-user')
   })
 
   test('converts PascalCase to kebab-case', () => {
-    assert.equal(toKebab('CreateUser'), 'create-user')
-    assert.equal(toKebab('HTTPServer'), 'http-server')
+    assert.equal(toSafeKebab('CreateUser'), 'create-user')
+    assert.equal(toSafeKebab('HTTPServer'), 'http-server')
   })
 
   test('sanitizes colons', () => {
     assert.equal(
-      toKebab('workflowStart:myWorkflow'),
+      toSafeKebab('workflowStart:myWorkflow'),
       'workflow-start-my-workflow'
     )
     assert.equal(
-      toKebab('http:options:/rpc/:rpcName'),
+      toSafeKebab('http:options:/rpc/:rpcName'),
       'http-options-rpc-rpc-name'
     )
   })
 
   test('sanitizes slashes', () => {
-    assert.equal(toKebab('http:get:/todos/:id'), 'http-get-todos-id')
+    assert.equal(toSafeKebab('http:get:/todos/:id'), 'http-get-todos-id')
   })
 
   test('collapses consecutive dashes', () => {
-    assert.equal(toKebab('a::b'), 'a-b')
-    assert.equal(toKebab('a://b'), 'a-b')
+    assert.equal(toSafeKebab('a::b'), 'a-b')
+    assert.equal(toSafeKebab('a://b'), 'a-b')
   })
 
   test('strips leading and trailing dashes', () => {
-    assert.equal(toKebab(':leadingColon'), 'leading-colon')
-    assert.equal(toKebab('/leadingSlash'), 'leading-slash')
+    assert.equal(toSafeKebab(':leadingColon'), 'leading-colon')
+    assert.equal(toSafeKebab('/leadingSlash'), 'leading-slash')
   })
 
   test('handles already kebab-case', () => {
-    assert.equal(toKebab('my-function'), 'my-function')
+    assert.equal(toSafeKebab('my-function'), 'my-function')
   })
 
   test('handles graph function IDs', () => {
     assert.equal(
-      toKebab('graphStart:todoReviewWorkflow:fetchOverdue'),
+      toSafeKebab('graphStart:todoReviewWorkflow:fetchOverdue'),
       'graph-start-todo-review-workflow-fetch-overdue'
     )
   })

--- a/packages/cli/src/deploy/analyzer/analyzer.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.ts
@@ -122,7 +122,7 @@ export function analyzeDeployment(
         handlers.push({ type: 'queue', queueName: queueMeta.name ?? queueName })
         queues.push({
           name: queueMeta.name ?? queueName,
-          consumerUnit: toKebab(funcId),
+          consumerUnit: toSafeKebab(funcId),
           consumerFunctionId: funcId,
         })
       }
@@ -139,7 +139,7 @@ export function analyzeDeployment(
         scheduledTasks.push({
           name: schedMeta.name,
           schedule: schedMeta.schedule,
-          unitName: toKebab(funcId),
+          unitName: toSafeKebab(funcId),
           functionId: funcId,
         })
       }
@@ -188,7 +188,7 @@ export function analyzeDeployment(
     }
 
     units.push({
-      name: toKebab(funcId),
+      name: toSafeKebab(funcId),
       role: 'function',
       target: resolveDeployTarget(funcMeta, serverlessIncompatible),
       functionIds: [funcId],
@@ -203,11 +203,13 @@ export function analyzeDeployment(
   for (const [agentName, agentMeta] of entries(state.agents.agentsMeta)) {
     const toolIds = agentMeta.tools ?? []
     const subAgentNames = agentMeta.agents ?? []
-    const unitName = `agent-${toKebab(agentName)}`
+    const unitName = `agent-${toSafeKebab(agentName)}`
 
     // Agent gateway depends on its tool function units
-    const toolUnitNames = toolIds.map((id) => toKebab(id))
-    const subAgentUnitNames = subAgentNames.map((sa) => `agent-${toKebab(sa)}`)
+    const toolUnitNames = toolIds.map((id) => toSafeKebab(id))
+    const subAgentUnitNames = subAgentNames.map(
+      (sa) => `agent-${toSafeKebab(sa)}`
+    )
 
     // Agent needs AI services
     const agentServices: ServiceRequirement[] = [
@@ -285,7 +287,7 @@ export function analyzeDeployment(
   const allMcpIds = [...mcpToolIds, ...mcpResourceIds, ...mcpPromptIds]
   if (allMcpIds.length > 0) {
     const unitName = 'mcp-server'
-    const mcpFuncUnitNames = allMcpIds.map((id) => toKebab(id))
+    const mcpFuncUnitNames = allMcpIds.map((id) => toSafeKebab(id))
 
     units.push({
       name: unitName,
@@ -311,8 +313,8 @@ export function analyzeDeployment(
     const funcIds = collectChannelFunctionIds(channelMeta)
     if (funcIds.length === 0) continue
 
-    const unitName = `channel-${toKebab(channelName)}`
-    const funcUnitNames = funcIds.map((id) => toKebab(id))
+    const unitName = `channel-${toSafeKebab(channelName)}`
+    const funcUnitNames = funcIds.map((id) => toSafeKebab(id))
 
     units.push({
       name: unitName,
@@ -455,7 +457,7 @@ function buildWorkflows(
       if ('flow' in node) continue
       if (!('rpcName' in node)) continue
 
-      const stepUnitName = toKebab(node.rpcName)
+      const stepUnitName = toSafeKebab(node.rpcName)
       const isAsync = node.options?.async === true
       const isInline = !isAsync && graph.inline === true
 
@@ -470,7 +472,7 @@ function buildWorkflows(
     }
 
     // Build orchestrator unit — no function code, just orchestration
-    const orchUnitName = `wf-${toKebab(graph.name)}`
+    const orchUnitName = `wf-${toSafeKebab(graph.name)}`
     const orchServices: ServiceRequirement[] = [
       { capability: 'workflow-state', sourceServiceName: 'workflowService' },
       { capability: 'queue', sourceServiceName: 'queueService' },
@@ -501,7 +503,7 @@ function buildWorkflows(
     ]
 
     // Orchestrator queue — the orchestrator consumes from this
-    const orchQueueName = `wf-orchestrator-${toKebab(graph.name)}`
+    const orchQueueName = `wf-orchestrator-${toSafeKebab(graph.name)}`
     const orchHandlers: DeploymentHandler[] = [
       { type: 'fetch', routes: wfRoutes },
       { type: 'queue', queueName: orchQueueName },
@@ -529,11 +531,11 @@ function buildWorkflows(
     // create queue definitions here. Step 7 wires them to units.
     for (const step of steps) {
       if (step.inline || !step.functionId) continue
-      const stepQueueName = `wf-step-${toKebab(step.functionId)}`
+      const stepQueueName = `wf-step-${toSafeKebab(step.functionId)}`
 
       queues.push({
         name: stepQueueName,
-        consumerUnit: toKebab(step.functionId),
+        consumerUnit: toSafeKebab(step.functionId),
         consumerFunctionId: `pikkuWorkflowWorker:${step.functionId}`,
       })
     }
@@ -661,7 +663,7 @@ function collectChannelFunctionIds(channelMeta: ChannelMeta): string[] {
 // Naming helpers
 // ---------------------------------------------------------------------------
 
-export function toKebab(str: string): string {
+export function toSafeKebab(str: string): string {
   return str
     .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
     .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')

--- a/packages/cli/src/deploy/analyzer/analyzer.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.ts
@@ -661,10 +661,13 @@ function collectChannelFunctionIds(channelMeta: ChannelMeta): string[] {
 // Naming helpers
 // ---------------------------------------------------------------------------
 
-function toKebab(str: string): string {
+export function toKebab(str: string): string {
   return str
     .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
     .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .replace(/[:/\\]/g, '-')
+    .replace(/--+/g, '-')
+    .replace(/^-|-$/g, '')
     .toLowerCase()
 }
 

--- a/packages/cli/src/deploy/codegen/per-unit-codegen.ts
+++ b/packages/cli/src/deploy/codegen/per-unit-codegen.ts
@@ -21,6 +21,7 @@ import type {
   DeploymentManifest,
   DeploymentUnit,
 } from '../analyzer/manifest.js'
+import { toSafeKebab } from '../analyzer/analyzer.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -160,13 +161,11 @@ function collectFilterNames(
         names.add('http:get:/workflow/:workflowName/status/:runId/stream')
         names.add('http:post:/workflow/:workflowName/graph/:nodeId')
         // Queue names for orchestrator and step workers
-        const toKebab = (s: string) =>
-          s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
-        names.add(`wf-orchestrator-${toKebab(wfDef.name)}`)
+        names.add(`wf-orchestrator-${toSafeKebab(wfDef.name)}`)
         for (const step of wfDef.steps) {
           if (step.functionId) {
             names.add(step.functionId)
-            names.add(`wf-step-${toKebab(step.functionId)}`)
+            names.add(`wf-step-${toSafeKebab(step.functionId)}`)
           }
         }
       }


### PR DESCRIPTION
## Summary
- `toKebab` now handles `:`, `/`, `\` by replacing with dashes
- Collapses consecutive dashes and strips leading/trailing dashes
- e.g. `graphStart:todoReviewWorkflow:fetchOverdue` → `graph-start-todo-review-workflow-fetch-overdue`

Fixes #430

## Test plan
- [x] 8 unit tests for toKebab covering camelCase, PascalCase, colons, slashes, edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)