### PR TITLE
fix(inspector): capture `deploy` field from function options

### DIFF
--- a/.changeset/inspector-deploy-field.md
+++ b/.changeset/inspector-deploy-field.md
@@ -1,0 +1,13 @@
+---
+'@pikku/inspector': patch
+---
+
+Inspector now captures the `deploy: 'serverless' | 'server' | 'auto'` option
+from `pikkuFunc` / `pikkuSessionlessFunc` calls, alongside the other runtime
+metadata (`expose`, `remote`, `mcp`, `readonly`, `approvalRequired`).
+
+Previously this field was defined on `FunctionRuntimeMeta` but never read
+from the user's source, so `deploy: 'server'` was silently dropped. That
+left downstream consumers — notably `@pikku/cli`'s deployment analyzer,
+which routes server-targeted functions to a container unit — treating
+every function as `serverless` regardless of its declared intent.

--- a/packages/inspector/src/add/add-functions.ts
+++ b/packages/inspector/src/add/add-functions.ts
@@ -339,6 +339,7 @@ export const addFunctions: AddWiring = (
   let remote: boolean | undefined
   let mcp: boolean | undefined
   let readonly_: boolean | undefined
+  let deploy: 'serverless' | 'server' | 'auto' | undefined
   let approvalRequired: boolean | undefined
   let approvalDescription: string | undefined
   let version: number | undefined
@@ -422,6 +423,11 @@ export const addFunctions: AddWiring = (
     remote = getPropertyValue(firstArg, 'remote') as boolean | undefined
     mcp = getPropertyValue(firstArg, 'mcp') as boolean | undefined
     readonly_ = getPropertyValue(firstArg, 'readonly') as boolean | undefined
+    deploy = getPropertyValue(firstArg, 'deploy') as
+      | 'serverless'
+      | 'server'
+      | 'auto'
+      | undefined
     approvalRequired = getPropertyValue(firstArg, 'approvalRequired') as
       | boolean
       | undefined
@@ -783,6 +789,7 @@ export const addFunctions: AddWiring = (
     remote: remote || undefined,
     mcp: mcpEnabled || undefined,
     readonly: readonly_ || undefined,
+    deploy: deploy || undefined,
     approvalRequired: approvalRequired || undefined,
     approvalDescription: approvalDescription || undefined,
     version,
@@ -817,9 +824,7 @@ export const addFunctions: AddWiring = (
 
   if (mcpEnabled) {
     if (!description) {
-      logger.warn(
-        `MCP tool '${name}' is missing a description.`
-      )
+      logger.warn(`MCP tool '${name}' is missing a description.`)
     }
     state.mcpEndpoints.files.add(node.getSourceFile().fileName)
     state.mcpEndpoints.toolsMeta[name] = {


### PR DESCRIPTION
## Summary

- Inspector's `addFunctions` now reads the `deploy` option from `pikkuFunc` / `pikkuSessionlessFunc` calls alongside the other runtime flags.
- Threads the value through into `pikku-functions-meta.gen.json` so downstream consumers (notably `@pikku/cli`'s `resolveDeployTarget`) see it.
- Changeset added.

## The bug

`FunctionRuntimeMeta` already types `deploy?: 'serverless' | 'server' | 'auto'` (see `packages/core/src/types/core.types.ts`). `@pikku/cli`'s `resolveDeployTarget` checks `funcMeta.deploy === 'server'` to route a function to the container-unit branch of the build pipeline (`packages/cli/src/deploy/analyzer/analyzer.ts`).

But `packages/inspector/src/add/add-functions.ts` never read the field out of user source. So the value was always \`undefined\` in the emitted meta, and every function was silently treated as \`serverless\` — even when the author wrote \`deploy: 'server'\` explicitly.

## Repro

\`\`\`ts
export const helloContainer = pikkuSessionlessFunc({
  deploy: 'server',
  func: async () => ({ ok: true }),
})
\`\`\`

Before this fix: \`pikku-functions-meta.gen.json\` has no \`deploy\` field, and \`pikku deploy plan --provider cloudflare\` emits it as a serverless Worker unit (\`target: 'serverless'\`) instead of routing it to the merged container unit.

After: the meta carries \`"deploy": "server"\`, the analyzer sees it, and the build pipeline emits the \`server/\` + \`server-proxy/\` artifacts as intended.

## Test plan

- [ ] Run \`pikku all\` against a project with a function marked \`deploy: 'server'\`; verify \`deploy\` appears in the generated meta.
- [ ] Run \`pikku deploy plan\` with an adapter that handles server-targeted units; verify the function lands in a container unit (\`server/Dockerfile\` + \`server-proxy/wrangler.toml\` emitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The inspector now correctly captures and preserves the deployment mode option (serverless, server, or auto) specified in function declarations. Previously, this configuration was not being read from user source code and was being lost, causing functions to incorrectly default to serverless behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->