### PR TITLE
feat(cli): add pikku dev command (all-in-one local dev server)

### DIFF
--- a/.changeset/pikku-dev-command.md
+++ b/.changeset/pikku-dev-command.md
@@ -1,5 +1,5 @@
 ---
-'@pikku/cli': minor
+'@pikku/cli': patch
 ---
 
 Add `pikku dev` command: an all-in-one local development server that wires

--- a/.changeset/pikku-dev-command.md
+++ b/.changeset/pikku-dev-command.md
@@ -1,0 +1,13 @@
+---
+'@pikku/cli': minor
+---
+
+Add `pikku dev` command: an all-in-one local development server that wires
+an HTTP + WebSocket server with in-memory scheduler, queue, workflow,
+trigger, and AI run-state services. Supports file watching with
+regeneration and hot module reload.
+
+Options:
+- `--port, -p` (default `3000`)
+- `--watch` (default `true`)
+- `--hmr` (default `true`)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,8 @@
     "@pikku/deploy-cloudflare": "^0.12.0",
     "@pikku/inspector": "^0.12.9",
     "@pikku/openapi-parser": "^0.12.10",
+    "@pikku/schedule": "^0.12.0",
+    "@pikku/ws": "^0.12.2",
     "@types/cookie": "^1.0.0",
     "@types/json-schema": "^7.0.15",
     "chalk": "^5.6.2",
