### PR TITLE
feat(content)!: bucket-aware ContentService with typed object args

### DIFF
--- a/.changeset/content-service-bucket-aware.md
+++ b/.changeset/content-service-bucket-aware.md
@@ -1,8 +1,8 @@
 ---
-'@pikku/core': major
-'@pikku/aws-services': major
-'@pikku/backblaze': major
-'@pikku/addon-workflow-screenshot': major
+'@pikku/core': patch
+'@pikku/aws-services': patch
+'@pikku/backblaze': patch
+'@pikku/addon-workflow-screenshot': patch
 ---
 
 feat(content)!: bucket-aware ContentService with typed object args

--- a/.changeset/content-service-bucket-aware.md
+++ b/.changeset/content-service-bucket-aware.md
@@ -1,0 +1,39 @@
+---
+'@pikku/core': major
+'@pikku/aws-services': major
+'@pikku/backblaze': major
+'@pikku/addon-workflow-screenshot': major
+---
+
+feat(content)!: bucket-aware ContentService with typed object args
+
+BREAKING CHANGE: All `ContentService` methods now take object args with a
+required `bucket` field. The interface is generic over `TBucket extends string`
+so callers can constrain bucket names to a typed union.
+
+Migration:
+
+```ts
+// Before
+content.getUploadURL(fileKey, contentType)
+content.signContentKey(key, expiresAt)
+content.writeFile(assetKey, stream)
+content.readFile(assetKey)
+content.deleteFile(assetKey)
+
+// After
+content.getUploadURL({ bucket, fileKey, contentType })
+content.signContentKey({ bucket, contentKey, dateLessThan: expiresAt })
+content.writeFile({ bucket, key, stream })
+content.readFile({ bucket, key })
+content.deleteFile({ bucket, key })
+```
+
+- New exported types: `SignContentKeyArgs`, `SignURLArgs`, `GetUploadURLArgs`,
+  `UploadURLResult`, `BucketKeyArgs`, `WriteFileArgs`, `CopyFileArgs`.
+- `LocalContent` stores objects under `<base>/<bucket>/<key>`.
+- `S3Content` and `B2Content` treat the logical bucket as a key prefix within
+  the configured underlying storage bucket.
+- `workflow-screenshot` addon takes `bucket?` / `key?` input; default bucket
+  resolved from `PIKKU_WORKFLOW_SCREENSHOT_BUCKET` variable, no hardcoded
+  fallback.

--- a/packages/addon/pikku-workflow-screenshot/src/functions/render-workflow-image.function.ts
+++ b/packages/addon/pikku-workflow-screenshot/src/functions/render-workflow-image.function.ts
@@ -3,16 +3,21 @@ import { pikkuSessionlessFunc } from '#pikku'
 
 export interface RenderWorkflowImageInput {
   workflowData: any
-  assetKey?: string
+  bucket?: string
+  key?: string
   width?: number
   height?: number
   format?: 'png' | 'jpeg'
 }
 
 export interface RenderWorkflowImageOutput {
+  bucket: string
+  key: string
   assetKey: string
   url?: string
 }
+
+const DEFAULT_BUCKET = 'workflow-screenshots'
 
 export const renderWorkflowImage = pikkuSessionlessFunc<
   RenderWorkflowImageInput,
@@ -25,7 +30,7 @@ export const renderWorkflowImage = pikkuSessionlessFunc<
   auth: false,
   func: async (
     { screenshotService, content, logger },
-    { workflowData, assetKey, width, height, format }
+    { workflowData, bucket, key, width, height, format }
   ) => {
     const imageBuffer = await screenshotService.renderWorkflowImage(
       workflowData,
@@ -33,22 +38,36 @@ export const renderWorkflowImage = pikkuSessionlessFunc<
     )
 
     const resolvedFormat = format || 'png'
-    const resolvedAssetKey =
-      assetKey || `workflow-screenshots/${Date.now()}.${resolvedFormat}`
+    const resolvedBucket = bucket || DEFAULT_BUCKET
+    const resolvedKey = key || `${Date.now()}.${resolvedFormat}`
 
     const stream = Readable.from(imageBuffer)
-    await content.writeFile(resolvedAssetKey, stream)
+    await content.writeFile({
+      bucket: resolvedBucket,
+      key: resolvedKey,
+      stream,
+    })
+    const assetKey = `${resolvedBucket}/${resolvedKey}`
 
     let url: string | undefined
     try {
       const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000)
-      url = await content.signContentKey(resolvedAssetKey, expiresAt)
+      url = await content.signContentKey({
+        bucket: resolvedBucket,
+        contentKey: resolvedKey,
+        dateLessThan: expiresAt,
+      })
     } catch {
       logger?.debug(
         'Content service does not support signing, returning asset key only'
       )
     }
 
-    return { assetKey: resolvedAssetKey, url }
+    return {
+      bucket: resolvedBucket,
+      key: resolvedKey,
+      assetKey,
+      url,
+    }
   },
 })

--- a/packages/addon/pikku-workflow-screenshot/src/functions/render-workflow-image.function.ts
+++ b/packages/addon/pikku-workflow-screenshot/src/functions/render-workflow-image.function.ts
@@ -17,8 +17,6 @@ export interface RenderWorkflowImageOutput {
   url?: string
 }
 
