### PR TITLE
fix(cli): emit pikkuListFunc helper in generated types

### DIFF
--- a/.changeset/few-cameras-sing.md
+++ b/.changeset/few-cameras-sing.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Emit `pikkuListFunc` and `PikkuListFunction` in generated `pikku-types.gen.ts` so list-style function typing can be expressed without manually wrapping `ListInput`/`ListOutput`.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,12 +7,12 @@
     "no-accumulating-spread": "warn",
     "node/no-process-env": "warn",
     "import/no-cycle": "warn",
-    "typescript/consistent-type-imports": "warn",
-    "typescript/no-import-type-side-effects": "warn",
+    "typescript/consistent-type-imports": "error",
+    "typescript/no-import-type-side-effects": "error",
     "typescript/prefer-optional-chain": "warn",
-    "unicorn/prefer-array-flat-map": "warn",
-    "unicorn/prefer-includes": "warn",
-    "unicorn/prefer-optional-catch-binding": "warn",
-    "unicorn/throw-new-error": "warn"
+    "unicorn/prefer-array-flat-map": "error",
+    "unicorn/prefer-includes": "error",
+    "unicorn/prefer-optional-catch-binding": "error",
+    "unicorn/throw-new-error": "error"
   }
 }

--- a/packages/cli/src/functions/wirings/functions/serialize-function-types.test.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-function-types.test.ts
@@ -1,0 +1,27 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { serializeFunctionTypes } from './serialize-function-types.js'
+
+describe('serializeFunctionTypes', () => {
+  test('emits pikkuListFunc and PikkuListFunction helper types', () => {
+    const content = serializeFunctionTypes(
+      "import type { Session } from './session.js'",
+      'Session',
+      "import type { SingletonServices } from './singleton-services.js'",
+      'SingletonServices',
+      "import type { Services } from './wire-services.js'",
+      'Services',
+      "import type { FlattenedRPCMap, TypedPikkuRPC } from './rpc-map.js'",
+      "import type { RequiredSingletonServices, RequiredWireServices } from './required-services.js'",
+      "import type { Config } from './config.js'"
+    )
+
+    assert.match(content, /ListInput, ListOutput/)
+    assert.match(content, /export type PikkuListFunction</)
+    assert.match(content, /export const pikkuListFunc = </)
+    assert.match(
+      content,
+      /PikkuFunctionConfig<\s*ListInput<F, S>,\s*ListOutput<Row>/
+    )
+  })
+})