@@ -47,7 +49,9 @@
     "zod-to-ts": "^2.0.0"
   },
   "devDependencies": {
-    "@types/node": "^24.11.0"
+    "@types/node": "^24.11.0",
+    "@types/ws": "^8",
+    "ws": "^8.18.0"
   },
   "files": [
     "dist",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,14 +44,14 @@
     "ts-json-schema-generator": "^2.5.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9",
+    "ws": "^8.18.0",
     "yaml": "^2.8.2",
     "zod": "^4.3.6",
     "zod-to-ts": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "^24.11.0",
-    "@types/ws": "^8",
-    "ws": "^8.18.0"
+    "@types/ws": "^8"
   },
   "files": [
     "dist",

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -11,6 +11,7 @@ import { all } from './functions/commands/all.js'
 import { bootstrap } from './functions/commands/bootstrap.js'
 import { watch } from './functions/commands/watch.js'
 import { consoleCommand } from './functions/commands/console.js'
+import { dev } from './functions/commands/dev.js'
 import { pikkuVersionsInit } from './functions/commands/versions-init.js'
 import { pikkuVersionsCheck } from './functions/commands/versions-check.js'
 import { pikkuVersionsUpdate } from './functions/commands/versions-update.js'
@@ -113,6 +114,26 @@ wireCLI({
         hmr: {
           description: 'Enable hot module reload for registered functions',
           default: false,
+        },
+      },
+    }),
+    dev: pikkuCLICommand({
+      func: dev,
+      description:
+        'Start a local development server with all services wired',
+      options: {
+        port: {
+          description: 'Port for the dev server',
+          default: '3000',
+          short: 'p',
+        },
+        watch: {
+          description: 'Watch for file changes and regenerate',
+          default: true,
+        },
+        hmr: {
+          description: 'Enable hot module reload',
+          default: true,
         },
       },
     }),

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -1,0 +1,237 @@
+import { createServer, type ServerResponse, type IncomingMessage } from 'http'
+import { join, resolve } from 'path'
+import { Readable } from 'stream'
+
+import { pikkuSessionlessFunc } from '#pikku'
+import chokidar from 'chokidar'
+import { pikkuDevReloader } from '@pikku/core/dev'
+import {
+  ConsoleLogger,
+  InMemoryQueueService,
+  InMemoryWorkflowService,
+  InMemoryTriggerService,
+  InMemoryAIRunStateService,
+} from '@pikku/core/services'
+import { stopSingletonServices } from '@pikku/core'
+import {
+  fetchData,
+  PikkuFetchHTTPResponse,
+  logRoutes,
+} from '@pikku/core/http'
+import { compileAllSchemas } from '@pikku/core/schema'
+import { pikkuWebsocketHandler } from '@pikku/ws'
+import { WebSocketServer } from 'ws'
+import { InMemorySchedulerService } from '@pikku/schedule'
+
+function incomingMessageToRequest(req: IncomingMessage): Request {
+  const url = new URL(req.url || '/', 'http://localhost')
+  const method = req.method ? req.method.toUpperCase() : 'GET'
+  const headers = new Headers()
+
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value) {
+      headers.set(key, Array.isArray(value) ? value.join(', ') : value)
+    }
+  }
+
+  let body: BodyInit | null = null
+  if (method !== 'GET' && method !== 'HEAD') {
+    body = Readable.toWeb(req) as unknown as BodyInit
+  }
+
+  return new Request(url.toString(), {
+    method,
+    headers,
+    body,
+    // @ts-ignore - duplex is needed for streaming body in Node.js
+    duplex: 'half',
+  })
+}
+
+async function writeResponse(
+  nodeRes: ServerResponse,
+  webResponse: Response
+): Promise<void> {
+  const headers: Record<string, string | string[]> = {}
+  webResponse.headers.forEach((value, name) => {
+    const lower = name.toLowerCase()
+    if (lower === 'set-cookie') {
+      const existing = headers[lower]
+      if (Array.isArray(existing)) {
+        existing.push(value)
+      } else {
+        headers[lower] = [value]
+      }
+    } else {
+      headers[lower] = value
+    }
+  })
+
+  nodeRes.writeHead(webResponse.status, headers)
+
+  if (webResponse.body) {
+    const reader = webResponse.body.getReader()
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        nodeRes.write(value)
+      }
+    } finally {
+      reader.releaseLock()
+    }
+  }
+
+  nodeRes.end()
+}
+
+export const dev = pikkuSessionlessFunc<
+  { port?: string; watch?: boolean; hmr?: boolean },
+  void
+>({
+  remote: true,
+  func: async (
+    { logger, config, getInspectorState },
+    { port, watch, hmr },
+    { rpc }
+  ) => {
+    const resolvedPort = parseInt(port || '3000', 10)
+    const hostname = 'localhost'
+    const enableWatch = watch !== false
+    const enableHmr = hmr !== false
+
+    await rpc.invoke('all')
+
+    const inspectorState = await getInspectorState(true)
+    const { pikkuConfigFactory, singletonServicesFactory } =
+      inspectorState.filesAndMethods
+
+    if (!pikkuConfigFactory || !singletonServicesFactory) {
+      logger.error(
+        'createConfig and createSingletonServices must be defined in your project'
+      )
+      return
+    }
+
+    const pikkuDir = resolve(config.rootDir, config.outDir)
+    const bootstrapPath = join(pikkuDir, 'pikku-bootstrap.gen.js')
+    await import(bootstrapPath)
+
+    const configModule = await import(pikkuConfigFactory.file)
+    const servicesModule = await import(singletonServicesFactory.file)
+    const userCreateConfig = configModule[pikkuConfigFactory.variable]
+    const userCreateSingletonServices =
+      servicesModule[singletonServicesFactory.variable]
+
+    const userConfig = await userCreateConfig()
+
+    const schedulerService = new InMemorySchedulerService()
+    const inMemoryServices = {
+      logger: new ConsoleLogger(),
+      schedulerService,
+      queueService: new InMemoryQueueService(),
+      workflowService: new InMemoryWorkflowService(),
+      triggerService: new InMemoryTriggerService(),
+      aiRunStateService: new InMemoryAIRunStateService(),
+    }
+
+    await userCreateSingletonServices(userConfig, inMemoryServices)
+
+    compileAllSchemas(logger)
+    logRoutes(logger)
+
+    const server = createServer(async (req, res) => {
+      const request = incomingMessageToRequest(req)
+      const pikkuResponse = new PikkuFetchHTTPResponse()
+      await fetchData(request, pikkuResponse, { respondWith404: true })
+      const response = pikkuResponse.toResponse()
+      await writeResponse(res, response)
+    })
+
+    const wss = new WebSocketServer({ noServer: true })
+    pikkuWebsocketHandler({ server, wss, logger })
+
+    await schedulerService.start()
+
+    await new Promise<void>((resolve) => {
+      server.listen(resolvedPort, hostname, () => {
+        logger.info(
+          `Dev server running at http://${hostname}:${resolvedPort}`
+        )
+        resolve()
+      })
+    })
+
+    process.removeAllListeners('SIGINT').on('SIGINT', async () => {
+      logger.info('Stopping dev server...')
+      await stopSingletonServices()
+      wss.close()
+      server.close()
+      process.exit(0)
+    })
+
+    if (enableHmr) {
+      await pikkuDevReloader({
+        srcDirectories: config.srcDirectories,
+        logger,
+      })
+    }
+
+    if (enableWatch) {
+      const configWatcher = chokidar.watch(config.srcDirectories, {
+        ignoreInitial: true,
+        ignored: /.*\.gen\.tsx?/,
+      })
+
+      let watcher = new chokidar.FSWatcher({})
+
+      const generatorWatcher = () => {
+        watcher.close()
+
+        logger.info(
+          `• Watching directories: \n  - ${config.srcDirectories.join('\n  - ')}`
+        )
+        watcher = chokidar.watch(config.srcDirectories, {
+          ignoreInitial: true,
+          ignored: /.*\.gen\.ts/,
+        })
+
+        watcher.on('ready', async () => {
+          const handle = async () => {
+            try {
+              const start = Date.now()
+              await rpc.invoke('all')
+              logger.info({
+                message: `✓ Generated in ${Date.now() - start}ms`,
+                type: 'timing',
+              })
+            } catch (err) {
+              console.error(err)
+              logger.error('Error running watch')
+            }
+          }
+
+          await handle()
+
+          let timeout: ReturnType<typeof setTimeout> | undefined
+
+          const deduped = (_file: string) => {
+            if (timeout) {
+              clearTimeout(timeout)
+            }
+            timeout = setTimeout(handle, 10)
+          }
+
+          watcher.on('change', deduped)
+          watcher.on('add', deduped)
+          watcher.on('unlink', deduped)
+        })
+      }
+
+      configWatcher.on('ready', generatorWatcher)
+      configWatcher.on('change', generatorWatcher)
+    }
+
+    await new Promise(() => {})
+  },
+})

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -3,7 +3,7 @@ import { join, resolve } from 'path'
 import { Readable } from 'stream'
 
 import { pikkuSessionlessFunc } from '#pikku'
