### PR TITLE
fix(cloudflare,cli): workflow-starter capability + CF Worker compat

### DIFF
--- a/.changeset/workflow-starter-cf-fixes.md
+++ b/.changeset/workflow-starter-cf-fixes.md
@@ -1,0 +1,35 @@
+---
+'@pikku/cli': patch
+'@pikku/cloudflare': patch
+'@pikku/deploy-cloudflare': patch
+---
+
+fix(cloudflare,cli): make workflow-starter usable + restore CF Worker compat
+
+Three fixes that unblock deploying graph-DSL workflows to Cloudflare
+Workers via Workers-for-Platforms:
+
+1. **`workflowStarter` / `graphStarter` scaffold now declares
+   `workflowService`.** Both functions delegate to `rpc.startWorkflow()`,
+   which requires `workflowService` on the services container at runtime.
+   The previous `(_services, ...)` signature hid that requirement, so the
+   analyzer didn't assign `workflow-state` capability to the unit and the
+   generated `entry.ts` left out `CloudflareWorkflowService` — calling
+   `POST /workflow/<name>/start` returned `WorkflowService service not
+   available`. Destructuring `{ workflowService }` (and asserting it) lets
+   the static analyzer pick up the capability automatically.
+
+2. **`@pikku/cloudflare` re-exports `getCloudflareEnv()`.** Lets user
+   `createSingletonServices` factories read CF bindings (D1, R2, KV, queue
+   producers) without threading `env` through every signature. Returns the
+   env captured by `setupServices` on the most recent request, or `null`
+   pre-request.
+
+3. **CF deploy provider opts out of the createRequire banner + aliases
+   every node builtin to its `node:` prefix.** CF Workers don't define
+   `import.meta.url`, so the previous unconditional banner crashed at
+   boot (`The argument 'path' must be a file URL ... Received 'undefined'`
+   at `node:module:34:15`). New `getNoRequireShim()` provider hook returns
+   true for CF; `nodejs_compat_v2` then handles builtins natively as long
+   as imports use the `node:` prefix, which `getAliases()` now ensures for
+   the full builtin list.

--- a/packages/cli/src/deploy/build-pipeline.ts
+++ b/packages/cli/src/deploy/build-pipeline.ts
@@ -144,6 +144,7 @@ export async function runBuildPipeline(options: {
         define: provider.getDefine?.(),
         platform: provider.getPlatform?.(),
         format: provider.getFormat?.(),
+        noRequireShim: provider.getNoRequireShim?.(),
       }
     )
     bundled = bundleResult.results
