### PR TITLE
chore: changeset bump → patch (pre-0.13 convention)

### DIFF
--- a/.changeset/fabric-template.md
+++ b/.changeset/fabric-template.md
@@ -1,5 +1,5 @@
 ---
-'create-pikku': minor
+'create-pikku': patch
 ---
 
 Add `fabric` template — clones `pikkujs/starter-template` verbatim, then prompts for the frontend scaffold to keep (react-vite-mantine static or nextjs-tailwind SSR) and removes the others. Backend (functions + sdk + sql) is always retained.


### PR DESCRIPTION
Last `create-pikku` changeset was `minor`. Per pre-0.13 convention everything is `patch`.