### PR TITLE
fix(inspector): exclude node_modules sources from project scan

### DIFF
--- a/.changeset/inspector-skip-node-modules.md
+++ b/.changeset/inspector-skip-node-modules.md
@@ -1,0 +1,22 @@
+---
+'@pikku/inspector': patch
+---
+
+fix(inspector): exclude node_modules sources from the project source-file filter
+
+When a project uses a yarn-workspace addon, `node_modules/@pkg/addon` symlinks
+back into a sibling package; those symlinked source files were passing the
+`startsWith(rootDir)` check and getting discovered as project sources.
+
+This caused two bugs:
+
+1. `Config`/`SingletonServices` etc. declared in the addon were collected
+   alongside the consumer's, producing `More than one CoreSingletonServices found`
+   during typesLookup.
+2. Addon RPC functions landed in the consumer's `RPCMap` at root scope
+   (unprefixed) and `wireAddon({ name, package })` was silently ignored — the
+   generated `FlattenedRPCMap` read `// No addon packages, use RPCMap directly`
+   even when the consumer's wiring registered the addon.
+
+The filter now also excludes any `/node_modules/` paths so symlinked addon
+sources aren't treated as project files.

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -250,11 +250,19 @@ export const inspect = async (
   const rootDir = options.rootDir || findCommonAncestor(routeFiles)
 
   const startSourceFiles = performance.now()
-  // Filter source files to only include files within the project rootDir
-  // This prevents picking up types from external packages (including workspace symlinks)
+  // Filter source files to only include files within the project rootDir.
+  // Also exclude anything reached through node_modules — in yarn workspace
+  // setups, `rootDir/node_modules/@scope/pkg` symlinks back into a sibling
+  // package whose files would otherwise be picked up and mistaken for project
+  // sources (producing "More than one CoreSingletonServices found" errors
+  // and polluting the RPC map with addon functions as root-scope entries).
   const sourceFiles = program
     .getSourceFiles()
-    .filter((sf) => sf.fileName.startsWith(rootDir))
+    .filter(
+      (sf) =>
+        sf.fileName.startsWith(rootDir) &&
+        !sf.fileName.includes('/node_modules/')
+    )
   logger.debug(
     `Got source files in ${(performance.now() - startSourceFiles).toFixed(2)}ms`
   )


### PR DESCRIPTION
## Summary

- Yarn-workspace addons symlink `node_modules/@pkg/addon` back into a sibling workspace package. The existing `startsWith(rootDir)` filter kept symlinked addon sources because the symlink path lives under `rootDir`.
- Two symptoms collapse into one fix:
  1. `More than one CoreSingletonServices found` during typesLookup (addon's interfaces collected alongside consumer's).
  2. Addon RPCs landed in consumer's `RPCMap` at root scope, unprefixed; `wireAddon({ name, package })` was silently ignored — generated `FlattenedRPCMap` read `// No addon packages, use RPCMap directly`.
- Filter now also excludes `/node_modules/` paths.

Closes #532.

## Test plan

- [ ] Verify with a yarn-workspace addon consumer: `pikku all` in the consumer no longer reports duplicate-type errors.
- [ ] Generated `FlattenedRPCMap` reflects registered `wireAddon` calls — consumer's `RPCMap` contains only local RPCs, addon RPCs appear namespace-prefixed.
- [ ] Non-workspace projects unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)