### PR TITLE
fix(cli): preserve user services during hot-reload codegen in pikku dev

### DIFF
--- a/.changeset/fix-dev-hot-reload-services.md
+++ b/.changeset/fix-dev-hot-reload-services.md
@@ -1,0 +1,9 @@
+---
+"@pikku/cli": patch
+---
+
+Fix race condition in `pikku dev` where hot-reload codegen replaced live user services with CLI-internal services.
+
+During a file-watch triggered re-run of `allWorkflow`, `runAllWithCommandState` unconditionally overwrote `singletonServices` with the CLI's own services object (which has `config` but no `kysely`, no content server, etc.). Any request that arrived during codegen — e.g. an auth callback — would crash because `kysely` was undefined.
+
+Fix: detect the hot-reload case (`previousSingletonServices` exists and differs from the CLI object), then build a hybrid — spread the live user services and overlay only `config` from the CLI. Codegen gets the paths it needs; concurrent requests continue to see the real services.

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -86,7 +86,24 @@ export const dev = pikkuSessionlessFunc<
         'workflows',
         'registrations'
       )
-      pikkuState(null, 'package', 'singletonServices', commandSingletonServices)
+      // During hot-reload (when user services are already live), build a hybrid services
+      // object: user services (so in-flight requests keep kysely/content/etc.) overlaid
+      // with the CLI config (outDir, scaffold, schemaDirectory, etc. — required by
+      // allWorkflow for code generation paths). Replacing the entire services object with
+      // commandSingletonServices during hot-reload caused a race condition where concurrent
+      // auth requests saw CLI services (no kysely) and crashed.
+      const isHotReload =
+        previousSingletonServices !== commandSingletonServices &&
+        !!previousSingletonServices
+      const codegenServices = isHotReload
+        ? ({
+            ...previousSingletonServices,
+            config:
+              commandSingletonServices?.config ??
+              previousSingletonServices.config,
+          } as typeof previousSingletonServices)
+        : commandSingletonServices
+      pikkuState(null, 'package', 'singletonServices', codegenServices)
       pikkuState(
         null,
         'function',


### PR DESCRIPTION
During a file-watch re-run of allWorkflow, singletonServices was unconditionally replaced with the CLI-internal services object (no kysely, no content server). Any concurrent request (e.g. auth callback) would crash with kysely undefined.

Fix: detect hot-reload via previousSingletonServices, build a hybrid that spreads user services and overlays only config from the CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed a hot-reload race condition in `pikku dev` that caused crashes during code generation when files were modified. The development server now restarts reliably without losing required dependencies, enabling uninterrupted development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->