-import chokidar from 'chokidar'
+import chokidar, { type FSWatcher } from 'chokidar'
 import { pikkuDevReloader } from '@pikku/core/dev'
 import {
   ConsoleLogger,
@@ -13,6 +13,7 @@ import {
   InMemoryAIRunStateService,
 } from '@pikku/core/services'
 import { stopSingletonServices } from '@pikku/core'
+import { pikkuState } from '@pikku/core/internal'
 import {
   fetchData,
   PikkuFetchHTTPResponse,
@@ -135,7 +136,11 @@ export const dev = pikkuSessionlessFunc<
       aiRunStateService: new InMemoryAIRunStateService(),
     }
 
-    await userCreateSingletonServices(userConfig, inMemoryServices)
+    const singletonServices = await userCreateSingletonServices(
+      userConfig,
+      inMemoryServices
+    )
+    pikkuState(null, 'package', 'singletonServices', singletonServices)
 
     compileAllSchemas(logger)
     logRoutes(logger)
@@ -162,12 +167,24 @@ export const dev = pikkuSessionlessFunc<
       })
     })
 
-    process.removeAllListeners('SIGINT').on('SIGINT', async () => {
+    let configWatcher: FSWatcher | undefined
+    let watcher: FSWatcher | undefined
+
+    process.once('SIGINT', async () => {
       logger.info('Stopping dev server...')
-      await stopSingletonServices()
-      wss.close()
-      server.close()
-      process.exit(0)
+      try {
+        await stopSingletonServices()
+        await configWatcher?.close()
+        await watcher?.close()
+        await new Promise<void>((resolve, reject) =>
+          wss.close((err) => (err ? reject(err) : resolve()))
+        )
+        await new Promise<void>((resolve, reject) =>
+          server.close((err) => (err ? reject(err) : resolve()))
+        )
+      } finally {
+        process.exit(0)
+      }
     })
 
     if (enableHmr) {
@@ -178,22 +195,22 @@ export const dev = pikkuSessionlessFunc<
     }
 
     if (enableWatch) {
-      const configWatcher = chokidar.watch(config.srcDirectories, {
+      const genIgnore = /\.gen\.tsx?$/
+
+      configWatcher = chokidar.watch(config.srcDirectories, {
         ignoreInitial: true,
-        ignored: /.*\.gen\.tsx?/,
+        ignored: genIgnore,
       })
 
-      let watcher = new chokidar.FSWatcher({})
-
       const generatorWatcher = () => {
-        watcher.close()
+        watcher?.close()
 
         logger.info(
           `• Watching directories: \n  - ${config.srcDirectories.join('\n  - ')}`
         )
         watcher = chokidar.watch(config.srcDirectories, {
           ignoreInitial: true,
-          ignored: /.*\.gen\.ts/,
+          ignored: genIgnore,
         })
 
         watcher.on('ready', async () => {
@@ -206,8 +223,7 @@ export const dev = pikkuSessionlessFunc<
                 type: 'timing',
               })
             } catch (err) {
-              console.error(err)
-              logger.error('Error running watch')
+              logger.error(`Error running watch: ${err}`)
             }
           }
 
@@ -222,9 +238,9 @@ export const dev = pikkuSessionlessFunc<
             timeout = setTimeout(handle, 10)
           }
 
-          watcher.on('change', deduped)
-          watcher.on('add', deduped)
-          watcher.on('unlink', deduped)
+          watcher?.on('change', deduped)
+          watcher?.on('add', deduped)
+          watcher?.on('unlink', deduped)
         })
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5307,9 +5307,12 @@ __metadata:
     "@pikku/deploy-cloudflare": "npm:^0.12.0"
     "@pikku/inspector": "npm:^0.12.9"
     "@pikku/openapi-parser": "npm:^0.12.10"
+    "@pikku/schedule": "npm:^0.12.0"
+    "@pikku/ws": "npm:^0.12.2"
     "@types/cookie": "npm:^1.0.0"
     "@types/json-schema": "npm:^7.0.15"
     "@types/node": "npm:^24.11.0"
+    "@types/ws": "npm:^8"
     chalk: "npm:^5.6.2"
     chokidar: "npm:^4.0.3"
     esbuild: "npm:~0.27.0"
@@ -5320,6 +5323,7 @@ __metadata:
     ts-json-schema-generator: "npm:^2.5.0"
     tsx: "npm:^4.21.0"
     typescript: "npm:^5.9"
+    ws: "npm:^8.18.0"
     yaml: "npm:^2.8.2"
     zod: "npm:^4.3.6"
     zod-to-ts: "npm:^2.0.0"
@@ -5832,7 +5836,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pikku/schedule@npm:^0.12.2, @pikku/schedule@workspace:packages/schedule":
+"@pikku/schedule@npm:^0.12.0, @pikku/schedule@npm:^0.12.2, @pikku/schedule@workspace:packages/schedule":
   version: 0.0.0-use.local
   resolution: "@pikku/schedule@workspace:packages/schedule"
   dependencies:


### PR DESCRIPTION
## Summary

Closes #490 (supersedes #502)

Adds a \`pikku dev\` CLI command that runs a local development server with all services pre-wired — HTTP, WebSockets, scheduler, queue, workflows, triggers, and AI run-state — backed by in-memory implementations. No need to stand up Redis/Postgres/BullMQ to iterate on functions locally.

**Why a new PR instead of #502:** the original branch (\`feature/490-pikku-dev-command\`) carried 16 unmerged workflow-DSL refactor commits that broke the CI \`Build\` step (strict DSL extraction rejects the \`typeGenerators.push(...)\` pattern in \`allWorkflow\`). This branch cherry-picks only the dev command on top of main, so it ships cleanly. The DSL refactor remains on the original branch for a separate PR.

### What's wired
- HTTP server via Node's \`http\` with \`fetchData\` bridge
- WebSocket server via \`@pikku/ws\` (\`pikkuWebsocketHandler\` + \`ws\`)
- In-memory services: \`InMemorySchedulerService\`, \`InMemoryQueueService\`, \`InMemoryWorkflowService\`, \`InMemoryTriggerService\`, \`InMemoryAIRunStateService\`
- Hot-module reload via \`pikkuDevReloader\`
- File watching: re-runs \`pikku all\` on src changes (debounced)
- Graceful shutdown on SIGINT

### Options
- \`--port, -p\` (default \`3000\`)
- \`--watch\` (default \`true\`)
- \`--hmr\` (default \`true\`)

### Also
- Adds \`@pikku/schedule\` and \`@pikku/ws\` as CLI runtime deps
- Adds \`ws\` + \`@types/ws\` as CLI devDependencies
- Adds a \`@pikku/cli\` minor changeset

## Test plan

- [ ] \`pikku dev\` starts on port 3000, logs routes
- [ ] HTTP requests hit functions correctly
- [ ] WebSocket connections upgrade and route to channel handlers
- [ ] Scheduler runs cron jobs in-memory
- [ ] Editing a \`.func.ts\` file triggers regeneration + HMR
- [ ] SIGINT shuts everything down cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pikku dev` command to run an all-in-one local dev server.
  * Server now includes HTTP + WebSocket support for local development.
  * File watching with regeneration and hot module reload (HMR) enabled by default.
  * New CLI options: `--port`/`-p` (default 3000), `--watch` (default true), `--hmr` (default true)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->