-const DEFAULT_BUCKET = 'workflow-screenshots'
-
 export const renderWorkflowImage = pikkuSessionlessFunc<
   RenderWorkflowImageInput,
   RenderWorkflowImageOutput
@@ -29,7 +27,7 @@ export const renderWorkflowImage = pikkuSessionlessFunc<
   expose: true,
   auth: false,
   func: async (
-    { screenshotService, content, logger },
+    { screenshotService, content, variables, logger },
     { workflowData, bucket, key, width, height, format }
   ) => {
     const imageBuffer = await screenshotService.renderWorkflowImage(
@@ -38,7 +36,13 @@ export const renderWorkflowImage = pikkuSessionlessFunc<
     )
 
     const resolvedFormat = format || 'png'
-    const resolvedBucket = bucket || DEFAULT_BUCKET
+    const resolvedBucket =
+      bucket || (await variables.get('PIKKU_WORKFLOW_SCREENSHOT_BUCKET'))
+    if (!resolvedBucket) {
+      throw new Error(
+        'Workflow screenshot bucket not configured: pass `bucket` in the input or set the PIKKU_WORKFLOW_SCREENSHOT_BUCKET variable.'
+      )
+    }
     const resolvedKey = key || `${Date.now()}.${resolvedFormat}`
 
     const stream = Readable.from(imageBuffer)

--- a/packages/addon/pikku-workflow-screenshot/test/src/screenshot.test.ts
+++ b/packages/addon/pikku-workflow-screenshot/test/src/screenshot.test.ts
@@ -79,14 +79,21 @@ test(
         'workflow-screenshot:renderWorkflowImage',
         {
           workflowData: sampleWorkflow,
-          assetKey: 'test-workflow.png',
+          bucket: 'workflow-screenshots',
+          key: 'test-workflow.png',
         }
       )
 
-      assert.equal(result.assetKey, 'test-workflow.png')
+      assert.equal(result.bucket, 'workflow-screenshots')
+      assert.equal(result.key, 'test-workflow.png')
+      assert.equal(result.assetKey, 'workflow-screenshots/test-workflow.png')
       assert.ok(result.url, 'Should return a signed URL')
 
-      const filePath = join(uploadPath, 'test-workflow.png')
+      const filePath = join(
+        uploadPath,
+        'workflow-screenshots',
+        'test-workflow.png'
+      )
       assert.ok(
         existsSync(filePath),
         `Screenshot file should exist at ${filePath}`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,7 +98,16 @@ export type { QueueService } from './wirings/queue/queue.types.js'
 export type { JWTService } from './services/jwt-service.js'
 export type { SecretService } from './services/secret-service.js'
 export type { VariablesService } from './services/variables-service.js'
-export type { ContentService } from './services/content-service.js'
+export type {
+  ContentService,
+  SignContentKeyArgs,
+  SignURLArgs,
+  GetUploadURLArgs,
+  UploadURLResult,
+  BucketKeyArgs,
+  WriteFileArgs,
+  CopyFileArgs,
+} from './services/content-service.js'
 export type { DeploymentService } from './services/deployment-service.js'
 export type { WorkflowService } from './services/workflow-service.js'
 export type { GatewayService } from './services/gateway-service.js'

--- a/packages/core/src/services/content-service.ts
+++ b/packages/core/src/services/content-service.ts
@@ -1,81 +1,109 @@
-export interface ContentService {
+/**
+ * Arguments for signing a content key into a time-limited URL.
+ */
+export interface SignContentKeyArgs<TBucket extends string = string> {
+  bucket: TBucket
+  contentKey: string
+  dateLessThan: Date
+  dateGreaterThan?: Date
+}
+
+/**
+ * Arguments for signing an arbitrary URL.
+ */
+export interface SignURLArgs {
+  url: string
+  dateLessThan: Date
+  dateGreaterThan?: Date
+}
+
+/**
+ * Arguments for minting a presigned upload URL.
+ */
+export interface GetUploadURLArgs<TBucket extends string = string> {
+  bucket: TBucket
+  fileKey: string
+  contentType: string
+  size?: number
+}
+
+/**
+ * Result of minting a presigned upload URL.
+ */
+export interface UploadURLResult {
+  uploadUrl: string
+  assetKey: string
+  uploadHeaders?: Record<string, string>
+  uploadMethod?: 'PUT' | 'POST'
+}
+
+/**
+ * Arguments for an operation that targets a single object by key.
+ */
+export interface BucketKeyArgs<TBucket extends string = string> {
+  bucket: TBucket
+  key: string
+}
+
+/**
+ * Arguments for writing a stream to storage.
+ */
+export interface WriteFileArgs<
+  TBucket extends string = string,
+> extends BucketKeyArgs<TBucket> {
+  stream: ReadableStream | NodeJS.ReadableStream
+}
+
+/**
+ * Arguments for copying a local file into storage.
+ */
+export interface CopyFileArgs<
+  TBucket extends string = string,
+> extends BucketKeyArgs<TBucket> {
+  fromAbsolutePath: string
+}
+
+export interface ContentService<TBucket extends string = string> {
   /**
    * Signs a content key to generate a secure, time-limited access URL.
-   * @param contentKey - The key representing the content object.
-   * @param dateLessThan - The expiration time for the signed URL.
-   * @param dateGreaterThan - (Optional) Start time before which access is denied.
    */
-  signContentKey(
-    contentKey: string,
-    dateLessThan: Date,
-    dateGreaterThan?: Date
-  ): Promise<string>
+  signContentKey(args: SignContentKeyArgs<TBucket>): Promise<string>
 
   /**
    * Signs an arbitrary URL to generate a secure, time-limited access URL.
-   * @param url - The full URL that needs signing.
-   * @param dateLessThan - The expiration time for the signed URL.
-   * @param dateGreaterThan - (Optional) Start time before which access is denied.
    */
-  signURL(
-    url: string,
-    dateLessThan: Date,
-    dateGreaterThan?: Date
-  ): Promise<string>
+  signURL(args: SignURLArgs): Promise<string>
 
   /**
    * Generates a signed URL for uploading a file directly to storage.
-   * @param fileKey - The desired key/location of the uploaded file.
-   * @param contentType - The MIME type of the file.
-   * @returns A signed upload URL and the finalized asset key.
+   * Bucket policy (size limits, MIME allowlist) is enforced by the implementation.
    */
-  getUploadURL(
-    fileKey: string,
-    contentType: string
-  ): Promise<{
-    uploadUrl: string
-    assetKey: string
-    uploadHeaders?: Record<string, string>
-    uploadMethod?: 'PUT' | 'POST'
-  }>
+  getUploadURL(args: GetUploadURLArgs<TBucket>): Promise<UploadURLResult>
 
   /**
    * Deletes a file from the storage backend.
-   * @param fileName - The name or key of the file to delete.
-   * @returns A boolean indicating success.
    */
-  deleteFile(fileName: string): Promise<boolean>
+  deleteFile(args: BucketKeyArgs<TBucket>): Promise<boolean>
 
   /**
-   * Uploads a file stream to storage under a specified asset key.
-   * @param assetKey - The key where the file will be saved.
-   * @param stream - A readable stream of the file contents.
-   * @returns A boolean indicating success.
+   * Uploads a file stream to storage under the specified bucket + key.
    */
-  writeFile(
-    assetKey: string,
-    stream: ReadableStream | NodeJS.ReadableStream
-  ): Promise<boolean>
+  writeFile(args: WriteFileArgs<TBucket>): Promise<boolean>
 
   /**
-   * Copies a file from a local absolute path into storage under a new asset key.
-   * @param assetKey - The destination key.
-   * @param fromAbsolutePath - The local absolute file path.
-   * @returns A boolean indicating success.
+   * Copies a file from a local absolute path into storage.
    */
-  copyFile(assetKey: string, fromAbsolutePath: string): Promise<boolean>
+  copyFile(args: CopyFileArgs<TBucket>): Promise<boolean>
 
   /**
    * Reads a file from storage as a readable stream.
-   * @param assetKey - The key of the file to read.
-   * @returns A readable file stream.
    */
-  readFile(assetKey: string): Promise<ReadableStream | NodeJS.ReadableStream>
+  readFile(
+    args: BucketKeyArgs<TBucket>
+  ): Promise<ReadableStream | NodeJS.ReadableStream>
 
   /**
    * Reads an entire file from storage into a Buffer.
-   * @param assetKey - The key of the file to read.
-   * @returns The file contents as a Buffer.
    */
-  readFileAsBuffer(assetKey: string): Promise<Buffer>
+  readFileAsBuffer(args: BucketKeyArgs<TBucket>): Promise<Buffer>
 }

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -25,7 +25,16 @@ export { InMemoryQueueService } from './in-memory-queue-service.js'
 export { InMemoryTriggerService } from './in-memory-trigger-service.js'
 export { InMemoryAIRunStateService } from './in-memory-ai-run-state-service.js'
 export { LocalGatewayService } from './local-gateway-service.js'
-export type { ContentService } from './content-service.js'
+export type {
+  ContentService,
+  SignContentKeyArgs,
+  SignURLArgs,
+  GetUploadURLArgs,
+  UploadURLResult,
+  BucketKeyArgs,
+  WriteFileArgs,
+  CopyFileArgs,
+} from './content-service.js'
 export type { JWTService } from './jwt-service.js'
 export type { Logger } from './logger.js'
 export type { SecretService } from './secret-service.js'

--- a/packages/core/src/services/local-content.ts
+++ b/packages/core/src/services/local-content.ts
@@ -1,7 +1,18 @@
 import { createReadStream, createWriteStream, promises } from 'fs'
 import { mkdir, readFile } from 'fs/promises'
 import { resolve, normalize } from 'path'
-import type { ContentService, JWTService, Logger } from '@pikku/core/services'
+import type {
+  BucketKeyArgs,
+  ContentService,
+  CopyFileArgs,
+  GetUploadURLArgs,
+  JWTService,
+  Logger,
+  SignContentKeyArgs,
+  SignURLArgs,
+  UploadURLResult,
+  WriteFileArgs,
+} from '@pikku/core/services'
 import { pipeline } from 'stream/promises'
 import type { Readable } from 'stream'
 
@@ -20,13 +31,18 @@ export class LocalContent implements ContentService {
     private jwt?: JWTService
   ) {}
 
-  private safePath(assetKey: string): string {
+  private safePath(bucket: string, key: string): string {
     const base = resolve(this.config.localFileUploadPath)
-    const target = resolve(base, normalize(assetKey))
+    const scoped = resolve(base, normalize(bucket))
+    const target = resolve(scoped, normalize(key))
     if (!target.startsWith(base + '/') && target !== base) {
       throw new Error('Invalid asset key')
     }
     return target
+  }
+
+  private joinKey(bucket: string, key: string): string {
+    return `${bucket}/${key}`
   }
 
   public async init() {}
@@ -58,105 +74,105 @@ export class LocalContent implements ContentService {
     return params.toString()
   }
 
-  public async signURL(
-    url: string,
-    dateLessThan: Date,
-    dateGreaterThan?: Date
-  ): Promise<string> {
-    const params = await this.signParams(dateLessThan, dateGreaterThan)
-    return `${url}?${params}`
+  public async signURL(args: SignURLArgs): Promise<string> {
+    const params = await this.signParams(
+      args.dateLessThan,
+      args.dateGreaterThan
+    )
+    return `${args.url}?${params}`
   }
 
-  public async signContentKey(
-    assetKey: string,
-    dateLessThan: Date,
-    dateGreaterThan?: Date
-  ): Promise<string> {
+  public async signContentKey(args: SignContentKeyArgs): Promise<string> {
+    const fullKey = this.joinKey(args.bucket, args.contentKey)
     const base = this.config.server
-      ? `${this.config.server}${this.config.assetUrlPrefix}/${assetKey}`
-      : `${this.config.assetUrlPrefix}/${assetKey}`
-    return this.signURL(base, dateLessThan, dateGreaterThan)
+      ? `${this.config.server}${this.config.assetUrlPrefix}/${fullKey}`
+      : `${this.config.assetUrlPrefix}/${fullKey}`
+    return this.signURL({
+      url: base,
+      dateLessThan: args.dateLessThan,
+      dateGreaterThan: args.dateGreaterThan,
+    })
   }
 
-  public async getUploadURL(assetKey: string) {
-    this.logger.debug(`Going to upload with key: ${assetKey}`)
+  public async getUploadURL(args: GetUploadURLArgs): Promise<UploadURLResult> {
+    const fullKey = this.joinKey(args.bucket, args.fileKey)
+    this.logger.debug(`Going to upload with key: ${fullKey}`)
     return {
-      uploadUrl: `${this.config.uploadUrlPrefix}/${assetKey}`,
-      assetKey,
+      uploadUrl: `${this.config.uploadUrlPrefix}/${fullKey}`,
+      assetKey: fullKey,
     }
   }
 
-  public async writeFile(
-    assetKey: string,
-    stream: ReadableStream | NodeJS.ReadableStream
-  ): Promise<boolean> {
-    this.logger.debug(`Writing file: ${assetKey}`)
+  public async writeFile(args: WriteFileArgs): Promise<boolean> {
+    this.logger.debug(`Writing file: ${args.bucket}/${args.key}`)
 
-    const path = this.safePath(assetKey)
+    const path = this.safePath(args.bucket, args.key)
 
     try {
       await this.createDirectoryForFile(path)
       const fileStream = createWriteStream(path)
-      // Use pipeline to properly manage stream piping and errors
-      await pipeline(stream as Readable, fileStream)
+      await pipeline(args.stream as Readable, fileStream)
       return true
     } catch (e) {
       console.error(e)
-      this.logger.error(`Error writing content ${assetKey}`, e)
+      this.logger.error(`Error writing content ${args.bucket}/${args.key}`, e)
       return false
     }
   }
 
-  public async copyFile(
-    assetKey: string,
-    fromAbsolutePath: string
-  ): Promise<boolean> {
-    this.logger.debug(`Writing file: ${assetKey}`)
+  public async copyFile(args: CopyFileArgs): Promise<boolean> {
+    this.logger.debug(`Writing file: ${args.bucket}/${args.key}`)
     try {
-      const path = this.safePath(assetKey)
+      const path = this.safePath(args.bucket, args.key)
       await this.createDirectoryForFile(path)
-      await promises.copyFile(fromAbsolutePath, path)
+      await promises.copyFile(args.fromAbsolutePath, path)
+      return true
     } catch (e) {
       console.error(e)
-      this.logger.error(`Error inserting content ${assetKey}`, e)
+      this.logger.error(`Error inserting content ${args.bucket}/${args.key}`, e)
     }
     return false
   }
 
   public async readFile(
-    assetKey: string
+    args: BucketKeyArgs
   ): Promise<ReadableStream | NodeJS.ReadableStream> {
-    this.logger.debug(`Getting key: ${assetKey}`)
+    this.logger.debug(`Getting key: ${args.bucket}/${args.key}`)
 
-    const filePath = this.safePath(assetKey)
+    const filePath = this.safePath(args.bucket, args.key)
 
     try {
       const stream = createReadStream(filePath)
-      // Handle early stream errors (like file not found, permission denied, etc.)
       stream.on('error', (err) => {
-        this.logger.error(`Error getting content ${assetKey}`, err)
+        this.logger.error(
+          `Error getting content ${args.bucket}/${args.key}`,
+          err
+        )
       })
 
       return stream
     } catch (e) {
-      this.logger.error(`Error setting up stream for ${assetKey}`, e)
+      this.logger.error(
+        `Error setting up stream for ${args.bucket}/${args.key}`,
+        e
+      )
       throw e
     }
   }
 
-  public async readFileAsBuffer(assetKey: string): Promise<Buffer> {
-    const filePath = this.safePath(assetKey)
-    this.logger.debug(`Reading file as buffer: ${assetKey}`)
+  public async readFileAsBuffer(args: BucketKeyArgs): Promise<Buffer> {
+    const filePath = this.safePath(args.bucket, args.key)
+    this.logger.debug(`Reading file as buffer: ${args.bucket}/${args.key}`)
     return readFile(filePath)
   }
 
-  public async deleteFile(assetKey: string): Promise<boolean> {
-    this.logger.debug(`deleting key: ${assetKey}`)
+  public async deleteFile(args: BucketKeyArgs): Promise<boolean> {
+    this.logger.debug(`deleting key: ${args.bucket}/${args.key}`)
     try {
-      await promises.unlink(this.safePath(assetKey))
+      await promises.unlink(this.safePath(args.bucket, args.key))
       return true
     } catch (e: any) {
-      this.logger.error(`Error deleting content ${assetKey}`, e)
+      this.logger.error(`Error deleting content ${args.bucket}/${args.key}`, e)
     }
     return false
   }

--- a/packages/services/aws-services/src/s3-content.ts
+++ b/packages/services/aws-services/src/s3-content.ts
@@ -5,12 +5,26 @@ import {
   GetObjectCommand,
 } from '@aws-sdk/client-s3'
 import { getSignedUrl as getS3SignedUrl } from '@aws-sdk/s3-request-presigner'
-import type { ContentService, Logger } from '@pikku/core/services'
+import type {
+  BucketKeyArgs,
+  ContentService,
+  CopyFileArgs,
+  GetUploadURLArgs,
+  Logger,
+  SignContentKeyArgs,
+  SignURLArgs,
+  UploadURLResult,
+  WriteFileArgs,
+} from '@pikku/core/services'
 import { readFile } from 'fs/promises'
 import { getSignedUrl } from '@aws-sdk/cloudfront-signer'
 import type { Readable } from 'stream'
 
 export interface S3ContentConfig {
+  /**
+   * The underlying S3 bucket. Logical (pseudo) buckets passed via the
+   * ContentService API are stored as path prefixes within this bucket.
+   */
   bucketName: string
   region: string
   endpoint?: string
@@ -30,41 +44,38 @@ export class S3Content implements ContentService {
     })
   }
 
-  public async signURL(
-    url: string,
-    dateLessThan: Date,
-    dateGreaterThan?: Date
-  ) {
+  private join(bucket: string, key: string): string {
+    return `${bucket}/${key}`
+  }
+
+  public async signURL(args: SignURLArgs) {
     try {
       return getSignedUrl({
         ...this.signConfig,
-        url,
-        dateLessThan: dateLessThan.toString(),
-        dateGreaterThan: dateGreaterThan?.toString(),
+        url: args.url,
+        dateLessThan: args.dateLessThan.toString(),
+        dateGreaterThan: args.dateGreaterThan?.toString(),
       })
     } catch {
-      this.logger.error(`Error signing url: ${url}`)
-      return url
+      this.logger.error(`Error signing url: ${args.url}`)
+      return args.url
     }
   }
 
-  public async signContentKey(
-    key: string,
-    dateLessThan: Date,
-    dateGreaterThan?: Date
-  ) {
-    return this.signURL(
-      `https://${this.config.bucketName}/${key}`,
-      dateLessThan,
-      dateGreaterThan
-    )
+  public async signContentKey(args: SignContentKeyArgs) {
+    return this.signURL({
+      url: `https://${this.config.bucketName}/${this.join(args.bucket, args.contentKey)}`,
+      dateLessThan: args.dateLessThan,
+      dateGreaterThan: args.dateGreaterThan,
+    })
   }
 
-  public async getUploadURL(Key: string, ContentType: string) {
+  public async getUploadURL(args: GetUploadURLArgs): Promise<UploadURLResult> {
+    const Key = this.join(args.bucket, args.fileKey)
     const command = new PutObjectCommand({
       Bucket: this.config.bucketName,
       Key,
-      ContentType,
+      ContentType: args.contentType,
     })
     return {
       uploadUrl: await getS3SignedUrl(this.s3, command, {
@@ -75,8 +86,9 @@ export class S3Content implements ContentService {
   }
 
   public async readFile(
-    Key: string
+    args: BucketKeyArgs
   ): Promise<ReadableStream | NodeJS.ReadableStream> {
+    const Key = this.join(args.bucket, args.key)
     this.logger.debug(`Getting file, key: ${Key}`)
 
     const response = await this.s3.send(
@@ -93,10 +105,8 @@ export class S3Content implements ContentService {
     return response.Body as NodeJS.ReadableStream
   }
 
-  public async writeFile(
-    Key: string,
-    stream: ReadableStream | NodeJS.ReadableStream
-  ): Promise<boolean> {
+  public async writeFile(args: WriteFileArgs): Promise<boolean> {
+    const Key = this.join(args.bucket, args.key)
     try {
       this.logger.debug(`Writing file, key: ${Key}`)
 
@@ -104,7 +114,7 @@ export class S3Content implements ContentService {
         new PutObjectCommand({
           Bucket: this.config.bucketName,
           Key,
-          Body: stream as Readable, // <- Pass the readable stream directly
+          Body: args.stream as Readable,
         })
       )
 
@@ -115,15 +125,18 @@ export class S3Content implements ContentService {
     }
   }
 
-  public async copyFile(Key: string, fromAbsolutePath: string) {
+  public async copyFile(args: CopyFileArgs) {
+    const Key = this.join(args.bucket, args.key)
     try {
-      this.logger.debug(`Uploading file, key: ${Key} from: ${fromAbsolutePath}`)
+      this.logger.debug(
+        `Uploading file, key: ${Key} from: ${args.fromAbsolutePath}`
+      )
 
       await this.s3.send(
         new PutObjectCommand({
           Bucket: this.config.bucketName,
           Key,
-          Body: await readFile(fromAbsolutePath),
+          Body: await readFile(args.fromAbsolutePath),
         })
       )
       return true
@@ -133,7 +146,8 @@ export class S3Content implements ContentService {
     }
   }
 
-  public async readFileAsBuffer(Key: string): Promise<Buffer> {
+  public async readFileAsBuffer(args: BucketKeyArgs): Promise<Buffer> {
+    const Key = this.join(args.bucket, args.key)
     this.logger.debug(`Getting file as buffer, key: ${Key}`)
 
     const response = await this.s3.send(
@@ -150,7 +164,8 @@ export class S3Content implements ContentService {
     return Buffer.from(await response.Body.transformToByteArray())
   }
 
-  public async deleteFile(Key: string) {
+  public async deleteFile(args: BucketKeyArgs) {
+    const Key = this.join(args.bucket, args.key)
     try {
       this.logger.debug(`Deleting file, key: ${Key}`)
       await this.s3.send(

--- a/packages/services/backblaze/src/b2-content.test.ts
+++ b/packages/services/backblaze/src/b2-content.test.ts
@@ -17,12 +17,15 @@ const logger = {
 
 describe('B2Content integration', async () => {
   if (!config.applicationKeyId || !config.applicationKey || !config.bucketId) {
-    console.log('Skipping B2 tests: set B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY, B2_BUCKET_ID')
+    console.log(
+      'Skipping B2 tests: set B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY, B2_BUCKET_ID'
+    )
     return
   }
 
   const b2 = new B2Content(config, logger as any)
-  const testFileName = `pikku-test-${Date.now()}.txt`
+  const bucket = 'pikku-test'
+  const testKey = `pikku-test-${Date.now()}.txt`
   const testContent = 'Hello from Pikku B2 integration test!'
 
   test('upload file via writeFile', async () => {
@@ -32,17 +35,17 @@ describe('B2Content integration', async () => {
         controller.close()
       },
     })
-    const result = await b2.writeFile(testFileName, stream)
+    const result = await b2.writeFile({ bucket, key: testKey, stream })
     assert.ok(result, 'writeFile should return true')
   })
 
   test('readFileAsBuffer returns correct content', async () => {
-    const buffer = await b2.readFileAsBuffer(testFileName)
+    const buffer = await b2.readFileAsBuffer({ bucket, key: testKey })
     assert.equal(buffer.toString(), testContent)
   })
 
   test('readFile returns a stream', async () => {
-    const stream = await b2.readFile(testFileName)
+    const stream = await b2.readFile({ bucket, key: testKey })
     const reader = (stream as ReadableStream).getReader()
     const chunks: Uint8Array[] = []
     while (true) {
@@ -55,28 +58,45 @@ describe('B2Content integration', async () => {
   })
 
   test('signContentKey returns a download URL', async () => {
-    const url = await b2.signContentKey(testFileName, new Date())
-    assert.ok(url.includes(testFileName), 'URL should contain the file name')
+    const url = await b2.signContentKey({
+      bucket,
+      contentKey: testKey,
+      dateLessThan: new Date(),
+    })
+    assert.ok(url.includes(testKey), 'URL should contain the file name')
     assert.ok(url.startsWith('https://'), 'URL should be https')
   })
 
   test('getUploadURL returns credentials with POST method', async () => {
-    const info = await b2.getUploadURL('test.txt', 'text/plain')
+    const info = await b2.getUploadURL({
+      bucket,
+      fileKey: 'test.txt',
+      contentType: 'text/plain',
+    })
     assert.ok(info.uploadUrl, 'Should have uploadUrl')
-    assert.equal(info.assetKey, 'test.txt')
+    assert.equal(info.assetKey, `${bucket}/test.txt`)
     assert.equal(info.uploadMethod, 'POST')
     assert.ok(info.uploadHeaders?.Authorization, 'Should have auth header')
-    assert.ok(info.uploadHeaders?.['X-Bz-File-Name'], 'Should have file name header')
-    assert.ok(info.uploadHeaders?.['Content-Type'], 'Should have content type header')
+    assert.ok(
+      info.uploadHeaders?.['X-Bz-File-Name'],
+      'Should have file name header'
+    )
+    assert.ok(
+      info.uploadHeaders?.['Content-Type'],
+      'Should have content type header'
+    )
   })
 
   test('deleteFile removes the file', async () => {
-    const result = await b2.deleteFile(testFileName)
+    const result = await b2.deleteFile({ bucket, key: testKey })
     assert.ok(result, 'deleteFile should return true')
   })
 
   test('deleteFile returns false for non-existent file', async () => {
-    const result = await b2.deleteFile('non-existent-file-12345.txt')
+    const result = await b2.deleteFile({
+      bucket,
+      key: 'non-existent-file-12345.txt',
+    })
     assert.equal(result, false)
   })
 })

--- a/packages/services/backblaze/src/b2-content.ts
+++ b/packages/services/backblaze/src/b2-content.ts
@@ -1,4 +1,14 @@
-import type { ContentService, Logger } from '@pikku/core/services'
+import type {
+  BucketKeyArgs,
+  ContentService,
+  CopyFileArgs,
+  GetUploadURLArgs,
+  Logger,
+  SignContentKeyArgs,
+  SignURLArgs,
+  UploadURLResult,
+  WriteFileArgs,
+} from '@pikku/core/services'
 import { createHash } from 'crypto'
 import { readFile } from 'fs/promises'
 
@@ -7,6 +17,10 @@ const B2_AUTH_URL = 'https://api.backblazeb2.com/b2api/v2/b2_authorize_account'
 export interface B2ContentConfig {
   applicationKeyId: string
   applicationKey: string
+  /**
+   * The underlying B2 bucket. Logical (pseudo) buckets passed via the
+   * ContentService API are stored as path prefixes within this bucket.
+   */
   bucketId: string
 }
 
@@ -30,6 +44,10 @@ export class B2Content implements ContentService {
     this.credentials = btoa(
       `${config.applicationKeyId}:${config.applicationKey}`
     )
+  }
+
+  private join(bucket: string, key: string): string {
+    return `${bucket}/${key}`
   }
 
   private async ensureAuthorized(): Promise<B2Auth> {
@@ -65,7 +83,7 @@ export class B2Content implements ContentService {
   private async getBucketName(): Promise<string> {
     if (!this.bucketName) {
       const data = await this.b2Post('b2_list_buckets', {
-        accountId: (await this.ensureAuthorized() as any).accountId,
+        accountId: ((await this.ensureAuthorized()) as any).accountId,
         bucketId: this.bucketId,
       })
       this.bucketName = data.buckets[0].bucketName
@@ -118,95 +136,95 @@ export class B2Content implements ContentService {
     return data.authorizationToken
   }
 
-  async signContentKey(
-    contentKey: string,
-    dateLessThan: Date,
-  ): Promise<string> {
+  async signContentKey(args: SignContentKeyArgs): Promise<string> {
+    const fullKey = this.join(args.bucket, args.contentKey)
     const auth = await this.ensureAuthorized()
     const bucketName = await this.getBucketName()
-    const durationSeconds = Math.max(1, Math.floor((dateLessThan.getTime() - Date.now()) / 1000))
-    const downloadAuth = await this.getDownloadAuthorization(contentKey, durationSeconds)
-    return `${auth.downloadUrl}/file/${bucketName}/${contentKey}?Authorization=${downloadAuth}`
+    const durationSeconds = Math.max(
+      1,
+      Math.floor((args.dateLessThan.getTime() - Date.now()) / 1000)
+    )
+    const downloadAuth = await this.getDownloadAuthorization(
+      fullKey,
+      durationSeconds
+    )
+    return `${auth.downloadUrl}/file/${bucketName}/${fullKey}?Authorization=${downloadAuth}`
   }
 
-  async signURL(
-    url: string,
-    dateLessThan: Date,
-  ): Promise<string> {
-    const durationSeconds = Math.max(1, Math.floor((dateLessThan.getTime() - Date.now()) / 1000))
-    const parsed = new URL(url)
+  async signURL(args: SignURLArgs): Promise<string> {
+    const durationSeconds = Math.max(
+      1,
+      Math.floor((args.dateLessThan.getTime() - Date.now()) / 1000)
+    )
+    const parsed = new URL(args.url)
     const pathParts = parsed.pathname.split('/file/')
     if (pathParts.length < 2) {
-      return url
+      return args.url
     }
     const filePrefix = pathParts[1]!.split('/').slice(1).join('/')
-    const downloadAuth = await this.getDownloadAuthorization(filePrefix, durationSeconds)
+    const downloadAuth = await this.getDownloadAuthorization(
+      filePrefix,
+      durationSeconds
+    )
     parsed.searchParams.set('Authorization', downloadAuth)
     return parsed.toString()
   }
 
-  async getUploadURL(
-    fileKey: string,
-    contentType: string
-  ): Promise<{
-    uploadUrl: string
-    assetKey: string
-    uploadHeaders?: Record<string, string>
-    uploadMethod?: 'PUT' | 'POST'
-  }> {
+  async getUploadURL(args: GetUploadURLArgs): Promise<UploadURLResult> {
+    const fullKey = this.join(args.bucket, args.fileKey)
     const { uploadUrl, authorizationToken } = await this.getUploadToken()
     return {
       uploadUrl,
-      assetKey: fileKey,
+      assetKey: fullKey,
       uploadMethod: 'POST',
       uploadHeaders: {
         Authorization: authorizationToken,
-        'X-Bz-File-Name': encodeURIComponent(fileKey),
-        'Content-Type': contentType,
+        'X-Bz-File-Name': encodeURIComponent(fullKey),
+        'Content-Type': args.contentType,
         'X-Bz-Content-Sha1': 'do_not_verify',
       },
     }
   }
 
-  async writeFile(
-    assetKey: string,
-    stream: ReadableStream | NodeJS.ReadableStream
-  ): Promise<boolean> {
+  async writeFile(args: WriteFileArgs): Promise<boolean> {
+    const fullKey = this.join(args.bucket, args.key)
     try {
-      this.logger.debug(`Writing file, key: ${assetKey}`)
+      this.logger.debug(`Writing file, key: ${fullKey}`)
       const chunks: Buffer[] = []
-      for await (const chunk of stream as AsyncIterable<Buffer>) {
+      for await (const chunk of args.stream as AsyncIterable<Buffer>) {
         chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
       }
-      await this.uploadData(assetKey, Buffer.concat(chunks))
+      await this.uploadData(fullKey, Buffer.concat(chunks))
       return true
     } catch (e: any) {
-      this.logger.error(`Error writing file, key: ${assetKey}`, e)
+      this.logger.error(`Error writing file, key: ${fullKey}`, e)
       return false
     }
   }
 
-  async copyFile(assetKey: string, fromAbsolutePath: string): Promise<boolean> {
+  async copyFile(args: CopyFileArgs): Promise<boolean> {
+    const fullKey = this.join(args.bucket, args.key)
     try {
       this.logger.debug(
-        `Uploading file, key: ${assetKey} from: ${fromAbsolutePath}`
+        `Uploading file, key: ${fullKey} from: ${args.fromAbsolutePath}`
       )
-      await this.uploadData(assetKey, await readFile(fromAbsolutePath))
+      await this.uploadData(fullKey, await readFile(args.fromAbsolutePath))
       return true
     } catch (e: any) {
-      this.logger.error(`Error copying file, key: ${assetKey}`, e)
+      this.logger.error(`Error copying file, key: ${fullKey}`, e)
       return false
     }
   }
 
   async readFile(
-    assetKey: string
+    args: BucketKeyArgs
   ): Promise<ReadableStream | NodeJS.ReadableStream> {
-    this.logger.debug(`Reading file, key: ${assetKey}`)
+    const fullKey = this.join(args.bucket, args.key)
+    this.logger.debug(`Reading file, key: ${fullKey}`)
     const auth = await this.ensureAuthorized()
     const bucketName = await this.getBucketName()
     const res = await fetch(
-      `${auth.downloadUrl}/file/${bucketName}/${assetKey}`,
+      `${auth.downloadUrl}/file/${bucketName}/${fullKey}`,
       { headers: { Authorization: auth.authorizationToken } }
     )
     if (!res.ok) {
@@ -215,12 +233,13 @@ export class B2Content implements ContentService {
     return res.body!
   }
 
-  async readFileAsBuffer(assetKey: string): Promise<Buffer> {
-    this.logger.debug(`Reading file as buffer, key: ${assetKey}`)
+  async readFileAsBuffer(args: BucketKeyArgs): Promise<Buffer> {
+    const fullKey = this.join(args.bucket, args.key)
+    this.logger.debug(`Reading file as buffer, key: ${fullKey}`)
     const auth = await this.ensureAuthorized()
     const bucketName = await this.getBucketName()
     const res = await fetch(
-      `${auth.downloadUrl}/file/${bucketName}/${assetKey}`,
+      `${auth.downloadUrl}/file/${bucketName}/${fullKey}`,
       { headers: { Authorization: auth.authorizationToken } }
     )
     if (!res.ok) {
@@ -229,26 +248,27 @@ export class B2Content implements ContentService {
     return Buffer.from(await res.arrayBuffer())
   }
 
-  async deleteFile(fileName: string): Promise<boolean> {
+  async deleteFile(args: BucketKeyArgs): Promise<boolean> {
+    const fullKey = this.join(args.bucket, args.key)
     try {
-      this.logger.debug(`Deleting file: ${fileName}`)
+      this.logger.debug(`Deleting file: ${fullKey}`)
       const data = await this.b2Post('b2_list_file_names', {
         bucketId: this.bucketId,
-        prefix: fileName,
+        prefix: fullKey,
         maxFileCount: 1,
       })
-      const file = data.files.find((f: any) => f.fileName === fileName)
+      const file = data.files.find((f: any) => f.fileName === fullKey)
       if (!file) {
-        this.logger.error(`File not found for deletion: ${fileName}`)
+        this.logger.error(`File not found for deletion: ${fullKey}`)
         return false
       }
       await this.b2Post('b2_delete_file_version', {
-        fileName,
+        fileName: fullKey,
         fileId: file.fileId,
       })
       return true
     } catch (e: any) {
-      this.logger.error(`Error deleting file: ${fileName}`, e)
+      this.logger.error(`Error deleting file: ${fullKey}`, e)
       return false
     }
   }


### PR DESCRIPTION
## Summary

BREAKING CHANGE: \`ContentService\` methods now take object args with a required \`bucket\` field. The interface is generic over \`TBucket extends string\` so callers can constrain bucket names to a typed union.

- New exported types: \`SignContentKeyArgs\`, \`SignURLArgs\`, \`GetUploadURLArgs\`, \`UploadURLResult\`, \`BucketKeyArgs\`, \`WriteFileArgs\`, \`CopyFileArgs\`
- \`LocalContent\` stores objects under \`<base>/<bucket>/<key>\`
- \`S3Content\` and \`B2Content\` treat the logical bucket as a key prefix within the configured underlying storage bucket
- \`workflow-screenshot\` addon now takes \`bucket?\` / \`key?\` input and returns both alongside the assembled \`assetKey\`

## Test plan

- [ ] CI passes
- [ ] @pikku/core, @pikku/aws-services, @pikku/backblaze tsc clean (verified locally)
- [ ] Sample upload via \`getUploadURL\` works end-to-end with the new bucket arg

🤖 Generated with [Claude Code](https://claude.com/claude-code)