### PR TITLE
feat(ai-agent): forward agent function name to LiteLLM as request metadata

### DIFF
--- a/.changeset/ai-agent-id-metadata.md
+++ b/.changeset/ai-agent-id-metadata.md
@@ -1,0 +1,8 @@
+---
+"@pikku/core": patch
+"@pikku/ai-vercel": patch
+---
+
+Forward pikkuAgent function name to LiteLLM as request metadata for per-agent usage breakdown.
+
+Adds an optional `agentId` field to `AIAgentRunnerParams`. The wiring layer (`runAIAgent`, `streamAIAgent`, and the resume path) sets this to the agent's registered function name before invoking the runner. `VercelAIAgentRunner` injects it into `providerOptions` as `metadata.agent_id` so LiteLLM includes it in spend logs, enabling per-agent token and cost breakdowns.

--- a/packages/core/src/services/ai-agent-runner-service.ts
+++ b/packages/core/src/services/ai-agent-runner-service.ts
@@ -14,6 +14,9 @@ export type AIAgentRunnerParams = {
   maxSteps: number
   toolChoice: 'auto' | 'required' | 'none'
   outputSchema?: Record<string, unknown>
+  /** Pikku agent function name — forwarded to the LLM proxy (LiteLLM) as
+   *  request-level metadata so usage can be broken down per agent. */
+  agentId?: string
 }
 
 export type AIAgentRunnerResult = {

--- a/packages/core/src/wirings/ai-agent/ai-agent-runner.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-runner.ts
@@ -84,6 +84,8 @@ export async function runAIAgent(
     workingMemorySchemaName,
   } = await prepareAgentRun(agentName, input, params, sessionMap)
 
+  runnerParams.agentId = agentName
+
   const singletonServices = getSingletonServices()
   const { aiRunState } = singletonServices
   if (!aiRunState) {
@@ -597,6 +599,7 @@ async function continueAfterToolResultSync(
     outputSchema: meta?.outputSchema
       ? pikkuState(packageName, 'misc', 'schemas').get(meta.outputSchema)
       : undefined,
+    agentId: run.agentName,
   }
 
   try {

--- a/packages/core/src/wirings/ai-agent/ai-agent-stream.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-stream.ts
@@ -595,6 +595,8 @@ export async function streamAIAgent(
     streamContext
   )
 
+  runnerParams.agentId = agentName
+
   const singletonServices = getSingletonServices()
   const { aiRunState } = singletonServices
   if (!aiRunState) {

--- a/packages/services/ai-vercel/src/vercel-ai-agent-runner.ts
+++ b/packages/services/ai-vercel/src/vercel-ai-agent-runner.ts
@@ -165,6 +165,14 @@ export class VercelAIAgentRunner implements AIAgentRunnerService {
     )
   }
 
+  private buildProviderOptions(params: AIAgentRunnerParams) {
+    if (!params.agentId) return undefined
+    const meta = { agent_id: params.agentId }
+    // Spread into the request body for every provider so LiteLLM picks up
+    // agent_id and includes it in the spend-log / generic_api callback.
+    return { openai: { metadata: meta }, anthropic: { metadata: meta } }
+  }
+
   async stream(
     params: AIAgentRunnerParams,
     channel: AIStreamChannel
@@ -202,6 +210,7 @@ export class VercelAIAgentRunner implements AIAgentRunnerService {
             }),
           }
         : {}),
+      providerOptions: this.buildProviderOptions(params),
     })
 
     try {
@@ -359,6 +368,7 @@ export class VercelAIAgentRunner implements AIAgentRunnerService {
             }),
           }
         : {}),
+      providerOptions: this.buildProviderOptions(params),
     })
 
     const step = result.steps[0]


### PR DESCRIPTION
## Summary

- Adds optional `agentId` field to `AIAgentRunnerParams`
- Wiring layer (`runAIAgent`, `streamAIAgent`, resume path) automatically sets `agentId` to the pikkuAgent function name before invoking the runner
- `VercelAIAgentRunner` injects `agentId` into `providerOptions` as `metadata.agent_id` so LiteLLM includes it in spend logs

Enables per-agent token and cost breakdowns in the AI usage dashboard without any LiteLLM config changes — the metadata flows through the OpenAI-compatible request body.

## Test plan

- [ ] Confirm `providerOptions.openai.metadata.agent_id` appears in LiteLLM spend logs after an agent run
- [ ] Verify agent breakdown dimension in the AI usage dashboard shows function names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-agent identification metadata is now captured and forwarded to usage logs, enabling a breakdown of token consumption and costs by individual AI agent.
  * Agent identifiers are automatically assigned from the agent's registered function name during execution and session resumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->