### PR TITLE
feat(assistant-ui): toolComponents prop for per-tool custom rendering

### DIFF
--- a/.changeset/assistant-ui-tool-components.md
+++ b/.changeset/assistant-ui-tool-components.md
@@ -1,0 +1,27 @@
+---
+'@pikku/assistant-ui': patch
+---
+
+`PikkuAgentChat` now accepts a `toolComponents` prop — a map of
+`toolName` → React component — for per-tool custom rendering inside
+the assistant bubble. Unmatched tool calls continue to fall through to
+the default expandable tool-call display.
+
+This unlocks generative-UI patterns: register a `renderWidget` tool on
+the agent, return structured props from it, and mount real UI (charts,
+diffs, cards) inline in the chat from the persisted tool-call args.
+Because the rendered widget is just a tool call under the hood, it
+survives refresh, streams correctly, and stays part of the thread's
+history.
+
+```tsx
+<PikkuAgentChat
+  agentName="myAgent"
+  threadId={threadId}
+  resourceId={userId}
+  api="/rpc/agent"
+  toolComponents={{
+    renderWidget: ({ args }) => <WidgetRegistry spec={args} />,
+  }}
+/>
+```

--- a/packages/assistant-ui/src/pikku-agent-chat.tsx
+++ b/packages/assistant-ui/src/pikku-agent-chat.tsx
@@ -5,6 +5,7 @@ import {
   ThreadPrimitive,
   MessagePrimitive,
   ComposerPrimitive,
+  type ToolCallMessagePartComponent,
 } from '@assistant-ui/react'
 import {
   usePikkuAgentRuntime,
@@ -25,6 +26,17 @@ export interface PikkuAgentChatProps extends PikkuAgentRuntimeOptions {
   dark?: boolean
   /** Max width of the chat content area. Defaults to 768. Set to 'none' for full width. */
   maxWidth?: number | 'none'
+  /**
+   * Per-tool renderers. Map `toolName` → React component to replace the
+   * default expandable tool-call box for that tool. Enables generative-UI
+   * patterns: e.g. register a `renderWidget` tool on the agent and mount
+   * real UI (charts, diffs, cards) inline in the assistant bubble from the
+   * persisted tool-call args.
+   *
+   * Any tool without an entry here falls through to the default renderer
+   * (which still respects `hideToolCalls` and the approval-request UI).
+   */
+  toolComponents?: Record<string, ToolCallMessagePartComponent>
 }
 
 interface ChatColors {
@@ -92,6 +104,9 @@ const darkColors: ChatColors = {
 
 const ColorsContext = createContext<ChatColors>(lightColors)
 const HideToolCallsContext = createContext<boolean | string[] | undefined>(undefined)
+const ToolComponentsContext = createContext<
+  Record<string, ToolCallMessagePartComponent> | undefined
+>(undefined)
 
 function shouldHideToolCall(
   hideToolCalls: boolean | string[] | undefined,
@@ -470,6 +485,7 @@ const UserMessage: FunctionComponent = () => {
 
 const AssistantMessage: FunctionComponent = () => {
   const colors = useContext(ColorsContext)
+  const toolComponents = useContext(ToolComponentsContext)
   return (
     <div
       style={{
@@ -495,6 +511,7 @@ const AssistantMessage: FunctionComponent = () => {
                 <MarkdownText text={text} colors={colors} />
               ),
               tools: {
+                by_name: toolComponents,
                 Fallback: (props) => (
                   <ToolCallDisplay
                     toolCallId={props.toolCallId}
@@ -592,7 +609,7 @@ const PikkuComposer: FunctionComponent<{ disabled?: boolean }> = ({
 }
 
 export function PikkuAgentChat(props: PikkuAgentChatProps) {
-  const { emptyMessage, hideToolCalls, dark, maxWidth = 768, ...runtimeOptions } = props
+  const { emptyMessage, hideToolCalls, dark, maxWidth = 768, toolComponents, ...runtimeOptions } = props
   const { runtime, isAwaitingApproval, pendingApprovals, handleApproval } =
     usePikkuAgentRuntime(runtimeOptions)
 
@@ -602,6 +619,7 @@ export function PikkuAgentChat(props: PikkuAgentChatProps) {
     <ColorsContext.Provider value={colors}>
     <PikkuApprovalContext.Provider value={{ pendingApprovals, handleApproval }}>
     <HideToolCallsContext.Provider value={hideToolCalls}>
+    <ToolComponentsContext.Provider value={toolComponents}>
     <AssistantRuntimeProvider runtime={runtime}>
       <div
         style={{
@@ -668,6 +686,7 @@ export function PikkuAgentChat(props: PikkuAgentChatProps) {
         </ThreadPrimitive.Root>
       </div>
     </AssistantRuntimeProvider>
+    </ToolComponentsContext.Provider>
     </HideToolCallsContext.Provider>
     </PikkuApprovalContext.Provider>
     </ColorsContext.Provider>


### PR DESCRIPTION
## Summary

- `PikkuAgentChat` now accepts a `toolComponents` map (`toolName` → React component) for per-tool custom rendering inside the assistant bubble.
- Unmatched tool calls still fall through to the existing expandable tool-call display and keep respecting `hideToolCalls` + approval UI.
- Unlocks generative-UI patterns: e.g. register a `renderWidget` tool on the agent, respond via tool call instead of prose, mount widgets (charts, diffs, cards) inline from the persisted args. Streams correctly, survives refresh, part of thread history.

```tsx
<PikkuAgentChat
  agentName="myAgent"
  threadId={threadId}
  resourceId={userId}
  api="/rpc/agent"
  toolComponents={{
    renderWidget: ({ args }) => <WidgetRegistry spec={args} />,
  }}
/>
```

## Test plan

- [ ] `yarn tsc` in `packages/assistant-ui` — verified clean locally
- [ ] Visual check: existing Fallback renderer still works for tools without a `toolComponents` entry
- [ ] Visual check: a registered tool name renders the supplied component instead of the Fallback
- [ ] Approval UI still engages for tools with `needsApproval`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom tool component rendering now available. The new `toolComponents` prop enables mapping tool names to custom React components for specialized rendering. Tools with custom components render using those components, while tools without mappings automatically fall back to the standard expandable display, preserving backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->