### PR TITLE
fix(console): show empty-state UI when no agents or workflows exist

### DIFF
--- a/.changeset/console-empty-state-ux.md
+++ b/.changeset/console-empty-state-ux.md
@@ -1,0 +1,5 @@
+---
+'@pikku/console': patch
+---
+
+Show the empty-state placeholder on `AgentsPage` and `WorkflowPage` when the project has no agents or workflows, instead of rendering the panel layout with a blank detail pane. Placeholder also gets a `minHeight` so it renders consistently.

--- a/.changeset/standalone-express-ws.md
+++ b/.changeset/standalone-express-ws.md
@@ -1,0 +1,13 @@
+---
+'@pikku/deploy-standalone': patch
+'@pikku/express': patch
+---
+
+Switch standalone deploy from uWebSockets.js to Express + ws
+
+- Replace PikkuUWSServer with PikkuExpressServer in generated entry
+- Add WebSocket support via ws + pikkuWebsocketHandler
+- Remove pkg binary compilation — ship bundle.js directly
+- Remove native module (uws .node) handling
+- Add loadSchemas: false to avoid global state resolution issues
+- Add getHttpServer() to PikkuExpressServer for ws attachment

--- a/packages/console/src/components/layout/EmptyStatePlaceholder.tsx
+++ b/packages/console/src/components/layout/EmptyStatePlaceholder.tsx
@@ -20,6 +20,7 @@ export const EmptyStatePlaceholder: React.FunctionComponent<
       gap="md"
       className={classes.emptyState}
       py="xl"
+      style={{ minHeight: '60vh' }}
     >
       <Icon size={48} strokeWidth={1} />
       <Text size="xl" fw={600}>

--- a/packages/console/src/pages/AgentsPage.tsx
+++ b/packages/console/src/pages/AgentsPage.tsx
@@ -125,6 +125,13 @@ const AgentDetailView: React.FunctionComponent<{ agentId: string }> = ({
 export const AgentsPage: React.FunctionComponent = () => {
   const [searchParams] = useSearchParams()
   const agentId = searchParams.get('id')
+  const { meta, loading } = usePikkuMeta()
+
+  const hasAgents = !loading && meta.agentsMeta && Object.keys(meta.agentsMeta).length > 0
+
+  if (!agentId && !hasAgents) {
+    return <AgentsList />
+  }
 
   return (
     <PanelProvider>

--- a/packages/console/src/pages/WorkflowPage.tsx
+++ b/packages/console/src/pages/WorkflowPage.tsx
@@ -28,6 +28,18 @@ function WorkflowPageInner() {
     )
   }
 
+  const workflows = meta.workflows || {}
+  const hasWorkflows = Object.keys(workflows).length > 0 || (aiWorkflows && aiWorkflows.length > 0)
+
+  if (!hasWorkflows) {
+    return (
+      <WorkflowsList
+        workflows={workflows}
+        aiWorkflows={aiWorkflows as any}
+      />
+    )
+  }
+
   return (
     <PanelProvider>
       <ResizablePanelLayout
@@ -41,7 +53,7 @@ function WorkflowPageInner() {
         hidePanel
       >
         <WorkflowsList
-          workflows={meta.workflows || {}}
+          workflows={workflows}
           aiWorkflows={aiWorkflows as any}
         />
       </ResizablePanelLayout>


### PR DESCRIPTION
## Summary

When a project has no agents or workflows, \`AgentsPage\` and \`WorkflowPage\` were rendering the panel layout with a blank detail area. This PR short-circuits to the list view — which already has an empty-state placeholder — when there's nothing to select.

Also gives \`EmptyStatePlaceholder\` a \`minHeight: 60vh\` so it renders consistently instead of collapsing against surrounding layout.

### Changes
- \`packages/console/src/pages/AgentsPage.tsx\` — render \`AgentsList\` when no \`agentId\` and no agents in \`meta.agentsMeta\`
- \`packages/console/src/pages/WorkflowPage.tsx\` — render \`WorkflowsList\` when no workflows (meta or AI workflows)
- \`packages/console/src/components/layout/EmptyStatePlaceholder.tsx\` — add \`minHeight: 60vh\`

## Test plan

- [ ] Fresh project (no agents/workflows) shows the empty-state placeholder on both pages
- [ ] Project with items still shows the panel layout
- [ ] Placeholder is vertically centered and sized consistently