### PR TITLE
docs(cli): fix bundled skills to match current API

### DIFF
--- a/packages/cli/skills/pikku-addon/SKILL.md
+++ b/packages/cli/skills/pikku-addon/SKILL.md
@@ -260,7 +260,7 @@ import { addon } from '#pikku'
 export const todoAgent = pikkuAIAgent({
   name: 'todo-agent',
   description: 'Manages a todo list',
-  instructions: 'You help users manage their todos.',
+  goal: 'You help users manage their todos.',
   model: 'openai/gpt-4o',
   tools: [
     addon('todos:listTodos'),

--- a/packages/cli/skills/pikku-ai-agent/SKILL.md
+++ b/packages/cli/skills/pikku-ai-agent/SKILL.md
@@ -38,7 +38,7 @@ import { pikkuAIAgent } from '#pikku'
 pikkuAIAgent({
   name: string,                  // Unique agent identifier
   description: string,           // What the agent does
-  instructions: string | string[],  // System prompt / behavior instructions
+  goal: string,                  // System prompt / behavior instructions
   model: string,                 // LLM model (e.g. 'openai/gpt-4o-mini')
   tools?: PikkuFunc[],           // Pikku functions the agent can call
   agents?: AIAgentConfig[],      // Sub-agents this agent can delegate to
@@ -115,7 +115,7 @@ await streamAIAgent(
 const todoAssistant = pikkuAIAgent({
   name: 'todo-assistant',
   description: 'A helpful assistant that manages todos',
-  instructions:
+  goal:
     'You help users manage their todo lists. Be concise and helpful.',
   model: 'openai/gpt-4o-mini',
   tools: [listTodos, createTodo, completeTodo],
@@ -190,7 +190,7 @@ export const completeTodo = pikkuFunc({
 const todoAssistant = pikkuAIAgent({
   name: 'todo-assistant',
   description: 'A helpful assistant that manages todos',
-  instructions: `You help users manage their todo lists.
+  goal: `You help users manage their todo lists.
     - Be concise and helpful
     - When creating todos, infer priority if not specified
     - When listing todos, summarize the results`,

--- a/packages/cli/skills/pikku-aws/SKILL.md
+++ b/packages/cli/skills/pikku-aws/SKILL.md
@@ -39,16 +39,16 @@ const content = new S3Content(
 )
 ```
 
-**Methods:**
+**Methods** (each takes a single arguments object including the `bucket`):
 
-- `signURL(url: string, dateLessThan: Date, dateGreaterThan?: Date): Promise<string>` — Sign a CloudFront URL
-- `signContentKey(key: string, dateLessThan: Date, dateGreaterThan?: Date): Promise<string>` — Sign a content key
-- `getUploadURL(Key: string, ContentType: string): Promise<{ uploadUrl, assetKey }>` — Get presigned upload URL
-- `readFile(Key: string): Promise<ReadableStream>` — Read file as stream
-- `readFileAsBuffer(Key: string): Promise<Buffer>` — Read file as buffer
-- `writeFile(Key: string, stream: ReadableStream): Promise<boolean>` — Write file from stream
-- `copyFile(Key: string, fromAbsolutePath: string): Promise<boolean>` — Copy local file to S3
-- `deleteFile(Key: string): Promise<boolean>` — Delete file
+- `signURL({ url, dateLessThan, dateGreaterThan? }): Promise<string>` — Sign a CloudFront URL
+- `signContentKey({ bucket, contentKey, dateLessThan, dateGreaterThan? }): Promise<string>` — Sign a content key
+- `getUploadURL({ bucket, fileKey, contentType, size? }): Promise<{ uploadUrl, assetKey, uploadMethod?, uploadHeaders? }>` — Get presigned upload URL
+- `readFile({ bucket, key }): Promise<ReadableStream | NodeJS.ReadableStream>` — Read file as stream
+- `readFileAsBuffer({ bucket, key }): Promise<Buffer>` — Read file as buffer
+- `writeFile({ bucket, key, stream }): Promise<boolean>` — Write file from stream
+- `copyFile({ bucket, key, fromAbsolutePath }): Promise<boolean>` — Copy local file to S3
+- `deleteFile({ bucket, key }): Promise<boolean>` — Delete file
 
 ### `SQSQueueService` (Queue)
 

--- a/packages/cli/skills/pikku-backblaze/SKILL.md
+++ b/packages/cli/skills/pikku-backblaze/SKILL.md
@@ -38,16 +38,16 @@ const content = new B2Content(
 )
 ```
 
-**Methods:**
+**Methods** (each takes a single arguments object including the `bucket`):
 
-- `signContentKey(key: string, dateLessThan: Date): Promise<string>` — Sign a content key
-- `signURL(url: string, dateLessThan: Date): Promise<string>` — Sign a URL
-- `getUploadURL(fileKey: string, contentType: string): Promise<{ uploadUrl, assetKey, uploadMethod?, uploadHeaders? }>` — Get upload URL
-- `writeFile(assetKey: string, stream: ReadableStream): Promise<boolean>` — Write file
-- `copyFile(assetKey: string, fromAbsolutePath: string): Promise<boolean>` — Copy local file to B2
-- `readFile(assetKey: string): Promise<ReadableStream>` — Read file as stream
-- `readFileAsBuffer(assetKey: string): Promise<Buffer>` — Read file as buffer
-- `deleteFile(fileName: string): Promise<boolean>` — Delete file
+- `signContentKey({ bucket, contentKey, dateLessThan, dateGreaterThan? }): Promise<string>` — Sign a content key
+- `signURL({ url, dateLessThan, dateGreaterThan? }): Promise<string>` — Sign a URL
+- `getUploadURL({ bucket, fileKey, contentType, size? }): Promise<{ uploadUrl, assetKey, uploadMethod?, uploadHeaders? }>` — Get upload URL
+- `writeFile({ bucket, key, stream }): Promise<boolean>` — Write file
+- `copyFile({ bucket, key, fromAbsolutePath }): Promise<boolean>` — Copy local file to B2
+- `readFile({ bucket, key }): Promise<ReadableStream | NodeJS.ReadableStream>` — Read file as stream
+- `readFileAsBuffer({ bucket, key }): Promise<Buffer>` — Read file as buffer
+- `deleteFile({ bucket, key }): Promise<boolean>` — Delete file
 
 ## Usage Patterns
 

--- a/packages/cli/skills/pikku-concepts/SKILL.md
+++ b/packages/cli/skills/pikku-concepts/SKILL.md
@@ -158,16 +158,10 @@ import '../../functions/.pikku/pikku-bootstrap.gen.js' // Generated — register
 const config = await createConfig()
 const singletonServices = await createSingletonServices(config)
 
-// Pick your runtime:
-const server = new PikkuFastifyServer(
-  config,
-  singletonServices,
-  createWireServices
-)
-// or: new PikkuExpressServer(config, singletonServices, createWireServices)
-// or: pikkuAWSLambdaHandler(singletonServices)
-// or: PikkuCloudflareHandler(singletonServices)
-// or: pikkuNextHandler(singletonServices)
+// Pick your runtime (services come from global state via the bootstrap import):
+const server = new PikkuFastifyServer(config, singletonServices.logger)
+// or: new PikkuExpressServer(config, singletonServices.logger)
+// or: new PikkuUWSServer(config, singletonServices.logger)
 
 await server.init()
 await server.start()

--- a/packages/cli/skills/pikku-http/SKILL.md
+++ b/packages/cli/skills/pikku-http/SKILL.md
@@ -218,7 +218,7 @@ wireHTTP({
 
 const getTodos = pikkuFunc({
   title: 'Get Todos',
-  func: async ({ db, channel }, {}) => {
+  func: async ({ db }, {}, { channel }) => {
     const todos = await db.getTodos()
 
     if (channel) {

--- a/packages/cli/skills/pikku-mcp/SKILL.md
+++ b/packages/cli/skills/pikku-mcp/SKILL.md
@@ -167,10 +167,23 @@ export const manageTodos = pikkuFunc({
 ```typescript
 // start.ts
 import { PikkuMCPServer } from '@pikku/modelcontextprotocol'
+import mcpJSON from './.pikku/mcp/mcp.gen.json' with { type: 'json' }
+import './.pikku/pikku-bootstrap.gen.js'
 
-const server = new PikkuMCPServer(config, singletonServices, createWireServices)
+const config = await createConfig()
+const singletonServices = await createSingletonServices(config)
+
+const server = new PikkuMCPServer(
+  {
+    name: 'pikku-mcp-server',
+    version: '1.0.0',
+    mcpJSON,
+    capabilities: { logging: {}, tools: {}, resources: {}, prompts: {} },
+  },
+  singletonServices.logger
+)
 await server.init()
-await server.start()
+await server.connectStdio() // or: await server.connectHTTP({ port: 3000 })
 ```
 
 ## Complete Example

--- a/packages/cli/skills/pikku-queue/SKILL.md
+++ b/packages/cli/skills/pikku-queue/SKILL.md
@@ -228,9 +228,9 @@ wireQueueWorker({
 // Enqueue from another function
 export const registerUser = pikkuSessionlessFunc({
   title: 'Register User',
-  func: async ({ db, queue }, { email, name }) => {
+  func: async ({ db, queueService }, { email, name }) => {
     const user = await db.createUser({ email, name })
-    await queue.add('welcome-emails', { userId: user.id })
+    await queueService.add('welcome-emails', { userId: user.id })
     return { user }
   },
 })

--- a/packages/cli/skills/pikku-security/SKILL.md
+++ b/packages/cli/skills/pikku-security/SKILL.md
@@ -130,10 +130,10 @@ const logRequest = pikkuMiddleware(async ({ logger }, wire, next) => {
 import { authBearer, authCookie, authAPIKey } from '@pikku/core/middleware'
 
 // JWT bearer token — reads Authorization header
-addHTTPMiddleware([authBearer()])
+addHTTPMiddleware('*', [authBearer()])
 
 // Cookie-based sessions — auto-refreshes JWT
-addHTTPMiddleware([
+addHTTPMiddleware('*', [
   authCookie({
     name: 'session',
     expiresIn: { value: 30, unit: 'day' },
@@ -142,7 +142,7 @@ addHTTPMiddleware([
 ])
 
 // API key — from x-api-key header or ?apiKey= query
-addHTTPMiddleware([authAPIKey({ source: 'all' })])
+addHTTPMiddleware('*', [authAPIKey({ source: 'all' })])
 ```
 
 ### Scoping: Where to Apply


### PR DESCRIPTION
## Summary

Aligned the bundled CLI skills (`packages/cli/skills/`) with the current `cloudflare-v6` API. Companion to the website docs audit ([pikkujs/website#14](https://github.com/pikkujs/website/pull/14)).

### What changed
- **pikku-queue** — enqueue uses `services.queueService.add()` (singleton producer), not the worker-only `wire.queue`.
- **pikku-ai-agent / pikku-addon** — agent config field is `goal` (not `instructions`).
- **pikku-security** — `addHTTPMiddleware` requires a pattern argument (`'*'` for global).
- **pikku-http** — wire members destructured from the 3rd (wire) argument.
- **pikku-mcp** — `new PikkuMCPServer(config, logger)` then `server.init()` + `connectStdio()`.
- **pikku-concepts** — full servers take `(config, logger)` then `await server.init()`.
- **pikku-aws / pikku-backblaze** — content methods take a single args object with `bucket`.

Base is `cloudflare-v6` (the API these skills target is not yet on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)