### PR TITLE
feat(core): scope bare rpc.invoke() calls to caller's addon package

### DIFF
--- a/.changeset/addon-scoped-rpc.md
+++ b/.changeset/addon-scoped-rpc.md
@@ -1,0 +1,16 @@
+---
+'@pikku/core': patch
+---
+
+feat(core): scope bare `rpc.invoke()` calls to the caller's addon package
+
+Addon functions calling `rpc.invoke('foo')` (bare, no colon) previously only
+resolved against root RPC meta and threw `RPCNotFoundError` for the addon's
+own functions, forcing authors to prefix every call with their consumer-facing
+namespace (`'cli:foo'`) — which couples the addon to its caller's `wireAddon({ name })`.
+
+`ContextAwareRPCService` now carries an optional `packageName` passed through
+from `runPikkuFunc` via `getContextRPCService`. For bare names from inside an
+addon, resolution first checks the caller's package function meta, then falls
+back to root. Applies to both `rpc.invoke()` and `rpc.rpcWithWire()`. Explicit
+namespaced calls (`'stripe:createCharge'`) and root-namespace calls are unchanged.

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -378,11 +378,16 @@ export const runPikkuFunc = async <In = any, Out = any>(
         wireServices && Object.keys(wireServices).length > 0
           ? { ...resolvedSingletonServices, ...wireServices }
           : resolvedSingletonServices
+      const callerPackageName = packageName
       Object.defineProperty(resolvedWire, 'rpc', {
         get() {
-          const rpc = rpcService.getContextRPCService(services, resolvedWire, {
-            sessionService,
-          })
+          const rpc = rpcService.getContextRPCService(
+            services,
+            resolvedWire,
+            { sessionService },
+            0,
+            callerPackageName
+          )
           Object.defineProperty(resolvedWire, 'rpc', {
             value: rpc,
             writable: true,

--- a/packages/core/src/wirings/rpc/rpc-runner.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.ts
@@ -54,17 +54,23 @@ export const resolveNamespace = (
   }
 }
 
-const getPikkuFunctionName = (
+/**
+ * Resolve a bare (non-namespaced) RPC name to its pikkuFuncId, preferring
+ * the caller's addon package when provided. Returns the function name plus
+ * the package scope that resolved it (null = root), so callers can thread
+ * the scope into runPikkuFunc without a second lookup.
+ */
+const resolvePikkuFunction = (
   rpcName: string,
   packageName: string | null = null
-): string => {
-  // For addon-scoped calls, try the caller's package function meta first
-  // (RPC meta only lives in root; addon functions are registered under their package)
+): { pikkuFuncId: string; packageName: string | null } => {
+  // Addon-scoped calls: try the caller's package function meta first.
+  // (RPC meta only lives in root; addon functions are registered under their package.)
   if (packageName) {
     const pkgFunctions = pikkuState(packageName, 'function', 'meta')
     const pkgMeta = pkgFunctions?.[rpcName]
     if (pkgMeta) {
-      return pkgMeta.pikkuFuncId || rpcName
+      return { pikkuFuncId: pkgMeta.pikkuFuncId || rpcName, packageName }
     }
   }
   const rpc = pikkuState(null, 'rpc', 'meta')
@@ -78,7 +84,7 @@ const getPikkuFunctionName = (
   if (!rpcMeta) {
     throw new RPCNotFoundError(rpcName)
   }
-  return rpcMeta
+  return { pikkuFuncId: rpcMeta, packageName: null }
 }
 
 // Context-aware RPC client for use within services
@@ -144,38 +150,22 @@ export class ContextAwareRPCService {
       }
     }
 
-    // Bare name from inside an addon: resolve against the caller's package
-    // before falling back to root. This matches the expectation that an
-    // addon's own RPCs are callable by their local name from within the addon.
-    if (this.packageName && !funcName.includes(':')) {
-      const pkgFunctions = pikkuState(this.packageName, 'function', 'meta')
-      if (pkgFunctions?.[funcName]) {
-        return runPikkuFunc<In, Out>(
-          'rpc',
-          funcName,
-          pkgFunctions[funcName].pikkuFuncId || funcName,
-          {
-            auth: this.options.requiresAuth,
-            singletonServices: this.services,
-            data: () => data,
-            wire: updatedWire,
-            packageName: this.packageName,
-          }
-        )
-      }
-    }
-
-    // Try local function, then fall back to deployment service (remote)
+    // Bare name: resolve via caller's package scope first (if any), then root.
+    // Note: intra-addon bare calls do NOT re-apply the addon's external
+    // addonConfig.auth/tags — those gates are only applied on the external
+    // 'namespace:func' boundary via invokeAddonFunction.
     try {
+      const resolved = resolvePikkuFunction(funcName, this.packageName)
       return await runPikkuFunc<In, Out>(
         'rpc',
         funcName,
-        getPikkuFunctionName(funcName),
+        resolved.pikkuFuncId,
         {
           auth: this.options.requiresAuth,
           singletonServices: this.services,
           data: () => data,
           wire: updatedWire,
+          packageName: resolved.packageName,
         }
       )
     } catch (e) {
@@ -266,17 +256,14 @@ export class ContextAwareRPCService {
     }
 
     try {
-      return await runPikkuFunc<In, Out>(
-        'rpc',
-        rpcName,
-        getPikkuFunctionName(rpcName),
-        {
-          auth: this.options.requiresAuth,
-          singletonServices: this.services,
-          data: () => data,
-          wire: mergedWire,
-        }
-      )
+      const resolved = resolvePikkuFunction(rpcName, this.packageName)
+      return await runPikkuFunc<In, Out>('rpc', rpcName, resolved.pikkuFuncId, {
+        auth: this.options.requiresAuth,
+        singletonServices: this.services,
+        data: () => data,
+        wire: mergedWire,
+        packageName: resolved.packageName,
+      })
     } catch (e) {
       if (e instanceof RPCNotFoundError && this.services.deploymentService) {
         const session =

--- a/packages/core/src/wirings/rpc/rpc-runner.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.ts
@@ -54,7 +54,19 @@ export const resolveNamespace = (
   }
 }
 
-const getPikkuFunctionName = (rpcName: string): string => {
+const getPikkuFunctionName = (
+  rpcName: string,
+  packageName: string | null = null
+): string => {
+  // For addon-scoped calls, try the caller's package function meta first
+  // (RPC meta only lives in root; addon functions are registered under their package)
+  if (packageName) {
+    const pkgFunctions = pikkuState(packageName, 'function', 'meta')
+    const pkgMeta = pkgFunctions?.[rpcName]
+    if (pkgMeta) {
+      return pkgMeta.pikkuFuncId || rpcName
+    }
+  }
   const rpc = pikkuState(null, 'rpc', 'meta')
   let rpcMeta = rpc[rpcName]
   if (!rpcMeta) {
@@ -77,7 +89,8 @@ export class ContextAwareRPCService {
     private options: {
       requiresAuth?: boolean
       sessionService?: SessionService<CoreUserSession>
-    }
+    },
+    private packageName: string | null = null
   ) {}
 
   public async rpcExposed(funcName: string, data: any): Promise<any> {
@@ -128,6 +141,27 @@ export class ContextAwareRPCService {
       } catch (addonErr) {
         if (!(addonErr instanceof RPCNotFoundError)) throw addonErr
         // Not an addon — fall through to local lookup
+      }
+    }
+
+    // Bare name from inside an addon: resolve against the caller's package
+    // before falling back to root. This matches the expectation that an
+    // addon's own RPCs are callable by their local name from within the addon.
+    if (this.packageName && !funcName.includes(':')) {
+      const pkgFunctions = pikkuState(this.packageName, 'function', 'meta')
+      if (pkgFunctions?.[funcName]) {
+        return runPikkuFunc<In, Out>(
+          'rpc',
+          funcName,
+          pkgFunctions[funcName].pikkuFuncId || funcName,
+          {
+            auth: this.options.requiresAuth,
+            singletonServices: this.services,
+            data: () => data,
+            wire: updatedWire,
+            packageName: this.packageName,
+          }
+        )
       }
     }
 
@@ -406,14 +440,20 @@ export class PikkuRPCService<
           sessionService?: SessionService<CoreUserSession>
         }
       | undefined,
-    depth: number = 0
+    depth: number = 0,
+    packageName: string | null = null
   ): TypedRPC {
     const options =
       typeof requiresAuthOrOptions === 'object' &&
       requiresAuthOrOptions !== null
         ? requiresAuthOrOptions
         : { requiresAuth: requiresAuthOrOptions }
-    const serviceRPC = new ContextAwareRPCService(services, wire, options)
+    const serviceRPC = new ContextAwareRPCService(
+      services,
+      wire,
+      options,
+      packageName
+    )
     return {
       depth,
       global: false,


### PR DESCRIPTION
## Summary

- Addon functions calling \`rpc.invoke('foo')\` (bare, no colon) previously only resolved against root RPC meta and threw \`RPCNotFoundError\` for the addon's own functions, forcing authors to prefix every call with their consumer-facing namespace (\`'cli:foo'\`) — which couples the addon to its caller's \`wireAddon({ name })\`.
- \`ContextAwareRPCService\` now carries an optional \`packageName\` passed through from \`runPikkuFunc\` via \`getContextRPCService\`. For bare names from inside an addon, resolution first checks the caller's package function meta, then falls back to root. Explicit namespaced calls (\`'stripe:createCharge'\`) and root-namespace calls are unchanged.

Closes #530.

## Test plan

- [ ] Existing RPC tests pass unchanged (root-namespace behavior preserved).
- [ ] Addon function calls \`rpc.invoke('internalFn')\` (bare name) and resolves to its own package's function, without needing to prefix with the consumer-defined namespace.
- [ ] Explicit \`rpc.invoke('otherAddon:fn')\` still works.
- [ ] Deployment-service fallback still fires when bare name misses both package scope and root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bare RPC calls made from addons now resolve against the calling addon first, then fall back to root—improving addon-scoped function discovery.

* **Improvements**
  * RPC context construction now includes addon package information, yielding more consistent and predictable cross-package RPC behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->