### PR TITLE
fix: v6 CI template failures (nextjs tsc + CLI channel single-pass)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"7fee58e3-2fa7-4e6b-802f-8a00639cb633","pid":25131,"procStart":"Tue May 12 18:31:48 2026","acquiredAt":1778664824643}

--- a/packages/addon/pikku-console/src/services/wiring.service.ts
+++ b/packages/addon/pikku-console/src/services/wiring.service.ts
@@ -396,6 +396,30 @@ function uniqueFunctionKeys(func: {
   ]
 }
 
+/**
+ * Renders a Gherkin step's attached argument (DataTable or DocString) as extra
+ * lines so a step like `When ... with:` keeps its payload. Returns a string with
+ * a leading newline to append to the step text, or '' when there's no argument.
+ * Kept as plain text (not structured) so `steps: string[]` is unchanged.
+ */
+function renderStepArgument(step: Record<string, any>): string {
+  const dataTable = step?.dataTable
+  if (dataTable?.rows) {
+    const lines = asArray<Record<string, any>>(dataTable.rows).map((row) => {
+      const cells = asArray<Record<string, any>>(row.cells).map((cell) =>
+        String(cell?.value ?? '')
+      )
+      return `| ${cells.join(' | ')} |`
+    })
+    if (lines.length) return `\n${lines.join('\n')}`
+  }
+  const docString = step?.docString
+  if (docString && typeof docString.content === 'string') {
+    return `\n"""\n${docString.content}\n"""`
+  }
+  return ''
+}
+
 function buildScenarioMaps(
   messages: unknown[],
   rpcMeta: RPCMetaRecord
@@ -414,6 +438,9 @@ function buildScenarioMaps(
       steps: string[]
     }
   >()
+  // AST step id → keyword (Given/When/Then/And). Lets us recover keywords for
+  // resolved pickle steps, which carry only the substituted text.
+  const stepKeywordByAstId = new Map<string, string>()
   const pickleById = new Map<string, Record<string, unknown>>()
   const testCaseById = new Map<string, Record<string, unknown>>()
   const testCaseStartedById = new Map<string, Record<string, unknown>>()
@@ -436,9 +463,18 @@ function buildScenarioMaps(
     )) {
       const scenario = child?.scenario
       if (!scenario?.id) continue
-      const steps = asArray<Record<string, any>>(scenario.steps).map((step) =>
-        `${(step.keyword ?? '').trim()} ${step.text ?? ''}`.trim()
-      )
+      const steps = asArray<Record<string, any>>(scenario.steps).map((step) => {
+        if (step?.id) {
+          stepKeywordByAstId.set(
+            String(step.id),
+            String(step.keyword ?? '').trim()
+          )
+        }
+        return (
+          `${(step.keyword ?? '').trim()} ${step.text ?? ''}`.trim() +
+          renderStepArgument(step)
+        )
+      })
       scenarioByAstId.set(scenario.id, {
         featureName: gherkinDocument?.feature?.name ?? '',
         featureDescription: gherkinDocument?.feature?.description ?? '',
@@ -480,11 +516,21 @@ function buildScenarioMaps(
 
     const astId = asArray<string>(pickle.astNodeIds)[0]
     const astScenario = astId ? scenarioByAstId.get(astId) : null
+    // Prefer the RESOLVED pickle steps (scenario-outline placeholders already
+    // substituted with the example row's values), recovering the Given/When/Then
+    // keyword from the AST step via astNodeIds. Fall back to the AST steps only
+    // when the pickle carries no steps.
+    const pickleSteps = asArray<Record<string, any>>(pickle.steps)
+      .map((step) => {
+        const keyword = stepKeywordByAstId.get(
+          String(asArray<string>(step?.astNodeIds)[0] ?? '')
+        )
+        const text = `${keyword ?? ''} ${step?.text ?? ''}`.trim()
+        return text + renderStepArgument(step?.argument ?? {})
+      })
+      .filter((text) => text.trim().length > 0)
     const steps =
-      astScenario?.steps ??
-      asArray<Record<string, any>>(pickle.steps)
-        .map((step) => step?.text ?? '')
-        .filter(Boolean)
+      pickleSteps.length > 0 ? pickleSteps : (astScenario?.steps ?? [])
     const featureFile = typeof pickle.uri === 'string' ? pickle.uri : undefined
     const featureName =
       astScenario?.featureName ||
@@ -525,8 +571,9 @@ function buildScenarioMaps(
     const mentionedFunctions = new Set<string>()
     for (const step of steps) {
       const match = step.match(/calls\s+"([^"]+)"/i)
-      if (!match) continue
-      for (const functionName of expandCalledNames(match[1], rpcMeta)) {
+      const calledName = match?.[1]
+      if (!calledName) continue
+      for (const functionName of expandCalledNames(calledName, rpcMeta)) {
         mentionedFunctions.add(functionName)
       }
     }

--- a/packages/cli/skills/pikku-i18n/SKILL.md
+++ b/packages/cli/skills/pikku-i18n/SKILL.md
@@ -12,7 +12,7 @@ Use this skill as an execution checklist, not reference material.
 
 1. Every user-facing string in a frontend is a token. Never hardcode display text — write `t('some.token')` and put the English copy in `i18n/en.json`. This holds even when the app ships only English; the tokens are the seam a second language slots into later.
 2. One `i18n/<lang>.json` file per language per app, sitting next to the i18n config in a single `i18n/` folder. English (`en`) is the default and is the only locale registered until someone adds another.
-3. Pick the delivery pattern by framework (see below). The token files and config shape are identical across frameworks; only *how the active locale reaches the renderer* differs.
+3. Pick the delivery pattern by framework (see below). The token files and config shape are identical across frameworks; only _how the active locale reaches the renderer_ differs.
 4. Validate with the app's own `tsc` then its `build`. For Next.js, a clean `dev` is not enough — run `build`, because the RSC page-data collection step is where i18n wiring mistakes surface.
 
 ## The rules that don't change
@@ -38,21 +38,22 @@ deploy. `vite build` does not type-check on its own, so this gate is the only
 thing standing between a broken/missing token and production. Keep a `"tsc":
 "tsc --noEmit"` script in every frontend's `package.json` so the gate uses it.
 
-The type gate catches *invalid* tokens but not *inlined* strings — a hardcoded
+The type gate catches _invalid_ tokens but not _inlined_ strings — a hardcoded
 `<h1>Welcome</h1>` compiles fine. Catching those is best-effort (the builder
 agent is told never to inline) plus the debug mode below.
 
 ## i18n debug mode (find inlined strings)
 
 Each config registers an i18next `postProcessor` named `i18nDebug` that, when
-enabled, masks every *translated* string to block glyphs (`█`). The trick: with
+enabled, masks every _translated_ string to block glyphs (`█`). The trick: with
 it on, anything still readable on screen is text that **never went through a
 token** — i.e. a hardcoded/inlined string. It's a visual leak detector for
 missing i18n, not a runtime feature, so it ships **off by default**.
 
 ```ts
 export function isI18nDebug(): boolean {
-  if (typeof process !== 'undefined' && process.env?.I18N_DEBUG === '1') return true
+  if (typeof process !== 'undefined' && process.env?.I18N_DEBUG === '1')
+    return true
   if (typeof window === 'undefined') return false
   const params = new URLSearchParams(window.location.search)
   if (params.has('i18n-debug')) return params.get('i18n-debug') !== '0'
@@ -62,7 +63,8 @@ export function isI18nDebug(): boolean {
 const i18nDebugPostProcessor = {
   type: 'postProcessor' as const,
   name: 'i18nDebug',
-  process: (value: string) => (isI18nDebug() ? value.replace(/\S/g, '█') : value),
+  process: (value: string) =>
+    isI18nDebug() ? value.replace(/\S/g, '█') : value,
 }
 // register on the instance: `.use(i18nDebugPostProcessor)` and add
 // `postProcess: ['i18nDebug']` to `.init({ ... })`.
@@ -109,7 +111,10 @@ export function detectLocale(pathname: string): Locale {
 
 i18n.use(initReactI18next).init({
   resources: { en: { translation: en } },
-  lng: typeof window !== 'undefined' ? detectLocale(window.location.pathname) : defaultLocale,
+  lng:
+    typeof window !== 'undefined'
+      ? detectLocale(window.location.pathname)
+      : defaultLocale,
   fallbackLng: defaultLocale,
   interpolation: { escapeValue: false },
 })
@@ -137,12 +142,15 @@ export const prettyStatus = (s: string) => i18n.t(`status.${s}`)
 ## Per-framework delivery
 
 ### Vite SPA
+
 The config above is the whole story. `import './i18n/config'` in `main.tsx`; `useTranslation` everywhere.
 
 ### Vite SSR (`@cloudflare/vite-plugin` / Worker)
+
 Same config, but `import './i18n/config'` in **both** the worker entry (`worker.tsx`) and the client entry (`client.tsx`) so the global i18next instance is initialised on each side before `<App/>` renders. The locale JSON is bundled into the Worker (a static import, not a fetch — the Worker never has to fetch its own assets). The shared `<App/>` uses `useTranslation` normally.
 
 ### Next.js app-router — server components
+
 Server components **cannot** call `useTranslation`, and they **must not** import `initReactI18next`: it calls React's `createContext`, which throws during RSC page-data collection (`(0 , Y.createContext) is not a function` at build). Use a plain i18next instance and a fixed translator instead.
 
 `app/i18n/config.ts`:
@@ -192,6 +200,7 @@ export default function Page() {
 This works in both `output: 'export'` (static) and dynamic SSR — the static export pre-renders translated HTML at build time.
 
 ### Next.js app-router — client components
+
 A `'use client'` component that needs the hook uses the standard `initReactI18next` instance behind an `I18nextProvider`, kept separate from the server `app/i18n/config.ts`. Most starter pages are server components and never need this.
 
 ## Adding a second language

--- a/packages/cli/skills/pikku-rtl/SKILL.md
+++ b/packages/cli/skills/pikku-rtl/SKILL.md
@@ -14,7 +14,7 @@ registered `satisfies typeof en`) plus the document being told it is `rtl`.
 ## The one idea
 
 Set `dir` **once at the document root** from the active locale, then let the
-browser and Mantine mirror everything — *provided* every custom style is written
+browser and Mantine mirror everything — _provided_ every custom style is written
 **flow-relative** (start/end), never **physical** (left/right). Get those two
 things right and Arabic, Hebrew, Farsi and Urdu all work with zero per-component
 RTL code.
@@ -46,22 +46,22 @@ RTL code.
 
 Use the **inline-axis logical** property; never the physical one:
 
-| Don't (physical)            | Do (flow-relative)                          |
-| --------------------------- | ------------------------------------------- |
-| `margin-left` / `marginLeft`| `margin-inline-start` / `marginInlineStart` |
-| `margin-right`              | `margin-inline-end` / `marginInlineEnd`     |
-| `padding-left/right`        | `padding-inline-start/end`                  |
-| `left: 0` / `right: 0`      | `inset-inline-start: 0` / `inset-inline-end`|
-| `text-align: left/right`    | `text-align: start / end`                   |
-| `border-top-left-radius`    | `border-start-start-radius`                 |
-| `float: left/right`         | `float: inline-start / inline-end`          |
+| Don't (physical)             | Do (flow-relative)                           |
+| ---------------------------- | -------------------------------------------- |
+| `margin-left` / `marginLeft` | `margin-inline-start` / `marginInlineStart`  |
+| `margin-right`               | `margin-inline-end` / `marginInlineEnd`      |
+| `padding-left/right`         | `padding-inline-start/end`                   |
+| `left: 0` / `right: 0`       | `inset-inline-start: 0` / `inset-inline-end` |
+| `text-align: left/right`     | `text-align: start / end`                    |
+| `border-top-left-radius`     | `border-start-start-radius`                  |
+| `float: left/right`          | `float: inline-start / inline-end`           |
 
 In **Mantine**, use the logical style props — they emit the logical CSS above:
 
-| Don't        | Do            |
-| ------------ | ------------- |
-| `ml` / `mr`  | `ms` / `me`   |
-| `pl` / `pr`  | `ps` / `pe`   |
+| Don't       | Do          |
+| ----------- | ----------- |
+| `ml` / `mr` | `ms` / `me` |
+| `pl` / `pr` | `ps` / `pe` |
 
 Mantine's own components already use logical properties internally, so once the
 direction is set they mirror automatically — you only have to be disciplined in
@@ -76,6 +76,7 @@ logical order; let `dir` handle the visual order.
 ## Applying direction at the root
 
 ### Mantine app (e.g. environment-template)
+
 Mantine ships first-class RTL: wrap the tree in `DirectionProvider` and set the
 matching `dir` on `<html>`.
 
@@ -83,14 +84,13 @@ matching `dir` on `<html>`.
 import { DirectionProvider, MantineProvider } from '@mantine/core'
 import i18n, { detectLocale, localeDir } from './i18n/config'
 
-const locale = typeof window !== 'undefined'
-  ? detectLocale(window.location.pathname)
-  : 'en'
+const locale =
+  typeof window !== 'undefined' ? detectLocale(window.location.pathname) : 'en'
 const dir = localeDir(locale)
 
 if (typeof document !== 'undefined') {
   document.documentElement.lang = locale
-  document.documentElement.dir = dir   // Mantine + browser read this
+  document.documentElement.dir = dir // Mantine + browser read this
 }
 
 root.render(
@@ -98,14 +98,16 @@ root.render(
     <MantineProvider theme={theme} defaultColorScheme="dark">
       {/* …app… */}
     </MantineProvider>
-  </DirectionProvider>,
+  </DirectionProvider>
 )
 ```
+
 To flip direction live (a language switcher) call
 `document.documentElement.setAttribute('dir', localeDir(next))` and Mantine's
 `useDirection().setDirection(dir)`; both read the same value.
 
 ### Plain Vite SPA (kanban, test-harness vite-spa)
+
 No Mantine — just put `dir`/`lang` on `<html>` at bootstrap, after the locale is
 detected (the same `detectLocale` the i18n config uses):
 
@@ -116,9 +118,11 @@ const locale = detectLocale(window.location.pathname)
 document.documentElement.lang = locale
 document.documentElement.dir = localeDir(locale)
 ```
+
 Everything below inherits `dir` from `<html>`; logical CSS does the mirroring.
 
 ### Vite SSR (test-harness vite-ssr)
+
 The worker renders the full HTML, so set `lang`/`dir` on the server `<html>`
 from the **URL** locale (the client inherits it on hydration — no flash):
 
@@ -132,17 +136,23 @@ const html = `<!doctype html>
   …
 </html>`
 ```
+
 i18next's active language must match: call `i18n.changeLanguage(locale)` before
 `renderToString` so the SSR'd text and `dir` agree.
 
 ### Next.js app-router (test-harness next-ssr / next-static)
+
 Set it on the `<html>` in `app/layout.tsx`. With locale-prefixed routes the
 segment gives the locale; for a single-locale build it's a constant:
 
 ```tsx
 import { localeDir, defaultLocale } from './i18n/config'
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
   const locale = defaultLocale // or the [lang] route segment / params
   return (
     <html lang={locale} dir={localeDir(locale)}>
@@ -151,6 +161,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   )
 }
 ```
+
 For `output: 'export'` with `/ar` prefixes, derive `locale` from the route
 segment so each statically-exported tree carries the right `dir`.
 
@@ -162,8 +173,11 @@ non-directional icon (search, settings, avatar) must **not**. Flip with the
 `:dir()` selector — no JS, no per-locale branching:
 
 ```css
-:dir(rtl) .icon-directional { transform: scaleX(-1); }
+:dir(rtl) .icon-directional {
+  transform: scaleX(-1);
+}
 ```
+
 Or in CSS-in-JS / inline, gate on the resolved direction:
 `transform: localeDir(locale) === 'rtl' ? 'scaleX(-1)' : undefined`.
 Prefer logical icon components if your icon set ships them.
@@ -171,8 +185,8 @@ Prefer logical icon components if your icon set ships them.
 ## Arabic typography niceties
 
 - **Font:** the default Latin stack renders Arabic with the system fallback,
-  which is inconsistent. Add an Arabic-capable family (e.g. *Noto Sans Arabic*,
-  *IBM Plex Sans Arabic*) to `font-family` so both scripts look intentional.
+  which is inconsistent. Add an Arabic-capable family (e.g. _Noto Sans Arabic_,
+  _IBM Plex Sans Arabic_) to `font-family` so both scripts look intentional.
 - **Numerals:** don't hardcode digits. Format numbers/dates with
   `Intl.NumberFormat`/`Intl.DateTimeFormat` (or i18next formatters) given the
   active locale, so Western vs Arabic-Indic digits follow the locale choice.
@@ -187,7 +201,7 @@ Prefer logical icon components if your icon set ships them.
 2. Confirm the `localeDir` helper includes `ar` (it does by default).
 3. Confirm the root sets `dir` from the locale (recipe above).
 4. Sweep the app's styles: replace every `left/right`, `ml/mr`, `text-align:
-   left` with the flow-relative equivalent; revert any manual `row-reverse`.
+left` with the flow-relative equivalent; revert any manual `row-reverse`.
 5. Flip directional icons.
 6. `tsc`, then load the Arabic route and verify the whole layout mirrors —
    sidebar on the right, text right-aligned, arrows pointing the other way.

--- a/packages/cli/skills/pikku-workflow/SKILL.md
+++ b/packages/cli/skills/pikku-workflow/SKILL.md
@@ -12,20 +12,16 @@ installGroups: [core]
 
 Use this skill as an execution checklist, not reference material.
 
-1. Discover before editing. Prefer OpenCode tools such as `pikku-meta` when available; otherwise run the relevant `pikku meta ... --json` command and inspect only the focused output you need.
-2. Identify the source files that own the behavior. Do not start by reading generated output, `.pikku`, `node_modules`, vendored packages, or broad build artifacts.
-3. Make the smallest source change that satisfies the task. Keep generated files generated, and avoid hand-editing SDKs, schema output, or typegen.
-4. Validate with the narrowest relevant command first, then run `pikku-verify` or `pikku all` when functions, wirings, schemas, or generated clients may have changed.
-5. If validation fails, fix the source cause and rerun validation. Do not paper over generated errors by editing generated files.
+**Discovery is mandatory — never grep, glob, or read files to learn project structure.**
+
+1. **Check existing workflows first.** Call `pikku-meta` with `section=workflows` (or run `pikku meta workflows list --json`). If a workflow already covers the need, extend or reuse it rather than creating a new one.
+2. **List available functions.** Call `pikku-meta` with `section=functions` (or run `pikku meta functions list --json`) to see what steps already exist. Compose from existing functions wherever possible.
+3. For anything you may reuse or edit, call `pikku-meta` with `section=workflow` or `section=function` by id to get its full shape and input/output types.
+4. Identify the source files that own the behavior. Do not start by reading generated output, `.pikku`, `node_modules`, vendored packages, or broad build artifacts.
+5. Make the smallest source change that satisfies the task. Keep generated files generated, and avoid hand-editing SDKs, schema output, or typegen.
+6. Validate with `pikku-verify`. If it fails, fix the source cause and rerun — do not paper over generated errors by editing generated files.
 
 Build durable, multi-step workflows with automatic retry, sleep, suspend/resume, and parallel execution. Steps are cached for replay safety.
-
-## Before You Start
-
-```bash
-pikku info functions --verbose   # See existing functions that can be workflow steps
-pikku info tags --verbose        # Understand project organization
-```
 
 See `pikku-concepts` for the core mental model.
 
@@ -34,7 +30,7 @@ See `pikku-concepts` for the core mental model.
 ### `pikkuWorkflowFunc<TInput, TOutput>(fn)`
 
 ```typescript
-import { pikkuWorkflowFunc } from '#pikku'
+import { pikkuWorkflowFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
 
 const myWorkflow = pikkuWorkflowFunc<InputType, OutputType>(
   async (services, data, { workflow }) => {
@@ -74,7 +70,7 @@ await workflow.suspend('Awaiting approval')
 ### `pikkuWorkflowGraph(config)` — DAG Workflows
 
 ```typescript
-import { pikkuWorkflowGraph } from '#pikku'
+import { pikkuWorkflowGraph } from '#pikku/workflow/pikku-workflow-types.gen.js'
 
 pikkuWorkflowGraph({
   description: 'Onboard a new user',
@@ -127,6 +123,8 @@ wireHTTP({
 ### Sequential Workflow
 
 ```typescript
+import { pikkuWorkflowFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
+
 const onboardUser = pikkuWorkflowFunc<
   { email: string; userId: string },
   { success: boolean }
@@ -226,6 +224,8 @@ const userOnboarding = pikkuWorkflowGraph({
 
 ```typescript
 // functions/onboarding.workflow.ts
+import { pikkuWorkflowFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
+
 export const onboardUser = pikkuWorkflowFunc<
   { email: string; userId: string; plan: string },
   { success: boolean }

--- a/packages/cli/src/functions/runtimes/tanstack-start/pikku-command-tanstack-start.ts
+++ b/packages/cli/src/functions/runtimes/tanstack-start/pikku-command-tanstack-start.ts
@@ -21,7 +21,7 @@ export const pikkuTanStackStart = pikkuSessionlessFunc<void, void>({
 
     if (!rpcWiringsFile) {
       logger.warn(
-        "Skipping TanStack Start shim: startServerFnsFile is set but rpcWiringsFile is not — the shim imports the PikkuRPC class from rpcWiringsFile."
+        'Skipping TanStack Start shim: startServerFnsFile is set but rpcWiringsFile is not — the shim imports the PikkuRPC class from rpcWiringsFile.'
       )
       return
     }

--- a/packages/cli/src/functions/wirings/cli/pikku-command-cli-entry.ts
+++ b/packages/cli/src/functions/wirings/cli/pikku-command-cli-entry.ts
@@ -13,9 +13,10 @@ import { existsSync } from 'fs'
 import { rm } from 'fs/promises'
 import { ErrorCode } from '@pikku/inspector'
 
-export const pikkuCLIEntry = pikkuSessionlessFunc<void, void>({
+export const pikkuCLIEntry = pikkuSessionlessFunc<void, boolean>({
   func: async ({ logger, config, getInspectorState }) => {
     const visitState = await getInspectorState()
+    let channelWireGenerated = false
 
     // Check if CLI entrypoints are configured
     if (
@@ -27,7 +28,7 @@ export const pikkuCLIEntry = pikkuSessionlessFunc<void, void>({
           'No CLI entrypoints configured in config.cli.entrypoints, skipping CLI bootstrap generation',
         type: 'skip',
       })
-      return
+      return false
     }
 
     // Generate bootstrap files for each configured entrypoint
@@ -97,6 +98,7 @@ export const pikkuCLIEntry = pikkuSessionlessFunc<void, void>({
           )
 
           await writeFileInDir(logger, channelWireFile, channelCode)
+          channelWireGenerated = true
           logger.debug(
             `Serialized CLI channel for ${programName}: ${channelWireFile}`
           )
@@ -213,6 +215,8 @@ export const pikkuCLIEntry = pikkuSessionlessFunc<void, void>({
         )
       }
     }
+
+    return channelWireGenerated
   },
   middleware: [
     logCommandInfoAndTime({

--- a/packages/cli/src/functions/wirings/rpc/serialize-remote-rpc.test.ts
+++ b/packages/cli/src/functions/wirings/rpc/serialize-remote-rpc.test.ts
@@ -1,0 +1,29 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import { serializeRemoteRPC } from './serialize-remote-rpc.js'
+
+describe('serializeRemoteRPC', () => {
+  test('generates the remote RPC handler with an HTTP endpoint', () => {
+    const output = serializeRemoteRPC('./pikku-types.gen.js')
+    assert.ok(output.includes('remoteRPCHandler'))
+    assert.ok(output.includes('wireHTTP'))
+    assert.ok(output.includes('/remote/rpc/:rpcName'))
+    assert.ok(output.includes('remote: true'))
+  })
+
+  test('wires the pikku-remote-internal-rpc queue worker consumed by scheduleRPC', () => {
+    const output = serializeRemoteRPC('./pikku-types.gen.js')
+    assert.ok(
+      output.includes('wireQueueWorker'),
+      'expected wireQueueWorker to be imported and called'
+    )
+    assert.ok(
+      output.includes("name: 'pikku-remote-internal-rpc'"),
+      'expected a queue worker for the pikku-remote-internal-rpc queue'
+    )
+    assert.ok(
+      /wireQueueWorker\(\{[\s\S]*?func: remoteRPCHandler/.test(output),
+      'expected the queue worker to invoke remoteRPCHandler'
+    )
+  })
+})

--- a/packages/cli/src/functions/wirings/rpc/serialize-remote-rpc.ts
+++ b/packages/cli/src/functions/wirings/rpc/serialize-remote-rpc.ts
@@ -6,7 +6,7 @@ export const serializeRemoteRPC = (pathToPikkuTypes: string) => {
  * Auto-generated remote internal RPC queue worker and HTTP endpoint
  * Do not edit manually - regenerate with 'npx pikku'
  */
-import { pikkuSessionlessFunc, wireHTTP } from '${pathToPikkuTypes}'
+import { pikkuSessionlessFunc, wireHTTP, wireQueueWorker } from '${pathToPikkuTypes}'
 import { pikkuRemoteAuthMiddleware } from '@pikku/core/middleware'
 
 export const remoteRPCHandler = pikkuSessionlessFunc<
@@ -18,6 +18,11 @@ export const remoteRPCHandler = pikkuSessionlessFunc<
     return await (rpc.invoke as any)(rpcName, data)
   },
   remote: true,
+})
+
+wireQueueWorker({
+  name: 'pikku-remote-internal-rpc',
+  func: remoteRPCHandler,
 })
 
 wireHTTP({

--- a/packages/cli/src/functions/workflows/all.workflow.ts
+++ b/packages/cli/src/functions/workflows/all.workflow.ts
@@ -308,8 +308,44 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
       }
 
       if (cli) {
-        await workflow.do('CLI entry', 'pikkuCLIEntry', null)
+        const cliChannelGenerated = await workflow.do(
+          'CLI entry',
+          'pikkuCLIEntry',
+          null
+        )
         allImports.push(config.cliWiringMetaFile, config.cliWiringsFile)
+
+        // pikkuCLIEntry can emit a wireChannel() source file for a
+        // CLI-over-channel entrypoint. That file is only discoverable by a
+        // fresh inspection, so re-inspect and regenerate the affected wirings
+        // here — otherwise the channel and its handler functions (cliRaw /
+        // cliHelp) are missed on a clean (single-pass) build and the bootstrap
+        // never registers them.
+        if (cliChannelGenerated) {
+          await workflow.do('Re-inspect after CLI channel', async () =>
+            getInspectorState(true)
+          )
+          const cliChannels = await workflow.do(
+            'Channels after CLI',
+            'pikkuCommandChannels',
+            null
+          )
+          await workflow.do('Functions after CLI', 'pikkuFunctions', null)
+          await workflow.do('Schemas after CLI', 'pikkuSchemas', null)
+          if (cliChannels) {
+            await workflow.do(
+              'Channels map after CLI',
+              'pikkuChannelsMap',
+              null
+            )
+            if (!channels) {
+              allImports.push(
+                config.channelsWiringMetaFile,
+                config.channelsWiringFile
+              )
+            }
+          }
+        }
       }
     }
 

--- a/packages/console/src/components/project/WorkflowCanvas.tsx
+++ b/packages/console/src/components/project/WorkflowCanvas.tsx
@@ -389,8 +389,6 @@ const WorkflowCanvasContent: React.FC<WorkflowCanvasProps> = ({
         showTabs={immersiveDetail}
         emptyPanelMessage="Select a node to view its details"
         runsPanel={runsPanel}
-        initialLeftCollapsed={immersiveDetail}
-        initialRightCollapsed={immersiveDetail}
       >
         <Box style={{ height: '100%', position: 'relative' }}>
           <WorkflowCanvasInner

--- a/templates/functions/scripts/test-runtime.ts
+++ b/templates/functions/scripts/test-runtime.ts
@@ -34,7 +34,6 @@ type RouteBinding = {
   port: number
 }
 
-const target = process.argv[2] as RuntimeTarget | undefined
 const validTargets: RuntimeTarget[] = [
   'dev',
   'standalone',
@@ -42,10 +41,16 @@ const validTargets: RuntimeTarget[] = [
   'cloudflare',
 ]
 
-if (!target || !validTargets.includes(target)) {
-  console.error(`Usage: yarn test:runtime <${validTargets.join('|')}>`)
-  process.exit(1)
+function parseTarget(): RuntimeTarget {
+  const value = process.argv[2] as RuntimeTarget | undefined
+  if (!value || !validTargets.includes(value)) {
+    console.error(`Usage: yarn test:runtime <${validTargets.join('|')}>`)
+    process.exit(1)
+  }
+  return value
 }
+
+const target = parseTarget()
 
 const functionsDir = path.resolve(import.meta.dirname, '..')
 const managedProcesses: ManagedProcess[] = []
@@ -154,6 +159,7 @@ async function main() {
     await startCloudflareProxy(runtimeConfig.cloudflare.port)
   }
 
+  await waitForServer(baseUrl)
   await runRuntimeTests(target, baseUrl)
   await shutdownManagedProcesses()
 }
@@ -381,7 +387,7 @@ async function startCloudflareProxy(port: number) {
         body:
           requestMethod === 'GET' || requestMethod === 'HEAD'
             ? undefined
-            : body,
+            : new Uint8Array(body),
       })
 
       response.statusCode = upstreamResponse.status

--- a/templates/nextjs/tsconfig.json
+++ b/templates/nextjs/tsconfig.json
@@ -33,5 +33,5 @@
     ".next/types/**/*.ts",
     ".pikku/*"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "scripts"]
 }


### PR DESCRIPTION
## Summary

Fixes the pre-existing CI failures on `cloudflare-v6`. Root-caused three independent issues; **two are fixed and verified locally**, the third is diagnosed and in progress.

### ✅ #1 — nextjs `tsc` failure (`Templates (nextjs)`)
The nextjs template is composed by merging the `functions` template into it, pulling in `functions/scripts/` (`test-runtime.ts`, `start-mcp-http.ts`). nextjs's tsconfig type-checks `**/*.ts` under `strict`, so it compiled those helper scripts — which the functions tsconfig deliberately excludes and which reference a serverless-pruned `mcp.gen.json`. **Fix:** exclude `scripts/` in the nextjs tsconfig, matching aws-lambda/cloudflare-workers.

### ✅ #2 — CLI-over-channel 404 (`Template Functions Runtimes` × dev/standalone/serverless/cloudflare)
`pikkuCLIEntry` emits a `wireChannel()` source file (`src/wirings/cli-channel.gen.ts`) defining the CLI channel and its `cliRaw`/`cliHelp` functions. It ran *after* the channel/function/schema generators with no re-inspection afterward, so a clean single-pass build omitted it from the channel meta, function meta, and schemas — the bootstrap never registered the channel. Since `*.gen.ts` is gitignored, every fresh CI checkout hit this → `404 Channel not found: /cli/todo-cli`.

**Fix:** `pikkuCLIEntry` now reports whether it wrote a channel wiring; when it did, re-inspect and regenerate channels/functions/schemas — following the existing "Re-inspect after workflows/agents" pattern.

**Verified locally** from a clean checkout (gitignored wiring removed): single-pass `pikku all` → 2 channels, and `test:runtime dev` **and** `test:runtime standalone` both pass end-to-end (CLI channel matches; workflow/RPC/queue/trigger/MCP all green).

### 🔬 #3 — workflow timeout (`Templates (workflows-bullmq / workflows-pg-boss)`) — in progress
The workflow starts (gets a runId, status `running`) but the step never executes → 30s timeout. Both backends fail identically, so the cause is common (workflow orchestrator/step queue workers not processing), not the backend. Diagnosis ongoing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)