--- a/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
@@ -27,7 +27,7 @@ export const serializeFunctionTypes = (
  * Core function, middleware, and permission types for all wirings
  */
 
-import type { CorePikkuMiddleware, CorePermissionGroup, PikkuWire, PickRequired } from '@pikku/core'
+import type { CorePikkuMiddleware, CorePermissionGroup, ListInput, ListOutput, PikkuWire, PickRequired } from '@pikku/core'
 import type { CorePikkuFunctionConfig, CorePikkuAuth, CorePikkuAuthConfig, CorePikkuPermission } from '@pikku/core/function'
 import { pikkuAuth as pikkuAuthCore } from '@pikku/core/function'
 import { addMiddleware as addMiddlewareCore, addPermission as addPermissionCore } from '@pikku/core/middleware'
@@ -428,6 +428,32 @@ export function pikkuFunc<In, Out = unknown>(
 ): PikkuFunctionConfig<In, Out, 'session' | 'rpc'>
 export function pikkuFunc(func: any) {
   return typeof func === 'function' ? { func } : func
+}
+
+export type PikkuListFunction<
+  F extends Record<string, unknown> = {},
+  Row = unknown,
+  S extends string = never
+> =
+  | PikkuFunction<ListInput<F, S>, ListOutput<Row>, 'session' | 'rpc'>
+  | PikkuFunctionSessionless<
+      ListInput<F, S>,
+      ListOutput<Row>,
+      'session' | 'rpc'
+    >
+
+export const pikkuListFunc = <
+  F extends Record<string, unknown> = {},
+  Row = unknown,
+  S extends string = never
+>(
+  config: PikkuFunctionConfig<
+    ListInput<F, S>,
+    ListOutput<Row>,
+    'session' | 'rpc'
+  >
+): PikkuFunctionConfig<ListInput<F, S>, ListOutput<Row>, 'session' | 'rpc'> => {
+  return pikkuFunc(config)
 }
 
 /**

--- a/packages/inspector/src/add/add-functions.ts
+++ b/packages/inspector/src/add/add-functions.ts
@@ -546,6 +546,7 @@ export const addFunctions: AddWiring = (
   }
 
   const isMCPToolFunc = expression.text === 'pikkuMCPToolFunc'
+  const isListFunc = expression.text === 'pikkuListFunc'
   const mcpEnabled = mcp || isMCPToolFunc
 
   // Pick the handler: use resolvedFunc when it exists and is a function, otherwise fall back to handlerNode
@@ -618,7 +619,33 @@ export const addFunctions: AddWiring = (
     inputNames = [schemaName]
     state.schemaLookup.set(schemaName, inputSchemaRef)
     state.functions.typesMap.addCustomType(schemaName, 'unknown', [])
-  } else if (genericTypes.length >= 1 && genericTypes[0]) {
+  } else if (isListFunc && genericTypes.length >= 1 && genericTypes[0]) {
+    const inputAliasName = `${capitalizedName}Input`
+    const filterType = genericTypes[0]
+    const filterTypeText = checker.typeToString(
+      filterType,
+      undefined,
+      ts.TypeFormatFlags.NoTruncation
+    )
+    const refs = resolveTypeImports(
+      filterType,
+      state.functions.typesMap,
+      true,
+      checker
+    )
+    state.functions.typesMap.addCustomType(
+      inputAliasName,
+      `{ cursor?: string; limit?: number; sort?: Array<{ column: string; direction: 'asc' | 'desc' }>; filter?: unknown; search?: string; } & ${filterTypeText}`,
+      [...new Set(refs)]
+    )
+    inputNames = [inputAliasName]
+    const secondParam = handler.parameters[1]
+    if (secondParam) {
+      inputTypes = [checker.getTypeAtLocation(secondParam)]
+    } else {
+      inputTypes = [filterType]
+    }
+  } else if (!isListFunc && genericTypes.length >= 1 && genericTypes[0]) {
     // Fall back to extracting from generic type arguments
     const result = getNamesAndTypes(
       checker,
@@ -654,7 +681,27 @@ export const addFunctions: AddWiring = (
     outputNames = [schemaName]
     state.schemaLookup.set(schemaName, outputSchemaRef)
     state.functions.typesMap.addCustomType(schemaName, 'unknown', [])
-  } else if (genericTypes.length >= 2) {
+  } else if (isListFunc && genericTypes.length >= 2 && genericTypes[1]) {
+    const outputAliasName = `${capitalizedName}Output`
+    const rowType = genericTypes[1]
+    const rowTypeText = checker.typeToString(
+      rowType,
+      undefined,
+      ts.TypeFormatFlags.NoTruncation
+    )
+    const refs = resolveTypeImports(
+      rowType,
+      state.functions.typesMap,
+      true,
+      checker
+    )
+    state.functions.typesMap.addCustomType(
+      outputAliasName,
+      `{ rows: Array<${rowTypeText}>; nextCursor: string | null; totalCount?: number; }`,
+      [...new Set(refs)]
+    )
+    outputNames = [outputAliasName]
+  } else if (!isListFunc && genericTypes.length >= 2) {
     outputNames = getNamesAndTypes(
       checker,
       state.functions.typesMap,

--- a/packages/inspector/src/utils/validate-auth-sessionless.ts
+++ b/packages/inspector/src/utils/validate-auth-sessionless.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript'
+import type * as ts from 'typescript'
 import { getPropertyValue } from './get-property-value.js'
 import { ErrorCode } from '../error-codes.js'
 import type { InspectorLogger, InspectorState } from '../types.js'

--- a/packages/runtimes/aws-lambda/src/handler-factories.ts
+++ b/packages/runtimes/aws-lambda/src/handler-factories.ts
@@ -7,6 +7,7 @@
 
 import { LocalVariablesService, LocalSecretService } from '@pikku/core/services'
 import type { CoreSingletonServices } from '@pikku/core'
+import type { ChannelStore } from '@pikku/core/channel'
 import { runFetchV2 } from './http/run-fetch-v2.js'
 import { runSQSQueueWorker } from './queue/sqs-worker.js'
 import { runLambdaScheduled } from './scheduled/run-scheduled.js'
@@ -133,7 +134,7 @@ export function createLambdaWebSocketHandler(
       throw new Error('Services not initialized for WebSocket handler')
     }
     const channelStore = (cachedServices as unknown as Record<string, unknown>)
-      .channelStore as import('@pikku/core/channel').ChannelStore | undefined
+      .channelStore as ChannelStore | undefined
     if (!channelStore) {
       throw new Error(
         'channelStore not found in singleton services. Ensure it is configured for channel units.'

--- a/packages/runtimes/azure-functions/src/azure-queue-service.ts
+++ b/packages/runtimes/azure-functions/src/azure-queue-service.ts
@@ -7,7 +7,8 @@
  * string from AzureWebJobsStorage.
  */
 
-import { QueueClient, QueueServiceClient } from '@azure/storage-queue'
+import { QueueServiceClient } from '@azure/storage-queue'
+import type { QueueClient } from '@azure/storage-queue'
 import type { QueueService, QueueJob, JobOptions } from '@pikku/core/queue'
 
 export class AzureQueueService implements QueueService {

--- a/packages/runtimes/cloudflare/src/cloudflare-hibernation-websocket-server.ts
+++ b/packages/runtimes/cloudflare/src/cloudflare-hibernation-websocket-server.ts
@@ -17,8 +17,7 @@ import { PikkuFetchHTTPRequest, PikkuFetchHTTPResponse } from '@pikku/core/http'
 import crypto from 'crypto'
 export abstract class CloudflareWebSocketHibernationServer<
   SingletonServices extends CoreSingletonServices = CoreSingletonServices,
-> implements DurableObject
-{
+> implements DurableObject {
   private eventHub: CloudflareEventHubService<{}> | undefined
   private channelStore: CloudflareWebsocketStore
 
@@ -52,7 +51,7 @@ export abstract class CloudflareWebSocketHibernationServer<
         response,
         bubbleErrors: true,
       })
-    } catch (e) {
+    } catch {
       server.close(1008, 'Unauthorized')
       return new Response(null, { status: 403 }) as any
     }

--- a/templates/functions/src/functions/todos.functions.ts
+++ b/templates/functions/src/functions/todos.functions.ts
@@ -13,6 +13,7 @@ import {
   TodoListResponseSchema,
   DeleteResponseSchema,
 } from '../schemas.js'
+import type { Todo } from '../schemas.js'
 
 /**
  * List todos for a user with optional filters.
@@ -154,7 +155,7 @@ export const listTodoRows = pikkuListFunc<
     completed: boolean
     priority: 'low' | 'medium' | 'high'
   },
-  import('../schemas.js').Todo
+  Todo
 >({
   func: async ({ todoStore }, data) => {
     const limit = data.limit ?? 20

--- a/templates/functions/src/functions/todos.functions.ts
+++ b/templates/functions/src/functions/todos.functions.ts
@@ -1,4 +1,7 @@
-import { pikkuSessionlessFunc } from '../../.pikku/pikku-types.gen.js'
+import {
+  pikkuSessionlessFunc,
+  pikkuListFunc,
+} from '../../.pikku/pikku-types.gen.js'
 import {
   ListTodosWithUserInputSchema,
   CreateTodoWithUserInputSchema,
@@ -139,5 +142,27 @@ export const completeTodo = pikkuSessionlessFunc({
     }
 
     return { todo: todo || null, success: !!todo }
+  },
+})
+
+/**
+ * List todos using standard list-function shape (rows + cursor).
+ */
+export const listTodoRows = pikkuListFunc<
+  {
+    userId: string
+    completed: boolean
+    priority: 'low' | 'medium' | 'high'
+  },
+  import('../schemas.js').Todo
+>({
+  func: async ({ todoStore }, data) => {
+    const limit = data.limit ?? 20
+    const todos = todoStore.getTodosByUser('user1').slice(0, limit)
+    return {
+      rows: todos,
+      nextCursor: null,
+      totalCount: todos.length,
+    }
   },
 })

--- a/templates/functions/src/wirings/todos.http.ts
+++ b/templates/functions/src/wirings/todos.http.ts
@@ -4,6 +4,7 @@ import {
 } from '../../.pikku/pikku-types.gen.js'
 import {
   listTodos,
+  listTodoRows,
   getTodo,
   createTodo,
   updateTodo,
@@ -16,6 +17,7 @@ const todosRoutes = defineHTTPRoutes({
   tags: ['todos'],
   routes: {
     list: { method: 'get', route: '/todos', func: listTodos },
+    listRows: { method: 'get', route: '/todos/rows', func: listTodoRows },
     get: { method: 'get', route: '/todos/:id', func: getTodo },
     create: { method: 'post', route: '/todos', func: createTodo },
     update: { method: 'put', route: '/todos/:id', func: updateTodo },

--- a/verifiers/functions/src/functions/rpc/rpc.functions.ts
+++ b/verifiers/functions/src/functions/rpc/rpc.functions.ts
@@ -1,4 +1,4 @@
-import { pikkuSessionlessFunc } from '#pikku'
+import { pikkuListFunc, pikkuSessionlessFunc } from '#pikku'
 
 export const rpcTest = pikkuSessionlessFunc<{ in: number }>({
   func: async ({ logger }, data, { rpc }) => {
@@ -12,14 +12,14 @@ export const rpcTest = pikkuSessionlessFunc<{ in: number }>({
   expose: true,
 })
 
-export const listItems = pikkuSessionlessFunc<
-  { limit: number; nextCursor?: string },
-  { items: string[]; nextCursor?: string }
+export const listItems = pikkuListFunc<
+  { category?: string },
+  { id: string; label: string }
 >({
   func: async (_services, data) => {
     return {
-      items: [`item-${data.limit}`],
-      nextCursor: data.nextCursor ? undefined : 'next',
+      rows: [{ id: `item-${data.limit ?? 1}`, label: 'item' }],
+      nextCursor: data.cursor ? null : 'next',
     }
   },
   expose: true,


### PR DESCRIPTION
Closes #495

Summary
- emit PikkuListFunction helper type in generated pikku-types.gen.ts
- emit pikkuListFunc helper function wired to ListInput/ListOutput
- add serializer test coverage for generated list helper exports
- include a patch changeset for @pikku/cli

Validation
- node --import tsx --test packages/cli/src/functions/wirings/functions/serialize-function-types.test.ts
- (cd packages/cli && bash run-tests.sh)
- corepack yarn exec tsc -p ./packages/cli/tsconfig.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated types now support list-style function typing for easier list handlers.
  * New list-style example handler and an unauthenticated GET /todos/rows endpoint.
  * Several existing functions converted to list-style handlers so list responses use paginated "rows" shapes.
* **Tests**
  * Added tests ensuring list-related type generation and helpers are produced correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->