@@ -277,6 +278,7 @@ export async function runBuildPipeline(options: {
         define: provider.getDefine?.(),
         platform: provider.getPlatform?.(),
         format: provider.getFormat?.(),
+        noRequireShim: provider.getNoRequireShim?.(),
         resolveOutputDir: (unit) =>
           unit.target === 'server' ? containerDir : join(unitsDir, unit.name),
       }

--- a/packages/cli/src/deploy/bundler/bundler.ts
+++ b/packages/cli/src/deploy/bundler/bundler.ts
@@ -101,6 +101,7 @@ interface BundleUnitOptions {
   define?: Record<string, string>
   platform?: 'node' | 'neutral' | 'browser'
   format?: 'esm' | 'cjs'
+  noRequireShim?: boolean
 }
 
 /**
@@ -152,11 +153,15 @@ async function bundleUnit(options: BundleUnitOptions): Promise<BundleResult> {
   // For ESM + node platform, CJS deps may use require() for builtins.
   // esbuild wraps these as __require() which fails at runtime in ESM.
   // The banner shims require via createRequire so CJS builtins resolve.
+  // Skipped when the provider opts out via `noRequireShim` (e.g. CF Workers
+  // — `import.meta.url` is undefined there, so the shim crashes at boot).
   const resolvedFormat = format ?? 'esm'
   const banner =
-    resolvedFormat === 'esm' && (platform ?? 'node') === 'node'
+    resolvedFormat === 'esm' &&
+    (platform ?? 'node') === 'node' &&
+    !options.noRequireShim
       ? {
-          js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
+          js: `import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);`,
         }
       : undefined
 
@@ -272,6 +277,7 @@ export async function bundleUnits(
     define?: Record<string, string>
     platform?: 'node' | 'neutral' | 'browser'
     format?: 'esm' | 'cjs'
+    noRequireShim?: boolean
     resolveOutputDir?: (unit: DeploymentUnit, baseOutputDir: string) => string
   }
 ): Promise<BundleOutput> {

--- a/packages/cli/src/deploy/provider-adapter.ts
+++ b/packages/cli/src/deploy/provider-adapter.ts
@@ -97,6 +97,12 @@ export interface ProviderAdapter {
   getFormat?(): 'esm' | 'cjs'
 
   /**
+   * Skip the createRequire banner. CF Workers should return true —
+   * `import.meta.url` is undefined there and the banner crashes at boot.
+   */
+  getNoRequireShim?(): boolean
+
+  /**
    * Generate additional provider-level config files (e.g. serverless.yml).
    * Returns a map of filename → content to write into the deploy directory.
    */

--- a/packages/cli/src/functions/wirings/workflow/serialize-workflow-routes.ts
+++ b/packages/cli/src/functions/wirings/workflow/serialize-workflow-routes.ts
@@ -27,7 +27,11 @@ export const workflowStarter = pikkuSessionlessFunc<
   { runId: string }
 >({
   auth: ${authFlag},
-  func: async (_services, { workflowName, data }, { rpc }) => {
+  // workflowService is destructured (even though we delegate via rpc) so the
+  // analyzer assigns workflow-state capability to this unit — without it,
+  // rpc.startWorkflow() runs against a container missing workflowService.
+  func: async ({ workflowService }, { workflowName, data }, { rpc }) => {
+    assertWorkflowService(workflowService)
     return await rpc.startWorkflow(workflowName as any, (data ?? {}) as any)
   },
 })
@@ -237,7 +241,10 @@ export const graphStarter = pikkuSessionlessFunc<
   { runId: string }
 >({
   auth: ${authFlag},
-  func: async (_services, { workflowName, nodeId, data }, { rpc }) => {
+  // See workflowStarter — destructure workflowService so the analyzer
+  // assigns workflow-state capability to this unit.
+  func: async ({ workflowService }, { workflowName, nodeId, data }, { rpc }) => {
+    assertWorkflowService(workflowService)
     return await rpc.startWorkflow(workflowName as any, (data ?? {}) as any, { startNode: nodeId })
   },
 })

--- a/packages/deploy/deploy-cloudflare/src/adapter.ts
+++ b/packages/deploy/deploy-cloudflare/src/adapter.ts
@@ -445,7 +445,60 @@ export class CloudflareProviderAdapter {
   }
 
   getAliases(): Record<string, string> {
-    return { crypto: 'node:crypto' }
+    // Map every node builtin to its `node:`-prefixed form. CF's
+    // nodejs_compat_v2 only resolves prefixed imports.
+    const builtins = [
+      'assert',
+      'async_hooks',
+      'buffer',
+      'child_process',
+      'cluster',
+      'console',
+      'constants',
+      'crypto',
+      'dgram',
+      'dns',
+      'domain',
+      'events',
+      'fs',
+      'http',
+      'http2',
+      'https',
+      'inspector',
+      'module',
+      'net',
+      'os',
+      'path',
+      'perf_hooks',
+      'process',
+      'punycode',
+      'querystring',
+      'readline',
+      'repl',
+      'stream',
+      'string_decoder',
+      'sys',
+      'timers',
+      'tls',
+      'trace_events',
+      'tty',
+      'url',
+      'util',
+      'v8',
+      'vm',
+      'wasi',
+      'worker_threads',
+      'zlib',
+    ]
+    const aliases: Record<string, string> = {}
+    for (const b of builtins) aliases[b] = `node:${b}`
+    return aliases
+  }
+
+  getNoRequireShim(): boolean {
+    // CF Workers don't define `import.meta.url`, so the createRequire shim
+    // crashes at boot. Skip it; nodejs_compat_v2 handles builtins natively.
+    return true
   }
 
   getDefine(): Record<string, string> {

--- a/packages/runtimes/cloudflare/src/handler-factories.ts
+++ b/packages/runtimes/cloudflare/src/handler-factories.ts
@@ -32,10 +32,23 @@ export interface ServiceFactories {
 
 let cachedServices: CoreSingletonServices | null = null
 
+let cachedEnv: CloudflareEnv | null = null
+
+/**
+ * Returns the Cloudflare `env` that was last passed into the worker handler,
+ * or `null` if called before any request. Lets user `createSingletonServices`
+ * read CF-specific bindings (D1, R2, KV, queue producers, etc.) without
+ * threading `env` through every signature.
+ */
+export function getCloudflareEnv(): CloudflareEnv | null {
+  return cachedEnv
+}
+
 async function setupServices(
   env: CloudflareEnv,
   factories: ServiceFactories
 ): Promise<CoreSingletonServices> {
+  cachedEnv = env
   if (cachedServices) return cachedServices
   const variables = new LocalVariablesService(
     env as Record<string, string | undefined>
@@ -103,12 +116,17 @@ async function processQueueBatch(batch: {
         throw new Error('CF Queues do not support waitForCompletion')
       },
     }
-    console.log(`[QUEUE] Running job: queue=${queueName}, id=${message.id}, data=${JSON.stringify(job.data).slice(0, 200)}`)
+    console.log(
+      `[QUEUE] Running job: queue=${queueName}, id=${message.id}, data=${JSON.stringify(job.data).slice(0, 200)}`
+    )
     try {
       await runQueueJob({ job })
       console.log(`[QUEUE] Job completed: queue=${queueName}, id=${message.id}`)
     } catch (e: unknown) {
-      console.error(`[QUEUE] Job failed: queue=${queueName}, id=${message.id}`, (e as Error).message)
+      console.error(
+        `[QUEUE] Job failed: queue=${queueName}, id=${message.id}`,
+        (e as Error).message
+      )
       throw e
     }
   }
@@ -137,44 +155,87 @@ export function createCloudflareHandler(
         const queueMeta = pikkuState(null, 'queue', 'meta')
         const workflowMeta = pikkuState(null, 'workflows', 'meta')
         const queueRegistrations = pikkuState(null, 'queue', 'registrations')
-        return new Response(JSON.stringify({
-          hasQueueService: !!services.queueService,
-          hasWorkflowService: !!services.workflowService,
-          queueMetaKeys: Object.keys(queueMeta ?? {}),
-          workflowMetaKeys: Object.keys(workflowMeta ?? {}),
-          queueRegistrationKeys: queueRegistrations ? [...queueRegistrations.keys()] : [],
-          envBindings: Object.keys(env).filter(k => k.includes('WF_') || k.includes('QUEUE') || k.includes('WORKFLOW')),
-        }, null, 2), { headers: { 'Content-Type': 'application/json' } })
+        return new Response(
+          JSON.stringify(
+            {
+              hasQueueService: !!services.queueService,
+              hasWorkflowService: !!services.workflowService,
+              queueMetaKeys: Object.keys(queueMeta ?? {}),
+              workflowMetaKeys: Object.keys(workflowMeta ?? {}),
+              queueRegistrationKeys: queueRegistrations
+                ? [...queueRegistrations.keys()]
+                : [],
+              envBindings: Object.keys(env).filter(
+                (k) =>
+                  k.includes('WF_') ||
+                  k.includes('QUEUE') ||
+                  k.includes('WORKFLOW')
+              ),
+            },
+            null,
+            2
+          ),
+          { headers: { 'Content-Type': 'application/json' } }
+        )
       }
 
       // Debug endpoint: /__pikku/test-step — test insertStepState + queueStepWorker
       if (url.pathname === '/__pikku/test-step') {
         try {
           const wfService = services.workflowService
-          if (!wfService) return new Response('No workflowService', { status: 500 })
+          if (!wfService)
+            return new Response('No workflowService', { status: 500 })
           const queueService = services.queueService
-          if (!queueService) return new Response('No queueService', { status: 500 })
+          if (!queueService)
+            return new Response('No queueService', { status: 500 })
 
           // Try insertStepState
           const testRunId = 'test-' + crypto.randomUUID().slice(0, 8)
           try {
-            await wfService.createRun('createAndNotifyWorkflow', { test: true }, false, 'test', { type: 'debug' })
+            await wfService.createRun(
+              'createAndNotifyWorkflow',
+              { test: true },
+              false,
+              'test',
+              { type: 'debug' }
+            )
           } catch (e: unknown) {
-            return new Response(JSON.stringify({ step: 'createRun', error: (e as Error).message }), { status: 500 })
+            return new Response(
+              JSON.stringify({
+                step: 'createRun',
+                error: (e as Error).message,
+              }),
+              { status: 500 }
+            )
           }
 
           // Try queue send
           try {
-            await queueService.add('wf-step-create-todo', { test: true, runId: testRunId })
+            await queueService.add('wf-step-create-todo', {
+              test: true,
+              runId: testRunId,
+            })
           } catch (e: unknown) {
-            return new Response(JSON.stringify({ step: 'queueSend', error: (e as Error).message }), { status: 500 })
+            return new Response(
+              JSON.stringify({
+                step: 'queueSend',
+                error: (e as Error).message,
+              }),
+              { status: 500 }
+            )
           }
 
           return new Response(JSON.stringify({ success: true, testRunId }), {
             headers: { 'Content-Type': 'application/json' },
           })
         } catch (e: unknown) {
-          return new Response(JSON.stringify({ error: (e as Error).message, stack: (e as Error).stack }), { status: 500 })
+          return new Response(
+            JSON.stringify({
+              error: (e as Error).message,
+              stack: (e as Error).stack,
+            }),
+            { status: 500 }
+          )
         }
       }
 
@@ -189,11 +250,17 @@ export function createCloudflareHandler(
     ) => {
       try {
         await setupServices(env, factories)
-        console.log(`[QUEUE] Processing batch from "${batch.queue}", ${batch.messages.length} messages`)
+        console.log(
+          `[QUEUE] Processing batch from "${batch.queue}", ${batch.messages.length} messages`
+        )
         await processQueueBatch(batch)
         console.log(`[QUEUE] Batch processed successfully`)
       } catch (e: unknown) {
-        console.error(`[QUEUE] Error processing batch:`, (e as Error).message, (e as Error).stack)
+        console.error(
+          `[QUEUE] Error processing batch:`,
+          (e as Error).message,
+          (e as Error).stack
+        )
         throw e
       }
     }

--- a/packages/runtimes/cloudflare/src/handler-factories.ts
+++ b/packages/runtimes/cloudflare/src/handler-factories.ts
@@ -179,66 +179,6 @@ export function createCloudflareHandler(
         )
       }
 
-      // Debug endpoint: /__pikku/test-step — test insertStepState + queueStepWorker
-      if (url.pathname === '/__pikku/test-step') {
-        try {
-          const wfService = services.workflowService
-          if (!wfService)
-            return new Response('No workflowService', { status: 500 })
-          const queueService = services.queueService
-          if (!queueService)
-            return new Response('No queueService', { status: 500 })
-
-          // Try insertStepState
-          const testRunId = 'test-' + crypto.randomUUID().slice(0, 8)
-          try {
-            await wfService.createRun(
-              'createAndNotifyWorkflow',
-              { test: true },
-              false,
-              'test',
-              { type: 'debug' }
-            )
-          } catch (e: unknown) {
-            return new Response(
-              JSON.stringify({
-                step: 'createRun',
-                error: (e as Error).message,
-              }),
-              { status: 500 }
-            )
-          }
-
-          // Try queue send
-          try {
-            await queueService.add('wf-step-create-todo', {
-              test: true,
-              runId: testRunId,
-            })
-          } catch (e: unknown) {
-            return new Response(
-              JSON.stringify({
-                step: 'queueSend',
-                error: (e as Error).message,
-              }),
-              { status: 500 }
-            )
-          }
-
-          return new Response(JSON.stringify({ success: true, testRunId }), {
-            headers: { 'Content-Type': 'application/json' },
-          })
-        } catch (e: unknown) {
-          return new Response(
-            JSON.stringify({
-              error: (e as Error).message,
-              stack: (e as Error).stack,
-            }),
-            { status: 500 }
-          )
-        }
-      }
-
       return runFetch(request, undefined, { exposeErrors: true })
     }
   }


### PR DESCRIPTION
- workflowStarter/graphStarter destructure workflowService so analyzer assigns workflow-state to the unit (their rpc.startWorkflow needs it)
- @pikku/cloudflare re-exports getCloudflareEnv() so user services factories can read env bindings (D1, R2, KV, queue producers)
- bundler skips createRequire banner when getNoRequireShim() returns true; CF adapter opts in (import.meta.url is undefined on CF Workers)
- CF adapter aliases every node builtin to its node: prefix so nodejs_compat_v2 resolves them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed boot crash when deploying workflows on Cloudflare Workers by disabling incompatible shim
  * Resolved workflow deployment issues on Workers-for-Platforms by ensuring proper service container exposure
  * Improved Node builtin module compatibility for Cloudflare environments

* **New Features**
  * Enhanced logging for queue job processing with improved error diagnostics
  * Extended environment binding access for service factories in Cloudflare deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->