### PR TITLE
feat(create): add fabric template that clones starter-template

### DIFF
--- a/.changeset/fabric-template.md
+++ b/.changeset/fabric-template.md
@@ -1,0 +1,5 @@
+---
+'create-pikku': minor
+---
+
+Add `fabric` template — clones `pikkujs/starter-template` verbatim, then prompts for the frontend scaffold to keep (react-vite-mantine static or nextjs-tailwind SSR) and removes the others. Backend (functions + sdk + sql) is always retained.

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -30,7 +30,7 @@ import {
 import { program } from 'commander'
 import { tmpdir } from 'os'
 import { spawnSync } from 'child_process'
-import { unlinkSync, writeFileSync } from 'fs'
+import fs, { unlinkSync, writeFileSync } from 'fs'
 
 const BASE_URL = 'gh:pikkujs/pikku/templates'
 
@@ -158,6 +158,12 @@ const templates = [
     template: 'gateway-whatsapp',
     description: 'A WhatsApp gateway template using Baileys (listener)',
     supports: [],
+  },
+  {
+    template: 'fabric',
+    description:
+      'The opinionated Pikku Fabric starter — backend + SDK + frontend scaffolds + Cucumber e2e',
+    supports: ['http', 'fullstack'],
   },
 ] as const
 
@@ -455,9 +461,56 @@ async function run() {
     await setupRepo(selectedOptions, 'yarn-workspace-starter')
   } else if (template === 'nextjs-full') {
     await setupRepo(selectedOptions, 'nextjs-app-starter')
+  } else if (template === 'fabric') {
+    await setupFabric(selectedOptions)
   } else {
     await setupTemplate(selectedOptions)
   }
+}
+
+const fabricApps = [
+  {
+    id: 'react-vite-mantine',
+    label: 'React + Vite + Mantine (static export)',
+  },
+  {
+    id: 'nextjs-tailwind',
+    label: 'Next.js 15 + Tailwind (SSR)',
+  },
+] as const
+
+async function setupFabric(cliOptions: CliOptions) {
+  // The Fabric starter ships every supported frontend in `apps/`.
+  // We clone it verbatim (via setupRepo) and then delete the apps the
+  // user didn't pick — same flow the e2e runner relies on.
+  const selectedApp = (await select({
+    message: 'Which frontend would you like to start with?',
+    choices: fabricApps.map(({ id, label }) => ({
+      name: label,
+      value: id,
+    })),
+  })) as (typeof fabricApps)[number]['id']
+
+  await setupRepo(cliOptions, 'starter-template')
+
+  const targetPath = path.join(process.cwd(), cliOptions.name)
+  const appsDir = path.join(targetPath, 'apps')
+
+  for (const app of fabricApps) {
+    if (app.id === selectedApp) continue
+    const appPath = path.join(appsDir, app.id)
+    try {
+      fs.rmSync(appPath, { recursive: true, force: true })
+    } catch {
+      // missing dir = nothing to clean
+    }
+  }
+
+  console.log(
+    chalk.green(
+      `\nKept apps/${selectedApp} — other frontend scaffolds removed.`
+    )
+  )
 }
 
 run()

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -468,42 +468,55 @@ async function run() {
   }
 }
 
-const fabricApps = [
-  {
-    id: 'react-vite-mantine',
-    label: 'React + Vite + Mantine (static export)',
-  },
-  {
-    id: 'nextjs-tailwind',
-    label: 'Next.js 15 + Tailwind (SSR)',
-  },
-] as const
+// Pretty labels for apps the starter ships. Anything missing from this map
+// falls back to the directory name in the picker.
+const fabricAppLabels: Record<string, string> = {
+  'react-vite-mantine': 'React + Vite + Mantine (static export)',
+  'nextjs-tailwind': 'Next.js 15 + Tailwind (SSR)',
+}
 
 async function setupFabric(cliOptions: CliOptions) {
-  // The Fabric starter ships every supported frontend in `apps/`.
-  // We clone it verbatim (via setupRepo) and then delete the apps the
-  // user didn't pick — same flow the e2e runner relies on.
-  const selectedApp = (await select({
-    message: 'Which frontend would you like to start with?',
-    choices: fabricApps.map(({ id, label }) => ({
-      name: label,
-      value: id,
-    })),
-  })) as (typeof fabricApps)[number]['id']
-
+  // Clone the starter first so the picker reflects whatever apps the
+  // template *actually* ships — avoids drift between this CLI and the
+  // template repo when new scaffolds are added.
   await setupRepo(cliOptions, 'starter-template')
 
   const targetPath = path.join(process.cwd(), cliOptions.name)
   const appsDir = path.join(targetPath, 'apps')
 
-  for (const app of fabricApps) {
-    if (app.id === selectedApp) continue
-    const appPath = path.join(appsDir, app.id)
-    try {
-      fs.rmSync(appPath, { recursive: true, force: true })
-    } catch {
-      // missing dir = nothing to clean
-    }
+  if (!fs.existsSync(appsDir)) {
+    console.log(
+      chalk.yellow(
+        'No apps/ directory in the cloned template — skipping app picker.'
+      )
+    )
+    return
+  }
+
+  const availableApps = fs
+    .readdirSync(appsDir, { withFileTypes: true })
+    .filter(
+      (d) =>
+        d.isDirectory() &&
+        fs.existsSync(path.join(appsDir, d.name, 'package.json'))
+    )
+    .map((d) => d.name)
+
+  if (availableApps.length === 0) return
+
+  const selectedApp = await select({
+    message: 'Which frontend would you like to start with?',
+    choices: availableApps.map((id) => ({
+      name: fabricAppLabels[id] ?? id,
+      value: id,
+    })),
+  })
+
+  // Safe from path traversal: ids come from a directory listing inside
+  // `appsDir`, never from user input or external config.
+  for (const id of availableApps) {
+    if (id === selectedApp) continue
+    fs.rmSync(path.join(appsDir, id), { recursive: true, force: true })
   }
 
   console.log(


### PR DESCRIPTION
## Summary

- Adds a \`fabric\` template option to \`create-pikku\` that clones the fabric starter-template repo
- App picker is now driven off the cloned starter contents instead of being hardcoded
- Includes changeset

## Test plan

- [ ] \`yarn create pikku my-app\` and pick \`fabric\` — verify clone + picker works
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)