### PR TITLE
feat(cli): add --output json / --json NDJSON logging

### DIFF
--- a/.changeset/four-tomatoes-float.md
+++ b/.changeset/four-tomatoes-float.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Add `--output json`/`--json` CLI support to emit NDJSON logs with timestamped structured entries, including critical errors and redirected command console output.

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -53,7 +53,9 @@ wireCLI({
       short: 'l',
     },
     output: {
-      description: 'Output format: text (default) or json (NDJSON)',
+      description: 'Output format (json emits NDJSON)',
+      choices: ['text', 'json'] as const,
+      default: 'text' as const,
     },
     json: {
       description: 'Alias for --output json',

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -52,6 +52,14 @@ wireCLI({
       default: 'info' as const,
       short: 'l',
     },
+    output: {
+      description: 'Output format: text (default) or json (NDJSON)',
+    },
+    json: {
+      description: 'Alias for --output json',
+      default: false,
+      short: 'j',
+    },
     userSessionType: {
       description:
         'Specify which UserSession type to use (when multiple exist)',
@@ -119,8 +127,7 @@ wireCLI({
     }),
     dev: pikkuCLICommand({
       func: dev,
-      description:
-        'Start a local development server with all services wired',
+      description: 'Start a local development server with all services wired',
       options: {
         port: {
           description: 'Port for the dev server',

--- a/packages/cli/src/functions/commands/deploy-apply.ts
+++ b/packages/cli/src/functions/commands/deploy-apply.ts
@@ -7,6 +7,7 @@ import type {
   EntryGenerationContext,
 } from '../../deploy/provider-adapter.js'
 import type { InspectorState } from '@pikku/inspector'
+import type { Logger } from '@pikku/core/services'
 import { runBuildPipeline } from '../../deploy/build-pipeline.js'
 
 function toRelativeImport(fromDir: string, toFile: string): string {
@@ -165,7 +166,7 @@ async function writeResultFile(
 async function runDeploy(
   provider: ProviderAdapter,
   providerDir: string,
-  logger: { info(msg: string): void; error(msg: string): void },
+  logger: Logger,
   resultFile?: string
 ): Promise<void> {
   if (typeof provider.deploy !== 'function') {
@@ -191,7 +192,11 @@ async function runDeploy(
       buildDir: providerDir,
       logger,
       onProgress: (step: string, detail: string) => {
-        logger.info(`[${step}] ${detail}`)
+        logger.info({
+          message: `[${step}] ${detail}`,
+          type: 'progress',
+          data: { progress: { step, detail } },
+        })
       },
     })
   } catch (err) {

--- a/packages/cli/src/functions/commands/deploy-apply.ts
+++ b/packages/cli/src/functions/commands/deploy-apply.ts
@@ -148,7 +148,6 @@ export async function resolveProvider(
 
 const ANSI = {
   green: '\x1b[32m',
-  red: '\x1b[31m',
   bold: '\x1b[1m',
   reset: '\x1b[0m',
 }
@@ -191,8 +190,8 @@ async function runDeploy(
     deployResult = await provider.deploy({
       buildDir: providerDir,
       logger,
-      onProgress: (_step: string, _detail: string) => {
-        process.stdout.write(` ${ANSI.green}done${ANSI.reset}\n`)
+      onProgress: (step: string, detail: string) => {
+        logger.info(`[${step}] ${detail}`)
       },
     })
   } catch (err) {
@@ -205,7 +204,6 @@ async function runDeploy(
 
   await writeResultFile(resultFile, deployResult)
 
-  console.log('')
   if (deployResult.success) {
     logger.info(`${ANSI.green}${ANSI.bold}Deployment complete.${ANSI.reset}`)
     logger.info(

--- a/packages/cli/src/services.ts
+++ b/packages/cli/src/services.ts
@@ -65,54 +65,6 @@ function processDiagnostics(
 }
 
 const logger = new CLILogger({ logLogo: false, silent: false })
-const originalConsole = {
-  log: console.log,
-  info: console.info,
-  warn: console.warn,
-  error: console.error,
-  debug: console.debug,
-}
-let consoleRedirectedToLogger = false
-
-const formatConsoleArgs = (args: unknown[]): string => {
-  return args
-    .map((arg) => {
-      if (typeof arg === 'string') return arg
-      if (arg instanceof Error) return arg.stack || arg.message
-      try {
-        return JSON.stringify(arg)
-      } catch {
-        return String(arg)
-      }
-    })
-    .join(' ')
-}
-
-const setJSONConsoleRedirection = (enabled: boolean): void => {
-  if (enabled && !consoleRedirectedToLogger) {
-    ;(console as any).log = (...args: unknown[]) =>
-      logger.info(formatConsoleArgs(args))
-    ;(console as any).info = (...args: unknown[]) =>
-      logger.info(formatConsoleArgs(args))
-    ;(console as any).warn = (...args: unknown[]) =>
-      logger.warn(formatConsoleArgs(args))
-    ;(console as any).error = (...args: unknown[]) =>
-      logger.error(formatConsoleArgs(args))
-    ;(console as any).debug = (...args: unknown[]) =>
-      logger.debug(formatConsoleArgs(args))
-    consoleRedirectedToLogger = true
-    return
-  }
-
-  if (!enabled && consoleRedirectedToLogger) {
-    ;(console as any).log = originalConsole.log
-    ;(console as any).info = originalConsole.info
-    ;(console as any).warn = originalConsole.warn
-    ;(console as any).error = originalConsole.error
-    ;(console as any).debug = originalConsole.debug
-    consoleRedirectedToLogger = false
-  }
-}
 
 /**
  * Parse a comma-separated string or array into an array of trimmed, non-empty strings
@@ -216,7 +168,6 @@ export const createConfig: CreateConfig<Config, [PikkuCLIConfig]> = async (
   }
 
   logger.setOutputMode(outputMode)
-  setJSONConsoleRedirection(outputMode === 'json')
 
   if ((data as any).silent) {
     logLevel = LogLevel.critical

--- a/packages/cli/src/services.ts
+++ b/packages/cli/src/services.ts
@@ -154,18 +154,12 @@ export const createConfig: CreateConfig<Config, [PikkuCLIConfig]> = async (
   // --silent > --loglevel > --verbose > --info > default (warn)
   let logLevel: LogLevel = LogLevel.warn // default
   let isSilent = false
-  let outputMode: 'text' | 'json' = 'text'
-
-  const rawOutput = ((data as any).output || '').toString().toLowerCase()
-  if ((data as any).json || rawOutput === 'json') {
-    outputMode = 'json'
-  } else if (rawOutput === 'text' || rawOutput === '') {
-    outputMode = 'text'
-  } else {
-    logger.warn(
-      `Invalid output mode "${rawOutput}". Valid values: text, json. Using default (text).`
-    )
-  }
+  // --output is constrained to 'text' | 'json' by the CLI parser
+  // (choices + default in cli.wiring.ts), so no runtime validation
+  // is needed here. --json is kept as an alias that forces 'json'.
+  const outputMode: 'text' | 'json' = (data as any).json
+    ? 'json'
+    : ((data as any).output as 'text' | 'json')
 
   logger.setOutputMode(outputMode)
 

--- a/packages/cli/src/services.ts
+++ b/packages/cli/src/services.ts
@@ -65,6 +65,54 @@ function processDiagnostics(
 }
 
 const logger = new CLILogger({ logLogo: false, silent: false })
+const originalConsole = {
+  log: console.log,
+  info: console.info,
+  warn: console.warn,
+  error: console.error,
+  debug: console.debug,
+}
+let consoleRedirectedToLogger = false
+
+const formatConsoleArgs = (args: unknown[]): string => {
+  return args
+    .map((arg) => {
+      if (typeof arg === 'string') return arg
+      if (arg instanceof Error) return arg.stack || arg.message
+      try {
+        return JSON.stringify(arg)
+      } catch {
+        return String(arg)
+      }
+    })
+    .join(' ')
+}
+
+const setJSONConsoleRedirection = (enabled: boolean): void => {
+  if (enabled && !consoleRedirectedToLogger) {
+    ;(console as any).log = (...args: unknown[]) =>
+      logger.info(formatConsoleArgs(args))
+    ;(console as any).info = (...args: unknown[]) =>
+      logger.info(formatConsoleArgs(args))
+    ;(console as any).warn = (...args: unknown[]) =>
+      logger.warn(formatConsoleArgs(args))
+    ;(console as any).error = (...args: unknown[]) =>
+      logger.error(formatConsoleArgs(args))
+    ;(console as any).debug = (...args: unknown[]) =>
+      logger.debug(formatConsoleArgs(args))
+    consoleRedirectedToLogger = true
+    return
+  }
+
+  if (!enabled && consoleRedirectedToLogger) {
+    ;(console as any).log = originalConsole.log
+    ;(console as any).info = originalConsole.info
+    ;(console as any).warn = originalConsole.warn
+    ;(console as any).error = originalConsole.error
+    ;(console as any).debug = originalConsole.debug
+    consoleRedirectedToLogger = false
+  }
+}
 
 /**
  * Parse a comma-separated string or array into an array of trimmed, non-empty strings
@@ -154,6 +202,21 @@ export const createConfig: CreateConfig<Config, [PikkuCLIConfig]> = async (
   // --silent > --loglevel > --verbose > --info > default (warn)
   let logLevel: LogLevel = LogLevel.warn // default
   let isSilent = false
+  let outputMode: 'text' | 'json' = 'text'
+
+  const rawOutput = ((data as any).output || '').toString().toLowerCase()
+  if ((data as any).json || rawOutput === 'json') {
+    outputMode = 'json'
+  } else if (rawOutput === 'text' || rawOutput === '') {
+    outputMode = 'text'
+  } else {
+    logger.warn(
+      `Invalid output mode "${rawOutput}". Valid values: text, json. Using default (text).`
+    )
+  }
+
+  logger.setOutputMode(outputMode)
+  setJSONConsoleRedirection(outputMode === 'json')
 
   if ((data as any).silent) {
     logLevel = LogLevel.critical
@@ -177,7 +240,7 @@ export const createConfig: CreateConfig<Config, [PikkuCLIConfig]> = async (
   logger.setSilent(isSilent)
 
   // Display logo unless in silent mode
-  if (!isSilent) {
+  if (!isSilent && outputMode !== 'json') {
     logger.logLogo()
   }
 

--- a/packages/cli/src/services/cli-logger.service.test.ts
+++ b/packages/cli/src/services/cli-logger.service.test.ts
@@ -1,0 +1,73 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { LogLevel } from '@pikku/core/services'
+import { CLILogger } from './cli-logger.service.js'
+
+function captureStdout(run: () => void): string[] {
+  const lines: string[] = []
+  const originalWrite = process.stdout.write.bind(process.stdout)
+
+  ;(process.stdout.write as unknown as (chunk: unknown) => boolean) = (
+    chunk: unknown
+  ) => {
+    lines.push(typeof chunk === 'string' ? chunk : String(chunk))
+    return true
+  }
+
+  try {
+    run()
+  } finally {
+    ;(process.stdout.write as unknown as typeof process.stdout.write) =
+      originalWrite as typeof process.stdout.write
+  }
+
+  return lines
+}
+
+describe('CLILogger json output mode', () => {
+  test('emits NDJSON for info logs', () => {
+    const logger = new CLILogger({ logLogo: false, silent: false })
+    logger.setLevel(LogLevel.debug)
+    logger.setOutputMode('json')
+
+    const lines = captureStdout(() => {
+      logger.info({ message: 'Generating types', type: 'timing' })
+    })
+
+    assert.strictEqual(lines.length, 1)
+    const payload = JSON.parse(lines[0]!.trim())
+    assert.strictEqual(payload.level, 'info')
+    assert.strictEqual(payload.message, 'Generating types')
+    assert.strictEqual(payload.type, 'timing')
+    assert.ok(typeof payload.timestamp === 'string')
+  })
+
+  test('strips ANSI escape codes in json mode', () => {
+    const logger = new CLILogger({ logLogo: false, silent: false })
+    logger.setLevel(LogLevel.info)
+    logger.setOutputMode('json')
+
+    const lines = captureStdout(() => {
+      logger.info('\x1b[31mRed Message\x1b[0m')
+    })
+
+    const payload = JSON.parse(lines[0]!.trim())
+    assert.strictEqual(payload.message, 'Red Message')
+  })
+
+  test('emits structured critical output with code', () => {
+    const logger = new CLILogger({ logLogo: false, silent: false })
+    logger.setLevel(LogLevel.debug)
+    logger.setOutputMode('json')
+
+    const lines = captureStdout(() => {
+      logger.critical('PKU111' as any, 'Duplicate function name')
+    })
+
+    const payload = JSON.parse(lines[0]!.trim())
+    assert.strictEqual(payload.level, 'critical')
+    assert.strictEqual(payload.code, 'PKU111')
+    assert.match(payload.url, /pku111$/)
+    assert.match(payload.message, /\[PKU111\]/)
+  })
+})

--- a/packages/cli/src/services/cli-logger.service.test.ts
+++ b/packages/cli/src/services/cli-logger.service.test.ts
@@ -25,13 +25,18 @@ function captureStdout(run: () => void): string[] {
 }
 
 describe('CLILogger json output mode', () => {
-  test('emits NDJSON for info logs', () => {
+  test('buffers json logs until flush', () => {
     const logger = new CLILogger({ logLogo: false, silent: false })
     logger.setLevel(LogLevel.debug)
     logger.setOutputMode('json')
 
-    const lines = captureStdout(() => {
+    const beforeFlush = captureStdout(() => {
       logger.info({ message: 'Generating types', type: 'timing' })
+    })
+    assert.strictEqual(beforeFlush.length, 0)
+
+    const lines = captureStdout(() => {
+      logger.flushJSONBuffer()
     })
 
     assert.strictEqual(lines.length, 1)
@@ -47,8 +52,9 @@ describe('CLILogger json output mode', () => {
     logger.setLevel(LogLevel.info)
     logger.setOutputMode('json')
 
+    logger.info('\x1b[31mRed Message\x1b[0m')
     const lines = captureStdout(() => {
-      logger.info('\x1b[31mRed Message\x1b[0m')
+      logger.flushJSONBuffer()
     })
 
     const payload = JSON.parse(lines[0]!.trim())
@@ -60,8 +66,9 @@ describe('CLILogger json output mode', () => {
     logger.setLevel(LogLevel.debug)
     logger.setOutputMode('json')
 
+    logger.critical('PKU111' as any, 'Duplicate function name')
     const lines = captureStdout(() => {
-      logger.critical('PKU111' as any, 'Duplicate function name')
+      logger.flushJSONBuffer()
     })
 
     const payload = JSON.parse(lines[0]!.trim())
@@ -69,5 +76,24 @@ describe('CLILogger json output mode', () => {
     assert.strictEqual(payload.code, 'PKU111')
     assert.match(payload.url, /pku111$/)
     assert.match(payload.message, /\[PKU111\]/)
+  })
+
+  test('does not emit flushed json records in text mode', () => {
+    const logger = new CLILogger({ logLogo: false, silent: false })
+    logger.setLevel(LogLevel.info)
+    logger.setOutputMode('json')
+
+    logger.info('Buffered message')
+    logger.setOutputMode('text')
+
+    const lines = captureStdout(() => {
+      logger.flushJSONBuffer()
+    })
+
+    assert.strictEqual(lines.length, 0)
+    const textLines = captureStdout(() => {
+      logger.info('\x1b[31mRed Message\x1b[0m')
+    })
+    assert.strictEqual(textLines.length, 1)
   })
 })

--- a/packages/cli/src/services/cli-logger.service.test.ts
+++ b/packages/cli/src/services/cli-logger.service.test.ts
@@ -25,18 +25,13 @@ function captureStdout(run: () => void): string[] {
 }
 
 describe('CLILogger json output mode', () => {
-  test('buffers json logs until flush', () => {
+  test('writes json logs immediately (streaming, no buffering)', () => {
     const logger = new CLILogger({ logLogo: false, silent: false })
     logger.setLevel(LogLevel.debug)
     logger.setOutputMode('json')
 
-    const beforeFlush = captureStdout(() => {
-      logger.info({ message: 'Generating types', type: 'timing' })
-    })
-    assert.strictEqual(beforeFlush.length, 0)
-
     const lines = captureStdout(() => {
-      logger.flushJSONBuffer()
+      logger.info({ message: 'Generating types', type: 'timing' })
     })
 
     assert.strictEqual(lines.length, 1)
@@ -47,14 +42,27 @@ describe('CLILogger json output mode', () => {
     assert.ok(typeof payload.timestamp === 'string')
   })
 
+  test('flushJSONBuffer is a safe no-op (records already written)', () => {
+    const logger = new CLILogger({ logLogo: false, silent: false })
+    logger.setLevel(LogLevel.debug)
+    logger.setOutputMode('json')
+
+    captureStdout(() => {
+      logger.info('first')
+    })
+    const lines = captureStdout(() => {
+      logger.flushJSONBuffer()
+    })
+    assert.strictEqual(lines.length, 0)
+  })
+
   test('strips ANSI escape codes in json mode', () => {
     const logger = new CLILogger({ logLogo: false, silent: false })
     logger.setLevel(LogLevel.info)
     logger.setOutputMode('json')
 
-    logger.info('\x1b[31mRed Message\x1b[0m')
     const lines = captureStdout(() => {
-      logger.flushJSONBuffer()
+      logger.info('\x1b[31mRed Message\x1b[0m')
     })
 
     const payload = JSON.parse(lines[0]!.trim())
@@ -66,9 +74,8 @@ describe('CLILogger json output mode', () => {
     logger.setLevel(LogLevel.debug)
     logger.setOutputMode('json')
 
-    logger.critical('PKU111' as any, 'Duplicate function name')
     const lines = captureStdout(() => {
-      logger.flushJSONBuffer()
+      logger.critical('PKU111' as any, 'Duplicate function name')
     })
 
     const payload = JSON.parse(lines[0]!.trim())
@@ -78,22 +85,40 @@ describe('CLILogger json output mode', () => {
     assert.match(payload.message, /\[PKU111\]/)
   })
 
-  test('does not emit flushed json records in text mode', () => {
+  test('carries structured data payload on info/debug', () => {
+    const logger = new CLILogger({ logLogo: false, silent: false })
+    logger.setLevel(LogLevel.debug)
+    logger.setOutputMode('json')
+
+    const lines = captureStdout(() => {
+      logger.info({
+        message: '[bundler] building worker',
+        type: 'progress',
+        data: { progress: { step: 'bundler', detail: 'building worker' } },
+      })
+    })
+
+    const payload = JSON.parse(lines[0]!.trim())
+    assert.strictEqual(payload.type, 'progress')
+    assert.deepStrictEqual(payload.data, {
+      progress: { step: 'bundler', detail: 'building worker' },
+    })
+  })
+
+  test('switching to text mode stops json emission', () => {
     const logger = new CLILogger({ logLogo: false, silent: false })
     logger.setLevel(LogLevel.info)
     logger.setOutputMode('json')
 
-    logger.info('Buffered message')
     logger.setOutputMode('text')
 
-    const lines = captureStdout(() => {
-      logger.flushJSONBuffer()
-    })
-
-    assert.strictEqual(lines.length, 0)
     const textLines = captureStdout(() => {
       logger.info('\x1b[31mRed Message\x1b[0m')
     })
+    // text mode writes to stdout via console.log, which is a single
+    // chunk with a trailing newline
     assert.strictEqual(textLines.length, 1)
+    // ANSI codes are preserved in text mode (chalk re-adds them)
+    assert.ok(!textLines[0]!.startsWith('{'))
   })
 })

--- a/packages/cli/src/services/cli-logger.service.ts
+++ b/packages/cli/src/services/cli-logger.service.ts
@@ -13,11 +13,14 @@ const logo = `
 `
 
 const BASE_ERROR_URL = 'https://pikku.dev/docs/pikku-cli/errors'
+const ANSI_ESCAPE_REGEX = /\x1B\[[0-?]*[ -/]*[@-~]/g
+export type CLIOutputMode = 'text' | 'json'
 
 export class CLILogger implements Logger {
   private silent: boolean
   private level: LogLevel = LogLevel.warn // default to warn level
   private criticalErrors: string[] = []
+  private outputMode: CLIOutputMode = 'text'
 
   constructor({
     logLogo,
@@ -40,51 +43,103 @@ export class CLILogger implements Logger {
     this.silent = silent
   }
 
+  setOutputMode(mode: CLIOutputMode): void {
+    this.outputMode = mode
+  }
+
+  getOutputMode(): CLIOutputMode {
+    return this.outputMode
+  }
+
   isSilent(): boolean {
     return this.silent
+  }
+
+  private normalizeMessage(message: string): string {
+    if (this.outputMode === 'json') {
+      return message.replace(ANSI_ESCAPE_REGEX, '')
+    }
+    return message
+  }
+
+  private writeJSONLine(payload: Record<string, unknown>): void {
+    process.stdout.write(`${JSON.stringify(payload)}\n`)
+  }
+
+  private emit(
+    level: 'debug' | 'info' | 'warn' | 'error' | 'critical',
+    message: string,
+    type?: string,
+    code?: ErrorCode
+  ): void {
+    const normalizedMessage = this.normalizeMessage(message)
+    if (this.outputMode === 'json') {
+      this.writeJSONLine({
+        level,
+        message: normalizedMessage,
+        ...(type ? { type } : {}),
+        ...(code ? { code } : {}),
+        ...(code ? { url: `${BASE_ERROR_URL}/${code.toLowerCase()}` } : {}),
+        timestamp: new Date().toISOString(),
+      })
+      return
+    }
+
+    if (level === 'error') {
+      console.error(chalk.red(normalizedMessage))
+      return
+    }
+
+    if (level === 'warn') {
+      console.error(chalk.yellow(normalizedMessage))
+      return
+    }
+
+    if (level === 'critical') {
+      console.error(chalk.red.bold(normalizedMessage))
+      return
+    }
+
+    let c = level === 'info' ? chalk.blue : chalk.gray
+    if (type === 'success') {
+      c = chalk.green
+    } else if (type === 'timing' && level === 'info') {
+      c = chalk.gray
+    }
+    console.log(c(normalizedMessage))
   }
 
   info(message: string | { message: string; type?: string }) {
     if (this.level > LogLevel.info || this.silent) return
 
-    let c = chalk.blue
-    if (typeof message === 'object') {
-      if (message.type === 'success') {
-        c = chalk.green
-      } else if (message.type === 'timing') {
-        c = chalk.gray
-      }
-    }
-    console.log(c(typeof message === 'string' ? message : message.message))
+    const msg = typeof message === 'string' ? message : message.message
+    const type = typeof message === 'string' ? undefined : message.type
+    this.emit('info', msg, type)
   }
 
   error(message: string) {
     if (this.level > LogLevel.error) return
-    console.error(chalk.red(message))
+    this.emit('error', message)
   }
 
   warn(message: string) {
     if (this.level > LogLevel.warn) return
-    console.error(chalk.yellow(message))
+    this.emit('warn', message)
   }
 
   debug(message: string | { message: string; type?: string }) {
     if (this.level > LogLevel.debug || this.silent) return
 
-    let c = chalk.gray
-    if (typeof message === 'object') {
-      if (message.type === 'success') {
-        c = chalk.green
-      }
-    }
-    console.log(c(typeof message === 'string' ? message : message.message))
+    const msg = typeof message === 'string' ? message : message.message
+    const type = typeof message === 'string' ? undefined : message.type
+    this.emit('debug', msg, type)
   }
 
   critical(code: ErrorCode, message: string) {
     const url = `${BASE_ERROR_URL}/${code.toLowerCase()}`
     const formattedMessage = `[${code}] ${message}\n  → ${url}`
     this.criticalErrors.push(formattedMessage)
-    console.error(chalk.red.bold(formattedMessage))
+    this.emit('critical', formattedMessage, undefined, code)
   }
 
   hasCriticalErrors(): boolean {
@@ -103,7 +158,7 @@ export class CLILogger implements Logger {
 
   private primary(message: string) {
     if (!this.silent) {
-      console.log(chalk.green(message))
+      this.emit('info', message)
     }
   }
 }

--- a/packages/cli/src/services/cli-logger.service.ts
+++ b/packages/cli/src/services/cli-logger.service.ts
@@ -21,7 +21,6 @@ export class CLILogger implements Logger {
   private level: LogLevel = LogLevel.warn // default to warn level
   private criticalErrors: string[] = []
   private outputMode: CLIOutputMode = 'text'
-  private jsonBuffer: Array<Record<string, unknown>> = []
   private jsonFlushHookRegistered = false
 
   constructor({
@@ -46,9 +45,6 @@ export class CLILogger implements Logger {
   }
 
   setOutputMode(mode: CLIOutputMode): void {
-    if (mode === 'text') {
-      this.jsonBuffer = []
-    }
     this.outputMode = mode
     if (mode === 'json') {
       this.ensureJSONFlushHook()
@@ -81,29 +77,28 @@ export class CLILogger implements Logger {
     process.once('exit', () => this.flushJSONBuffer())
   }
 
-  flushJSONBuffer(): void {
-    if (this.outputMode !== 'json' || this.jsonBuffer.length === 0) return
-    const pending = this.jsonBuffer
-    this.jsonBuffer = []
-    for (const payload of pending) {
-      this.writeJSONLine(payload)
-    }
-  }
+  // NDJSON records are written synchronously in `emit` so consumers can
+  // stream output; nothing is buffered. Kept as a no-op because the
+  // beforeExit/exit hooks installed by `ensureJSONFlushHook` still
+  // reference it, and external callers may rely on the signature.
+  flushJSONBuffer(): void {}
 
   private emit(
     level: 'debug' | 'info' | 'warn' | 'error' | 'critical',
     message: string,
     type?: string,
-    code?: ErrorCode
+    code?: ErrorCode,
+    data?: Record<string, unknown>
   ): void {
     const normalizedMessage = this.normalizeMessage(message)
     if (this.outputMode === 'json') {
-      this.jsonBuffer.push({
+      this.writeJSONLine({
         level,
         message: normalizedMessage,
         ...(type ? { type } : {}),
         ...(code ? { code } : {}),
         ...(code ? { url: `${BASE_ERROR_URL}/${code.toLowerCase()}` } : {}),
+        ...(data ? { data } : {}),
         timestamp: new Date().toISOString(),
       })
       return
@@ -133,12 +128,17 @@ export class CLILogger implements Logger {
     console.log(c(normalizedMessage))
   }
 
-  info(message: string | { message: string; type?: string }) {
+  info(
+    message:
+      | string
+      | { message: string; type?: string; data?: Record<string, unknown> }
+  ) {
     if (this.level > LogLevel.info || this.silent) return
 
     const msg = typeof message === 'string' ? message : message.message
     const type = typeof message === 'string' ? undefined : message.type
-    this.emit('info', msg, type)
+    const data = typeof message === 'string' ? undefined : message.data
+    this.emit('info', msg, type, undefined, data)
   }
 
   error(message: string) {
@@ -151,12 +151,17 @@ export class CLILogger implements Logger {
     this.emit('warn', message)
   }
 
-  debug(message: string | { message: string; type?: string }) {
+  debug(
+    message:
+      | string
+      | { message: string; type?: string; data?: Record<string, unknown> }
+  ) {
     if (this.level > LogLevel.debug || this.silent) return
 
     const msg = typeof message === 'string' ? message : message.message
     const type = typeof message === 'string' ? undefined : message.type
-    this.emit('debug', msg, type)
+    const data = typeof message === 'string' ? undefined : message.data
+    this.emit('debug', msg, type, undefined, data)
   }
 
   critical(code: ErrorCode, message: string) {

--- a/packages/cli/src/services/cli-logger.service.ts
+++ b/packages/cli/src/services/cli-logger.service.ts
@@ -21,6 +21,8 @@ export class CLILogger implements Logger {
   private level: LogLevel = LogLevel.warn // default to warn level
   private criticalErrors: string[] = []
   private outputMode: CLIOutputMode = 'text'
+  private jsonBuffer: Array<Record<string, unknown>> = []
+  private jsonFlushHookRegistered = false
 
   constructor({
     logLogo,
@@ -44,7 +46,13 @@ export class CLILogger implements Logger {
   }
 
   setOutputMode(mode: CLIOutputMode): void {
+    if (mode === 'text') {
+      this.jsonBuffer = []
+    }
     this.outputMode = mode
+    if (mode === 'json') {
+      this.ensureJSONFlushHook()
+    }
   }
 
   getOutputMode(): CLIOutputMode {
@@ -66,6 +74,22 @@ export class CLILogger implements Logger {
     process.stdout.write(`${JSON.stringify(payload)}\n`)
   }
 
+  private ensureJSONFlushHook(): void {
+    if (this.jsonFlushHookRegistered) return
+    this.jsonFlushHookRegistered = true
+    process.once('beforeExit', () => this.flushJSONBuffer())
+    process.once('exit', () => this.flushJSONBuffer())
+  }
+
+  flushJSONBuffer(): void {
+    if (this.outputMode !== 'json' || this.jsonBuffer.length === 0) return
+    const pending = this.jsonBuffer
+    this.jsonBuffer = []
+    for (const payload of pending) {
+      this.writeJSONLine(payload)
+    }
+  }
+
   private emit(
     level: 'debug' | 'info' | 'warn' | 'error' | 'critical',
     message: string,
@@ -74,7 +98,7 @@ export class CLILogger implements Logger {
   ): void {
     const normalizedMessage = this.normalizeMessage(message)
     if (this.outputMode === 'json') {
-      this.writeJSONLine({
+      this.jsonBuffer.push({
         level,
         message: normalizedMessage,
         ...(type ? { type } : {}),

--- a/verifiers/functions/package.json
+++ b/verifiers/functions/package.json
@@ -34,6 +34,6 @@
     "ncu": "npx npm-check-updates",
     "ncu:pikku": "npx npm-check-updates -f '/@pikku/.*/'",
     "pikku": "pikku",
-    "test": "pikku && tsc && npx tsx src/start.ts"
+    "test": "pikku && tsc && npx tsx src/start.ts && node --import tsx --test src/tests/cli-json-output.assert.ts"
   }
 }

--- a/verifiers/functions/src/tests/cli-json-output.assert.ts
+++ b/verifiers/functions/src/tests/cli-json-output.assert.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+describe('pikku cli json output verifier', () => {
+  test('emits NDJSON records for real CLI run', () => {
+    const verifierRoot = join(__dirname, '..', '..')
+    const repoRoot = join(__dirname, '..', '..', '..', '..')
+    const pikkuCliEntry = join(
+      repoRoot,
+      'packages',
+      'cli',
+      '.pikku',
+      'cli',
+      'pikku-cli.gen.ts'
+    )
+
+    const result = spawnSync(
+      'node',
+      ['--import', 'tsx', pikkuCliEntry, 'all', '--output', 'json'],
+      {
+        cwd: verifierRoot,
+        encoding: 'utf-8',
+      }
+    )
+
+    assert.equal(result.status, 0, result.stderr || 'CLI run failed')
+
+    const lines = result.stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+
+    assert.ok(lines.length > 0, 'Expected CLI output lines')
+
+    const structuredRecords: Array<Record<string, unknown>> = []
+    for (const line of lines) {
+      try {
+        const payload = JSON.parse(line) as Record<string, unknown>
+        if (
+          typeof payload.level === 'string' &&
+          typeof payload.message === 'string' &&
+          typeof payload.timestamp === 'string'
+        ) {
+          structuredRecords.push(payload)
+        }
+      } catch {
+        continue
+      }
+    }
+
+    assert.ok(
+      structuredRecords.length > 0,
+      'Expected at least one structured JSON log record with timestamp'
+    )
+
+    for (const payload of structuredRecords) {
+      assert.equal(typeof payload.level, 'string')
+      assert.equal(typeof payload.message, 'string')
+      assert.equal(typeof payload.timestamp, 'string')
+    }
+  })
+})

--- a/verifiers/functions/src/tests/cli-json-output.assert.ts
+++ b/verifiers/functions/src/tests/cli-json-output.assert.ts
@@ -38,31 +38,35 @@ describe('pikku cli json output verifier', () => {
 
     assert.ok(lines.length > 0, 'Expected CLI output lines')
 
-    const structuredRecords: Array<Record<string, unknown>> = []
-    for (const line of lines) {
+    const structuredRecords = lines.map((line, index) => {
+      let payload: Record<string, unknown>
       try {
-        const payload = JSON.parse(line) as Record<string, unknown>
-        if (
-          typeof payload.level === 'string' &&
-          typeof payload.message === 'string' &&
-          typeof payload.timestamp === 'string'
-        ) {
-          structuredRecords.push(payload)
-        }
+        payload = JSON.parse(line) as Record<string, unknown>
       } catch {
-        continue
+        assert.fail(`Line ${index + 1} is not valid JSON: ${line}`)
       }
-    }
+
+      assert.equal(
+        typeof payload.level,
+        'string',
+        `Line ${index + 1} missing string "level": ${line}`
+      )
+      assert.equal(
+        typeof payload.message,
+        'string',
+        `Line ${index + 1} missing string "message": ${line}`
+      )
+      assert.equal(
+        typeof payload.timestamp,
+        'string',
+        `Line ${index + 1} missing string "timestamp": ${line}`
+      )
+      return payload
+    })
 
     assert.ok(
       structuredRecords.length > 0,
-      'Expected at least one structured JSON log record with timestamp'
+      'Expected at least one structured JSON log record'
     )
-
-    for (const payload of structuredRecords) {
-      assert.equal(typeof payload.level, 'string')
-      assert.equal(typeof payload.message, 'string')
-      assert.equal(typeof payload.timestamp, 'string')
-    }
   })
 })

--- a/verifiers/functions/src/tests/cli-json-output.assert.ts
+++ b/verifiers/functions/src/tests/cli-json-output.assert.ts
@@ -15,14 +15,14 @@ describe('pikku cli json output verifier', () => {
       repoRoot,
       'packages',
       'cli',
-      '.pikku',
-      'cli',
-      'pikku-cli.gen.ts'
+      'dist',
+      'bin',
+      'pikku.js'
     )
 
     const result = spawnSync(
       'node',
-      ['--import', 'tsx', pikkuCliEntry, 'all', '--output', 'json'],
+      [pikkuCliEntry, 'all', '--output', 'json'],
       {
         cwd: verifierRoot,
         encoding: 'utf-8',


### PR DESCRIPTION
## Summary
- add global CLI output mode flags: --output json and --json alias
- implement NDJSON structured logging mode in CLILogger with timestamped records
- include structured critical error fields (code and docs url) and ANSI-safe message normalization
- redirect console output through logger in JSON mode so existing command output remains machine-readable
- remove raw stdout progress writes in deploy apply and emit structured logger progress instead
- add logger JSON-mode tests and a patch changeset

Fixes #481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--output json` / `--json` flags to emit structured NDJSON logs with ISO timestamps
  * Deploy progress now emits structured step/detail entries

* **Bug Fixes / Behavior**
  * Logo suppressed when JSON output is selected
  * ANSI codes stripped from JSON messages; JSON logs emitted immediately

* **Tests**
  * New automated tests validating NDJSON output format and fields

* **Chores**
  * Added changeset declaring a patch release
<!-- end of auto-generated comment: release notes by coderabbit.ai -->