### PR TITLE
fix(inspector): critical on duplicate function names

### DIFF
--- a/.changeset/curvy-bananas-rule.md
+++ b/.changeset/curvy-bananas-rule.md
@@ -1,0 +1,5 @@
+---
+'@pikku/inspector': patch
+---
+
+Log a critical inspector error when multiple functions resolve to the same `pikku` function name, instead of silently allowing routing map collisions.

--- a/.changeset/curvy-bananas-rule.md
+++ b/.changeset/curvy-bananas-rule.md
@@ -2,4 +2,4 @@
 '@pikku/inspector': patch
 ---
 
-Log a critical inspector error when multiple functions resolve to the same `pikku` function name, instead of silently allowing routing map collisions.
+Log a critical inspector error when multiple functions resolve to the same `pikku` function name, instead of silently allowing routing map collisions. This may cause builds to fail if multiple functions previously resolved to the same `pikku` function name.

--- a/packages/cli/src/functions/wirings/channels/pikku-command-channels.ts
+++ b/packages/cli/src/functions/wirings/channels/pikku-command-channels.ts
@@ -8,7 +8,10 @@ import {
   hasVerboseFields,
 } from '../../../utils/strip-verbose-meta.js'
 
-export const pikkuChannels = pikkuSessionlessFunc<void, boolean | undefined>({
+export const pikkuCommandChannels = pikkuSessionlessFunc<
+  void,
+  boolean | undefined
+>({
   func: async ({ logger, config, getInspectorState }) => {
     const visitState = await getInspectorState()
     const {

--- a/packages/cli/src/functions/wirings/http/pikku-command-http-routes.ts
+++ b/packages/cli/src/functions/wirings/http/pikku-command-http-routes.ts
@@ -8,77 +8,79 @@ import {
   hasVerboseFields,
 } from '../../../utils/strip-verbose-meta.js'
 
-export const pikkuHTTP = pikkuSessionlessFunc<void, boolean | undefined>({
-  func: async ({ logger, config, getInspectorState }) => {
-    const visitState = await getInspectorState()
-    const {
-      httpWiringsFile,
-      httpWiringMetaFile,
-      httpWiringMetaJsonFile,
-      packageMappings,
-      schema,
-    } = config
-    const { http } = visitState
-
-    if (http.files.size === 0 || Object.keys(http.meta).length === 0) {
-      return undefined
-    }
-
-    await writeFileInDir(
-      logger,
-      httpWiringsFile,
-      serializeFileImports(
-        'wireHTTP',
+export const pikkuCommandHTTP = pikkuSessionlessFunc<void, boolean | undefined>(
+  {
+    func: async ({ logger, config, getInspectorState }) => {
+      const visitState = await getInspectorState()
+      const {
         httpWiringsFile,
-        http.files,
-        packageMappings
-      )
-    )
+        httpWiringMetaFile,
+        httpWiringMetaJsonFile,
+        packageMappings,
+        schema,
+      } = config
+      const { http } = visitState
 
-    // Write minimal JSON (runtime-only fields)
-    const minimalMeta = stripVerboseFields(http.meta)
-    await writeFileInDir(
-      logger,
-      httpWiringMetaJsonFile,
-      JSON.stringify(minimalMeta, null, 2)
-    )
+      if (http.files.size === 0 || Object.keys(http.meta).length === 0) {
+        return undefined
+      }
 
-    // Write verbose JSON only if it has additional fields
-    if (hasVerboseFields(http.meta)) {
-      const verbosePath = httpWiringMetaJsonFile.replace(
-        /\.gen\.json$/,
-        '-verbose.gen.json'
-      )
       await writeFileInDir(
         logger,
-        verbosePath,
-        JSON.stringify(http.meta, null, 2)
+        httpWiringsFile,
+        serializeFileImports(
+          'wireHTTP',
+          httpWiringsFile,
+          http.files,
+          packageMappings
+        )
       )
-    }
 
-    // Generate TypeScript file that imports the minimal JSON
-    const jsonImportPath = getFileImportRelativePath(
-      httpWiringMetaFile,
-      httpWiringMetaJsonFile,
-      packageMappings
-    )
-    const supportsImportAttributes = schema?.supportsImportAttributes ?? false
-    const importStatement = supportsImportAttributes
-      ? `import metaData from '${jsonImportPath}' with { type: 'json' }`
-      : `import metaData from '${jsonImportPath}'`
+      // Write minimal JSON (runtime-only fields)
+      const minimalMeta = stripVerboseFields(http.meta)
+      await writeFileInDir(
+        logger,
+        httpWiringMetaJsonFile,
+        JSON.stringify(minimalMeta, null, 2)
+      )
 
-    await writeFileInDir(
-      logger,
-      httpWiringMetaFile,
-      `import { pikkuState } from '@pikku/core/internal'\nimport type { HTTPWiringsMeta } from '@pikku/core/http'\n${importStatement}\npikkuState(null, 'http', 'meta', metaData as HTTPWiringsMeta)`
-    )
+      // Write verbose JSON only if it has additional fields
+      if (hasVerboseFields(http.meta)) {
+        const verbosePath = httpWiringMetaJsonFile.replace(
+          /\.gen\.json$/,
+          '-verbose.gen.json'
+        )
+        await writeFileInDir(
+          logger,
+          verbosePath,
+          JSON.stringify(http.meta, null, 2)
+        )
+      }
 
-    return true
-  },
-  middleware: [
-    logCommandInfoAndTime({
-      commandStart: 'Finding HTTP routes',
-      commandEnd: 'Found HTTP routes',
-    }),
-  ],
-})
+      // Generate TypeScript file that imports the minimal JSON
+      const jsonImportPath = getFileImportRelativePath(
+        httpWiringMetaFile,
+        httpWiringMetaJsonFile,
+        packageMappings
+      )
+      const supportsImportAttributes = schema?.supportsImportAttributes ?? false
+      const importStatement = supportsImportAttributes
+        ? `import metaData from '${jsonImportPath}' with { type: 'json' }`
+        : `import metaData from '${jsonImportPath}'`
+
+      await writeFileInDir(
+        logger,
+        httpWiringMetaFile,
+        `import { pikkuState } from '@pikku/core/internal'\nimport type { HTTPWiringsMeta } from '@pikku/core/http'\n${importStatement}\npikkuState(null, 'http', 'meta', metaData as HTTPWiringsMeta)`
+      )
+
+      return true
+    },
+    middleware: [
+      logCommandInfoAndTime({
+        commandStart: 'Finding HTTP routes',
+        commandEnd: 'Found HTTP routes',
+      }),
+    ],
+  }
+)

--- a/packages/cli/src/functions/wirings/queue/pikku-command-queue-map.ts
+++ b/packages/cli/src/functions/wirings/queue/pikku-command-queue-map.ts
@@ -3,7 +3,7 @@ import { writeFileInDir } from '../../../utils/file-writer.js'
 import { logCommandInfoAndTime } from '../../../middleware/log-command-info-and-time.js'
 import { serializeQueueMap } from './serialize-queue-map.js'
 
-export const pikkuQueueMap = pikkuSessionlessFunc<void, void>({
+export const pikkuCommandQueueMap = pikkuSessionlessFunc<void, void>({
   func: async ({ logger, config, getInspectorState }) => {
     const { queueWorkers, functions, resolvedIOTypes } =
       await getInspectorState()

--- a/packages/cli/src/functions/wirings/queue/pikku-command-queue.ts
+++ b/packages/cli/src/functions/wirings/queue/pikku-command-queue.ts
@@ -12,7 +12,10 @@ import {
   hasVerboseFields,
 } from '../../../utils/strip-verbose-meta.js'
 
-export const pikkuQueue = pikkuSessionlessFunc<void, boolean | undefined>({
+export const pikkuCommandQueue = pikkuSessionlessFunc<
+  void,
+  boolean | undefined
+>({
   func: async ({ logger, config, getInspectorState }) => {
     const visitState = await getInspectorState()
     const {

--- a/packages/cli/src/functions/workflows/all.workflow.ts
+++ b/packages/cli/src/functions/workflows/all.workflow.ts
@@ -197,7 +197,7 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
 
     if (!config.addon) {
       const [http, scheduler, triggers] = await Promise.all([
-        workflow.do('HTTP', 'pikkuHTTP', null),
+        workflow.do('HTTP', 'pikkuCommandHTTP', null),
         workflow.do('Scheduler', 'pikkuScheduler', null),
         workflow.do('Trigger', 'pikkuTrigger', null),
       ])
@@ -244,8 +244,8 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
 
     if (!config.addon) {
       const [queues, channels, gateways, mcp, cli] = await Promise.all([
-        workflow.do('Queue', 'pikkuQueue', null),
-        workflow.do('Channels', 'pikkuChannels', null),
+        workflow.do('Queue', 'pikkuCommandQueue', null),
+        workflow.do('Channels', 'pikkuCommandChannels', null),
         workflow.do('Gateway', 'pikkuGateway', null),
         workflow.do('MCP', 'pikkuMCP', null),
         workflow.do('CLI', 'pikkuCLI', null),
@@ -253,7 +253,7 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
 
       if (queues) {
         await Promise.all([
-          workflow.do('Queue map', 'pikkuQueueMap', null),
+          workflow.do('Queue map', 'pikkuCommandQueueMap', null),
           workflow.do('Queue service', 'pikkuQueueService', null),
         ])
         allImports.push(

--- a/packages/inspector/src/add/add-functions.test.ts
+++ b/packages/inspector/src/add/add-functions.test.ts
@@ -55,4 +55,56 @@ describe('addFunctions duplicate name handling', () => {
       await rm(rootDir, { recursive: true, force: true })
     }
   })
+
+  test('allows same base function name across files when versions differ', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-versioned-function-'))
+    const fileA = join(rootDir, 'a.ts')
+    const fileB = join(rootDir, 'b.ts')
+
+    await writeFile(
+      fileA,
+      [
+        "import { pikkuFunc } from '@pikku/core'",
+        'export const createUser = pikkuFunc({',
+        '  version: 1,',
+        '  func: async () => ({ ok: true })',
+        '})',
+      ].join('\n')
+    )
+
+    await writeFile(
+      fileB,
+      [
+        "import { pikkuFunc } from '@pikku/core'",
+        'export const createUser = pikkuFunc({',
+        '  version: 2,',
+        '  func: async () => ({ ok: true })',
+        '})',
+      ].join('\n')
+    )
+
+    const criticals: Array<{ code: string; message: string }> = []
+    const logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      critical: (code: string, message: string) => {
+        criticals.push({ code, message })
+      },
+    }
+
+    try {
+      const state = await inspect(logger, [fileA, fileB], { rootDir })
+      const nameCollision = criticals.find(
+        (entry) => entry.code === ErrorCode.DUPLICATE_FUNCTION_NAME
+      )
+      assert.equal(nameCollision, undefined)
+      assert.strictEqual(state.rpc.internalMeta['createUser'], 'createUser@v2')
+      assert.ok(state.functions.meta['createUser@v1'])
+      assert.ok(state.functions.meta['createUser@v2'])
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/inspector/src/add/add-functions.test.ts
+++ b/packages/inspector/src/add/add-functions.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { inspect } from '../inspector.js'
 import { ErrorCode } from '../error-codes.js'
+import type { InspectorLogger } from '../types.js'
 
 describe('addFunctions duplicate name handling', () => {
   test('logs a critical error when function name is duplicated across files', async () => {
@@ -32,15 +33,16 @@ describe('addFunctions duplicate name handling', () => {
       ].join('\n')
     )
 
-    const criticals: Array<{ code: string; message: string }> = []
-    const logger = {
+    const criticals: Array<{ code: ErrorCode; message: string }> = []
+    const logger: InspectorLogger = {
       debug: () => {},
       info: () => {},
       warn: () => {},
       error: () => {},
-      critical: (code: string, message: string) => {
+      critical: (code: ErrorCode, message: string) => {
         criticals.push({ code, message })
       },
+      hasCriticalErrors: () => criticals.length > 0,
     }
 
     try {
@@ -49,7 +51,7 @@ describe('addFunctions duplicate name handling', () => {
         (entry) => entry.code === ErrorCode.DUPLICATE_FUNCTION_NAME
       )
       assert.ok(nameCollision)
-      assert.match(nameCollision.message, /createUser/)
+      assert.match(nameCollision!.message, /createUser/)
       assert.strictEqual(state.rpc.internalMeta['createUser'], 'createUser')
     } finally {
       await rm(rootDir, { recursive: true, force: true })
@@ -83,15 +85,16 @@ describe('addFunctions duplicate name handling', () => {
       ].join('\n')
     )
 
-    const criticals: Array<{ code: string; message: string }> = []
-    const logger = {
+    const criticals: Array<{ code: ErrorCode; message: string }> = []
+    const logger: InspectorLogger = {
       debug: () => {},
       info: () => {},
       warn: () => {},
       error: () => {},
-      critical: (code: string, message: string) => {
+      critical: (code: ErrorCode, message: string) => {
         criticals.push({ code, message })
       },
+      hasCriticalErrors: () => criticals.length > 0,
     }
 
     try {
@@ -103,6 +106,62 @@ describe('addFunctions duplicate name handling', () => {
       assert.strictEqual(state.rpc.internalMeta['createUser'], 'createUser@v2')
       assert.ok(state.functions.meta['createUser@v1'])
       assert.ok(state.functions.meta['createUser@v2'])
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  test('logs a critical error when exposed function name is duplicated across files', async () => {
+    const rootDir = await mkdtemp(
+      join(tmpdir(), 'pikku-exposed-duplicate-function-')
+    )
+    const fileA = join(rootDir, 'a.ts')
+    const fileB = join(rootDir, 'b.ts')
+
+    await writeFile(
+      fileA,
+      [
+        "import { pikkuFunc } from '@pikku/core'",
+        'export const createUser = pikkuFunc({',
+        '  expose: true,',
+        '  func: async () => ({ ok: true })',
+        '})',
+      ].join('\n')
+    )
+
+    await writeFile(
+      fileB,
+      [
+        "import { pikkuFunc } from '@pikku/core'",
+        'export const createUser = pikkuFunc({',
+        '  expose: true,',
+        '  func: async () => ({ ok: true })',
+        '})',
+      ].join('\n')
+    )
+
+    const criticals: Array<{ code: ErrorCode; message: string }> = []
+    const logger: InspectorLogger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      critical: (code: ErrorCode, message: string) => {
+        criticals.push({ code, message })
+      },
+      hasCriticalErrors: () => criticals.length > 0,
+    }
+
+    try {
+      await inspect(logger, [fileA, fileB], { rootDir })
+      const nameCollision = criticals.find(
+        (entry) => entry.code === ErrorCode.DUPLICATE_FUNCTION_NAME
+      )
+      assert.ok(nameCollision)
+      assert.match(
+        nameCollision!.message,
+        /Function name 'createUser' is not unique/
+      )
     } finally {
       await rm(rootDir, { recursive: true, force: true })
     }

--- a/packages/inspector/src/add/add-functions.test.ts
+++ b/packages/inspector/src/add/add-functions.test.ts
@@ -1,0 +1,58 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { inspect } from '../inspector.js'
+import { ErrorCode } from '../error-codes.js'
+
+describe('addFunctions duplicate name handling', () => {
+  test('logs a critical error when function name is duplicated across files', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-duplicate-function-'))
+    const fileA = join(rootDir, 'a.ts')
+    const fileB = join(rootDir, 'b.ts')
+
+    await writeFile(
+      fileA,
+      [
+        "import { pikkuFunc } from '@pikku/core'",
+        'export const createUser = pikkuFunc({',
+        '  func: async () => ({ ok: true })',
+        '})',
+      ].join('\n')
+    )
+
+    await writeFile(
+      fileB,
+      [
+        "import { pikkuFunc } from '@pikku/core'",
+        'export const createUser = pikkuFunc({',
+        '  func: async () => ({ ok: true })',
+        '})',
+      ].join('\n')
+    )
+
+    const criticals: Array<{ code: string; message: string }> = []
+    const logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      critical: (code: string, message: string) => {
+        criticals.push({ code, message })
+      },
+    }
+
+    try {
+      const state = await inspect(logger, [fileA, fileB], { rootDir })
+      const nameCollision = criticals.find(
+        (entry) => entry.code === ErrorCode.DUPLICATE_FUNCTION_NAME
+      )
+      assert.ok(nameCollision)
+      assert.match(nameCollision.message, /createUser/)
+      assert.strictEqual(state.rpc.internalMeta['createUser'], 'createUser')
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/inspector/src/add/add-functions.ts
+++ b/packages/inspector/src/add/add-functions.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript'
-import type { AddWiring, SchemaRef } from '../types.js'
+import type { AddWiring, InspectorState, SchemaRef } from '../types.js'
 import { detectSchemaVendorOrError } from '../utils/detect-schema-vendor.js'
 import type { TypesMap } from '../types-map.js'
 import {
@@ -285,6 +285,17 @@ function unwrapPromise(checker: ts.TypeChecker, type: ts.Type): ts.Type {
   }
 
   return type
+}
+
+const resolveExistingFunctionSource = (
+  state: InspectorState,
+  pikkuFuncId: string
+): string | null => {
+  return (
+    state.functions.meta[pikkuFuncId]?.sourceFile ||
+    state.rpc.internalFiles.get(pikkuFuncId)?.path ||
+    null
+  )
 }
 
 /**
@@ -731,6 +742,50 @@ export const addFunctions: AddWiring = (
     state.typesLookup.set(pikkuFuncId, inputTypes)
   }
 
+  const sourceFile = node.getSourceFile().fileName
+  const existingFunction = state.functions.meta[pikkuFuncId]
+  if (
+    existingFunction &&
+    existingFunction.sourceFile &&
+    existingFunction.sourceFile !== sourceFile
+  ) {
+    logger.critical(
+      ErrorCode.DUPLICATE_FUNCTION_NAME,
+      `Function name '${name}' is not unique. ` +
+        `'${pikkuFuncId}' is already defined in '${existingFunction.sourceFile}' and cannot be redefined in '${sourceFile}'.`
+    )
+    return
+  }
+
+  if (exportedName || explicitName) {
+    const existingInternal = state.rpc.internalMeta[name]
+    if (existingInternal && existingInternal !== pikkuFuncId) {
+      const existingSource =
+        resolveExistingFunctionSource(state, existingInternal) || 'unknown file'
+      logger.critical(
+        ErrorCode.DUPLICATE_FUNCTION_NAME,
+        `Function name '${name}' is not unique. ` +
+          `It already points to '${existingInternal}' in '${existingSource}', but '${pikkuFuncId}' in '${sourceFile}' tried to use the same name.`
+      )
+      return
+    }
+
+    if (expose) {
+      const existingExposed = state.rpc.exposedMeta[name]
+      if (existingExposed && existingExposed !== pikkuFuncId) {
+        const existingSource =
+          resolveExistingFunctionSource(state, existingExposed) ||
+          'unknown file'
+        logger.critical(
+          ErrorCode.DUPLICATE_FUNCTION_NAME,
+          `Exposed function name '${name}' is not unique. ` +
+            `It already points to '${existingExposed}' in '${existingSource}', but '${pikkuFuncId}' in '${sourceFile}' tried to use the same name.`
+        )
+        return
+      }
+    }
+  }
+
   // --- resolve middleware ---
   let middleware = objectNode
     ? resolveMiddleware(state, objectNode, tags, checker)
@@ -801,7 +856,7 @@ export const addFunctions: AddWiring = (
     middleware,
     permissions,
     isDirectFunction,
-    sourceFile: node.getSourceFile().fileName,
+    sourceFile,
     exportedName: exportedName || undefined,
   }
 

--- a/packages/inspector/src/add/add-functions.ts
+++ b/packages/inspector/src/add/add-functions.ts
@@ -9,7 +9,7 @@ import {
 import { extractFunctionNode } from '../utils/extract-function-node.js'
 import { extractUsedWires } from '../utils/extract-services.js'
 import type { FunctionServicesMeta } from '@pikku/core'
-import { formatVersionedId } from '@pikku/core'
+import { formatVersionedId, parseVersionedId } from '@pikku/core'
 import {
   getPropertyValue,
   getCommonWireMetaData,
@@ -296,6 +296,20 @@ const resolveExistingFunctionSource = (
     state.rpc.internalFiles.get(pikkuFuncId)?.path ||
     null
   )
+}
+
+const areCompatibleFunctionIds = (
+  existingId: string,
+  incomingId: string
+): boolean => {
+  if (existingId === incomingId) {
+    return true
+  }
+
+  const existingParsed = parseVersionedId(existingId)
+  const incomingParsed = parseVersionedId(incomingId)
+
+  return existingParsed.baseName === incomingParsed.baseName
 }
 
 /**
@@ -759,7 +773,10 @@ export const addFunctions: AddWiring = (
 
   if (exportedName || explicitName) {
     const existingInternal = state.rpc.internalMeta[name]
-    if (existingInternal && existingInternal !== pikkuFuncId) {
+    if (
+      existingInternal &&
+      !areCompatibleFunctionIds(existingInternal, pikkuFuncId)
+    ) {
       const existingSource =
         resolveExistingFunctionSource(state, existingInternal) || 'unknown file'
       logger.critical(
@@ -772,7 +789,10 @@ export const addFunctions: AddWiring = (
 
     if (expose) {
       const existingExposed = state.rpc.exposedMeta[name]
-      if (existingExposed && existingExposed !== pikkuFuncId) {
+      if (
+        existingExposed &&
+        !areCompatibleFunctionIds(existingExposed, pikkuFuncId)
+      ) {
         const existingSource =
           resolveExistingFunctionSource(state, existingExposed) ||
           'unknown file'

--- a/packages/inspector/src/error-codes.ts
+++ b/packages/inspector/src/error-codes.ts
@@ -53,6 +53,7 @@ export enum ErrorCode {
 
   // Versioning errors
   DUPLICATE_FUNCTION_VERSION = 'PKU850',
+  DUPLICATE_FUNCTION_NAME = 'PKU851',
 
   // Contract versioning errors
   MANIFEST_MISSING = 'PKU860',


### PR DESCRIPTION
## Summary
- add inspector critical error for duplicate function-name collisions that would overwrite routing and RPC maps
- add regression test covering duplicate exported function names across files
- make CLI command wiring function IDs unique (pikkuCommandHTTP, pikkuCommandQueue, pikkuCommandChannels, pikkuCommandQueueMap) and update all workflow calls
- add patch changeset for @pikku/inspector

Fixes #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Inspector now detects and reports critical errors when multiple functions map to the same name, preventing silent acceptance of duplicate definitions.

## Tests
* Added validation tests for duplicate function name detection during the inspection process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->