### PR TITLE
fix(cloudflare): preserve WebSocketHibernationServer export in channe…

### DIFF
--- a/.changeset/cloudflare-channel-bundle-fix.md
+++ b/.changeset/cloudflare-channel-bundle-fix.md
@@ -1,0 +1,25 @@
+---
+'@pikku/cloudflare': patch
+'@pikku/deploy-cloudflare': patch
+---
+
+fix(cloudflare): channel unit bundle was missing the `WebSocketHibernationServer` named re-export
+
+Two issues blocked Workers-for-Platforms channel deploys:
+
+1. The CF deploy adapter generated `entry.ts` with
+   `export { PikkuWebSocketHibernationServer ... } from '@pikku/cloudflare/websocket'`,
+   but `PikkuWebSocketHibernationServer` actually lives in
+   `@pikku/cloudflare/handler` (`/websocket` exports the abstract base
+   `CloudflareWebSocketHibernationServer`). Switched the adapter import to
+   `/handler`.
+2. With `bundle: true, format: 'esm'`, esbuild tree-shook the named
+   re-export because nothing inside the bundle used it — leaving CF to
+   reject the upload with `10070: Cannot apply new-class migration to
+   class 'WebSocketHibernationServer' that is not exported by script`.
+   Added `sideEffects` to `@pikku/cloudflare`'s package.json marking
+   `handler-factories.js` and `cloudflare-hibernation-websocket-server.js`
+   as side-effectful so esbuild preserves the export.
+
+Together these let `wireChannel(...)` units deploy to a Workers-for-Platforms
+dispatch namespace with the DO migration accepted.

--- a/packages/deploy/deploy-cloudflare/src/adapter.ts
+++ b/packages/deploy/deploy-cloudflare/src/adapter.ts
@@ -239,7 +239,7 @@ export class CloudflareProviderAdapter {
       ``,
       ...this.generatePlatformServicesBlock(ctx, platform),
       ``,
-      `export { PikkuWebSocketHibernationServer as WebSocketHibernationServer } from '@pikku/cloudflare/websocket'`,
+      `export { PikkuWebSocketHibernationServer as WebSocketHibernationServer } from '@pikku/cloudflare/handler'`,
       `export default createCloudflareWebSocketHandler({ createConfig: ${ctx.configVar}, createSingletonServices: ${ctx.servicesVar}, createPlatformServices })`,
       ``,
     ]

--- a/packages/runtimes/cloudflare/package.json
+++ b/packages/runtimes/cloudflare/package.json
@@ -6,6 +6,10 @@
   "module": "dist/index.js",
   "main": "dist/index.js",
   "type": "module",
+  "sideEffects": [
+    "./dist/handler-factories.js",
+    "./dist/cloudflare-hibernation-websocket-server.js"
+  ],
   "scripts": {
     "tsc": "tsc",
     "ncu": "npx npm-check-updates",


### PR DESCRIPTION
…l bundle

- Adapter was importing PikkuWebSocketHibernationServer from /websocket (abstract base lives there), but the concrete class is in /handler.
- Added sideEffects to @pikku/cloudflare so esbuild's tree-shaker doesn't drop the named re-export when only `default` is referenced inside the bundle.

Without these, CF Workers-for-Platforms rejects channel unit uploads with "Cannot apply new-class migration to class 'WebSocketHibernationServer' that is not exported by script" (code 10070).