### PR TITLE
fix(addon-graph): align packaging with addon-console so dist is the source of truth

### DIFF
--- a/.changeset/addon-graph-packaging.md
+++ b/.changeset/addon-graph-packaging.md
@@ -1,0 +1,14 @@
+---
+'@pikku/addon-graph': patch
+---
+
+Fix packaging so the published tarball is actually consumable.
+
+The previous `package.json#exports` entry mapped `./.pikku/*` to the top-level `./.pikku/*` directory, but `npm pack` only picks up the JSON-format files there — the compiled `pikku-bootstrap.gen.js` and friends only land under `./dist/.pikku/`. Consumers importing `@pikku/addon-graph/.pikku/pikku-bootstrap.gen.js` (which the pikku CLI does on every project that depends on this addon) hit `ERR_MODULE_NOT_FOUND`. Aligns the layout with `@pikku/addon-console`:
+
+- `exports."./.pikku/*"` now resolves under `./dist/.pikku/`.
+- `files` drops the unbuilt top-level `.pikku/` directory.
+- `imports."#pikku"` gets a `import` resolution pointing at the compiled output.
+- `build` no longer copies the unbuilt `.pikku/` over the compiled output, so the dist tree stays clean.
+
+No source changes — addons consuming `@pikku/addon-graph` previously failed to boot; now they boot.

--- a/packages/addon/pikku-graph/package.json
+++ b/packages/addon/pikku-graph/package.json
@@ -1,27 +1,26 @@
 {
   "name": "@pikku/addon-graph",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "imports": {
-    "#pikku": "./.pikku/pikku-types.gen.ts"
+    "#pikku": {
+      "types": "./.pikku/pikku-types.gen.ts",
+      "import": "./dist/.pikku/pikku-types.gen.js"
+    }
   },
   "exports": {
-    ".": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
-    },
-    "./.pikku/*": "./.pikku/*",
-    "./.pikku/pikku-metadata.gen.json": "./.pikku/pikku-metadata.gen.json",
+    ".": "./dist/.pikku/pikku-bootstrap.gen.js",
+    "./.pikku/*": "./dist/.pikku/*",
+    "./.pikku/pikku-metadata.gen.json": "./dist/.pikku/pikku-metadata.gen.json",
     "./.pikku/rpc/pikku-rpc-wirings-map.internal.gen.js": {
-      "types": "./.pikku/rpc/pikku-rpc-wirings-map.internal.gen.d.ts"
+      "types": "./dist/.pikku/rpc/pikku-rpc-wirings-map.internal.gen.d.ts"
     }
   },
   "files": [
-    "dist",
-    ".pikku"
+    "dist"
   ],
   "scripts": {
-    "build": "pikku all && tsc && cp -r .pikku dist/",
+    "build": "pikku all && tsc && cp .pikku/rpc/*.d.ts dist/.pikku/rpc/ 2>/dev/null; cp .pikku/agent/*.d.ts dist/.pikku/agent/ 2>/dev/null; cp .pikku/workflow/*.d.ts dist/.pikku/workflow/ 2>/dev/null; true",
     "pikku": "pikku all",
     "ncu": "npx npm-check-updates",
     "pretest": "pikku all",

--- a/packages/addon/pikku-graph/package.json
+++ b/packages/addon/pikku-graph/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "pikku all && tsc && cp .pikku/rpc/*.d.ts dist/.pikku/rpc/ 2>/dev/null; cp .pikku/agent/*.d.ts dist/.pikku/agent/ 2>/dev/null; cp .pikku/workflow/*.d.ts dist/.pikku/workflow/ 2>/dev/null; true",
+    "build": "pikku all && tsc && (cp .pikku/rpc/*.d.ts dist/.pikku/rpc/ 2>/dev/null || true) && (cp .pikku/agent/*.d.ts dist/.pikku/agent/ 2>/dev/null || true) && (cp .pikku/workflow/*.d.ts dist/.pikku/workflow/ 2>/dev/null || true)",
     "pikku": "pikku all",
     "ncu": "npx npm-check-updates",
     "pretest": "pikku all",


### PR DESCRIPTION
## Summary
- Mirror `@pikku/addon-console` packaging: exports resolve under `dist/.pikku/`, `files` drops the unbuilt top-level `.pikku/`, and the build no longer overwrites compiled output by copying `.pikku/` into `dist/`.
- Fixes `ERR_MODULE_NOT_FOUND` on `@pikku/addon-graph/.pikku/pikku-bootstrap.gen.js` for fresh `npm install` consumers — the published tarball was shipping the unbuilt top-level `.pikku/` (JSON only), but exports pointed there instead of at the compiled `dist/.pikku/`.
- Includes a changeset.

## Test plan
- [ ] Fresh install of `@pikku/addon-graph` and import `@pikku/addon-graph/.pikku/pikku-bootstrap.gen.js` — should resolve.
- [ ] CI build of the package passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed module import failures in the pikku CLI and addon-graph consumers that resulted in `ERR_MODULE_NOT_FOUND` errors. Updated package configuration and build process to align published artifacts with runtime resolution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->