### PR TITLE
deploy: emit deployment-manifest and exact dependency metadata

### DIFF
--- a/packages/cli/src/deploy/analyzer/manifest.ts
+++ b/packages/cli/src/deploy/analyzer/manifest.ts
@@ -62,10 +62,12 @@ export interface DeploymentUnit {
   bundleHash?: string
   /** Final bundle size in bytes (set by build pipeline) */
   bundleSizeBytes?: number
-  /** SHA-256 of sorted external package map (set by build pipeline) */
-  externalPackagesHash?: string
-  /** External runtime dependencies used by this unit (set by build pipeline) */
-  externalPackages?: Record<string, string>
+  /** SHA-256 of sorted exact dependency map (set by build pipeline) */
+  exactDependenciesHash?: string
+  /** Top-level exact runtime dependency versions for this unit (set by build pipeline) */
+  exactDependencies?: Record<string, string>
+  /** Top-level exact optional runtime dependency versions for this unit (set by build pipeline) */
+  exactOptionalDependencies?: Record<string, string>
 }
 
 export interface QueueDefinition {

--- a/packages/cli/src/deploy/analyzer/manifest.ts
+++ b/packages/cli/src/deploy/analyzer/manifest.ts
@@ -58,6 +58,14 @@ export interface DeploymentUnit {
   /** What runtime handlers this unit needs to export */
   handlers: DeploymentHandler[]
   tags: string[]
+  /** SHA-256 of final bundled artifact (set by build pipeline) */
+  bundleHash?: string
+  /** Final bundle size in bytes (set by build pipeline) */
+  bundleSizeBytes?: number
+  /** SHA-256 of sorted external package map (set by build pipeline) */
+  externalPackagesHash?: string
+  /** External runtime dependencies used by this unit (set by build pipeline) */
+  externalPackages?: Record<string, string>
 }
 
 export interface QueueDefinition {

--- a/packages/cli/src/deploy/build-pipeline.ts
+++ b/packages/cli/src/deploy/build-pipeline.ts
@@ -32,6 +32,22 @@ export interface BuildPipelineResult {
   codegenErrors: Array<{ unitName: string; error: string }>
 }
 
+function attachBundleMetadata(
+  manifest: DeploymentManifest,
+  bundled: BundleResult[]
+): void {
+  if (bundled.length === 0) return
+  const byUnitName = new Map(bundled.map((b) => [b.unitName, b]))
+  for (const unit of manifest.units) {
+    const bundle = byUnitName.get(unit.name)
+    if (!bundle) continue
+    unit.bundleHash = bundle.bundleHash
+    unit.bundleSizeBytes = bundle.bundleSizeBytes
+    unit.externalPackagesHash = bundle.externalPackagesHash
+    unit.externalPackages = bundle.externalPackages
+  }
+}
+
 function findLockfile(projectDir: string): string | null {
   for (const name of ['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml']) {
     const p = join(projectDir, name)
@@ -121,13 +137,16 @@ export async function runBuildPipeline(options: {
     )
     bundled = bundleResult.results
     bundleErrors = bundleResult.errors
+    attachBundleMetadata(manifest, bundled)
 
     logger.info(
       `Bundled standalone${bundleErrors.length > 0 ? ` (${bundleErrors.length} errors)` : ''}`
     )
   } else {
     // Multi-unit mode: per-function decomposition
-    const serverlessUnits = manifest.units.filter((u) => u.target === 'serverless')
+    const serverlessUnits = manifest.units.filter(
+      (u) => u.target === 'serverless'
+    )
     const serverUnits = manifest.units.filter((u) => u.target === 'server')
 
     logger.info(
@@ -149,8 +168,8 @@ export async function runBuildPipeline(options: {
     // Server units share a single codegen pass (step 2b).
     const serverlessManifest = { ...manifest, units: serverlessUnits }
     logger.info('Generating per-unit codegen...')
-    const { unitPikkuDirs, errors: serverlessCodegenErrors } = await generatePerUnitCodegen(
-      {
+    const { unitPikkuDirs, errors: serverlessCodegenErrors } =
+      await generatePerUnitCodegen({
         projectDir,
         manifest: serverlessManifest,
         inspectorState,
@@ -164,8 +183,7 @@ export async function runBuildPipeline(options: {
             logger.error(`  Codegen: ${unitName} failed — ${error}`)
           }
         },
-      }
-    )
+      })
     codegenErrors = serverlessCodegenErrors
 
     // Step 2b: Server units — single codegen pass with all server function IDs
@@ -194,8 +212,10 @@ export async function runBuildPipeline(options: {
           deployDir: providerDir,
           onProgress: (unitName, status, error) => {
             if (status === 'start') logger.info(`  Codegen: ${unitName}...`)
-            else if (status === 'done') logger.info(`  Codegen: ${unitName} done`)
-            else if (status === 'error') logger.error(`  Codegen: ${unitName} failed — ${error}`)
+            else if (status === 'done')
+              logger.info(`  Codegen: ${unitName} done`)
+            else if (status === 'error')
+              logger.error(`  Codegen: ${unitName} failed — ${error}`)
           },
         })
 
@@ -205,7 +225,9 @@ export async function runBuildPipeline(options: {
       // Replace individual server units with the merged one in the manifest
       manifest.units = [...serverlessUnits, mergedServerUnit]
 
-      logger.info(`  Server container: ${serverUnits.length} functions merged into one unit`)
+      logger.info(
+        `  Server container: ${serverUnits.length} functions merged into one unit`
+      )
     }
 
     logger.info(`Codegen complete: ${unitPikkuDirs.size} units`)
@@ -244,6 +266,7 @@ export async function runBuildPipeline(options: {
     )
     bundled = bundleResult.results
     bundleErrors = bundleResult.errors
+    attachBundleMetadata(manifest, bundled)
 
     logger.info(
       `Bundled ${bundled.length} units${bundleErrors.length > 0 ? ` (${bundleErrors.length} failed)` : ''}`

--- a/packages/cli/src/deploy/build-pipeline.ts
+++ b/packages/cli/src/deploy/build-pipeline.ts
@@ -26,11 +26,17 @@ export interface BuildLogger {
 export interface BuildPipelineResult {
   manifest: DeploymentManifest
   providerDir: string
+  deploymentManifestPath: string
+  infraPath: string | null
   projectId: string
   bundled: BundleResult[]
   bundleErrors: Array<{ unitName: string; error: string }>
   codegenErrors: Array<{ unitName: string; error: string }>
 }
+
+const MERGED_SERVER_UNIT_NAME = 'pikku-server-container'
+const UNITS_DIR_NAME = 'units'
+const CONTAINER_DIR_NAME = 'container'
 
 function attachBundleMetadata(
   manifest: DeploymentManifest,
@@ -43,8 +49,9 @@ function attachBundleMetadata(
     if (!bundle) continue
     unit.bundleHash = bundle.bundleHash
     unit.bundleSizeBytes = bundle.bundleSizeBytes
-    unit.externalPackagesHash = bundle.externalPackagesHash
-    unit.externalPackages = bundle.externalPackages
+    unit.exactDependenciesHash = bundle.exactDependenciesHash
+    unit.exactDependencies = bundle.exactDependencies
+    unit.exactOptionalDependencies = bundle.exactOptionalDependencies
   }
 }
 
@@ -91,6 +98,10 @@ export async function runBuildPipeline(options: {
   let bundled: BundleResult[] = []
   let bundleErrors: Array<{ unitName: string; error: string }> = []
   let codegenErrors: Array<{ unitName: string; error: string }> = []
+  let infraPath: string | null = null
+  const deploymentManifestPath = join(providerDir, 'deployment-manifest.json')
+  const unitsDir = join(providerDir, UNITS_DIR_NAME)
+  const containerDir = join(providerDir, CONTAINER_DIR_NAME)
 
   if (provider.singleUnit) {
     // Single-unit mode: bundle everything into one unit, use project's .pikku/ directly
@@ -157,6 +168,8 @@ export async function runBuildPipeline(options: {
       return {
         manifest,
         providerDir,
+        deploymentManifestPath,
+        infraPath,
         projectId,
         bundled: [],
         bundleErrors: [],
@@ -173,7 +186,7 @@ export async function runBuildPipeline(options: {
         projectDir,
         manifest: serverlessManifest,
         inspectorState,
-        deployDir: providerDir,
+        deployDir: unitsDir,
         onProgress: (unitName, status, error) => {
           if (status === 'start') {
             logger.info(`  Codegen: ${unitName}...`)
@@ -188,7 +201,7 @@ export async function runBuildPipeline(options: {
 
     // Step 2b: Server units — single codegen pass with all server function IDs
     if (serverUnits.length > 0) {
-      const serverUnitName = 'server'
+      const serverUnitName = MERGED_SERVER_UNIT_NAME
 
       // Create a merged server unit with all server function IDs
       const mergedServerUnit: DeploymentManifest['units'][0] = {
@@ -209,7 +222,8 @@ export async function runBuildPipeline(options: {
           projectDir,
           manifest: serverManifest,
           inspectorState,
-          deployDir: providerDir,
+          deployDir: containerDir,
+          resolveUnitDir: () => containerDir,
           onProgress: (unitName, status, error) => {
             if (status === 'start') logger.info(`  Codegen: ${unitName}...`)
             else if (status === 'done')
@@ -240,7 +254,8 @@ export async function runBuildPipeline(options: {
       const pikkuDir = unitPikkuDirs.get(unit.name)
       if (!pikkuDir) continue
 
-      const unitDir = join(providerDir, unit.name)
+      const unitDir =
+        unit.target === 'server' ? containerDir : join(unitsDir, unit.name)
       const entryPath = join(unitDir, 'entry.ts')
       await mkdir(unitDir, { recursive: true })
 
@@ -262,6 +277,8 @@ export async function runBuildPipeline(options: {
         define: provider.getDefine?.(),
         platform: provider.getPlatform?.(),
         format: provider.getFormat?.(),
+        resolveOutputDir: (unit) =>
+          unit.target === 'server' ? containerDir : join(unitsDir, unit.name),
       }
     )
     bundled = bundleResult.results
@@ -280,9 +297,18 @@ export async function runBuildPipeline(options: {
   }
 
   // Step 4: Generate configs + infra manifest
+  await mkdir(providerDir, { recursive: true })
+  await writeFile(
+    deploymentManifestPath,
+    JSON.stringify(manifest, null, 2),
+    'utf-8'
+  )
+  logger.info('Generated deployment manifest')
+
   const infraContent = provider.generateInfraManifest(manifest)
   if (infraContent) {
-    await writeFile(join(providerDir, 'infra.json'), infraContent, 'utf-8')
+    infraPath = join(providerDir, 'infra.json')
+    await writeFile(infraPath, infraContent, 'utf-8')
     logger.info('Generated infrastructure manifest')
   }
 
@@ -297,7 +323,11 @@ export async function runBuildPipeline(options: {
 
   const lockfileSrc = findLockfile(projectDir)
   for (const unit of manifest.units) {
-    const unitDir = join(providerDir, unit.name)
+    const unitDir = provider.singleUnit
+      ? join(providerDir, unit.name)
+      : unit.target === 'server'
+        ? containerDir
+        : join(unitsDir, unit.name)
     await mkdir(unitDir, { recursive: true })
     const configs = provider.generateUnitConfigs(unit, manifest, projectId)
     for (const [filename, content] of configs) {
@@ -312,6 +342,8 @@ export async function runBuildPipeline(options: {
   return {
     manifest,
     providerDir,
+    deploymentManifestPath,
+    infraPath,
     projectId,
     bundled,
     bundleErrors,

--- a/packages/cli/src/deploy/bundler/bundler.ts
+++ b/packages/cli/src/deploy/bundler/bundler.ts
@@ -89,6 +89,7 @@ function createDeadModuleStubPlugin(patterns: RegExp[]): Plugin {
 const BUNDLE_FILENAME = 'bundle.js'
 const METAFILE_FILENAME = 'metafile.json'
 const PACKAGE_JSON_FILENAME = 'package.json'
+const EXACT_DEPENDENCIES_FILENAME = 'exact-dependencies.json'
 
 interface BundleUnitOptions {
   unit: DeploymentUnit
@@ -128,6 +129,7 @@ async function bundleUnit(options: BundleUnitOptions): Promise<BundleResult> {
   const bundlePath = join(unitOutputDir, BUNDLE_FILENAME)
   const metafilePath = join(unitOutputDir, METAFILE_FILENAME)
   const packageJsonPath = join(unitOutputDir, PACKAGE_JSON_FILENAME)
+  const exactDependenciesPath = join(unitOutputDir, EXACT_DEPENDENCIES_FILENAME)
 
   // Determine which gen files to stub based on per-unit service requirements
   const deadPatterns = await getDeadGenFilePatterns(unitOutputDir)
@@ -184,11 +186,36 @@ async function bundleUnit(options: BundleUnitOptions): Promise<BundleResult> {
   await writeFile(metafilePath, metafileJson, 'utf-8')
 
   // Extract dependencies and generate minimal package.json
-  const dependencies = await extractDependencies(result.metafile, projectDir)
-  const packageJson = generateMinimalPackageJson(unit.name, dependencies)
+  const { exactDependencies, exactOptionalDependencies } =
+    await extractDependencies(result.metafile, projectDir)
+  const packageJson = generateMinimalPackageJson(
+    unit.name,
+    exactDependencies,
+    exactOptionalDependencies
+  )
   await writeFile(
     packageJsonPath,
     JSON.stringify(packageJson, null, 2),
+    'utf-8'
+  )
+  await writeFile(
+    exactDependenciesPath,
+    JSON.stringify(
+      {
+        dependencies: Object.fromEntries(
+          Object.entries(exactDependencies).sort(([a], [b]) =>
+            a.localeCompare(b)
+          )
+        ),
+        optionalDependencies: Object.fromEntries(
+          Object.entries(exactOptionalDependencies).sort(([a], [b]) =>
+            a.localeCompare(b)
+          )
+        ),
+      },
+      null,
+      2
+    ),
     'utf-8'
   )
 
@@ -196,11 +223,16 @@ async function bundleUnit(options: BundleUnitOptions): Promise<BundleResult> {
   const bundleStat = await stat(bundlePath)
   const bundleContents = await readFile(bundlePath)
   const bundleHash = createHash('sha256').update(bundleContents).digest('hex')
-  const externalPackagesHash = createHash('sha256')
+  const exactDependenciesHash = createHash('sha256')
     .update(
-      JSON.stringify(
-        Object.entries(dependencies).sort(([a], [b]) => a.localeCompare(b))
-      )
+      JSON.stringify({
+        dependencies: Object.entries(exactDependencies).sort(([a], [b]) =>
+          a.localeCompare(b)
+        ),
+        optionalDependencies: Object.entries(exactOptionalDependencies).sort(
+          ([a], [b]) => a.localeCompare(b)
+        ),
+      })
     )
     .digest('hex')
 
@@ -208,11 +240,13 @@ async function bundleUnit(options: BundleUnitOptions): Promise<BundleResult> {
     unitName: unit.name,
     bundlePath,
     packageJsonPath,
+    exactDependenciesPath,
     metafilePath,
     bundleSizeBytes: bundleStat.size,
     bundleHash,
-    externalPackagesHash,
-    externalPackages: dependencies,
+    exactDependenciesHash,
+    exactDependencies,
+    exactOptionalDependencies,
   }
 }
 
@@ -238,6 +272,7 @@ export async function bundleUnits(
     define?: Record<string, string>
     platform?: 'node' | 'neutral' | 'browser'
     format?: 'esm' | 'cjs'
+    resolveOutputDir?: (unit: DeploymentUnit, baseOutputDir: string) => string
   }
 ): Promise<BundleOutput> {
   const buildDir = outputDir ?? join(projectDir, '.deploy', 'build')
@@ -258,7 +293,9 @@ export async function bundleUnits(
       continue
     }
 
-    const unitOutputDir = join(buildDir, unit.name)
+    const unitOutputDir = options?.resolveOutputDir
+      ? options.resolveOutputDir(unit, buildDir)
+      : join(buildDir, unit.name)
 
     try {
       const result = await bundleUnit({

--- a/packages/cli/src/deploy/bundler/bundler.ts
+++ b/packages/cli/src/deploy/bundler/bundler.ts
@@ -13,6 +13,7 @@
 import { build, type Plugin } from 'esbuild'
 import { writeFile, mkdir, stat, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { createHash } from 'node:crypto'
 
 import {
   extractDependencies,
@@ -150,9 +151,12 @@ async function bundleUnit(options: BundleUnitOptions): Promise<BundleResult> {
   // esbuild wraps these as __require() which fails at runtime in ESM.
   // The banner shims require via createRequire so CJS builtins resolve.
   const resolvedFormat = format ?? 'esm'
-  const banner = resolvedFormat === 'esm' && (platform ?? 'node') === 'node'
-    ? { js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);` }
-    : undefined
+  const banner =
+    resolvedFormat === 'esm' && (platform ?? 'node') === 'node'
+      ? {
+          js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
+        }
+      : undefined
 
   const result = await build({
     entryPoints: [entryPath],
@@ -190,6 +194,15 @@ async function bundleUnit(options: BundleUnitOptions): Promise<BundleResult> {
 
   // Get bundle size
   const bundleStat = await stat(bundlePath)
+  const bundleContents = await readFile(bundlePath)
+  const bundleHash = createHash('sha256').update(bundleContents).digest('hex')
+  const externalPackagesHash = createHash('sha256')
+    .update(
+      JSON.stringify(
+        Object.entries(dependencies).sort(([a], [b]) => a.localeCompare(b))
+      )
+    )
+    .digest('hex')
 
   return {
     unitName: unit.name,
@@ -197,6 +210,8 @@ async function bundleUnit(options: BundleUnitOptions): Promise<BundleResult> {
     packageJsonPath,
     metafilePath,
     bundleSizeBytes: bundleStat.size,
+    bundleHash,
+    externalPackagesHash,
     externalPackages: dependencies,
   }
 }

--- a/packages/cli/src/deploy/bundler/dep-extractor.ts
+++ b/packages/cli/src/deploy/bundler/dep-extractor.ts
@@ -51,12 +51,57 @@ export function parsePackageName(specifier: string): string | null {
     return null
   }
   const builtins = new Set([
-    'assert', 'buffer', 'child_process', 'cluster', 'console', 'constants',
-    'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'http2',
-    'https', 'inspector', 'module', 'net', 'os', 'path', 'perf_hooks',
-    'process', 'punycode', 'querystring', 'readline', 'repl', 'stream',
-    'string_decoder', 'sys', 'timers', 'tls', 'tty', 'url', 'util',
-    'v8', 'vm', 'wasi', 'worker_threads', 'zlib',
+    'assert',
+    'buffer',
+    'child_process',
+    'cluster',
+    'console',
+    'constants',
+    'crypto',
+    'dgram',
+    'dns',
+    'domain',
+    'events',
+    'fs',
+    'http',
+    'http2',
+    'https',
+    'inspector',
+    'module',
+    'net',
+    'os',
+    'path',
+    'perf_hooks',
+    'process',
+    'punycode',
+    'querystring',
+    'readline',
+    'repl',
+    'stream',
+    'string_decoder',
+    'sys',
+    'timers',
+    'tls',
+    'tty',
+    'url',
+    'util',
+    'v8',
+    'vm',
+    'wasi',
+    'worker_threads',
+    'zlib',
+    'async_hooks',
+    'child_process',
+    'cluster',
+    'diagnostics_channel',
+    'dns/promises',
+    'fs/promises',
+    'readline/promises',
+    'stream/consumers',
+    'stream/promises',
+    'stream/web',
+    'timers/promises',
+    'util/types',
   ])
   if (builtins.has(specifier.split('/')[0])) {
     return null
@@ -75,7 +120,7 @@ export function parsePackageName(specifier: string): string | null {
 
 interface ProjectDeps {
   dependencies: Record<string, string>
-  devDependencies: Record<string, string>
+  optionalDependencies: Record<string, string>
 }
 
 /**
@@ -85,7 +130,7 @@ async function readProjectDependencies(
   projectDir: string
 ): Promise<ProjectDeps> {
   const dependencies: Record<string, string> = {}
-  const devDependencies: Record<string, string> = {}
+  const optionalDependencies: Record<string, string> = {}
 
   // Walk up the directory tree to find all package.json files
   // (handles monorepo setups where deps are in the root package.json)
@@ -96,14 +141,15 @@ async function readProjectDependencies(
       const content = await readFile(pkgJsonPath, 'utf-8')
       const pkg = JSON.parse(content) as {
         dependencies?: Record<string, string>
+        optionalDependencies?: Record<string, string>
         devDependencies?: Record<string, string>
       }
       // Don't overwrite — closest package.json wins
       for (const [k, v] of Object.entries(pkg.dependencies ?? {})) {
         if (!(k in dependencies)) dependencies[k] = v
       }
-      for (const [k, v] of Object.entries(pkg.devDependencies ?? {})) {
-        if (!(k in devDependencies)) devDependencies[k] = v
+      for (const [k, v] of Object.entries(pkg.optionalDependencies ?? {})) {
+        if (!(k in optionalDependencies)) optionalDependencies[k] = v
       }
     } catch {
       // No package.json at this level
@@ -113,7 +159,7 @@ async function readProjectDependencies(
     dir = parent
   }
 
-  return { dependencies, devDependencies }
+  return { dependencies, optionalDependencies }
 }
 
 /**
@@ -191,11 +237,33 @@ function parseYarnLockKeyLine(line: string): string[] {
  * Resolves the exact version for a package, trying yarn.lock first,
  * then falling back to the version range from package.json.
  */
-function resolveVersion(
+async function resolveInstalledPackageVersion(
+  packageName: string,
+  projectDir: string
+): Promise<string | null> {
+  let dir = projectDir
+  while (true) {
+    const pkgPath = join(dir, 'node_modules', packageName, 'package.json')
+    try {
+      const content = await readFile(pkgPath, 'utf-8')
+      const pkg = JSON.parse(content) as { version?: string }
+      if (pkg.version) return pkg.version
+    } catch {
+      // Keep walking up to workspace root
+    }
+    const parent = join(dir, '..')
+    if (parent === dir) break
+    dir = parent
+  }
+  return null
+}
+
+async function resolveVersion(
   packageName: string,
   projectDeps: ProjectDeps,
-  yarnLockVersions: Map<string, string>
-): string {
+  yarnLockVersions: Map<string, string>,
+  projectDir: string
+): Promise<string | null> {
   // Prefer exact version from yarn.lock
   const locked = yarnLockVersions.get(packageName)
   if (locked) return locked
@@ -204,12 +272,16 @@ function resolveVersion(
   const fromDeps = projectDeps.dependencies[packageName]
   if (fromDeps) return fromDeps
 
-  const fromDevDeps = projectDeps.devDependencies[packageName]
-  if (fromDevDeps) return fromDevDeps
+  const fromOptionalDeps = projectDeps.optionalDependencies[packageName]
+  if (fromOptionalDeps) return fromOptionalDeps
 
-  // Last resort: use wildcard (will get latest on install)
-  console.warn(`Could not resolve version for package '${packageName}', defaulting to '*'`)
-  return '*'
+  const installedVersion = await resolveInstalledPackageVersion(
+    packageName,
+    projectDir
+  )
+  if (installedVersion) return installedVersion
+
+  return null
 }
 
 /**
@@ -222,11 +294,14 @@ function resolveVersion(
 export async function extractDependencies(
   metafile: Metafile,
   projectDir: string
-): Promise<Record<string, string>> {
+): Promise<{
+  exactDependencies: Record<string, string>
+  exactOptionalDependencies: Record<string, string>
+}> {
   const externalPackages = extractExternalPackages(metafile)
 
   if (externalPackages.size === 0) {
-    return {}
+    return { exactDependencies: {}, exactOptionalDependencies: {} }
   }
 
   const [projectDeps, yarnLockVersions] = await Promise.all([
@@ -234,13 +309,30 @@ export async function extractDependencies(
     readYarnLockVersions(projectDir),
   ])
 
-  const dependencies: Record<string, string> = {}
+  const exactDependencies: Record<string, string> = {}
+  const exactOptionalDependencies: Record<string, string> = {}
 
   for (const pkg of [...externalPackages].sort()) {
-    dependencies[pkg] = resolveVersion(pkg, projectDeps, yarnLockVersions)
+    const version = await resolveVersion(
+      pkg,
+      projectDeps,
+      yarnLockVersions,
+      projectDir
+    )
+    if (!version) {
+      // Some packages are optional-at-runtime (e.g. ws acceleration addons).
+      // Keep deploy planning deterministic without forcing a hard failure.
+      exactOptionalDependencies[pkg] = '*'
+      continue
+    }
+    if (pkg in projectDeps.optionalDependencies) {
+      exactOptionalDependencies[pkg] = version
+    } else {
+      exactDependencies[pkg] = version
+    }
   }
 
-  return dependencies
+  return { exactDependencies, exactOptionalDependencies }
 }
 
 /**
@@ -248,7 +340,8 @@ export async function extractDependencies(
  */
 export function generateMinimalPackageJson(
   unitName: string,
-  dependencies: Record<string, string>
+  dependencies: Record<string, string>,
+  optionalDependencies: Record<string, string>
 ): Record<string, unknown> {
   return {
     name: unitName,
@@ -256,5 +349,6 @@ export function generateMinimalPackageJson(
     type: 'module',
     main: 'bundle.js',
     dependencies,
+    optionalDependencies,
   }
 }

--- a/packages/cli/src/deploy/bundler/types.ts
+++ b/packages/cli/src/deploy/bundler/types.ts
@@ -15,6 +15,8 @@ export interface BundleResult {
   packageJsonPath: string
   metafilePath: string
   bundleSizeBytes: number
+  bundleHash: string
+  externalPackagesHash: string
   externalPackages: Record<string, string>
 }
 

--- a/packages/cli/src/deploy/bundler/types.ts
+++ b/packages/cli/src/deploy/bundler/types.ts
@@ -13,11 +13,13 @@ export interface BundleResult {
   unitName: string
   bundlePath: string
   packageJsonPath: string
+  exactDependenciesPath: string
   metafilePath: string
   bundleSizeBytes: number
   bundleHash: string
-  externalPackagesHash: string
-  externalPackages: Record<string, string>
+  exactDependenciesHash: string
+  exactDependencies: Record<string, string>
+  exactOptionalDependencies: Record<string, string>
 }
 
 export interface BundleError {

--- a/packages/cli/src/deploy/codegen/per-unit-codegen.ts
+++ b/packages/cli/src/deploy/codegen/per-unit-codegen.ts
@@ -42,6 +42,8 @@ export interface PerUnitCodegenOptions {
     status: 'start' | 'done' | 'error',
     error?: string
   ) => void
+  /** Resolve unit output directory (defaults to <deployDir>/<unit-name>) */
+  resolveUnitDir?: (unit: DeploymentUnit, baseDeployDir: string) => string
 }
 
 export interface PerUnitCodegenResult {
@@ -221,7 +223,9 @@ export async function generatePerUnitCodegen(
 
       onProgress?.(unit.name, 'start')
 
-      const unitDir = join(baseDir, unit.name)
+      const unitDir = options.resolveUnitDir
+        ? options.resolveUnitDir(unit, baseDir)
+        : join(baseDir, unit.name)
       const unitPikkuDir = join(unitDir, '.pikku')
       await mkdir(unitDir, { recursive: true })
 

--- a/packages/cli/src/deploy/plan/planner.ts
+++ b/packages/cli/src/deploy/plan/planner.ts
@@ -36,18 +36,18 @@ function diffUnits(
       (typeof desired.bundleHash === 'string' &&
         typeof existing.bundleHash === 'string' &&
         desired.bundleHash !== existing.bundleHash) ||
-      (typeof desired.externalPackagesHash === 'string' &&
-        typeof existing.externalPackagesHash === 'string' &&
-        desired.externalPackagesHash !== existing.externalPackagesHash)
+      (typeof desired.exactDependenciesHash === 'string' &&
+        typeof existing.exactDependenciesHash === 'string' &&
+        desired.exactDependenciesHash !== existing.exactDependenciesHash)
     ) {
       const bundleChanged =
         typeof desired.bundleHash === 'string' &&
         typeof existing.bundleHash === 'string' &&
         desired.bundleHash !== existing.bundleHash
       const depsChanged =
-        typeof desired.externalPackagesHash === 'string' &&
-        typeof existing.externalPackagesHash === 'string' &&
-        desired.externalPackagesHash !== existing.externalPackagesHash
+        typeof desired.exactDependenciesHash === 'string' &&
+        typeof existing.exactDependenciesHash === 'string' &&
+        desired.exactDependenciesHash !== existing.exactDependenciesHash
 
       changes.push({
         action: 'update',
@@ -64,7 +64,7 @@ function diffUnits(
         details: {
           functionIds: desired.functionIds,
           bundleHash: desired.bundleHash,
-          externalPackagesHash: desired.externalPackagesHash,
+          exactDependenciesHash: desired.exactDependenciesHash,
         },
       })
     }

--- a/packages/cli/src/deploy/plan/planner.ts
+++ b/packages/cli/src/deploy/plan/planner.ts
@@ -32,15 +32,40 @@ function diffUnits(
       })
     } else if (
       !arraysEqual(existing.functionIds, desired.functionIds) ||
-      existing.role !== desired.role
+      existing.role !== desired.role ||
+      (typeof desired.bundleHash === 'string' &&
+        typeof existing.bundleHash === 'string' &&
+        desired.bundleHash !== existing.bundleHash) ||
+      (typeof desired.externalPackagesHash === 'string' &&
+        typeof existing.externalPackagesHash === 'string' &&
+        desired.externalPackagesHash !== existing.externalPackagesHash)
     ) {
+      const bundleChanged =
+        typeof desired.bundleHash === 'string' &&
+        typeof existing.bundleHash === 'string' &&
+        desired.bundleHash !== existing.bundleHash
+      const depsChanged =
+        typeof desired.externalPackagesHash === 'string' &&
+        typeof existing.externalPackagesHash === 'string' &&
+        desired.externalPackagesHash !== existing.externalPackagesHash
+
       changes.push({
         action: 'update',
         resourceType: 'unit',
         name: desired.name,
         role: desired.role,
-        reason: 'code changed',
-        details: { functionIds: desired.functionIds },
+        reason: bundleChanged
+          ? depsChanged
+            ? 'bundle + dependencies changed'
+            : 'bundle changed'
+          : depsChanged
+            ? 'dependencies changed'
+            : 'code changed',
+        details: {
+          functionIds: desired.functionIds,
+          bundleHash: desired.bundleHash,
+          externalPackagesHash: desired.externalPackagesHash,
+        },
       })
     }
   }

--- a/packages/cli/src/deploy/plan/provider.ts
+++ b/packages/cli/src/deploy/plan/provider.ts
@@ -7,7 +7,7 @@ export interface CurrentState {
     functionIds: string[]
     role: string
     bundleHash?: string
-    externalPackagesHash?: string
+    exactDependenciesHash?: string
   }>
   queues: Array<{ name: string }>
   scheduledTasks: Array<{ unitName: string; schedule: string; name?: string }>

--- a/packages/cli/src/deploy/plan/provider.ts
+++ b/packages/cli/src/deploy/plan/provider.ts
@@ -6,6 +6,8 @@ export interface CurrentState {
     name: string
     functionIds: string[]
     role: string
+    bundleHash?: string
+    externalPackagesHash?: string
   }>
   queues: Array<{ name: string }>
   scheduledTasks: Array<{ unitName: string; schedule: string; name?: string }>

--- a/packages/cli/src/functions/commands/deploy-plan.ts
+++ b/packages/cli/src/functions/commands/deploy-plan.ts
@@ -119,7 +119,13 @@ export const deployPlan = pikkuSessionlessFunc<
             unitCount: result.bundled.length,
             totalSizeBytes: totalSize,
             errors: result.bundleErrors,
-            manifest: result.manifest,
+            codegenErrors: result.codegenErrors,
+            summary: plan.summary,
+            changeCount: plan.changes.length,
+            artifacts: {
+              deploymentManifestPath: result.deploymentManifestPath,
+              infraPath: result.infraPath,
+            },
           },
           null,
           2

--- a/packages/cli/src/functions/wirings/console/pikku-command-console-functions.ts
+++ b/packages/cli/src/functions/wirings/console/pikku-command-console-functions.ts
@@ -5,7 +5,12 @@ import { logCommandInfoAndTime } from '../../../middleware/log-command-info-and-
 import { serializeConsoleFunctions } from './serialize-console-functions.js'
 
 export const pikkuConsoleFunctions = pikkuSessionlessFunc<void, boolean>({
-  func: async ({ logger, config }) => {
+  func: async ({ logger, config, variables }) => {
+    const deployCodegenFlag = await variables.get('PIKKU_DEPLOY_CODEGEN')
+    if (deployCodegenFlag === '1') {
+      return false
+    }
+
     if (config.scaffold?.console) {
       const pathToPikkuTypes = getFileImportRelativePath(
         config.consoleFunctionsFile,
@@ -20,7 +25,11 @@ export const pikkuConsoleFunctions = pikkuSessionlessFunc<void, boolean>({
       await writeFileInDir(
         logger,
         config.consoleFunctionsFile,
-        serializeConsoleFunctions(pathToPikkuTypes, pathToAgentTypes, config.globalHTTPPrefix || '')
+        serializeConsoleFunctions(
+          pathToPikkuTypes,
+          pathToAgentTypes,
+          config.globalHTTPPrefix || ''
+        )
       )
       return true
     }

--- a/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
@@ -353,10 +353,13 @@ export type PikkuFunctionConfigWithSchema<
   RequiredWires extends keyof PikkuWire = never
 > = {
   name?: string
+  description?: string
   tags?: string[]
   expose?: boolean
   mcp?: boolean
   internal?: boolean
+  remote?: boolean
+  deploy?: 'serverless' | 'server' | 'auto'
   approvalRequired?: boolean
   approvalDescription?: InputSchema extends StandardSchemaV1 ? PikkuApprovalDescription<InferSchemaOutput<InputSchema>> : never
   func: PikkuFunction<
@@ -445,6 +448,7 @@ export type PikkuFunctionSessionlessConfigWithSchema<
   mcp?: boolean
   internal?: boolean
   remote?: boolean
+  deploy?: 'serverless' | 'server' | 'auto'
   approvalRequired?: boolean
   approvalDescription?: InputSchema extends StandardSchemaV1 ? PikkuApprovalDescription<InferSchemaOutput<InputSchema>> : never
   func: PikkuFunctionSessionless<

--- a/packages/cli/src/functions/wirings/rpc/pikku-command-public-rpc.ts
+++ b/packages/cli/src/functions/wirings/rpc/pikku-command-public-rpc.ts
@@ -5,7 +5,12 @@ import { logCommandInfoAndTime } from '../../../middleware/log-command-info-and-
 import { serializePublicRPC } from './serialize-public-rpc.js'
 
 export const pikkuPublicRPC = pikkuSessionlessFunc<void, boolean>({
-  func: async ({ logger, config }) => {
+  func: async ({ logger, config, variables }) => {
+    const deployCodegenFlag = await variables.get('PIKKU_DEPLOY_CODEGEN')
+    if (deployCodegenFlag === '1') {
+      return false
+    }
+
     if (config.scaffold?.rpc) {
       const pathToPikkuTypes = getFileImportRelativePath(
         config.publicRpcFile,

--- a/packages/cli/src/functions/wirings/rpc/pikku-command-remote-rpc.ts
+++ b/packages/cli/src/functions/wirings/rpc/pikku-command-remote-rpc.ts
@@ -5,7 +5,12 @@ import { logCommandInfoAndTime } from '../../../middleware/log-command-info-and-
 import { serializeRemoteRPC } from './serialize-remote-rpc.js'
 
 export const pikkuRemoteRPC = pikkuSessionlessFunc<void, boolean>({
-  func: async ({ logger, config }) => {
+  func: async ({ logger, config, variables }) => {
+    const deployCodegenFlag = await variables.get('PIKKU_DEPLOY_CODEGEN')
+    if (deployCodegenFlag === '1') {
+      return false
+    }
+
     if (config.remoteRpcWorkersFile) {
       const pathToPikkuTypes = getFileImportRelativePath(
         config.remoteRpcWorkersFile,

--- a/packages/core/src/function/functions.types.ts
+++ b/packages/core/src/function/functions.types.ts
@@ -74,15 +74,8 @@ export type CorePikkuFunctionSessionless<
 export type CorePikkuPermission<
   In = any,
   Services extends CoreSingletonServices = CoreServices,
-  Wire extends PikkuWire<
-    In,
-    never,
-    false,
-    CoreUserSession,
-    any,
-    never,
-    never
-  > = PikkuWire<In, never, false, CoreUserSession, never, never, never>,
+  Wire extends PikkuWire<In, never, false, CoreUserSession, any, never, never> =
+    PikkuWire<In, never, false, CoreUserSession, never, never, never>,
 > = (services: Services, data: In, wire: Wire) => Promise<boolean>
 
 /**
@@ -269,11 +262,8 @@ export type CorePikkuFunctionConfig<
   PikkuFunction extends
     | CorePikkuFunction<any, any, any, any, any>
     | CorePikkuFunctionSessionless<any, any, any, any, any>,
-  PikkuPermission extends CorePikkuPermission<
-    any,
-    any,
-    any
-  > = CorePikkuPermission<any>,
+  PikkuPermission extends CorePikkuPermission<any, any, any> =
+    CorePikkuPermission<any>,
   PikkuMiddleware extends CorePikkuMiddleware<any, any> = CorePikkuMiddleware<
     any,
     any
@@ -292,6 +282,7 @@ export type CorePikkuFunctionConfig<
   remote?: boolean
   mcp?: boolean
   readonly?: boolean
+  deploy?: 'serverless' | 'server' | 'auto'
   approvalRequired?: boolean
   approvalDescription?: any
   func: PikkuFunction

--- a/packages/deploy/deploy-cloudflare/src/deploy.ts
+++ b/packages/deploy/deploy-cloudflare/src/deploy.ts
@@ -351,14 +351,31 @@ async function deployWorkerBatch(
   client: CloudflareClient,
   projectId: string,
   buildDir: string,
-  units: Array<[string, { bindings: string[]; role: string }]>,
+  units: Array<
+    [
+      string,
+      {
+        bindings: string[]
+        role: string
+        target: 'serverless' | 'server'
+      },
+    ]
+  >,
   resourceIds: ResourceIds,
   result: DeployResult,
   log: (step: string, detail: string) => void
 ): Promise<void> {
+  const resolveBundlePath = (
+    unitName: string,
+    target: 'serverless' | 'server'
+  ): string =>
+    target === 'server'
+      ? join(buildDir, 'container', 'bundle.js')
+      : join(buildDir, 'units', unitName, 'bundle.js')
+
   const tasks = units.map(async ([unitName, unitManifest]) => {
     const workerName = toWorkerName(projectId, unitName)
-    const bundlePath = join(buildDir, unitName, 'bundle.js')
+    const bundlePath = resolveBundlePath(unitName, unitManifest.target)
 
     try {
       const script = await readFile(bundlePath, 'utf-8')

--- a/packages/deploy/deploy-cloudflare/test-full-deploy.ts
+++ b/packages/deploy/deploy-cloudflare/test-full-deploy.ts
@@ -128,7 +128,9 @@ async function main() {
   }
 
   for (const b of bundles) {
-    const deps = Object.keys(b.externalPackages).length
+    const deps =
+      Object.keys(b.exactDependencies).length +
+      Object.keys(b.exactOptionalDependencies).length
     console.log(
       `  ${ANSI.dim}${b.workerName.padEnd(35)} ${formatBytes(b.bundleSizeBytes).padStart(8)}  ${deps} deps${ANSI.reset}`
     )

--- a/templates/functions/src/functions/queue.functions.ts
+++ b/templates/functions/src/functions/queue.functions.ts
@@ -8,6 +8,7 @@ import {
  * Queue worker: Process todo reminder jobs.
  */
 export const processReminder = pikkuSessionlessFunc({
+  deploy: 'server',
   input: ProcessReminderInputSchema,
   output: ProcessReminderOutputSchema,
   func: async ({ logger, todoStore }, { todoId, userId }) => {

--- a/templates/functions/src/functions/queue.functions.ts
+++ b/templates/functions/src/functions/queue.functions.ts
@@ -8,7 +8,6 @@ import {
  * Queue worker: Process todo reminder jobs.
  */
 export const processReminder = pikkuSessionlessFunc({
-  deploy: 'server',
   input: ProcessReminderInputSchema,
   output: ProcessReminderOutputSchema,
   func: async ({ logger, todoStore }, { todoId, userId }) => {

--- a/templates/functions/src/functions/todos.functions.ts
+++ b/templates/functions/src/functions/todos.functions.ts
@@ -44,6 +44,7 @@ export const getTodo = pikkuSessionlessFunc({
 export const createTodo = pikkuSessionlessFunc({
   description:
     'Create a new todo item with title, description, priority, dueDate, and tags',
+  deploy: 'server',
   mcp: true,
   input: CreateTodoWithUserInputSchema,
   output: CreateTodoOutputSchema,

--- a/templates/functions/src/functions/todos.functions.ts
+++ b/templates/functions/src/functions/todos.functions.ts
@@ -45,7 +45,6 @@ export const createTodo = pikkuSessionlessFunc({
   description:
     'Create a new todo item with title, description, priority, dueDate, and tags',
   mcp: true,
-  deploy: 'server',
   input: CreateTodoWithUserInputSchema,
   output: CreateTodoOutputSchema,
   func: async (

--- a/templates/functions/src/functions/todos.functions.ts
+++ b/templates/functions/src/functions/todos.functions.ts
@@ -45,6 +45,7 @@ export const createTodo = pikkuSessionlessFunc({
   description:
     'Create a new todo item with title, description, priority, dueDate, and tags',
   mcp: true,
+  deploy: 'server',
   input: CreateTodoWithUserInputSchema,
   output: CreateTodoOutputSchema,
   func: async (

--- a/verifiers/deploy-azure/test-deploy.ts
+++ b/verifiers/deploy-azure/test-deploy.ts
@@ -8,40 +8,97 @@
 import { execSync } from 'child_process'
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
+import { createHash } from 'crypto'
 
 const FUNCTIONS_DIR = join(process.cwd(), '..', '..', 'templates', 'functions')
+const REPO_ROOT = join(process.cwd(), '..', '..')
+const PIKKU_BIN = join(REPO_ROOT, 'packages', 'cli', 'dist', 'bin', 'pikku.js')
 const DEPLOY_DIR = join(FUNCTIONS_DIR, '.deploy', 'azure')
+const PLAN_RESULT_FILE = join(DEPLOY_DIR, 'plan-result.json')
+const DEPLOYMENT_MANIFEST_FILE = join(DEPLOY_DIR, 'deployment-manifest.json')
+const SERVER_UNIT_NAME = 'pikku-server-container'
+const UNITS_DIR = join(DEPLOY_DIR, 'units')
+const CONTAINER_DIR = join(DEPLOY_DIR, 'container')
 
 console.log('Setting up: running pikku codegen + deploy plan (azure)...')
 execSync('rm -rf .deploy src/scaffold', { cwd: FUNCTIONS_DIR, stdio: 'pipe' })
-execSync('yarn pikku', { cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 60_000 })
-execSync('yarn pikku deploy plan --provider azure', {
-  cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 300_000,
+execSync(`node ${PIKKU_BIN}`, {
+  cwd: FUNCTIONS_DIR,
+  stdio: 'pipe',
+  timeout: 60_000,
 })
+execSync(
+  `node ${PIKKU_BIN} deploy plan --provider azure --result-file .deploy/azure/plan-result.json`,
+  {
+    cwd: FUNCTIONS_DIR,
+    stdio: 'pipe',
+    timeout: 300_000,
+  }
+)
 console.log('Setup complete.\n')
 
-function readText(path: string): string { return readFileSync(path, 'utf-8') }
-function readJSON(path: string): Record<string, unknown> { return JSON.parse(readText(path)) }
+function readText(path: string): string {
+  return readFileSync(path, 'utf-8')
+}
+function readJSON(path: string): Record<string, unknown> {
+  return JSON.parse(readText(path))
+}
+function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex')
+}
 function getUnitDirs(): string[] {
-  if (!existsSync(DEPLOY_DIR)) return []
-  return readdirSync(DEPLOY_DIR).filter((d) => {
-    const p = join(DEPLOY_DIR, d)
+  if (!existsSync(UNITS_DIR)) return []
+  const dirs = readdirSync(UNITS_DIR).filter((d) => {
+    const p = join(UNITS_DIR, d)
     return statSync(p).isDirectory() && existsSync(join(p, 'bundle.js'))
   })
+  if (existsSync(join(CONTAINER_DIR, 'bundle.js'))) {
+    dirs.push(SERVER_UNIT_NAME)
+  }
+  return dirs
+}
+function getUnitPath(unitName: string): string {
+  return unitName === SERVER_UNIT_NAME
+    ? CONTAINER_DIR
+    : join(UNITS_DIR, unitName)
 }
 
 let failures = 0
 const results: Array<{ name: string; passed: boolean; error?: string }> = []
 function check(name: string, fn: () => void) {
-  try { fn(); results.push({ name, passed: true }) }
-  catch (e) { failures++; results.push({ name, passed: false, error: (e as Error).message }) }
+  try {
+    fn()
+    results.push({ name, passed: true })
+  } catch (e) {
+    failures++
+    results.push({ name, passed: false, error: (e as Error).message })
+  }
 }
 function assertContains(actual: string[], expected: string[], label: string) {
   const missing = expected.filter((e) => !actual.includes(e))
-  if (missing.length > 0) throw new Error(`${label}: missing [${missing.join(', ')}]`)
+  if (missing.length > 0)
+    throw new Error(`${label}: missing [${missing.join(', ')}]`)
 }
 
 const unitDirs = getUnitDirs()
+const planResult = existsSync(PLAN_RESULT_FILE)
+  ? (readJSON(PLAN_RESULT_FILE) as {
+      success?: boolean
+      artifacts?: { deploymentManifestPath?: string }
+    })
+  : null
+const deploymentManifestPath =
+  typeof planResult?.artifacts?.deploymentManifestPath === 'string' &&
+  existsSync(planResult.artifacts.deploymentManifestPath)
+    ? planResult.artifacts.deploymentManifestPath
+    : existsSync(DEPLOYMENT_MANIFEST_FILE)
+      ? DEPLOYMENT_MANIFEST_FILE
+      : null
+const deploymentManifest = deploymentManifestPath
+  ? (readJSON(deploymentManifestPath) as {
+      units?: Array<Record<string, unknown>>
+    })
+  : null
 
 // --- Azure config ---
 check('host.json: version 2.0', () => {
@@ -49,7 +106,10 @@ check('host.json: version 2.0', () => {
   if (host.version !== '2.0') throw new Error(`Version: ${host.version}`)
 })
 check('local.settings.json: has IsEncrypted + Values', () => {
-  const s = readJSON(join(DEPLOY_DIR, 'local.settings.json')) as Record<string, unknown>
+  const s = readJSON(join(DEPLOY_DIR, 'local.settings.json')) as Record<
+    string,
+    unknown
+  >
   if (s.IsEncrypted === undefined) throw new Error('Missing IsEncrypted')
   if (!s.Values) throw new Error('Missing Values')
 })
@@ -58,13 +118,133 @@ check('infra.json: has projectId + units', () => {
   if (!infra.projectId) throw new Error('Missing projectId')
   if (!infra.units) throw new Error('Missing units')
 })
+check('plan-result.json: success + deployment manifest units', () => {
+  if (!planResult) throw new Error('Missing plan-result.json')
+  if (planResult.success !== true)
+    throw new Error('Plan result is not success=true')
+  const units = deploymentManifest?.units ?? []
+  if (units.length === 0) throw new Error('No manifest units in plan result')
+})
+check(
+  'plan manifest: bundle/exact dependency hashes are present + valid',
+  () => {
+    const units = deploymentManifest?.units ?? []
+    if (units.length === 0) throw new Error('No manifest units to validate')
+
+    for (const u of units) {
+      const unitName = String(u.name ?? '')
+      const bundleHash = String(u.bundleHash ?? '')
+      const exactDependenciesHash = String(u.exactDependenciesHash ?? '')
+      const exactDependencies = (u.exactDependencies ?? {}) as Record<
+        string,
+        string
+      >
+      const exactOptionalDependencies = (u.exactOptionalDependencies ??
+        {}) as Record<string, string>
+      if (!/^[a-f0-9]{64}$/.test(bundleHash))
+        throw new Error(`${unitName}: invalid bundleHash`)
+      if (!/^[a-f0-9]{64}$/.test(exactDependenciesHash)) {
+        throw new Error(`${unitName}: invalid exactDependenciesHash`)
+      }
+
+      const bundleContent = readText(join(getUnitPath(unitName), 'bundle.js'))
+      if (sha256(bundleContent) !== bundleHash)
+        throw new Error(`${unitName}: bundleHash mismatch`)
+
+      const pkg = readJSON(join(getUnitPath(unitName), 'package.json')) as {
+        dependencies?: Record<string, string>
+        optionalDependencies?: Record<string, string>
+      }
+      const deps = pkg.dependencies ?? {}
+      const optionalDeps = pkg.optionalDependencies ?? {}
+      const depsHash = sha256(
+        JSON.stringify({
+          dependencies: Object.entries(deps).sort(([a], [b]) =>
+            a.localeCompare(b)
+          ),
+          optionalDependencies: Object.entries(optionalDeps).sort(([a], [b]) =>
+            a.localeCompare(b)
+          ),
+        })
+      )
+      if (depsHash !== exactDependenciesHash) {
+        throw new Error(`${unitName}: exactDependenciesHash mismatch`)
+      }
+
+      const expectedDependencies = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(deps).sort(([a], [b]) => a.localeCompare(b))
+        )
+      )
+      const actualDependencies = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(exactDependencies).sort(([a], [b]) =>
+            a.localeCompare(b)
+          )
+        )
+      )
+      if (actualDependencies !== expectedDependencies) {
+        throw new Error(`${unitName}: exactDependencies payload mismatch`)
+      }
+
+      const expectedOptionalDependencies = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(optionalDeps).sort(([a], [b]) => a.localeCompare(b))
+        )
+      )
+      const actualOptionalDependencies = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(exactOptionalDependencies).sort(([a], [b]) =>
+            a.localeCompare(b)
+          )
+        )
+      )
+      if (actualOptionalDependencies !== expectedOptionalDependencies) {
+        throw new Error(
+          `${unitName}: exactOptionalDependencies payload mismatch`
+        )
+      }
+
+      const exactDepsFile = readJSON(
+        join(getUnitPath(unitName), 'exact-dependencies.json')
+      ) as {
+        dependencies?: Record<string, string>
+        optionalDependencies?: Record<string, string>
+      }
+      const fileDeps = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(exactDepsFile.dependencies ?? {}).sort(([a], [b]) =>
+            a.localeCompare(b)
+          )
+        )
+      )
+      const fileOptionalDeps = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(exactDepsFile.optionalDependencies ?? {}).sort(
+            ([a], [b]) => a.localeCompare(b)
+          )
+        )
+      )
+      if (fileDeps !== actualDependencies) {
+        throw new Error(
+          `${unitName}: exact-dependencies.json dependencies mismatch`
+        )
+      }
+      if (fileOptionalDeps !== actualOptionalDependencies) {
+        throw new Error(
+          `${unitName}: exact-dependencies.json optionalDependencies mismatch`
+        )
+      }
+    }
+  }
+)
 
 // --- Units ---
-check('HTTP units: greet, list-todos, create-todo, update-todo', () => {
-  assertContains(unitDirs, ['greet', 'list-todos', 'create-todo', 'update-todo'], 'HTTP')
+check('HTTP units: greet, list-todos, update-todo', () => {
+  assertContains(unitDirs, ['greet', 'list-todos', 'update-todo'], 'HTTP')
 })
-check('queue unit: process-reminder', () => {
-  assertContains(unitDirs, ['process-reminder'], 'Queue')
+check('server unit exists for server-target functions', () => {
+  assertContains(unitDirs, [SERVER_UNIT_NAME], 'Server')
 })
 check('scheduled units: daily-summary, weekly-cleanup', () => {
   assertContains(unitDirs, ['daily-summary', 'weekly-cleanup'], 'Scheduled')
@@ -81,18 +261,42 @@ check('channel units (>= 1)', () => {
   if (ch.length < 1) throw new Error(`Got ${ch.length}`)
 })
 check('workflow step units: send-notification, schedule-reminder', () => {
-  assertContains(unitDirs, ['send-notification', 'schedule-reminder'], 'Step units')
+  assertContains(
+    unitDirs,
+    ['send-notification', 'schedule-reminder'],
+    'Step units'
+  )
 })
-check('total units >= 30', () => {
-  if (unitDirs.length < 30) throw new Error(`Got ${unitDirs.length}`)
+check('total units >= 29', () => {
+  if (unitDirs.length < 29) throw new Error(`Got ${unitDirs.length}`)
 })
+check(
+  'plan manifest: server unit includes createTodo + processReminder',
+  () => {
+    const units = deploymentManifest?.units ?? []
+    const serverUnit = units.find((u) => u.name === SERVER_UNIT_NAME)
+    if (!serverUnit) throw new Error('Missing server unit in manifest')
+    const functionIds = (serverUnit.functionIds ?? []) as string[]
+    if (!functionIds.includes('createTodo')) {
+      throw new Error('server unit missing createTodo')
+    }
+    if (!functionIds.includes('processReminder')) {
+      throw new Error('server unit missing processReminder')
+    }
+  }
+)
 
 // --- Entry content ---
 check('HTTP entries reference Azure handler', () => {
   for (const u of ['greet', 'list-todos']) {
     if (!unitDirs.includes(u)) continue
-    const entry = readText(join(DEPLOY_DIR, u, 'entry.ts'))
-    if (!entry.includes('app.http') && !entry.includes('Azure') && !entry.includes('azure') && !entry.includes('handler')) {
+    const entry = readText(join(getUnitPath(u), 'entry.ts'))
+    if (
+      !entry.includes('app.http') &&
+      !entry.includes('Azure') &&
+      !entry.includes('azure') &&
+      !entry.includes('handler')
+    ) {
       throw new Error(`${u} entry missing Azure handler`)
     }
   }
@@ -101,13 +305,15 @@ check('HTTP entries reference Azure handler', () => {
 // --- Bundles ---
 check('no unit exceeds 5MB', () => {
   for (const u of unitDirs) {
-    const s = statSync(join(DEPLOY_DIR, u, 'bundle.js')).size
-    if (s > 5 * 1024 * 1024) throw new Error(`${u}: ${(s / 1024 / 1024).toFixed(1)}MB`)
+    const s = statSync(join(getUnitPath(u), 'bundle.js')).size
+    if (s > 5 * 1024 * 1024)
+      throw new Error(`${u}: ${(s / 1024 / 1024).toFixed(1)}MB`)
   }
 })
 check('every unit has entry.ts', () => {
   for (const u of unitDirs) {
-    if (!existsSync(join(DEPLOY_DIR, u, 'entry.ts'))) throw new Error(`${u} missing entry.ts`)
+    if (!existsSync(join(getUnitPath(u), 'entry.ts')))
+      throw new Error(`${u} missing entry.ts`)
   }
 })
 

--- a/verifiers/deploy-cloudflare/test-deploy.ts
+++ b/verifiers/deploy-cloudflare/test-deploy.ts
@@ -8,18 +8,33 @@
 import { execSync } from 'child_process'
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
+import { createHash } from 'crypto'
 
 const FUNCTIONS_DIR = join(process.cwd(), '..', '..', 'templates', 'functions')
+const REPO_ROOT = join(process.cwd(), '..', '..')
+const PIKKU_BIN = join(REPO_ROOT, 'packages', 'cli', 'dist', 'bin', 'pikku.js')
 const DEPLOY_DIR = join(FUNCTIONS_DIR, '.deploy', 'cloudflare')
+const PLAN_RESULT_FILE = join(DEPLOY_DIR, 'plan-result.json')
+const DEPLOYMENT_MANIFEST_FILE = join(DEPLOY_DIR, 'deployment-manifest.json')
+const SERVER_UNIT_NAME = 'pikku-server-container'
+const UNITS_DIR = join(DEPLOY_DIR, 'units')
+const CONTAINER_DIR = join(DEPLOY_DIR, 'container')
 
 console.log('Setting up: running pikku codegen + deploy plan (cloudflare)...')
 execSync('rm -rf .deploy src/scaffold', { cwd: FUNCTIONS_DIR, stdio: 'pipe' })
-execSync('yarn pikku', { cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 60_000 })
-execSync('yarn pikku deploy plan --provider cloudflare', {
+execSync(`node ${PIKKU_BIN}`, {
   cwd: FUNCTIONS_DIR,
   stdio: 'pipe',
-  timeout: 300_000,
+  timeout: 60_000,
 })
+execSync(
+  `node ${PIKKU_BIN} deploy plan --provider cloudflare --result-file .deploy/cloudflare/plan-result.json`,
+  {
+    cwd: FUNCTIONS_DIR,
+    stdio: 'pipe',
+    timeout: 300_000,
+  }
+)
 console.log('Setup complete.\n')
 
 function readJSON(path: string): Record<string, unknown> {
@@ -28,16 +43,40 @@ function readJSON(path: string): Record<string, unknown> {
 function readText(path: string): string {
   return readFileSync(path, 'utf-8')
 }
+function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex')
+}
 function getUnitDirs(): string[] {
-  if (!existsSync(DEPLOY_DIR)) return []
-  return readdirSync(DEPLOY_DIR).filter((d) => {
-    const p = join(DEPLOY_DIR, d)
+  if (!existsSync(UNITS_DIR)) return []
+  const dirs = readdirSync(UNITS_DIR).filter((d) => {
+    const p = join(UNITS_DIR, d)
     return statSync(p).isDirectory() && existsSync(join(p, 'bundle.js'))
   })
+  if (existsSync(join(CONTAINER_DIR, 'bundle.js'))) {
+    dirs.push(SERVER_UNIT_NAME)
+  }
+  return dirs
+}
+function getUnitPath(unitName: string): string {
+  return unitName === SERVER_UNIT_NAME
+    ? CONTAINER_DIR
+    : join(UNITS_DIR, unitName)
 }
 function getUnitServices(unitName: string): Record<string, boolean> {
-  const path = join(DEPLOY_DIR, unitName, '.pikku', 'pikku-services.gen.ts')
-  if (!existsSync(path)) return {}
+  const baseUnitPath = getUnitPath(unitName)
+  const directPath = join(baseUnitPath, '.pikku', 'pikku-services.gen.ts')
+  const nestedPath = join(
+    baseUnitPath,
+    SERVER_UNIT_NAME,
+    '.pikku',
+    'pikku-services.gen.ts'
+  )
+  const path = existsSync(directPath)
+    ? directPath
+    : existsSync(nestedPath)
+      ? nestedPath
+      : ''
+  if (!path) return {}
   const content = readText(path)
   const match = content.match(
     /export const requiredSingletonServices = \{([^}]+)\}/
@@ -72,6 +111,24 @@ const unitDirs = getUnitDirs()
 const infra = existsSync(join(DEPLOY_DIR, 'infra.json'))
   ? readJSON(join(DEPLOY_DIR, 'infra.json'))
   : null
+const planResult = existsSync(PLAN_RESULT_FILE)
+  ? (readJSON(PLAN_RESULT_FILE) as {
+      success?: boolean
+      artifacts?: { deploymentManifestPath?: string }
+    })
+  : null
+const deploymentManifestPath =
+  typeof planResult?.artifacts?.deploymentManifestPath === 'string' &&
+  existsSync(planResult.artifacts.deploymentManifestPath)
+    ? planResult.artifacts.deploymentManifestPath
+    : existsSync(DEPLOYMENT_MANIFEST_FILE)
+      ? DEPLOYMENT_MANIFEST_FILE
+      : null
+const deploymentManifest = deploymentManifestPath
+  ? (readJSON(deploymentManifestPath) as {
+      units?: Array<Record<string, unknown>>
+    })
+  : null
 
 // --- Infra manifest ---
 check('infra.json: has projectId, units, resources', () => {
@@ -80,6 +137,126 @@ check('infra.json: has projectId, units, resources', () => {
   if (!infra.units) throw new Error('Missing units')
   if (!infra.resources) throw new Error('Missing resources')
 })
+check('plan-result.json: success + deployment manifest units', () => {
+  if (!planResult) throw new Error('Missing plan-result.json')
+  if (planResult.success !== true)
+    throw new Error('Plan result is not success=true')
+  const units = deploymentManifest?.units ?? []
+  if (units.length === 0) throw new Error('No manifest units in plan result')
+})
+check(
+  'plan manifest: bundle/exact dependency hashes are present + valid',
+  () => {
+    const units = deploymentManifest?.units ?? []
+    if (units.length === 0) throw new Error('No manifest units to validate')
+
+    for (const u of units) {
+      const unitName = String(u.name ?? '')
+      const bundleHash = String(u.bundleHash ?? '')
+      const exactDependenciesHash = String(u.exactDependenciesHash ?? '')
+      const exactDependencies = (u.exactDependencies ?? {}) as Record<
+        string,
+        string
+      >
+      const exactOptionalDependencies = (u.exactOptionalDependencies ??
+        {}) as Record<string, string>
+      if (!/^[a-f0-9]{64}$/.test(bundleHash)) {
+        throw new Error(`${unitName}: invalid bundleHash`)
+      }
+      if (!/^[a-f0-9]{64}$/.test(exactDependenciesHash)) {
+        throw new Error(`${unitName}: invalid exactDependenciesHash`)
+      }
+
+      const bundleContent = readText(join(getUnitPath(unitName), 'bundle.js'))
+      const actualBundleHash = sha256(bundleContent)
+      if (actualBundleHash !== bundleHash) {
+        throw new Error(`${unitName}: bundleHash mismatch`)
+      }
+
+      const pkg = readJSON(join(getUnitPath(unitName), 'package.json')) as {
+        dependencies?: Record<string, string>
+        optionalDependencies?: Record<string, string>
+      }
+      const deps = pkg.dependencies ?? {}
+      const optionalDeps = pkg.optionalDependencies ?? {}
+      const depsHash = sha256(
+        JSON.stringify({
+          dependencies: Object.entries(deps).sort(([a], [b]) =>
+            a.localeCompare(b)
+          ),
+          optionalDependencies: Object.entries(optionalDeps).sort(([a], [b]) =>
+            a.localeCompare(b)
+          ),
+        })
+      )
+      if (depsHash !== exactDependenciesHash) {
+        throw new Error(`${unitName}: exactDependenciesHash mismatch`)
+      }
+      const expectedDependencies = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(deps).sort(([a], [b]) => a.localeCompare(b))
+        )
+      )
+      const actualDependencies = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(exactDependencies).sort(([a], [b]) =>
+            a.localeCompare(b)
+          )
+        )
+      )
+      if (actualDependencies !== expectedDependencies) {
+        throw new Error(`${unitName}: exactDependencies payload mismatch`)
+      }
+      const expectedOptionalDependencies = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(optionalDeps).sort(([a], [b]) => a.localeCompare(b))
+        )
+      )
+      const actualOptionalDependencies = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(exactOptionalDependencies).sort(([a], [b]) =>
+            a.localeCompare(b)
+          )
+        )
+      )
+      if (actualOptionalDependencies !== expectedOptionalDependencies) {
+        throw new Error(
+          `${unitName}: exactOptionalDependencies payload mismatch`
+        )
+      }
+      const exactDepsFile = readJSON(
+        join(getUnitPath(unitName), 'exact-dependencies.json')
+      ) as {
+        dependencies?: Record<string, string>
+        optionalDependencies?: Record<string, string>
+      }
+      const fileDeps = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(exactDepsFile.dependencies ?? {}).sort(([a], [b]) =>
+            a.localeCompare(b)
+          )
+        )
+      )
+      const fileOptionalDeps = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(exactDepsFile.optionalDependencies ?? {}).sort(
+            ([a], [b]) => a.localeCompare(b)
+          )
+        )
+      )
+      if (fileDeps !== actualDependencies) {
+        throw new Error(
+          `${unitName}: exact-dependencies.json dependencies mismatch`
+        )
+      }
+      if (fileOptionalDeps !== actualOptionalDependencies) {
+        throw new Error(
+          `${unitName}: exact-dependencies.json optionalDependencies mismatch`
+        )
+      }
+    }
+  }
+)
 check('infra.json: has queues (todo-reminders + workflow)', () => {
   const resources = infra!.resources as Record<string, unknown[]>
   if ((resources.queues ?? []).length < 3)
@@ -96,15 +273,11 @@ check('infra.json: has cron triggers', () => {
 })
 
 // --- Units ---
-check('HTTP units: greet, list-todos, create-todo, update-todo', () => {
-  assertContains(
-    unitDirs,
-    ['greet', 'list-todos', 'create-todo', 'update-todo'],
-    'HTTP'
-  )
+check('HTTP units: greet, list-todos, update-todo', () => {
+  assertContains(unitDirs, ['greet', 'list-todos', 'update-todo'], 'HTTP')
 })
-check('queue unit: process-reminder', () => {
-  assertContains(unitDirs, ['process-reminder'], 'Queue')
+check('server unit exists for server-target functions', () => {
+  assertContains(unitDirs, [SERVER_UNIT_NAME], 'Server')
 })
 check('scheduled units: daily-summary, weekly-cleanup', () => {
   assertContains(unitDirs, ['daily-summary', 'weekly-cleanup'], 'Scheduled')
@@ -131,25 +304,40 @@ check(
     )
   }
 )
-check('total units >= 30', () => {
-  if (unitDirs.length < 30) throw new Error(`Got ${unitDirs.length}`)
+check('total units >= 29', () => {
+  if (unitDirs.length < 29) throw new Error(`Got ${unitDirs.length}`)
 })
+check(
+  'plan manifest: server unit includes createTodo + processReminder',
+  () => {
+    const units = deploymentManifest?.units ?? []
+    const serverUnit = units.find((u) => u.name === SERVER_UNIT_NAME)
+    if (!serverUnit) throw new Error('Missing server unit in manifest')
+    const functionIds = (serverUnit.functionIds ?? []) as string[]
+    if (!functionIds.includes('createTodo')) {
+      throw new Error('server unit missing createTodo')
+    }
+    if (!functionIds.includes('processReminder')) {
+      throw new Error('server unit missing processReminder')
+    }
+  }
+)
 
 // --- Tree-shaking ---
 check('greet entry uses @pikku/cloudflare/handler (not barrel)', () => {
-  const entry = readText(join(DEPLOY_DIR, 'greet', 'entry.ts'))
+  const entry = readText(join(getUnitPath('greet'), 'entry.ts'))
   if (!entry.includes('@pikku/cloudflare/handler'))
     throw new Error('Missing /handler')
   if (entry.includes("from '@pikku/cloudflare'")) throw new Error('Uses barrel')
 })
 check('greet entry: no CloudflareWorkflowService', () => {
-  const entry = readText(join(DEPLOY_DIR, 'greet', 'entry.ts'))
+  const entry = readText(join(getUnitPath('greet'), 'entry.ts'))
   if (entry.includes('CloudflareWorkflowService'))
     throw new Error('Should not import workflow')
 })
 check('orchestrator entry uses @pikku/cloudflare/d1', () => {
   const wf = unitDirs.filter((d) => d.startsWith('wf-'))
-  const entry = readText(join(DEPLOY_DIR, wf[0], 'entry.ts'))
+  const entry = readText(join(getUnitPath(wf[0]), 'entry.ts'))
   if (!entry.includes('@pikku/cloudflare/d1')) throw new Error('Missing /d1')
 })
 
@@ -159,41 +347,36 @@ check('orchestrator entry uses @pikku/cloudflare/d1', () => {
 //   const svc = getUnitServices('greet')
 //   if (svc.workflowService !== false) throw new Error(`Got ${svc.workflowService}`)
 // })
-check(
-  'create-todo (step worker): workflowService=true, queueService=true',
-  () => {
-    const svc = getUnitServices('create-todo')
-    if (svc.workflowService !== true)
-      throw new Error(`workflowService=${svc.workflowService}`)
-    if (svc.queueService !== true)
-      throw new Error(`queueService=${svc.queueService}`)
-  }
-)
+check('server unit: queueService=true', () => {
+  const svc = getUnitServices(SERVER_UNIT_NAME)
+  if (svc.queueService !== true)
+    throw new Error(`queueService=${svc.queueService}`)
+})
 
 // --- Bundles ---
 check('no unit exceeds 5MB', () => {
   for (const u of unitDirs) {
-    const s = statSync(join(DEPLOY_DIR, u, 'bundle.js')).size
+    const s = statSync(join(getUnitPath(u), 'bundle.js')).size
     if (s > 5 * 1024 * 1024)
       throw new Error(`${u}: ${(s / 1024 / 1024).toFixed(1)}MB`)
   }
 })
 check('every unit has entry.ts', () => {
   for (const u of unitDirs) {
-    if (!existsSync(join(DEPLOY_DIR, u, 'entry.ts')))
+    if (!existsSync(join(getUnitPath(u), 'entry.ts')))
       throw new Error(`${u} missing entry.ts`)
   }
 })
 
 // --- No server container ---
-check('no server container (no serverlessIncompatible)', () => {
-  if (existsSync(join(DEPLOY_DIR, 'server'))) throw new Error('server/ exists')
-  if (existsSync(join(DEPLOY_DIR, 'server-proxy')))
-    throw new Error('server-proxy/ exists')
+check('server container bundle is emitted', () => {
+  if (!existsSync(join(CONTAINER_DIR, 'bundle.js'))) {
+    throw new Error('server bundle missing')
+  }
 })
 check('no Dockerfiles', () => {
   for (const u of unitDirs) {
-    if (existsSync(join(DEPLOY_DIR, u, 'Dockerfile')))
+    if (existsSync(join(getUnitPath(u), 'Dockerfile')))
       throw new Error(`${u} has Dockerfile`)
   }
 })

--- a/verifiers/deploy-serverless/test-deploy.ts
+++ b/verifiers/deploy-serverless/test-deploy.ts
@@ -8,40 +8,97 @@
 import { execSync } from 'child_process'
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
+import { createHash } from 'crypto'
 
 const FUNCTIONS_DIR = join(process.cwd(), '..', '..', 'templates', 'functions')
+const REPO_ROOT = join(process.cwd(), '..', '..')
+const PIKKU_BIN = join(REPO_ROOT, 'packages', 'cli', 'dist', 'bin', 'pikku.js')
 const DEPLOY_DIR = join(FUNCTIONS_DIR, '.deploy', 'serverless')
+const PLAN_RESULT_FILE = join(DEPLOY_DIR, 'plan-result.json')
+const DEPLOYMENT_MANIFEST_FILE = join(DEPLOY_DIR, 'deployment-manifest.json')
+const SERVER_UNIT_NAME = 'pikku-server-container'
+const UNITS_DIR = join(DEPLOY_DIR, 'units')
+const CONTAINER_DIR = join(DEPLOY_DIR, 'container')
 
 console.log('Setting up: running pikku codegen + deploy plan (serverless)...')
 execSync('rm -rf .deploy src/scaffold', { cwd: FUNCTIONS_DIR, stdio: 'pipe' })
-execSync('yarn pikku', { cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 60_000 })
-execSync('yarn pikku deploy plan --provider serverless', {
-  cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 300_000,
+execSync(`node ${PIKKU_BIN}`, {
+  cwd: FUNCTIONS_DIR,
+  stdio: 'pipe',
+  timeout: 60_000,
 })
+execSync(
+  `node ${PIKKU_BIN} deploy plan --provider serverless --result-file .deploy/serverless/plan-result.json`,
+  {
+    cwd: FUNCTIONS_DIR,
+    stdio: 'pipe',
+    timeout: 300_000,
+  }
+)
 console.log('Setup complete.\n')
 
-function readText(path: string): string { return readFileSync(path, 'utf-8') }
-function readJSON(path: string): Record<string, unknown> { return JSON.parse(readText(path)) }
+function readText(path: string): string {
+  return readFileSync(path, 'utf-8')
+}
+function readJSON(path: string): Record<string, unknown> {
+  return JSON.parse(readText(path))
+}
+function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex')
+}
 function getUnitDirs(): string[] {
-  if (!existsSync(DEPLOY_DIR)) return []
-  return readdirSync(DEPLOY_DIR).filter((d) => {
-    const p = join(DEPLOY_DIR, d)
+  if (!existsSync(UNITS_DIR)) return []
+  const dirs = readdirSync(UNITS_DIR).filter((d) => {
+    const p = join(UNITS_DIR, d)
     return statSync(p).isDirectory() && existsSync(join(p, 'bundle.js'))
   })
+  if (existsSync(join(CONTAINER_DIR, 'bundle.js'))) {
+    dirs.push(SERVER_UNIT_NAME)
+  }
+  return dirs
+}
+function getUnitPath(unitName: string): string {
+  return unitName === SERVER_UNIT_NAME
+    ? CONTAINER_DIR
+    : join(UNITS_DIR, unitName)
 }
 
 let failures = 0
 const results: Array<{ name: string; passed: boolean; error?: string }> = []
 function check(name: string, fn: () => void) {
-  try { fn(); results.push({ name, passed: true }) }
-  catch (e) { failures++; results.push({ name, passed: false, error: (e as Error).message }) }
+  try {
+    fn()
+    results.push({ name, passed: true })
+  } catch (e) {
+    failures++
+    results.push({ name, passed: false, error: (e as Error).message })
+  }
 }
 function assertContains(actual: string[], expected: string[], label: string) {
   const missing = expected.filter((e) => !actual.includes(e))
-  if (missing.length > 0) throw new Error(`${label}: missing [${missing.join(', ')}]`)
+  if (missing.length > 0)
+    throw new Error(`${label}: missing [${missing.join(', ')}]`)
 }
 
 const unitDirs = getUnitDirs()
+const planResult = existsSync(PLAN_RESULT_FILE)
+  ? (readJSON(PLAN_RESULT_FILE) as {
+      success?: boolean
+      artifacts?: { deploymentManifestPath?: string }
+    })
+  : null
+const deploymentManifestPath =
+  typeof planResult?.artifacts?.deploymentManifestPath === 'string' &&
+  existsSync(planResult.artifacts.deploymentManifestPath)
+    ? planResult.artifacts.deploymentManifestPath
+    : existsSync(DEPLOYMENT_MANIFEST_FILE)
+      ? DEPLOYMENT_MANIFEST_FILE
+      : null
+const deploymentManifest = deploymentManifestPath
+  ? (readJSON(deploymentManifestPath) as {
+      units?: Array<Record<string, unknown>>
+    })
+  : null
 
 // --- serverless.yml ---
 check('serverless.yml: has provider + functions sections', () => {
@@ -49,9 +106,9 @@ check('serverless.yml: has provider + functions sections', () => {
   if (!yml.includes('provider:')) throw new Error('Missing provider')
   if (!yml.includes('functions:')) throw new Error('Missing functions')
 })
-check('serverless.yml: references greet, list-todos, create-todo', () => {
+check('serverless.yml: references greet, list-todos, update-todo', () => {
   const yml = readText(join(DEPLOY_DIR, 'serverless.yml'))
-  for (const n of ['greet', 'list-todos', 'create-todo']) {
+  for (const n of ['greet', 'list-todos', 'update-todo']) {
     if (!yml.includes(n)) throw new Error(`Missing: ${n}`)
   }
 })
@@ -61,15 +118,136 @@ check('serverless.yml: has todo-reminders queue', () => {
 })
 check('serverless.yml: has schedule events', () => {
   const yml = readText(join(DEPLOY_DIR, 'serverless.yml'))
-  if (!yml.includes('schedule') && !yml.includes('cron')) throw new Error('Missing schedule')
+  if (!yml.includes('schedule') && !yml.includes('cron'))
+    throw new Error('Missing schedule')
 })
+check('plan-result.json: success + deployment manifest units', () => {
+  if (!planResult) throw new Error('Missing plan-result.json')
+  if (planResult.success !== true)
+    throw new Error('Plan result is not success=true')
+  const units = deploymentManifest?.units ?? []
+  if (units.length === 0) throw new Error('No manifest units in plan result')
+})
+check(
+  'plan manifest: bundle/exact dependency hashes are present + valid',
+  () => {
+    const units = deploymentManifest?.units ?? []
+    if (units.length === 0) throw new Error('No manifest units to validate')
+
+    for (const u of units) {
+      const unitName = String(u.name ?? '')
+      const bundleHash = String(u.bundleHash ?? '')
+      const exactDependenciesHash = String(u.exactDependenciesHash ?? '')
+      const exactDependencies = (u.exactDependencies ?? {}) as Record<
+        string,
+        string
+      >
+      const exactOptionalDependencies = (u.exactOptionalDependencies ??
+        {}) as Record<string, string>
+      if (!/^[a-f0-9]{64}$/.test(bundleHash))
+        throw new Error(`${unitName}: invalid bundleHash`)
+      if (!/^[a-f0-9]{64}$/.test(exactDependenciesHash)) {
+        throw new Error(`${unitName}: invalid exactDependenciesHash`)
+      }
+
+      const bundleContent = readText(join(getUnitPath(unitName), 'bundle.js'))
+      if (sha256(bundleContent) !== bundleHash)
+        throw new Error(`${unitName}: bundleHash mismatch`)
+
+      const pkg = readJSON(join(getUnitPath(unitName), 'package.json')) as {
+        dependencies?: Record<string, string>
+        optionalDependencies?: Record<string, string>
+      }
+      const deps = pkg.dependencies ?? {}
+      const optionalDeps = pkg.optionalDependencies ?? {}
+      const depsHash = sha256(
+        JSON.stringify({
+          dependencies: Object.entries(deps).sort(([a], [b]) =>
+            a.localeCompare(b)
+          ),
+          optionalDependencies: Object.entries(optionalDeps).sort(([a], [b]) =>
+            a.localeCompare(b)
+          ),
+        })
+      )
+      if (depsHash !== exactDependenciesHash) {
+        throw new Error(`${unitName}: exactDependenciesHash mismatch`)
+      }
+
+      const expectedDependencies = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(deps).sort(([a], [b]) => a.localeCompare(b))
+        )
+      )
+      const actualDependencies = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(exactDependencies).sort(([a], [b]) =>
+            a.localeCompare(b)
+          )
+        )
+      )
+      if (actualDependencies !== expectedDependencies) {
+        throw new Error(`${unitName}: exactDependencies payload mismatch`)
+      }
+
+      const expectedOptionalDependencies = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(optionalDeps).sort(([a], [b]) => a.localeCompare(b))
+        )
+      )
+      const actualOptionalDependencies = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(exactOptionalDependencies).sort(([a], [b]) =>
+            a.localeCompare(b)
+          )
+        )
+      )
+      if (actualOptionalDependencies !== expectedOptionalDependencies) {
+        throw new Error(
+          `${unitName}: exactOptionalDependencies payload mismatch`
+        )
+      }
+
+      const exactDepsFile = readJSON(
+        join(getUnitPath(unitName), 'exact-dependencies.json')
+      ) as {
+        dependencies?: Record<string, string>
+        optionalDependencies?: Record<string, string>
+      }
+      const fileDeps = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(exactDepsFile.dependencies ?? {}).sort(([a], [b]) =>
+            a.localeCompare(b)
+          )
+        )
+      )
+      const fileOptionalDeps = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(exactDepsFile.optionalDependencies ?? {}).sort(
+            ([a], [b]) => a.localeCompare(b)
+          )
+        )
+      )
+      if (fileDeps !== actualDependencies) {
+        throw new Error(
+          `${unitName}: exact-dependencies.json dependencies mismatch`
+        )
+      }
+      if (fileOptionalDeps !== actualOptionalDependencies) {
+        throw new Error(
+          `${unitName}: exact-dependencies.json optionalDependencies mismatch`
+        )
+      }
+    }
+  }
+)
 
 // --- Units ---
-check('HTTP units: greet, list-todos, create-todo, update-todo', () => {
-  assertContains(unitDirs, ['greet', 'list-todos', 'create-todo', 'update-todo'], 'HTTP')
+check('HTTP units: greet, list-todos, update-todo', () => {
+  assertContains(unitDirs, ['greet', 'list-todos', 'update-todo'], 'HTTP')
 })
-check('queue unit: process-reminder', () => {
-  assertContains(unitDirs, ['process-reminder'], 'Queue')
+check('server unit exists for server-target functions', () => {
+  assertContains(unitDirs, [SERVER_UNIT_NAME], 'Server')
 })
 check('scheduled units: daily-summary, weekly-cleanup', () => {
   assertContains(unitDirs, ['daily-summary', 'weekly-cleanup'], 'Scheduled')
@@ -86,22 +264,43 @@ check('channel units (>= 1)', () => {
   if (ch.length < 1) throw new Error(`Got ${ch.length}`)
 })
 check('workflow step units: send-notification, schedule-reminder', () => {
-  assertContains(unitDirs, ['send-notification', 'schedule-reminder'], 'Step units')
+  assertContains(
+    unitDirs,
+    ['send-notification', 'schedule-reminder'],
+    'Step units'
+  )
 })
-check('total units >= 30', () => {
-  if (unitDirs.length < 30) throw new Error(`Got ${unitDirs.length}`)
+check('total units >= 29', () => {
+  if (unitDirs.length < 29) throw new Error(`Got ${unitDirs.length}`)
 })
+check(
+  'plan manifest: server unit includes createTodo + processReminder',
+  () => {
+    const units = deploymentManifest?.units ?? []
+    const serverUnit = units.find((u) => u.name === SERVER_UNIT_NAME)
+    if (!serverUnit) throw new Error('Missing server unit in manifest')
+    const functionIds = (serverUnit.functionIds ?? []) as string[]
+    if (!functionIds.includes('createTodo')) {
+      throw new Error('server unit missing createTodo')
+    }
+    if (!functionIds.includes('processReminder')) {
+      throw new Error('server unit missing processReminder')
+    }
+  }
+)
 
 // --- Bundles ---
 check('no unit exceeds 5MB', () => {
   for (const u of unitDirs) {
-    const s = statSync(join(DEPLOY_DIR, u, 'bundle.js')).size
-    if (s > 5 * 1024 * 1024) throw new Error(`${u}: ${(s / 1024 / 1024).toFixed(1)}MB`)
+    const s = statSync(join(getUnitPath(u), 'bundle.js')).size
+    if (s > 5 * 1024 * 1024)
+      throw new Error(`${u}: ${(s / 1024 / 1024).toFixed(1)}MB`)
   }
 })
 check('every unit has entry.ts', () => {
   for (const u of unitDirs) {
-    if (!existsSync(join(DEPLOY_DIR, u, 'entry.ts'))) throw new Error(`${u} missing entry.ts`)
+    if (!existsSync(join(getUnitPath(u), 'entry.ts')))
+      throw new Error(`${u} missing entry.ts`)
   }
 })
 

--- a/verifiers/deploy-standalone/test-deploy.ts
+++ b/verifiers/deploy-standalone/test-deploy.ts
@@ -8,19 +8,41 @@
 import { execSync, spawn } from 'child_process'
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
+import { createHash } from 'crypto'
 
 const FUNCTIONS_DIR = join(process.cwd(), '..', '..', 'templates', 'functions')
+const REPO_ROOT = join(process.cwd(), '..', '..')
+const PIKKU_BIN = join(REPO_ROOT, 'packages', 'cli', 'dist', 'bin', 'pikku.js')
 const DEPLOY_DIR = join(FUNCTIONS_DIR, '.deploy', 'standalone')
+const PLAN_RESULT_FILE = join(DEPLOY_DIR, 'plan-result.json')
+const DEPLOYMENT_MANIFEST_FILE = join(DEPLOY_DIR, 'deployment-manifest.json')
 
 console.log('Setting up: running pikku codegen + deploy plan (standalone)...')
 execSync('rm -rf .deploy src/scaffold', { cwd: FUNCTIONS_DIR, stdio: 'pipe' })
-execSync('yarn pikku', { cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 60_000 })
-execSync('yarn pikku deploy plan --provider standalone', {
-  cwd: FUNCTIONS_DIR, stdio: 'pipe', timeout: 300_000,
+execSync(`node ${PIKKU_BIN}`, {
+  cwd: FUNCTIONS_DIR,
+  stdio: 'pipe',
+  timeout: 60_000,
 })
+execSync(
+  `node ${PIKKU_BIN} deploy plan --provider standalone --result-file .deploy/standalone/plan-result.json`,
+  {
+    cwd: FUNCTIONS_DIR,
+    stdio: 'pipe',
+    timeout: 300_000,
+  }
+)
 console.log('Setup complete.\n')
 
-function readText(path: string): string { return readFileSync(path, 'utf-8') }
+function readText(path: string): string {
+  return readFileSync(path, 'utf-8')
+}
+function readJSON(path: string): Record<string, unknown> {
+  return JSON.parse(readText(path))
+}
+function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex')
+}
 function getUnitDirs(): string[] {
   if (!existsSync(DEPLOY_DIR)) return []
   return readdirSync(DEPLOY_DIR).filter((d) => {
@@ -43,16 +65,173 @@ async function check(name: string, fn: () => void | Promise<void>) {
 
 const unitDirs = getUnitDirs()
 const unitName = unitDirs[0]
+const planResult = existsSync(PLAN_RESULT_FILE)
+  ? (readJSON(PLAN_RESULT_FILE) as {
+      success?: boolean
+      artifacts?: { deploymentManifestPath?: string }
+    })
+  : null
+const deploymentManifestPath =
+  typeof planResult?.artifacts?.deploymentManifestPath === 'string' &&
+  existsSync(planResult.artifacts.deploymentManifestPath)
+    ? planResult.artifacts.deploymentManifestPath
+    : existsSync(DEPLOYMENT_MANIFEST_FILE)
+      ? DEPLOYMENT_MANIFEST_FILE
+      : null
+const deploymentManifest = deploymentManifestPath
+  ? (readJSON(deploymentManifestPath) as {
+      units?: Array<Record<string, unknown>>
+    })
+  : null
 
 // --- Single unit mode ---
 check('exactly 1 unit (singleUnit mode)', () => {
-  if (unitDirs.length !== 1) throw new Error(`Expected 1, got ${unitDirs.length}: ${unitDirs.join(', ')}`)
+  if (unitDirs.length !== 1)
+    throw new Error(
+      `Expected 1, got ${unitDirs.length}: ${unitDirs.join(', ')}`
+    )
+})
+check('plan-result.json: success + one deployment manifest unit', () => {
+  if (!planResult) throw new Error('Missing plan-result.json')
+  if (planResult.success !== true)
+    throw new Error('Plan result is not success=true')
+  const units = deploymentManifest?.units ?? []
+  if (units.length !== 1)
+    throw new Error(`Expected 1 manifest unit, got ${units.length}`)
+})
+check(
+  'plan manifest: bundle/exact dependency hashes are present + valid',
+  () => {
+    const units = deploymentManifest?.units ?? []
+    if (units.length !== 1)
+      throw new Error(`Expected 1 unit, got ${units.length}`)
+    const u = units[0]
+    const manifestUnitName = String(u.name ?? '')
+    const bundleHash = String(u.bundleHash ?? '')
+    const exactDependenciesHash = String(u.exactDependenciesHash ?? '')
+    const exactDependencies = (u.exactDependencies ?? {}) as Record<
+      string,
+      string
+    >
+    const exactOptionalDependencies = (u.exactOptionalDependencies ??
+      {}) as Record<string, string>
+
+    if (!/^[a-f0-9]{64}$/.test(bundleHash))
+      throw new Error(`${manifestUnitName}: invalid bundleHash`)
+    if (!/^[a-f0-9]{64}$/.test(exactDependenciesHash)) {
+      throw new Error(`${manifestUnitName}: invalid exactDependenciesHash`)
+    }
+
+    const bundleContent = readText(
+      join(DEPLOY_DIR, manifestUnitName, 'bundle.js')
+    )
+    if (sha256(bundleContent) !== bundleHash)
+      throw new Error(`${manifestUnitName}: bundleHash mismatch`)
+
+    const pkg = readJSON(
+      join(DEPLOY_DIR, manifestUnitName, 'package.json')
+    ) as {
+      dependencies?: Record<string, string>
+      optionalDependencies?: Record<string, string>
+    }
+    const deps = pkg.dependencies ?? {}
+    const optionalDeps = pkg.optionalDependencies ?? {}
+    const depsHash = sha256(
+      JSON.stringify({
+        dependencies: Object.entries(deps).sort(([a], [b]) =>
+          a.localeCompare(b)
+        ),
+        optionalDependencies: Object.entries(optionalDeps).sort(([a], [b]) =>
+          a.localeCompare(b)
+        ),
+      })
+    )
+    if (depsHash !== exactDependenciesHash) {
+      throw new Error(`${manifestUnitName}: exactDependenciesHash mismatch`)
+    }
+
+    const expectedDependencies = JSON.stringify(
+      Object.fromEntries(
+        Object.entries(deps).sort(([a], [b]) => a.localeCompare(b))
+      )
+    )
+    const actualDependencies = JSON.stringify(
+      Object.fromEntries(
+        Object.entries(exactDependencies).sort(([a], [b]) => a.localeCompare(b))
+      )
+    )
+    if (actualDependencies !== expectedDependencies) {
+      throw new Error(`${manifestUnitName}: exactDependencies payload mismatch`)
+    }
+
+    const expectedOptionalDependencies = JSON.stringify(
+      Object.fromEntries(
+        Object.entries(optionalDeps).sort(([a], [b]) => a.localeCompare(b))
+      )
+    )
+    const actualOptionalDependencies = JSON.stringify(
+      Object.fromEntries(
+        Object.entries(exactOptionalDependencies).sort(([a], [b]) =>
+          a.localeCompare(b)
+        )
+      )
+    )
+    if (actualOptionalDependencies !== expectedOptionalDependencies) {
+      throw new Error(
+        `${manifestUnitName}: exactOptionalDependencies payload mismatch`
+      )
+    }
+
+    const exactDepsFile = readJSON(
+      join(DEPLOY_DIR, manifestUnitName, 'exact-dependencies.json')
+    ) as {
+      dependencies?: Record<string, string>
+      optionalDependencies?: Record<string, string>
+    }
+    const fileDeps = JSON.stringify(
+      Object.fromEntries(
+        Object.entries(exactDepsFile.dependencies ?? {}).sort(([a], [b]) =>
+          a.localeCompare(b)
+        )
+      )
+    )
+    const fileOptionalDeps = JSON.stringify(
+      Object.fromEntries(
+        Object.entries(exactDepsFile.optionalDependencies ?? {}).sort(
+          ([a], [b]) => a.localeCompare(b)
+        )
+      )
+    )
+    if (fileDeps !== actualDependencies) {
+      throw new Error(
+        `${manifestUnitName}: exact-dependencies.json dependencies mismatch`
+      )
+    }
+    if (fileOptionalDeps !== actualOptionalDependencies) {
+      throw new Error(
+        `${manifestUnitName}: exact-dependencies.json optionalDependencies mismatch`
+      )
+    }
+  }
+)
+check('plan manifest: single unit includes server-target functions', () => {
+  const units = deploymentManifest?.units ?? []
+  if (units.length !== 1)
+    throw new Error(`Expected 1 unit, got ${units.length}`)
+  const functionIds = (units[0].functionIds ?? []) as string[]
+  if (!functionIds.includes('createTodo')) {
+    throw new Error('single unit missing createTodo')
+  }
+  if (!functionIds.includes('processReminder')) {
+    throw new Error('single unit missing processReminder')
+  }
 })
 
 check('bundle > 100KB and < 10MB', () => {
   const s = statSync(join(DEPLOY_DIR, unitName, 'bundle.js')).size
   if (s < 100 * 1024) throw new Error(`Too small: ${(s / 1024).toFixed(0)}KB`)
-  if (s > 10 * 1024 * 1024) throw new Error(`Too large: ${(s / 1024 / 1024).toFixed(1)}MB`)
+  if (s > 10 * 1024 * 1024)
+    throw new Error(`Too large: ${(s / 1024 / 1024).toFixed(1)}MB`)
 })
 
 check('bundle is ESM (not CJS require)', () => {
@@ -67,11 +246,13 @@ check('bundle is ESM (not CJS require)', () => {
 // --- Entry content ---
 check('entry: PikkuExpressServer', () => {
   const e = readText(join(DEPLOY_DIR, unitName, 'entry.ts'))
-  if (!e.includes('PikkuExpressServer')) throw new Error('Missing PikkuExpressServer')
+  if (!e.includes('PikkuExpressServer'))
+    throw new Error('Missing PikkuExpressServer')
 })
 check('entry: InMemorySchedulerService', () => {
   const e = readText(join(DEPLOY_DIR, unitName, 'entry.ts'))
-  if (!e.includes('InMemorySchedulerService')) throw new Error('Missing scheduler')
+  if (!e.includes('InMemorySchedulerService'))
+    throw new Error('Missing scheduler')
 })
 check('entry: bootstrap import', () => {
   const e = readText(join(DEPLOY_DIR, unitName, 'entry.ts'))
@@ -89,7 +270,8 @@ check('entry: graceful shutdown', () => {
 
 // --- No infra ---
 check('no infra.json', () => {
-  if (existsSync(join(DEPLOY_DIR, 'infra.json'))) throw new Error('Should not exist')
+  if (existsSync(join(DEPLOY_DIR, 'infra.json')))
+    throw new Error('Should not exist')
 })
 
 // ---------------------------------------------------------------------------
@@ -107,12 +289,21 @@ async function startServer(): Promise<ReturnType<typeof spawn>> {
 
   // Wait for ready
   await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error('Server start timeout (5s)')), 5000)
+    const timeout = setTimeout(
+      () => reject(new Error('Server start timeout (5s)')),
+      5000
+    )
     const interval = setInterval(async () => {
       try {
         const res = await fetch(`http://0.0.0.0:${port}/health-check`)
-        if (res.ok) { clearInterval(interval); clearTimeout(timeout); resolve() }
-      } catch { /* not ready */ }
+        if (res.ok) {
+          clearInterval(interval)
+          clearTimeout(timeout)
+          resolve()
+        }
+      } catch {
+        /* not ready */
+      }
     }, 200)
   })
 
@@ -135,8 +326,11 @@ try {
       body: JSON.stringify({ rpcName: 'greet', data: { name: 'Verifier' } }),
     })
     if (!res.ok) throw new Error(`Status ${res.status}: ${await res.text()}`)
-    const body = await res.json() as Record<string, unknown>
-    if (typeof body.message !== 'string' || !body.message.includes('Verifier')) {
+    const body = (await res.json()) as Record<string, unknown>
+    if (
+      typeof body.message !== 'string' ||
+      !body.message.includes('Verifier')
+    ) {
       throw new Error(`Unexpected response: ${JSON.stringify(body)}`)
     }
   })
@@ -144,7 +338,7 @@ try {
   await check('runtime: GET /todos returns array', async () => {
     const res = await fetch(`http://0.0.0.0:${port}/todos`)
     if (!res.ok) throw new Error(`Status ${res.status}`)
-    const body = await res.json() as Record<string, unknown>
+    const body = (await res.json()) as Record<string, unknown>
     if (!body.todos) throw new Error(`Missing todos: ${JSON.stringify(body)}`)
   })
 
@@ -152,16 +346,23 @@ try {
     const res = await fetch(`http://0.0.0.0:${port}/todos`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: 'Verifier Test', priority: 'low', tags: ['test'] }),
+      body: JSON.stringify({
+        title: 'Verifier Test',
+        priority: 'low',
+        tags: ['test'],
+      }),
     })
     if (!res.ok) throw new Error(`Status ${res.status}: ${await res.text()}`)
   })
-
 } catch (e) {
   // Server failed to start — check already recorded the error
   if (!results.some((r) => r.name.startsWith('runtime:'))) {
     failures++
-    results.push({ name: 'runtime: server start', passed: false, error: (e as Error).message })
+    results.push({
+      name: 'runtime: server start',
+      passed: false,
+      error: (e as Error).message,
+    })
   }
 } finally {
   if (proc) {


### PR DESCRIPTION
## Summary\n- add canonical deployment-manifest.json output from deploy plan/apply build pipeline\n- slim plan-result.json to run-report fields + artifact paths\n- replace externalPackages metadata with exactDependencies/exactOptionalDependencies + exactDependenciesHash\n- emit per-unit exact-dependencies.json\n- keep bundleHash for code-change detection\n- update planner/provider to diff on exactDependenciesHash\n- keep server container codegen writing directly to container/.pikku (no post-move)\n- prevent deploy codegen from regenerating repo scaffold files\n- update deploy verifiers (cloudflare/serverless/azure/standalone) to assert new artifacts/fields\n\n## Validation\n- @pikku/verifiers-deploy-cloudflare\n- @pikku/verifiers-deploy-serverless\n- @pikku/verifiers-deploy-azure\n- @pikku/verifiers-deploy-standalone\n(all passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added integrity hashing for bundles and dependency manifests for artifact verification.
  * Introduced structured output directories separating unit bundles and server container bundles.
  * Enhanced deploy-plan output to include manifest and infra artifact paths.
  * Added per-function deploy target option (server/serverless/auto) for finer deployment control.

* **Chores**
  * Deployment manifest now includes exact dependency maps and optional-dependency separation for validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->