### PR TITLE
Add audit capture and Kysely audit wrapper

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -144,7 +144,6 @@ jobs:
             cloudflare-websocket,
             nextjs,
             mcp-server,
-            cli,
             pg-boss,
             bullmq,
             workflows-bullmq,
@@ -188,6 +187,53 @@ jobs:
       SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
       DATABASE_URL: postgres://postgres:password@localhost:5432/pikku_workspace_starter
       REDIS_URL: redis://localhost:6379
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      SLS_TELEMETRY_DISABLED: 1
+      SLS_NOTIFICATIONS_MODE: off
+
+  templates-no-services:
+    name: Templates (${{ matrix.version }}, ${{ matrix.template }}, ${{ matrix.package-manager }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [24]
+        template: [cli]
+        package-manager: [yarn]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.version }}
+      - name: Test template
+        timeout-minutes: 2
+        run: ./scripts/test-template.sh ${{ matrix.template }} ${{ github.ref_name }}
+        env:
+          TEMPLATE_V8_COVERAGE_DIR: ${{ runner.temp }}/template-coverage/${{ matrix.template }}/raw
+      - name: Generate template coverage report
+        if: always()
+        run: |
+          if find "${{ runner.temp }}/template-coverage/${{ matrix.template }}/raw" -type f -name '*.json' -print -quit >/dev/null 2>&1; then
+            npx --yes c8@11.0.0 report \
+              --temp-directory "${{ runner.temp }}/template-coverage/${{ matrix.template }}/raw" \
+              --reporter=lcov \
+              --report-dir "${{ runner.temp }}/template-coverage/${{ matrix.template }}/report" \
+              --exclude '.pikku/**' \
+              --exclude 'client/**' \
+              --exclude 'src/tests/**'
+          fi
+      - name: Upload template coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: ${{ runner.temp }}/template-coverage/${{ matrix.template }}/report/lcov.info
+          flags: templates
+          name: template-${{ matrix.template }}
+        continue-on-error: true
+    env:
+      SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SLS_TELEMETRY_DISABLED: 1
       SLS_NOTIFICATIONS_MODE: off

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,6 @@ jobs:
             cloudflare-websocket,
             nextjs,
             mcp-server,
-            cli,
             pg-boss,
             bullmq,
             workflows-bullmq,
@@ -151,6 +150,31 @@ jobs:
       SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
       DATABASE_URL: postgres://postgres:password@localhost:5432/pikku_workspace_starter
       REDIS_URL: redis://localhost:6379
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      SLS_TELEMETRY_DISABLED: 1
+      SLS_NOTIFICATIONS_MODE: off
+
+  templates-no-services:
+    name: Templates (${{ matrix.version }}, ${{ matrix.template }}, ${{ matrix.package-manager }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [24]
+        template: [cli]
+        package-manager: [yarn]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.version }}
+      - name: Test template
+        timeout-minutes: 2
+        run: ./scripts/test-template.sh ${{ matrix.template }} ${{ github.ref_name }}
+    env:
+      SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SLS_TELEMETRY_DISABLED: 1
       SLS_NOTIFICATIONS_MODE: off
@@ -188,7 +212,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [verifiers, templates, template-runtime-targets, e2e]
+    needs:
+      [verifiers, templates, templates-no-services, template-runtime-targets, e2e]
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}

--- a/packages/core/src/function/function-runner.test.ts
+++ b/packages/core/src/function/function-runner.test.ts
@@ -971,12 +971,12 @@ describe('runPikkuFunc - Integration Tests', () => {
   })
 
   test('should expose resolved audit metadata on the wire for audited functions', async () => {
-    let receivedWire: any
+    let receivedAudit: any
 
     addTestFunction('auditedWire', {
       audit: { durability: 'transactional' },
       func: async (_services: any, _data: any, wire: any) => {
-        receivedWire = wire
+        receivedAudit = wire.audit
         return 'ok'
       },
     })
@@ -989,7 +989,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     })
 
     assert.equal(result, 'ok')
-    assert.deepEqual(receivedWire.audit, { durability: 'transactional' })
+    assert.deepEqual(receivedAudit, { durability: 'transactional' })
   })
 
   test('should leave wire audit metadata undefined when audit is disabled', async () => {
@@ -1011,6 +1011,73 @@ describe('runPikkuFunc - Integration Tests', () => {
 
     assert.equal(result, 'ok')
     assert.equal(receivedWire.audit, undefined)
+  })
+
+  test('should restore parent audit metadata after nested non-audited calls', async () => {
+    let auditBeforeChild: any
+    let auditAfterChild: any
+
+    addTestFunction('childPlain', {
+      func: async () => 'child-ok',
+    })
+
+    addTestFunction('parentAudited', {
+      audit: true,
+      func: async (_services: any, _data: any, wire: any) => {
+        auditBeforeChild = wire.audit
+        await runPikkuFunc('rpc', 'nested-child-wire', 'childPlain', {
+          singletonServices: mockSingletonServices,
+          data: () => ({}),
+          auth: false,
+          wire,
+        })
+        auditAfterChild = wire.audit
+        return 'parent-ok'
+      },
+    })
+
+    const result = await runPikkuFunc(
+      'rpc',
+      'nested-parent-wire',
+      'parentAudited',
+      {
+        singletonServices: mockSingletonServices,
+        data: () => ({}),
+        auth: false,
+        wire: {},
+      }
+    )
+
+    assert.equal(result, 'parent-ok')
+    assert.deepEqual(auditBeforeChild, { durability: 'best-effort' })
+    assert.deepEqual(auditAfterChild, { durability: 'best-effort' })
+  })
+
+  test('should expose the resolved base function id after version fallback', async () => {
+    let receivedFunctionId: any
+
+    addTestFunction('versionedBase', {
+      audit: true,
+      func: async (_services: any, _data: any, wire: any) => {
+        receivedFunctionId = wire.functionId
+        return 'ok'
+      },
+    })
+
+    const result = await runPikkuFunc(
+      'rpc',
+      'wire-version-fallback',
+      'versionedBase@v2',
+      {
+        singletonServices: mockSingletonServices,
+        data: () => ({}),
+        auth: false,
+        wire: {},
+      }
+    )
+
+    assert.equal(result, 'ok')
+    assert.equal(receivedFunctionId, 'versionedBase')
   })
 })
 

--- a/packages/core/src/function/function-runner.test.ts
+++ b/packages/core/src/function/function-runner.test.ts
@@ -1053,6 +1053,102 @@ describe('runPikkuFunc - Integration Tests', () => {
     assert.deepEqual(auditAfterChild, { durability: 'best-effort' })
   })
 
+  test('should preserve parent audit metadata across rpc sub-calls to non-audited functions', async () => {
+    let parentAuditBeforeChild: any
+    let parentAuditAfterChild: any
+    let parentFunctionIdBeforeChild: any
+    let parentFunctionIdAfterChild: any
+    let childAudit: any
+    let childFunctionId: any
+
+    addTestFunction('rpcChildPlain', {
+      func: async (_services: any, _data: any, wire: any) => {
+        childAudit = wire.audit
+        childFunctionId = wire.functionId
+        return 'child-ok'
+      },
+    })
+
+    addTestFunction('rpcParentAudited', {
+      audit: true,
+      func: async (_services: any, _data: any, wire: any) => {
+        parentAuditBeforeChild = wire.audit
+        parentFunctionIdBeforeChild = wire.functionId
+        const childResult = await wire.rpc.invoke('rpcChildPlain', {})
+        parentAuditAfterChild = wire.audit
+        parentFunctionIdAfterChild = wire.functionId
+        return childResult
+      },
+    })
+
+    const result = await runPikkuFunc(
+      'rpc',
+      'rpc-parent-wire',
+      'rpcParentAudited',
+      {
+        singletonServices: mockSingletonServices,
+        data: () => ({}),
+        auth: false,
+        wire: {},
+      }
+    )
+
+    assert.equal(result, 'child-ok')
+    assert.deepEqual(parentAuditBeforeChild, { durability: 'best-effort' })
+    assert.deepEqual(parentAuditAfterChild, { durability: 'best-effort' })
+    assert.equal(parentFunctionIdBeforeChild, 'rpcParentAudited')
+    assert.equal(parentFunctionIdAfterChild, 'rpcParentAudited')
+    assert.equal(childAudit, undefined)
+    assert.equal(childFunctionId, 'rpcChildPlain')
+  })
+
+  test('should bind audited rpc sub-calls to the child invocation context', async () => {
+    let parentAuditBeforeChild: any
+    let parentAuditAfterChild: any
+    let parentFunctionIdAfterChild: any
+    let childAudit: any
+    let childFunctionId: any
+
+    addTestFunction('rpcChildAudited', {
+      audit: { durability: 'transactional' },
+      func: async (_services: any, _data: any, wire: any) => {
+        childAudit = wire.audit
+        childFunctionId = wire.functionId
+        return 'child-audited-ok'
+      },
+    })
+
+    addTestFunction('rpcParentAuditedChild', {
+      audit: true,
+      func: async (_services: any, _data: any, wire: any) => {
+        parentAuditBeforeChild = wire.audit
+        const childResult = await wire.rpc.invoke('rpcChildAudited', {})
+        parentAuditAfterChild = wire.audit
+        parentFunctionIdAfterChild = wire.functionId
+        return childResult
+      },
+    })
+
+    const result = await runPikkuFunc(
+      'rpc',
+      'rpc-parent-child-audit-wire',
+      'rpcParentAuditedChild',
+      {
+        singletonServices: mockSingletonServices,
+        data: () => ({}),
+        auth: false,
+        wire: {},
+      }
+    )
+
+    assert.equal(result, 'child-audited-ok')
+    assert.deepEqual(parentAuditBeforeChild, { durability: 'best-effort' })
+    assert.deepEqual(parentAuditAfterChild, { durability: 'best-effort' })
+    assert.equal(parentFunctionIdAfterChild, 'rpcParentAuditedChild')
+    assert.deepEqual(childAudit, { durability: 'transactional' })
+    assert.equal(childFunctionId, 'rpcChildAudited')
+  })
+
   test('should expose the resolved base function id after version fallback', async () => {
     let receivedFunctionId: any
 

--- a/packages/core/src/function/function-runner.test.ts
+++ b/packages/core/src/function/function-runner.test.ts
@@ -969,6 +969,49 @@ describe('runPikkuFunc - Integration Tests', () => {
     assert.equal(result, true)
     assert.ok(receivedWire.rpc)
   })
+
+  test('should expose resolved audit metadata on the wire for audited functions', async () => {
+    let receivedWire: any
+
+    addTestFunction('auditedWire', {
+      audit: { durability: 'transactional' },
+      func: async (_services: any, _data: any, wire: any) => {
+        receivedWire = wire
+        return 'ok'
+      },
+    })
+
+    const result = await runPikkuFunc('rpc', 'wire-audit-on', 'auditedWire', {
+      singletonServices: mockSingletonServices,
+      data: () => ({}),
+      auth: false,
+      wire: {},
+    })
+
+    assert.equal(result, 'ok')
+    assert.deepEqual(receivedWire.audit, { durability: 'transactional' })
+  })
+
+  test('should leave wire audit metadata undefined when audit is disabled', async () => {
+    let receivedWire: any
+
+    addTestFunction('plainWire', {
+      func: async (_services: any, _data: any, wire: any) => {
+        receivedWire = wire
+        return 'ok'
+      },
+    })
+
+    const result = await runPikkuFunc('rpc', 'wire-audit-off', 'plainWire', {
+      singletonServices: mockSingletonServices,
+      data: () => ({}),
+      auth: false,
+      wire: {},
+    })
+
+    assert.equal(result, 'ok')
+    assert.equal(receivedWire.audit, undefined)
+  })
 })
 
 describe('function-runner helpers', () => {

--- a/packages/core/src/function/function-runner.test.ts
+++ b/packages/core/src/function/function-runner.test.ts
@@ -785,6 +785,55 @@ describe('runPikkuFunc - Integration Tests', () => {
     assert.deepEqual(receivedSession, { userId: 'user-1', loaded: true })
   })
 
+  test('should expose middleware-set session to createWireServices credential lookups', async () => {
+    let credentialLookups = 0
+    let receivedCredential: any
+    const sessionService = new PikkuSessionService<any>()
+
+    addTestFunction('credentialWire', {
+      middleware: [
+        async (_services: any, wire: any, next: any) => {
+          wire.setSession({ userId: 'user-1' })
+          await next()
+        },
+      ],
+      func: async (_services: any, _data: any, wire: any) => {
+        return wire.getSession()
+      },
+    })
+
+    await runPikkuFunc('rpc', Math.random().toString(), 'credentialWire', {
+      singletonServices: {
+        ...mockSingletonServices,
+        credentialService: {
+          getAll: async (userId: string) => {
+            credentialLookups++
+            assert.equal(userId, 'user-1')
+            return {
+              'user-oauth': { accessToken: 'token-1' },
+            }
+          },
+        },
+      } as any,
+      createWireServices: async (_services: any, wire: any) => {
+        receivedCredential = await wire.getCredential('user-oauth')
+        return {}
+      },
+      data: () => ({}),
+      auth: false,
+      wire: {
+        session: undefined,
+        setSession: (session: any) => sessionService.setInitial(session),
+        getSession: () => sessionService.get(),
+        hasSessionChanged: () => sessionService.sessionChanged,
+      } as any,
+      sessionService,
+    })
+
+    assert.equal(credentialLookups, 1)
+    assert.deepEqual(receivedCredential, { accessToken: 'token-1' })
+  })
+
   test('should pass addon-scoped singleton services and wrap bare workflow names', async () => {
     pikkuState(null, 'addons', 'packages').set('stripe', {
       package: '@addon/stripe',

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -336,11 +336,15 @@ export const runPikkuFunc = async <In = any, Out = any>(
   }
 
   const resolvedAuditConfig = resolveAuditConfig(funcConfig.audit)
-  const invocationWire = {
-    ...resolvedWire,
-    functionId: resolvedFunctionId,
-    audit: resolvedAuditConfig,
-  } satisfies PikkuWire
+  const invocationWire = resolvedWire as PikkuWire
+  const previousFunctionId = invocationWire.functionId
+  const previousAudit = invocationWire.audit
+  const previousRpcDescriptor = Object.getOwnPropertyDescriptor(
+    invocationWire,
+    'rpc'
+  )
+  invocationWire.functionId = resolvedFunctionId
+  invocationWire.audit = resolvedAuditConfig
 
   // Convert tags to PermissionMetadata and merge with inheritedPermissions
   let mergedInheritedPermissions: PermissionMetadata[]
@@ -471,10 +475,7 @@ export const runPikkuFunc = async <In = any, Out = any>(
       return await funcConfig.func(services, actualData, invocationWire)
     } finally {
       if (wireServices && Object.keys(wireServices).length > 0) {
-        await closeWireServices(
-          resolvedSingletonServices.logger,
-          wireServices
-        )
+        await closeWireServices(resolvedSingletonServices.logger, wireServices)
       }
     }
   }
@@ -488,13 +489,45 @@ export const runPikkuFunc = async <In = any, Out = any>(
   })
 
   if (allMiddleware.length > 0) {
-    return (await runMiddleware<CorePikkuMiddleware>(
-      resolvedSingletonServices,
-      invocationWire,
-      allMiddleware,
-      executeFunction
-    )) as Out
+    try {
+      return (await runMiddleware<CorePikkuMiddleware>(
+        resolvedSingletonServices,
+        invocationWire,
+        allMiddleware,
+        executeFunction
+      )) as Out
+    } finally {
+      if (previousRpcDescriptor) {
+        Object.defineProperty(invocationWire, 'rpc', previousRpcDescriptor)
+      }
+      if (previousFunctionId === undefined) {
+        delete (invocationWire as any).functionId
+      } else {
+        invocationWire.functionId = previousFunctionId
+      }
+      if (previousAudit === undefined) {
+        delete (invocationWire as any).audit
+      } else {
+        invocationWire.audit = previousAudit
+      }
+    }
   }
 
-  return (await executeFunction()) as Out
+  try {
+    return (await executeFunction()) as Out
+  } finally {
+    if (previousRpcDescriptor) {
+      Object.defineProperty(invocationWire, 'rpc', previousRpcDescriptor)
+    }
+    if (previousFunctionId === undefined) {
+      delete (invocationWire as any).functionId
+    } else {
+      invocationWire.functionId = previousFunctionId
+    }
+    if (previousAudit === undefined) {
+      delete (invocationWire as any).audit
+    } else {
+      invocationWire.audit = previousAudit
+    }
+  }
 }

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -36,6 +36,7 @@ import {
   createWireServicesCredentialWireProps,
 } from '../services/credential-wire-service.js'
 import { defaultPikkuUserIdResolver } from '../services/pikku-user-id.js'
+import { resolveAuditConfig } from '../services/audit-service.js'
 import { rpcService } from '../wirings/rpc/rpc-runner.js'
 import { closeWireServices } from '../utils.js'
 
@@ -262,6 +263,7 @@ export const runPikkuFunc = async <In = any, Out = any>(
 ): Promise<Out> => {
   wire.wireType ??= wireType
   wire.wireId ??= wireId
+  wire.functionId ??= funcName
 
   const funcMap = pikkuState(packageName, 'function', 'functions')
   let funcConfig = funcMap.get(funcName)
@@ -331,6 +333,9 @@ export const runPikkuFunc = async <In = any, Out = any>(
       createWireServicesCredentialWireProps(resolvedCredentialWireService)
     )
   }
+
+  const resolvedAuditConfig = resolveAuditConfig(funcConfig.audit)
+  resolvedWire.audit = resolvedAuditConfig
 
   // Convert tags to PermissionMetadata and merge with inheritedPermissions
   let mergedInheritedPermissions: PermissionMetadata[]

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -263,7 +263,6 @@ export const runPikkuFunc = async <In = any, Out = any>(
 ): Promise<Out> => {
   wire.wireType ??= wireType
   wire.wireId ??= wireId
-  wire.functionId ??= funcName
 
   const funcMap = pikkuState(packageName, 'function', 'functions')
   let funcConfig = funcMap.get(funcName)
@@ -289,6 +288,8 @@ export const runPikkuFunc = async <In = any, Out = any>(
   if (!funcMeta) {
     throw new Error(`Function meta not found: ${funcName}`)
   }
+
+  const resolvedFunctionId = funcMeta.pikkuFuncId ?? funcName
 
   // For addon packages, get or create their singleton services
   const resolvedSingletonServices = packageName
@@ -334,159 +335,169 @@ export const runPikkuFunc = async <In = any, Out = any>(
     )
   }
 
+  const previousFunctionId = resolvedWire.functionId
+  const previousAudit = resolvedWire.audit
+  resolvedWire.functionId = resolvedFunctionId
   const resolvedAuditConfig = resolveAuditConfig(funcConfig.audit)
   resolvedWire.audit = resolvedAuditConfig
-
-  // Convert tags to PermissionMetadata and merge with inheritedPermissions
-  let mergedInheritedPermissions: PermissionMetadata[]
-  if (tags && tags.length > 0) {
-    mergedInheritedPermissions = [
-      ...(inheritedPermissions || []),
-      ...tags.map((tag) => ({ type: 'tag' as const, tag })),
-    ]
-  } else {
-    mergedInheritedPermissions = inheritedPermissions || []
-  }
-
-  // Helper function to run permissions and execute the function
-  const executeFunction = async () => {
-    await resolveSession(
-      resolvedWire,
-      resolvedSingletonServices,
-      sessionService
-    )
-
-    if (sessionService) {
-      resolvedWire.session = sessionService.freezeInitial()
-      resolvedWire.setSession = (s: any) => sessionService.set(s)
-      resolvedWire.clearSession = () => sessionService.clear()
-      resolvedWire.getSession = () => sessionService.get()
-      resolvedWire.hasSessionChanged = () => sessionService.sessionChanged
+  try {
+    // Convert tags to PermissionMetadata and merge with inheritedPermissions
+    let mergedInheritedPermissions: PermissionMetadata[]
+    if (tags && tags.length > 0) {
+      mergedInheritedPermissions = [
+        ...(inheritedPermissions || []),
+        ...tags.map((tag) => ({ type: 'tag' as const, tag })),
+      ]
+    } else {
+      mergedInheritedPermissions = inheritedPermissions || []
     }
 
-    const session = resolvedWire.session
+    // Helper function to run permissions and execute the function
+    const executeFunction = async () => {
+      await resolveSession(
+        resolvedWire,
+        resolvedSingletonServices,
+        sessionService
+      )
 
-    if (funcMeta.sessionless) {
-      if (wiringAuth === true || funcConfig.auth === true) {
+      if (sessionService) {
+        resolvedWire.session = sessionService.freezeInitial()
+        resolvedWire.setSession = (s: any) => sessionService.set(s)
+        resolvedWire.clearSession = () => sessionService.clear()
+        resolvedWire.getSession = () => sessionService.get()
+        resolvedWire.hasSessionChanged = () => sessionService.sessionChanged
+      }
+
+      const session = resolvedWire.session
+
+      if (funcMeta.sessionless) {
+        if (wiringAuth === true || funcConfig.auth === true) {
+          if (!session) {
+            throw new ForbiddenError('Authentication required')
+          }
+        }
+      } else if (funcMeta.sessionless === false) {
+        if (wiringAuth === false || funcConfig.auth === false) {
+          resolvedSingletonServices.logger.warn(
+            `Function '${funcName}' requires a session but auth was explicitly disabled — use pikkuSessionlessFunc instead.`
+          )
+        }
         if (!session) {
           throw new ForbiddenError('Authentication required')
         }
+      } else {
+        // TODO: Remove after a couple of releases — backward compat for
+        // generated metadata that doesn't include the `sessionless` field yet.
+        if (wiringAuth === true || funcConfig.auth === true) {
+          if (!session) {
+            throw new ForbiddenError('Authentication required')
+          }
+        }
       }
-    } else if (funcMeta.sessionless === false) {
-      if (wiringAuth === false || funcConfig.auth === false) {
-        resolvedSingletonServices.logger.warn(
-          `Function '${funcName}' requires a session but auth was explicitly disabled — use pikkuSessionlessFunc instead.`
+
+      if ((session as any)?.readonly && !funcMeta.readonly) {
+        throw new ReadonlySessionError()
+      }
+
+      // Evaluate the data from the lazy function
+      const actualData = await data()
+
+      // Validate and coerce data if schema is defined
+      const inputSchemaName = funcMeta.inputSchemaName
+      if (inputSchemaName) {
+        // Coerce (top level) data types before validation (e.g. string→array, string→date)
+        if (coerceDataFromSchema) {
+          coerceTopLevelDataFromSchema(inputSchemaName, actualData, packageName)
+        }
+        // Validate request data against the defined schema, if any
+        await validateSchema(
+          resolvedSingletonServices.logger,
+          resolvedSingletonServices.schema,
+          inputSchemaName,
+          actualData,
+          packageName
         )
       }
-      if (!session) {
-        throw new ForbiddenError('Authentication required')
+
+      if (
+        mergedInheritedPermissions.length > 0 ||
+        wirePermissions ||
+        funcMeta.permissions ||
+        funcConfig.permissions
+      ) {
+        await runPermissions(wireType, wireId, {
+          wireInheritedPermissions: mergedInheritedPermissions,
+          wirePermissions: wirePermissions,
+          funcInheritedPermissions: funcMeta.permissions,
+          funcPermissions: funcConfig.permissions,
+          services: resolvedSingletonServices,
+          wire: resolvedWire as any,
+          data: actualData,
+          packageName,
+        })
       }
-    } else {
-      // TODO: Remove after a couple of releases — backward compat for
-      // generated metadata that doesn't include the `sessionless` field yet.
-      if (wiringAuth === true || funcConfig.auth === true) {
-        if (!session) {
-          throw new ForbiddenError('Authentication required')
+
+      let wireServices: Record<string, unknown> | undefined
+      try {
+        wireServices = (await resolvedCreateWireServices?.(
+          resolvedSingletonServices,
+          resolvedWire
+        )) as Record<string, unknown> | undefined
+        const services =
+          wireServices && Object.keys(wireServices).length > 0
+            ? { ...resolvedSingletonServices, ...wireServices }
+            : resolvedSingletonServices
+        const callerPackageName = packageName
+        Object.defineProperty(resolvedWire, 'rpc', {
+          get() {
+            const rpc = rpcService.getContextRPCService(
+              services,
+              resolvedWire,
+              { sessionService },
+              0,
+              callerPackageName
+            )
+            Object.defineProperty(resolvedWire, 'rpc', {
+              value: rpc,
+              writable: true,
+              configurable: true,
+            })
+            return rpc
+          },
+          configurable: true,
+          enumerable: true,
+        })
+        return await funcConfig.func(services, actualData, resolvedWire)
+      } finally {
+        if (wireServices && Object.keys(wireServices).length > 0) {
+          await closeWireServices(
+            resolvedSingletonServices.logger,
+            wireServices
+          )
         }
       }
     }
 
-    if ((session as any)?.readonly && !funcMeta.readonly) {
-      throw new ReadonlySessionError()
-    }
+    const allMiddleware = combineMiddleware(wireType, wireId, {
+      wireInheritedMiddleware: inheritedMiddleware,
+      wireMiddleware,
+      funcInheritedMiddleware: funcMeta.middleware,
+      funcMiddleware: funcConfig.middleware,
+      packageName,
+    })
 
-    // Evaluate the data from the lazy function
-    const actualData = await data()
-
-    // Validate and coerce data if schema is defined
-    const inputSchemaName = funcMeta.inputSchemaName
-    if (inputSchemaName) {
-      // Coerce (top level) data types before validation (e.g. string→array, string→date)
-      if (coerceDataFromSchema) {
-        coerceTopLevelDataFromSchema(inputSchemaName, actualData, packageName)
-      }
-      // Validate request data against the defined schema, if any
-      await validateSchema(
-        resolvedSingletonServices.logger,
-        resolvedSingletonServices.schema,
-        inputSchemaName,
-        actualData,
-        packageName
-      )
-    }
-
-    if (
-      mergedInheritedPermissions.length > 0 ||
-      wirePermissions ||
-      funcMeta.permissions ||
-      funcConfig.permissions
-    ) {
-      await runPermissions(wireType, wireId, {
-        wireInheritedPermissions: mergedInheritedPermissions,
-        wirePermissions: wirePermissions,
-        funcInheritedPermissions: funcMeta.permissions,
-        funcPermissions: funcConfig.permissions,
-        services: resolvedSingletonServices,
-        wire: resolvedWire as any,
-        data: actualData,
-        packageName,
-      })
-    }
-
-    let wireServices: Record<string, unknown> | undefined
-    try {
-      wireServices = (await resolvedCreateWireServices?.(
+    if (allMiddleware.length > 0) {
+      return (await runMiddleware<CorePikkuMiddleware>(
         resolvedSingletonServices,
-        resolvedWire
-      )) as Record<string, unknown> | undefined
-      const services =
-        wireServices && Object.keys(wireServices).length > 0
-          ? { ...resolvedSingletonServices, ...wireServices }
-          : resolvedSingletonServices
-      const callerPackageName = packageName
-      Object.defineProperty(resolvedWire, 'rpc', {
-        get() {
-          const rpc = rpcService.getContextRPCService(
-            services,
-            resolvedWire,
-            { sessionService },
-            0,
-            callerPackageName
-          )
-          Object.defineProperty(resolvedWire, 'rpc', {
-            value: rpc,
-            writable: true,
-            configurable: true,
-          })
-          return rpc
-        },
-        configurable: true,
-        enumerable: true,
-      })
-      return await funcConfig.func(services, actualData, resolvedWire)
-    } finally {
-      if (wireServices && Object.keys(wireServices).length > 0) {
-        await closeWireServices(resolvedSingletonServices.logger, wireServices)
-      }
+        resolvedWire,
+        allMiddleware,
+        executeFunction
+      )) as Out
     }
+
+    return (await executeFunction()) as Out
+  } finally {
+    resolvedWire.functionId = previousFunctionId
+    resolvedWire.audit = previousAudit
   }
-
-  const allMiddleware = combineMiddleware(wireType, wireId, {
-    wireInheritedMiddleware: inheritedMiddleware,
-    wireMiddleware,
-    funcInheritedMiddleware: funcMeta.middleware,
-    funcMiddleware: funcConfig.middleware,
-    packageName,
-  })
-
-  if (allMiddleware.length > 0) {
-    return (await runMiddleware<CorePikkuMiddleware>(
-      resolvedSingletonServices,
-      resolvedWire,
-      allMiddleware,
-      executeFunction
-    )) as Out
-  }
-
-  return (await executeFunction()) as Out
 }

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -335,169 +335,166 @@ export const runPikkuFunc = async <In = any, Out = any>(
     )
   }
 
-  const previousFunctionId = resolvedWire.functionId
-  const previousAudit = resolvedWire.audit
-  resolvedWire.functionId = resolvedFunctionId
   const resolvedAuditConfig = resolveAuditConfig(funcConfig.audit)
-  resolvedWire.audit = resolvedAuditConfig
-  try {
-    // Convert tags to PermissionMetadata and merge with inheritedPermissions
-    let mergedInheritedPermissions: PermissionMetadata[]
-    if (tags && tags.length > 0) {
-      mergedInheritedPermissions = [
-        ...(inheritedPermissions || []),
-        ...tags.map((tag) => ({ type: 'tag' as const, tag })),
-      ]
-    } else {
-      mergedInheritedPermissions = inheritedPermissions || []
+  const invocationWire = {
+    ...resolvedWire,
+    functionId: resolvedFunctionId,
+    audit: resolvedAuditConfig,
+  } satisfies PikkuWire
+
+  // Convert tags to PermissionMetadata and merge with inheritedPermissions
+  let mergedInheritedPermissions: PermissionMetadata[]
+  if (tags && tags.length > 0) {
+    mergedInheritedPermissions = [
+      ...(inheritedPermissions || []),
+      ...tags.map((tag) => ({ type: 'tag' as const, tag })),
+    ]
+  } else {
+    mergedInheritedPermissions = inheritedPermissions || []
+  }
+
+  // Helper function to run permissions and execute the function
+  const executeFunction = async () => {
+    await resolveSession(
+      invocationWire,
+      resolvedSingletonServices,
+      sessionService
+    )
+
+    if (sessionService) {
+      invocationWire.session = sessionService.freezeInitial()
+      invocationWire.setSession = (s: any) => sessionService.set(s)
+      invocationWire.clearSession = () => sessionService.clear()
+      invocationWire.getSession = () => sessionService.get()
+      invocationWire.hasSessionChanged = () => sessionService.sessionChanged
     }
 
-    // Helper function to run permissions and execute the function
-    const executeFunction = async () => {
-      await resolveSession(
-        resolvedWire,
-        resolvedSingletonServices,
-        sessionService
-      )
+    const session = invocationWire.session
 
-      if (sessionService) {
-        resolvedWire.session = sessionService.freezeInitial()
-        resolvedWire.setSession = (s: any) => sessionService.set(s)
-        resolvedWire.clearSession = () => sessionService.clear()
-        resolvedWire.getSession = () => sessionService.get()
-        resolvedWire.hasSessionChanged = () => sessionService.sessionChanged
-      }
-
-      const session = resolvedWire.session
-
-      if (funcMeta.sessionless) {
-        if (wiringAuth === true || funcConfig.auth === true) {
-          if (!session) {
-            throw new ForbiddenError('Authentication required')
-          }
-        }
-      } else if (funcMeta.sessionless === false) {
-        if (wiringAuth === false || funcConfig.auth === false) {
-          resolvedSingletonServices.logger.warn(
-            `Function '${funcName}' requires a session but auth was explicitly disabled — use pikkuSessionlessFunc instead.`
-          )
-        }
+    if (funcMeta.sessionless) {
+      if (wiringAuth === true || funcConfig.auth === true) {
         if (!session) {
           throw new ForbiddenError('Authentication required')
         }
-      } else {
-        // TODO: Remove after a couple of releases — backward compat for
-        // generated metadata that doesn't include the `sessionless` field yet.
-        if (wiringAuth === true || funcConfig.auth === true) {
-          if (!session) {
-            throw new ForbiddenError('Authentication required')
-          }
-        }
       }
-
-      if ((session as any)?.readonly && !funcMeta.readonly) {
-        throw new ReadonlySessionError()
-      }
-
-      // Evaluate the data from the lazy function
-      const actualData = await data()
-
-      // Validate and coerce data if schema is defined
-      const inputSchemaName = funcMeta.inputSchemaName
-      if (inputSchemaName) {
-        // Coerce (top level) data types before validation (e.g. string→array, string→date)
-        if (coerceDataFromSchema) {
-          coerceTopLevelDataFromSchema(inputSchemaName, actualData, packageName)
-        }
-        // Validate request data against the defined schema, if any
-        await validateSchema(
-          resolvedSingletonServices.logger,
-          resolvedSingletonServices.schema,
-          inputSchemaName,
-          actualData,
-          packageName
+    } else if (funcMeta.sessionless === false) {
+      if (wiringAuth === false || funcConfig.auth === false) {
+        resolvedSingletonServices.logger.warn(
+          `Function '${funcName}' requires a session but auth was explicitly disabled — use pikkuSessionlessFunc instead.`
         )
       }
-
-      if (
-        mergedInheritedPermissions.length > 0 ||
-        wirePermissions ||
-        funcMeta.permissions ||
-        funcConfig.permissions
-      ) {
-        await runPermissions(wireType, wireId, {
-          wireInheritedPermissions: mergedInheritedPermissions,
-          wirePermissions: wirePermissions,
-          funcInheritedPermissions: funcMeta.permissions,
-          funcPermissions: funcConfig.permissions,
-          services: resolvedSingletonServices,
-          wire: resolvedWire as any,
-          data: actualData,
-          packageName,
-        })
+      if (!session) {
+        throw new ForbiddenError('Authentication required')
       }
-
-      let wireServices: Record<string, unknown> | undefined
-      try {
-        wireServices = (await resolvedCreateWireServices?.(
-          resolvedSingletonServices,
-          resolvedWire
-        )) as Record<string, unknown> | undefined
-        const services =
-          wireServices && Object.keys(wireServices).length > 0
-            ? { ...resolvedSingletonServices, ...wireServices }
-            : resolvedSingletonServices
-        const callerPackageName = packageName
-        Object.defineProperty(resolvedWire, 'rpc', {
-          get() {
-            const rpc = rpcService.getContextRPCService(
-              services,
-              resolvedWire,
-              { sessionService },
-              0,
-              callerPackageName
-            )
-            Object.defineProperty(resolvedWire, 'rpc', {
-              value: rpc,
-              writable: true,
-              configurable: true,
-            })
-            return rpc
-          },
-          configurable: true,
-          enumerable: true,
-        })
-        return await funcConfig.func(services, actualData, resolvedWire)
-      } finally {
-        if (wireServices && Object.keys(wireServices).length > 0) {
-          await closeWireServices(
-            resolvedSingletonServices.logger,
-            wireServices
-          )
+    } else {
+      // TODO: Remove after a couple of releases — backward compat for
+      // generated metadata that doesn't include the `sessionless` field yet.
+      if (wiringAuth === true || funcConfig.auth === true) {
+        if (!session) {
+          throw new ForbiddenError('Authentication required')
         }
       }
     }
 
-    const allMiddleware = combineMiddleware(wireType, wireId, {
-      wireInheritedMiddleware: inheritedMiddleware,
-      wireMiddleware,
-      funcInheritedMiddleware: funcMeta.middleware,
-      funcMiddleware: funcConfig.middleware,
-      packageName,
-    })
-
-    if (allMiddleware.length > 0) {
-      return (await runMiddleware<CorePikkuMiddleware>(
-        resolvedSingletonServices,
-        resolvedWire,
-        allMiddleware,
-        executeFunction
-      )) as Out
+    if ((session as any)?.readonly && !funcMeta.readonly) {
+      throw new ReadonlySessionError()
     }
 
-    return (await executeFunction()) as Out
-  } finally {
-    resolvedWire.functionId = previousFunctionId
-    resolvedWire.audit = previousAudit
+    // Evaluate the data from the lazy function
+    const actualData = await data()
+
+    // Validate and coerce data if schema is defined
+    const inputSchemaName = funcMeta.inputSchemaName
+    if (inputSchemaName) {
+      // Coerce (top level) data types before validation (e.g. string→array, string→date)
+      if (coerceDataFromSchema) {
+        coerceTopLevelDataFromSchema(inputSchemaName, actualData, packageName)
+      }
+      // Validate request data against the defined schema, if any
+      await validateSchema(
+        resolvedSingletonServices.logger,
+        resolvedSingletonServices.schema,
+        inputSchemaName,
+        actualData,
+        packageName
+      )
+    }
+
+    if (
+      mergedInheritedPermissions.length > 0 ||
+      wirePermissions ||
+      funcMeta.permissions ||
+      funcConfig.permissions
+    ) {
+      await runPermissions(wireType, wireId, {
+        wireInheritedPermissions: mergedInheritedPermissions,
+        wirePermissions: wirePermissions,
+        funcInheritedPermissions: funcMeta.permissions,
+        funcPermissions: funcConfig.permissions,
+        services: resolvedSingletonServices,
+        wire: invocationWire as any,
+        data: actualData,
+        packageName,
+      })
+    }
+
+    let wireServices: Record<string, unknown> | undefined
+    try {
+      wireServices = (await resolvedCreateWireServices?.(
+        resolvedSingletonServices,
+        invocationWire
+      )) as Record<string, unknown> | undefined
+      const services =
+        wireServices && Object.keys(wireServices).length > 0
+          ? { ...resolvedSingletonServices, ...wireServices }
+          : resolvedSingletonServices
+      const callerPackageName = packageName
+      Object.defineProperty(invocationWire, 'rpc', {
+        get() {
+          const rpc = rpcService.getContextRPCService(
+            services,
+            invocationWire,
+            { sessionService },
+            0,
+            callerPackageName
+          )
+          Object.defineProperty(invocationWire, 'rpc', {
+            value: rpc,
+            writable: true,
+            configurable: true,
+          })
+          return rpc
+        },
+        configurable: true,
+        enumerable: true,
+      })
+      return await funcConfig.func(services, actualData, invocationWire)
+    } finally {
+      if (wireServices && Object.keys(wireServices).length > 0) {
+        await closeWireServices(
+          resolvedSingletonServices.logger,
+          wireServices
+        )
+      }
+    }
   }
+
+  const allMiddleware = combineMiddleware(wireType, wireId, {
+    wireInheritedMiddleware: inheritedMiddleware,
+    wireMiddleware,
+    funcInheritedMiddleware: funcMeta.middleware,
+    funcMiddleware: funcConfig.middleware,
+    packageName,
+  })
+
+  if (allMiddleware.length > 0) {
+    return (await runMiddleware<CorePikkuMiddleware>(
+      resolvedSingletonServices,
+      invocationWire,
+      allMiddleware,
+      executeFunction
+    )) as Out
+  }
+
+  return (await executeFunction()) as Out
 }

--- a/packages/core/src/function/functions.types.ts
+++ b/packages/core/src/function/functions.types.ts
@@ -285,6 +285,11 @@ export type CorePikkuFunctionConfig<
   readonly?: boolean
   deploy?: 'serverless' | 'server' | 'auto'
   approvalRequired?: boolean
+  audit?:
+    | boolean
+    | {
+        durability?: 'best-effort' | 'transactional'
+      }
   approvalDescription?: any
   func: PikkuFunction
   auth?: boolean

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -123,6 +123,25 @@ export type { GatewayService } from './services/gateway-service.js'
 export type { TriggerService } from './services/trigger-service.js'
 export type { SchemaService } from './services/schema-service.js'
 export type { SessionService } from './services/user-session-service.js'
+export {
+  NoopAuditService,
+  createInvocationAudit,
+  resolveAuditActorFromWire,
+  resolveAuditConfig,
+} from './services/audit-service.js'
+export type {
+  AuditActor,
+  AuditConfig,
+  AuditDurability,
+  AuditEvent,
+  AuditEventBatch,
+  AuditLog,
+  AuditLogWriteInput,
+  AuditOutcome,
+  AuditService,
+  AuditSource,
+  ResolvedAuditConfig,
+} from './services/audit-service.js'
 export type { AIAgentRunnerService } from './services/ai-agent-runner-service.js'
 export type { AIRunStateService } from './services/ai-run-state-service.js'
 export type { AIStorageService } from './services/ai-storage-service.js'

--- a/packages/core/src/services/audit-service.test.ts
+++ b/packages/core/src/services/audit-service.test.ts
@@ -1,0 +1,44 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createInvocationAudit,
+  type AuditEvent,
+  type AuditEventBatch,
+} from './audit-service.js'
+
+describe('audit-service', () => {
+  test('best-effort flush failures are logged and do not throw', async () => {
+    const warnings: unknown[][] = []
+    const audit = createInvocationAudit(
+      {
+        async audit(_event: AuditEvent): Promise<void> {
+          throw new Error('should not use single-event write')
+        },
+        async write(_batch: AuditEventBatch): Promise<void> {
+          throw new Error('sink failed')
+        },
+      },
+      {
+        wireType: 'rpc',
+        wireId: 'wire-best-effort',
+        functionId: 'bestEffortFunc',
+        audit: { durability: 'best-effort' },
+        logger: {
+          warn: (...args: unknown[]) => warnings.push(args),
+        },
+      } as any
+    )
+
+    await audit.write({
+      type: 'db.query',
+      source: 'auto',
+      queryId: 'q-1',
+    })
+
+    await assert.doesNotReject(async () => {
+      await audit.close()
+    })
+    assert.equal(warnings.length, 1)
+    assert.equal(warnings[0]?.[0], 'best-effort audit flush failed')
+  })
+})

--- a/packages/core/src/services/audit-service.ts
+++ b/packages/core/src/services/audit-service.ts
@@ -119,13 +119,20 @@ class InvocationAuditLog implements AuditLog {
       queryEvents[0]!.queryId = null
     }
 
-    if (this.service.write) {
-      await this.service.write(batch)
-      return
-    }
+    try {
+      if (this.service.write) {
+        await this.service.write(batch)
+        return
+      }
 
-    for (const event of batch) {
-      await this.service.audit(event)
+      for (const event of batch) {
+        await this.service.audit(event)
+      }
+    } catch (error) {
+      ;(this.wire as any).logger?.warn?.(
+        'best-effort audit flush failed',
+        error
+      )
     }
   }
 

--- a/packages/core/src/services/audit-service.ts
+++ b/packages/core/src/services/audit-service.ts
@@ -1,0 +1,191 @@
+import type {
+  CoreUserSession,
+  PikkuWire,
+  PikkuWiringTypes,
+} from '../types/core.types.js'
+
+export type AuditDurability = 'best-effort' | 'transactional'
+export type AuditOutcome = 'success' | 'failed' | 'denied'
+export type AuditSource = 'auto' | 'explicit'
+
+export type AuditConfig =
+  | boolean
+  | {
+      durability?: AuditDurability
+    }
+
+export type ResolvedAuditConfig = {
+  durability: AuditDurability
+}
+
+export type AuditActor = {
+  userId?: string
+  orgId?: string
+  pikkuUserId?: string
+}
+
+export type AuditEvent = {
+  eventId?: string
+  type: string
+  source: AuditSource
+  outcome?: AuditOutcome
+  occurredAt: string
+  functionId?: string
+  wireType?: PikkuWiringTypes
+  wireId?: string
+  traceId?: string
+  transactionId?: string | null
+  queryId?: string | null
+  actor?: AuditActor
+  input?: unknown
+  metadata?: Record<string, unknown>
+}
+
+export type AuditEventBatch = AuditEvent[]
+
+export interface AuditService {
+  audit(event: AuditEvent): Promise<void>
+  write?(batch: AuditEventBatch): Promise<void>
+}
+
+export class NoopAuditService implements AuditService {
+  async audit(_event: AuditEvent): Promise<void> {}
+
+  async write(_batch: AuditEventBatch): Promise<void> {}
+}
+
+export type AuditLogWriteInput = Omit<AuditEvent, 'occurredAt'>
+
+export interface AuditLog {
+  readonly config: ResolvedAuditConfig | undefined
+  write(event: AuditLogWriteInput): Promise<void>
+  flush(): Promise<void>
+  close(): Promise<void>
+}
+
+class DisabledInvocationAudit implements AuditLog {
+  public readonly config = undefined
+  private warned = false
+
+  constructor(
+    private readonly wire: PikkuWire<any, any, any, CoreUserSession>
+  ) {}
+
+  async write(_event: AuditLogWriteInput): Promise<void> {
+    if (!this.warned) {
+      this.warned = true
+      ;(this.wire as any).logger?.warn?.(
+        'audit.write() called for an invocation without wire.audit enabled'
+      )
+    }
+  }
+
+  async flush(): Promise<void> {}
+
+  async close(): Promise<void> {}
+}
+
+class InvocationAuditLog implements AuditLog {
+  private readonly buffer: AuditEvent[] = []
+
+  constructor(
+    public readonly config: ResolvedAuditConfig,
+    private readonly service: AuditService,
+    private readonly wire: PikkuWire<any, any, any, CoreUserSession>
+  ) {}
+
+  async write(event: AuditLogWriteInput): Promise<void> {
+    const resolved = this.resolveEvent(event)
+
+    if (this.config.durability === 'transactional') {
+      await this.service.audit(resolved)
+      return
+    }
+
+    this.buffer.push(resolved)
+  }
+
+  async flush(): Promise<void> {
+    if (
+      this.config.durability === 'transactional' ||
+      this.buffer.length === 0
+    ) {
+      return
+    }
+
+    const batch = this.buffer.splice(0, this.buffer.length)
+    const queryEvents = batch.filter((event) => event.queryId != null)
+    if (queryEvents.length === 1) {
+      queryEvents[0]!.queryId = null
+    }
+
+    if (this.service.write) {
+      await this.service.write(batch)
+      return
+    }
+
+    for (const event of batch) {
+      await this.service.audit(event)
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.flush()
+  }
+
+  private resolveEvent(event: AuditLogWriteInput): AuditEvent {
+    return {
+      functionId: this.wire.functionId,
+      wireType: this.wire.wireType,
+      wireId: this.wire.wireId,
+      traceId: this.wire.traceId,
+      actor: event.actor ?? resolveAuditActorFromWire(this.wire),
+      ...event,
+      occurredAt: new Date().toISOString(),
+    }
+  }
+}
+
+export const resolveAuditConfig = (
+  config?: AuditConfig
+): ResolvedAuditConfig | undefined => {
+  if (config === true) {
+    return { durability: 'best-effort' }
+  }
+
+  if (!config) {
+    return undefined
+  }
+
+  return {
+    durability: config.durability ?? 'best-effort',
+  }
+}
+
+export const createInvocationAudit = (
+  service: AuditService,
+  wire: PikkuWire<any, any, any, CoreUserSession>
+): AuditLog => {
+  if (!wire.audit) {
+    return new DisabledInvocationAudit(wire)
+  }
+
+  return new InvocationAuditLog(wire.audit, service, wire)
+}
+
+export const resolveAuditActorFromWire = (
+  wire: PikkuWire<any, any, any, CoreUserSession>
+): AuditActor | undefined => {
+  const session = wire.session as CoreUserSession | undefined
+  const actor: AuditActor = {
+    userId: session?.userId,
+    orgId: session?.orgId,
+    pikkuUserId: wire.pikkuUserId,
+  }
+
+  if (!actor.userId && !actor.orgId && !actor.pikkuUserId) {
+    return undefined
+  }
+
+  return actor
+}

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -88,6 +88,25 @@ export type {
 export type { VariableStatus, VariableMeta } from './typed-variables-service.js'
 export type { MetaService } from './meta-service.js'
 export type { SessionStore } from './session-store.js'
+export {
+  NoopAuditService,
+  createInvocationAudit,
+  resolveAuditActorFromWire,
+  resolveAuditConfig,
+} from './audit-service.js'
+export type {
+  AuditActor,
+  AuditConfig,
+  AuditDurability,
+  AuditEvent,
+  AuditEventBatch,
+  AuditLog,
+  AuditLogWriteInput,
+  AuditOutcome,
+  AuditService,
+  AuditSource,
+  ResolvedAuditConfig,
+} from './audit-service.js'
 export { InMemorySessionStore } from './in-memory-session-store.js'
 export type {
   MCPMeta,

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -38,6 +38,10 @@ import type { CredentialService } from '../services/credential-service.js'
 import type { EmailService } from '../services/email-service.js'
 import type { MetaService } from '../services/meta-service.js'
 import type { SessionStore } from '../services/session-store.js'
+import type {
+  AuditDurability,
+  AuditService,
+} from '../services/audit-service.js'
 
 export type PikkuWiringTypes =
   | 'http'
@@ -197,7 +201,10 @@ export type CoreConfig<Config extends Record<string, unknown> = {}> = {
 /**
  * Represents a core user session, which can be extended for more specific session information.
  */
-export interface CoreUserSession {}
+export interface CoreUserSession {
+  userId?: string
+  orgId?: string
+}
 
 /**
  * Interface for core singleton services provided by Pikku.
@@ -244,6 +251,8 @@ export interface CoreSingletonServices<Config extends CoreConfig = CoreConfig> {
   emailService?: EmailService
   /** Meta service for reading .pikku metadata files (filesystem on Node, R2/KV on CF) */
   metaService?: MetaService
+  /** Audit service for durable or staged audit event capture */
+  audit: AuditService
   /** Session store for persisting user sessions keyed by pikkuUserId */
   sessionStore?: SessionStore
 }
@@ -266,6 +275,8 @@ export type PikkuWire<
   wireId: string
   /** Trace ID for distributed tracing — propagated across remote RPC calls via x-trace-id header */
   traceId: string
+  /** Function id for the current invocation */
+  functionId: string
   http: PikkuHTTP<In>
   mcp: PikkuMCP<MCPTools>
   rpc: TypedRPC
@@ -301,6 +312,10 @@ export type PikkuWire<
   getCredentials: () =>
     | Record<string, unknown>
     | Promise<Record<string, unknown>>
+  /** Resolved function audit metadata for this invocation, if enabled */
+  audit: {
+    durability: AuditDurability
+  }
 }>
 
 /**

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -252,7 +252,7 @@ export interface CoreSingletonServices<Config extends CoreConfig = CoreConfig> {
   /** Meta service for reading .pikku metadata files (filesystem on Node, R2/KV on CF) */
   metaService?: MetaService
   /** Audit service for durable or staged audit event capture */
-  audit: AuditService
+  audit?: AuditService
   /** Session store for persisting user sessions keyed by pikkuUserId */
   sessionStore?: SessionStore
 }

--- a/packages/runtimes/next/src/pikku-session.ts
+++ b/packages/runtimes/next/src/pikku-session.ts
@@ -1,5 +1,8 @@
 import { runMiddleware } from '@pikku/core'
-import { PikkuSessionService } from '@pikku/core/services'
+import {
+  PikkuSessionService,
+  createMiddlewareSessionWireProps,
+} from '@pikku/core/services'
 import { PikkuFetchHTTPRequest } from '@pikku/core/http'
 import type {
   CoreSingletonServices,
@@ -20,16 +23,16 @@ export const getSession = async <UserSession extends CoreUserSession>(
   middleware: CorePikkuMiddleware[]
 ): Promise<UserSession | undefined> => {
   const request = new PikkuFetchHTTPRequest(nextRequest)
-  const userSession = new PikkuSessionService<UserSession>(
+  const userSession = new PikkuSessionService<CoreUserSession>(
     singletonServices.sessionStore as any
   )
   await runMiddleware(
     singletonServices,
     {
       http: { request },
-      session: userSession,
+      ...createMiddlewareSessionWireProps(userSession),
     },
     middleware as any
   )
-  return userSession.get()
+  return userSession.get() as UserSession | undefined
 }

--- a/packages/services/kysely/src/create-audited-kysely.test.ts
+++ b/packages/services/kysely/src/create-audited-kysely.test.ts
@@ -1,0 +1,560 @@
+import { afterEach, describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import Database from 'better-sqlite3'
+import { Kysely, SqliteDialect, type Generated } from 'kysely'
+import {
+  createInvocationAudit,
+  NoopAuditService,
+  type AuditEvent,
+  type AuditService,
+} from '../../../core/src/index.js'
+
+import { createAuditedKysely } from './create-audited-kysely.js'
+
+interface TodoTable {
+  id: Generated<number>
+  title: string
+  done: number
+}
+
+interface TestDB {
+  todos: TodoTable
+}
+
+interface AuditEventTable {
+  eventId: string
+  occurredAt: string
+  type: string
+  source: string
+  outcome: string | null
+  functionId: string | null
+  wireType: string | null
+  wireId: string | null
+  traceId: string | null
+  transactionId: string | null
+  queryId: string | null
+  actorUserId: string | null
+  actorOrgId: string | null
+  actorPikkuUserId: string | null
+  metadataJson: string | null
+}
+
+interface AuditVerifierDB extends TestDB {
+  audit_events: AuditEventTable
+}
+
+function createDb(): Kysely<TestDB> {
+  return new Kysely<TestDB>({
+    dialect: new SqliteDialect({
+      database: new Database(':memory:'),
+    }),
+  })
+}
+
+async function createTodosTable(db: Kysely<TestDB>): Promise<void> {
+  await db.schema
+    .createTable('todos')
+    .addColumn('id', 'integer', (col) => col.primaryKey().autoIncrement())
+    .addColumn('title', 'text', (col) => col.notNull())
+    .addColumn('done', 'integer', (col) => col.notNull().defaultTo(0))
+    .execute()
+}
+
+async function createAuditEventsTable(
+  db: Kysely<AuditVerifierDB>
+): Promise<void> {
+  await db.schema
+    .createTable('audit_events')
+    .addColumn('eventId', 'text', (col) => col.primaryKey())
+    .addColumn('occurredAt', 'text', (col) => col.notNull())
+    .addColumn('type', 'text', (col) => col.notNull())
+    .addColumn('source', 'text', (col) => col.notNull())
+    .addColumn('outcome', 'text')
+    .addColumn('functionId', 'text')
+    .addColumn('wireType', 'text')
+    .addColumn('wireId', 'text')
+    .addColumn('traceId', 'text')
+    .addColumn('transactionId', 'text')
+    .addColumn('queryId', 'text')
+    .addColumn('actorUserId', 'text')
+    .addColumn('actorOrgId', 'text')
+    .addColumn('actorPikkuUserId', 'text')
+    .addColumn('metadataJson', 'text')
+    .execute()
+}
+
+class ImmediateAuditService implements AuditService {
+  constructor(private readonly db: Kysely<AuditVerifierDB>) {}
+
+  async audit(event: AuditEvent): Promise<void> {
+    await this.insertEvent(event)
+  }
+
+  async write(batch: AuditEvent[]): Promise<void> {
+    for (const event of batch) {
+      await this.insertEvent(event)
+    }
+  }
+
+  private async insertEvent(event: AuditEvent): Promise<void> {
+    await this.db
+      .insertInto('audit_events')
+      .values({
+        eventId:
+          event.eventId ??
+          `${event.traceId ?? 'trace'}:${event.queryId ?? 'single'}:${event.occurredAt}`,
+        occurredAt: event.occurredAt,
+        type: event.type,
+        source: event.source,
+        outcome: event.outcome ?? null,
+        functionId: event.functionId ?? null,
+        wireType: event.wireType ?? null,
+        wireId: event.wireId ?? null,
+        traceId: event.traceId ?? null,
+        transactionId: event.transactionId ?? null,
+        queryId: event.queryId ?? null,
+        actorUserId: event.actor?.userId ?? null,
+        actorOrgId: event.actor?.orgId ?? null,
+        actorPikkuUserId: event.actor?.pikkuUserId ?? null,
+        metadataJson: event.metadata ? JSON.stringify(event.metadata) : null,
+      })
+      .execute()
+  }
+}
+
+async function countPersistedEvents(
+  db: Kysely<AuditVerifierDB>
+): Promise<number> {
+  const row = await db
+    .selectFrom('audit_events')
+    .select((eb) => eb.fn.countAll<number>().as('count'))
+    .executeTakeFirstOrThrow()
+
+  return Number(row.count)
+}
+
+async function listPersistedEvents(
+  db: Kysely<AuditVerifierDB>
+): Promise<
+  Array<AuditEventTable & { metadata: Record<string, unknown> | null }>
+> {
+  const rows = await db
+    .selectFrom('audit_events')
+    .selectAll()
+    .orderBy('occurredAt', 'asc')
+    .execute()
+
+  return rows.map((row) => ({
+    ...row,
+    metadata: row.metadataJson
+      ? (JSON.parse(row.metadataJson) as Record<string, unknown>)
+      : null,
+  }))
+}
+
+describe('createAuditedKysely', () => {
+  const dbs: Kysely<TestDB>[] = []
+
+  afterEach(async () => {
+    while (dbs.length > 0) {
+      const db = dbs.pop()!
+      await db.destroy()
+    }
+  })
+
+  test('captures insert queries through the invocation audit wrapper', async () => {
+    const events: AuditEvent[] = []
+    const db = createDb()
+    dbs.push(db)
+    await createTodosTable(db)
+
+    const auditService: AuditService = {
+      audit: async (event) => {
+        events.push(event)
+      },
+      write: async (batch) => {
+        events.push(...batch)
+      },
+    }
+    const wire: any = {
+      wireType: 'rpc',
+      wireId: 'wire-1',
+      traceId: 'trace-1',
+      functionId: 'todos:create',
+      session: { userId: 'user-1', orgId: 'org-1' },
+      pikkuUserId: 'user-1',
+      audit: { durability: 'best-effort' },
+      logger: { warn: () => {} },
+    }
+    const audit = createInvocationAudit(auditService, wire)
+    const auditedDb = createAuditedKysely(db, { audit })
+
+    await auditedDb
+      .insertInto('todos')
+      .values({ title: 'write tests', done: 0 })
+      .execute()
+    await audit.close()
+
+    assert.equal(events.length, 1)
+    assert.equal(events[0]?.type, 'db.query')
+    assert.equal(events[0]?.traceId, 'trace-1')
+    assert.equal(events[0]?.functionId, 'todos:create')
+    assert.equal(events[0]?.queryId, null)
+    assert.deepEqual(events[0]?.metadata, {
+      queryKind: 'insert',
+      tables: ['todos'],
+      changedColumns: ['title', 'done'],
+      changes: { title: 'write tests', done: 0 },
+      rowCount: 1,
+    })
+    assert.deepEqual(events[0]?.actor, {
+      userId: 'user-1',
+      orgId: 'org-1',
+      pikkuUserId: 'user-1',
+    })
+  })
+
+  test('captures update changes from the query tree', async () => {
+    const events: AuditEvent[] = []
+    const db = createDb()
+    dbs.push(db)
+    await createTodosTable(db)
+    await db.insertInto('todos').values({ title: 'before', done: 0 }).execute()
+
+    const audit = createInvocationAudit(
+      {
+        audit: async (event) => {
+          events.push(event)
+        },
+        write: async (batch) => {
+          events.push(...batch)
+        },
+      },
+      {
+        wireType: 'rpc',
+        wireId: 'wire-2',
+        traceId: 'trace-2',
+        functionId: 'todos:update',
+        session: { userId: 'user-2' },
+        pikkuUserId: 'user-2',
+        audit: { durability: 'best-effort' },
+        logger: { warn: () => {} },
+      } as any
+    )
+    const auditedDb = createAuditedKysely(db, { audit })
+
+    await auditedDb
+      .updateTable('todos')
+      .set({ title: 'after', done: 1 })
+      .where('id', '=', 1)
+      .execute()
+    await audit.close()
+
+    assert.equal(events.length, 1)
+    assert.equal(events[0]?.metadata?.queryKind, 'update')
+    assert.deepEqual(events[0]?.metadata?.changedColumns, ['title', 'done'])
+    assert.deepEqual(events[0]?.metadata?.changes, {
+      title: 'after',
+      done: 1,
+    })
+    assert.deepEqual(events[0]?.actor, {
+      userId: 'user-2',
+      orgId: undefined,
+      pikkuUserId: 'user-2',
+    })
+  })
+
+  test('keeps query ids when multiple queries are captured in one invocation', async () => {
+    const events: AuditEvent[] = []
+    const db = createDb()
+    dbs.push(db)
+    await createTodosTable(db)
+
+    const audit = createInvocationAudit(
+      {
+        audit: async (event) => {
+          events.push(event)
+        },
+        write: async (batch) => {
+          events.push(...batch)
+        },
+      },
+      {
+        wireType: 'rpc',
+        wireId: 'wire-3',
+        traceId: 'trace-3',
+        functionId: 'todos:multi',
+        session: { userId: 'user-3' },
+        pikkuUserId: 'user-3',
+        audit: { durability: 'best-effort' },
+        logger: { warn: () => {} },
+      } as any
+    )
+    const auditedDb = createAuditedKysely(db, {
+      audit,
+      transactionId: 'tx-1',
+    })
+
+    await auditedDb
+      .insertInto('todos')
+      .values({ title: 'first', done: 0 })
+      .execute()
+    await auditedDb
+      .insertInto('todos')
+      .values({ title: 'second', done: 1 })
+      .execute()
+    await audit.close()
+
+    assert.equal(events.length, 2)
+    assert.equal(events[0]?.transactionId, 'tx-1')
+    assert.equal(events[1]?.transactionId, 'tx-1')
+    assert.equal(events[0]?.queryId, 'q-1')
+    assert.equal(events[1]?.queryId, 'q-2')
+  })
+
+  test('captures select queries by default', async () => {
+    const events: AuditEvent[] = []
+    const db = createDb()
+    dbs.push(db)
+    await createTodosTable(db)
+    await db.insertInto('todos').values({ title: 'read me', done: 0 }).execute()
+
+    const audit = createInvocationAudit(
+      {
+        audit: async (event) => {
+          events.push(event)
+        },
+        write: async (batch) => {
+          events.push(...batch)
+        },
+      },
+      {
+        wireType: 'rpc',
+        wireId: 'wire-4',
+        audit: { durability: 'best-effort' },
+        logger: { warn: () => {} },
+      } as any
+    )
+    const auditedDb = createAuditedKysely(db, { audit })
+
+    await auditedDb.selectFrom('todos').selectAll().execute()
+    await audit.close()
+
+    assert.equal(events.length, 1)
+    assert.equal(events[0]?.metadata?.queryKind, 'select')
+    assert.deepEqual(events[0]?.metadata?.tables, ['todos'])
+  })
+
+  test('can skip select auditing when auditReads is false', async () => {
+    const events: AuditEvent[] = []
+    const db = createDb()
+    dbs.push(db)
+    await createTodosTable(db)
+    await db
+      .insertInto('todos')
+      .values({ title: 'skip read', done: 0 })
+      .execute()
+
+    const audit = createInvocationAudit(
+      {
+        audit: async (event) => {
+          events.push(event)
+        },
+        write: async (batch) => {
+          events.push(...batch)
+        },
+      },
+      {
+        wireType: 'rpc',
+        wireId: 'wire-5',
+        audit: { durability: 'best-effort' },
+        logger: { warn: () => {} },
+      } as any
+    )
+    const auditedDb = createAuditedKysely(db, {
+      audit,
+      auditReads: false,
+    })
+
+    await auditedDb.selectFrom('todos').selectAll().execute()
+    await audit.close()
+
+    assert.equal(events.length, 0)
+  })
+
+  test('noops when audit is not enabled on the wire', async () => {
+    const db = createDb()
+    dbs.push(db)
+    await createTodosTable(db)
+
+    const audit = createInvocationAudit(new NoopAuditService(), {
+      wireType: 'rpc',
+      wireId: 'wire-6',
+      logger: { warn: () => {} },
+    } as any)
+    const auditedDb = createAuditedKysely(db, { audit })
+
+    await auditedDb
+      .insertInto('todos')
+      .values({ title: 'noop', done: 0 })
+      .execute()
+    await audit.close()
+
+    assert.ok(true)
+  })
+
+  test('persists read and update queries after best-effort flush', async () => {
+    const db = createDb() as Kysely<AuditVerifierDB>
+    dbs.push(db as unknown as Kysely<TestDB>)
+    await createTodosTable(db)
+    await createAuditEventsTable(db)
+    await db.insertInto('todos').values({ title: 'seed', done: 0 }).execute()
+
+    const audit = createInvocationAudit(new ImmediateAuditService(db), {
+      wireType: 'rpc',
+      wireId: 'wire-best-effort',
+      traceId: 'trace-best-effort',
+      functionId: 'todos:best-effort',
+      session: { userId: 'user-best-effort' },
+      pikkuUserId: 'user-best-effort',
+      audit: { durability: 'best-effort' },
+      logger: { warn: () => {} },
+    } as any)
+    const auditedDb = createAuditedKysely(db, { audit })
+
+    const beforeCount = await countPersistedEvents(db)
+    await auditedDb
+      .selectFrom('todos')
+      .selectAll()
+      .where('id', '=', 1)
+      .executeTakeFirstOrThrow()
+    await auditedDb
+      .updateTable('todos')
+      .set({ done: 1 })
+      .where('id', '=', 1)
+      .execute()
+    const insideCount = await countPersistedEvents(db)
+
+    assert.equal(beforeCount, 0)
+    assert.equal(insideCount, 0)
+
+    await audit.close()
+
+    const persisted = await listPersistedEvents(db)
+    assert.equal(persisted.length, 2)
+    assert.deepEqual(
+      persisted.map((event) => event.metadata?.queryKind),
+      ['select', 'update']
+    )
+    assert.deepEqual(
+      persisted.map((event) => event.traceId),
+      ['trace-best-effort', 'trace-best-effort']
+    )
+    assert.deepEqual(
+      persisted.map((event) => event.functionId),
+      ['todos:best-effort', 'todos:best-effort']
+    )
+    assert.deepEqual(
+      persisted.map((event) => event.actorUserId),
+      ['user-best-effort', 'user-best-effort']
+    )
+    assert.equal(persisted[0]?.queryId, 'q-1')
+    assert.equal(persisted[1]?.queryId, 'q-2')
+    assert.deepEqual(persisted[1]?.metadata?.changedColumns, ['done'])
+    assert.deepEqual(persisted[1]?.metadata?.changes, { done: 1 })
+  })
+
+  test('writes read and update audit events immediately in transactional mode', async () => {
+    const db = createDb()
+    dbs.push(db)
+    await createTodosTable(db)
+    await db.insertInto('todos').values({ title: 'seed', done: 0 }).execute()
+
+    const events: AuditEvent[] = []
+    const audit = createInvocationAudit(
+      {
+        audit: async (event) => {
+          events.push(event)
+        },
+      },
+      {
+        wireType: 'rpc',
+        wireId: 'wire-transactional',
+        traceId: 'trace-transactional',
+        functionId: 'todos:transactional',
+        session: { userId: 'user-transactional' },
+        pikkuUserId: 'user-transactional',
+        audit: { durability: 'transactional' },
+        logger: { warn: () => {} },
+      } as any
+    )
+
+    const counts: number[] = []
+
+    await db.transaction().execute(async (trx) => {
+      const auditedTrx = createAuditedKysely(trx as Kysely<TestDB>, {
+        audit,
+        transactionId: 'tx-verifier-1',
+      })
+
+      await auditedTrx
+        .selectFrom('todos')
+        .selectAll()
+        .where('id', '=', 1)
+        .executeTakeFirstOrThrow()
+      counts.push(events.length)
+
+      await auditedTrx
+        .updateTable('todos')
+        .set({ done: 1 })
+        .where('id', '=', 1)
+        .execute()
+      counts.push(events.length)
+    })
+
+    assert.deepEqual(counts, [1, 2])
+    assert.equal(events.length, 2)
+    assert.deepEqual(
+      events.map((event) => event.transactionId),
+      ['tx-verifier-1', 'tx-verifier-1']
+    )
+    assert.deepEqual(
+      events.map((event) => event.metadata?.queryKind),
+      ['select', 'update']
+    )
+    assert.deepEqual(events[1]?.metadata?.changes, { done: 1 })
+  })
+
+  test('does not persist audit rows when the invocation is not audited', async () => {
+    const db = createDb() as Kysely<AuditVerifierDB>
+    dbs.push(db as unknown as Kysely<TestDB>)
+    await createTodosTable(db)
+    await createAuditEventsTable(db)
+    await db.insertInto('todos').values({ title: 'seed', done: 0 }).execute()
+
+    const audit = createInvocationAudit(new ImmediateAuditService(db), {
+      wireType: 'rpc',
+      wireId: 'wire-plain',
+      traceId: 'trace-plain',
+      functionId: 'todos:plain',
+      session: { userId: 'user-plain' },
+      pikkuUserId: 'user-plain',
+      logger: { warn: () => {} },
+    } as any)
+    const auditedDb = createAuditedKysely(db, { audit })
+
+    await auditedDb
+      .selectFrom('todos')
+      .selectAll()
+      .where('id', '=', 1)
+      .executeTakeFirstOrThrow()
+    await auditedDb
+      .updateTable('todos')
+      .set({ done: 1 })
+      .where('id', '=', 1)
+      .execute()
+    await audit.close()
+
+    assert.equal(await countPersistedEvents(db), 0)
+  })
+})

--- a/packages/services/kysely/src/create-audited-kysely.ts
+++ b/packages/services/kysely/src/create-audited-kysely.ts
@@ -1,0 +1,254 @@
+import type { AuditLog } from '@pikku/core'
+import type {
+  Kysely,
+  KyselyPlugin,
+  PluginTransformQueryArgs,
+  PluginTransformResultArgs,
+  QueryResult,
+  RootOperationNode,
+  UnknownRow,
+} from 'kysely'
+
+export interface CreateAuditedKyselyOptions {
+  audit: AuditLog
+  auditReads?: boolean
+  eventType?: string
+  transactionId?: string | null
+  queryIdPrefix?: string
+}
+
+type AuditedQuery = {
+  queryKind: 'select' | 'insert' | 'update' | 'delete'
+  queryId: string
+  tables: string[]
+  changedColumns?: string[]
+  changes?: unknown
+}
+
+const QUERY_KIND_BY_NODE: Record<
+  string,
+  AuditedQuery['queryKind'] | undefined
+> = {
+  SelectQueryNode: 'select',
+  InsertQueryNode: 'insert',
+  UpdateQueryNode: 'update',
+  DeleteQueryNode: 'delete',
+}
+
+function getIdentifierName(node: unknown): string | undefined {
+  if (!node || typeof node !== 'object') return undefined
+  const candidate = node as {
+    name?: string
+    column?: { name?: string }
+    identifier?: { name?: string }
+    table?: { identifier?: { name?: string } }
+  }
+  return (
+    candidate.name ??
+    candidate.column?.name ??
+    candidate.identifier?.name ??
+    candidate.table?.identifier?.name
+  )
+}
+
+function collectTableNames(node: unknown, out: Set<string>): void {
+  if (!node || typeof node !== 'object') return
+
+  const candidate = node as {
+    kind?: string
+    table?: { identifier?: { name?: string } }
+  }
+
+  if (
+    candidate.kind === 'TableNode' &&
+    typeof candidate.table?.identifier?.name === 'string'
+  ) {
+    out.add(candidate.table.identifier.name)
+  }
+
+  for (const value of Object.values(node as Record<string, unknown>)) {
+    if (Array.isArray(value)) {
+      for (const item of value) collectTableNames(item, out)
+      continue
+    }
+    collectTableNames(value, out)
+  }
+}
+
+function extractValue(node: unknown): unknown {
+  if (!node || typeof node !== 'object') return node
+
+  const candidate = node as {
+    kind?: string
+    value?: unknown
+    values?: unknown[]
+    left?: unknown
+    right?: unknown
+  }
+
+  switch (candidate.kind) {
+    case 'ValueNode':
+      return candidate.value
+    case 'PrimitiveValueListNode':
+    case 'ValueListNode':
+      return (candidate.values ?? []).map(extractValue)
+    case 'DefaultInsertValueNode':
+      return '[default]'
+    case 'ColumnNode':
+    case 'ReferenceNode':
+      return `[${candidate.kind}]`
+    case 'RawNode':
+      return '[raw]'
+    case 'SelectQueryNode':
+      return '[subquery]'
+    case 'ParensNode':
+      return extractValue((candidate as { node?: unknown }).node)
+    case 'BinaryOperationNode':
+      return {
+        left: extractValue(candidate.left),
+        right: extractValue(candidate.right),
+      }
+    default:
+      return `[${candidate.kind ?? 'expression'}]`
+  }
+}
+
+function extractInsertChanges(node: any): {
+  changedColumns?: string[]
+  changes?: unknown
+} {
+  const columns = Array.isArray(node.columns)
+    ? node.columns
+        .map((column: unknown) => getIdentifierName(column))
+        .filter(Boolean)
+    : []
+  const values = Array.isArray(node.values?.values) ? node.values.values : []
+  if (columns.length === 0 || values.length === 0) {
+    return {
+      changedColumns: columns.length > 0 ? columns : undefined,
+    }
+  }
+
+  const rows = values.map((row: any) => {
+    const rowValues = Array.isArray(row?.values)
+      ? row.values.map(extractValue)
+      : []
+    return Object.fromEntries(
+      columns.map((column, index) => [column, rowValues[index]])
+    )
+  })
+
+  return {
+    changedColumns: columns,
+    changes: rows.length === 1 ? rows[0] : rows,
+  }
+}
+
+function extractUpdateChanges(node: any): {
+  changedColumns?: string[]
+  changes?: unknown
+} {
+  const updates = Array.isArray(node.updates) ? node.updates : []
+  const entries = updates
+    .map((update: any) => {
+      const column = getIdentifierName(update.column)
+      if (!column) return null
+      return [column, extractValue(update.value)] as const
+    })
+    .filter(Boolean) as Array<readonly [string, unknown]>
+
+  if (entries.length === 0) {
+    return {}
+  }
+
+  return {
+    changedColumns: entries.map(([column]) => column),
+    changes: Object.fromEntries(entries),
+  }
+}
+
+function extractChangeSet(
+  node: RootOperationNode,
+  queryKind: AuditedQuery['queryKind']
+) {
+  if (queryKind === 'insert') {
+    return extractInsertChanges(node as any)
+  }
+  if (queryKind === 'update') {
+    return extractUpdateChanges(node as any)
+  }
+  return {}
+}
+
+class AuditedKyselyPlugin implements KyselyPlugin {
+  private readonly pending = new Map<unknown, AuditedQuery>()
+  private queryCounter = 0
+
+  constructor(private readonly options: CreateAuditedKyselyOptions) {}
+
+  transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+    const queryKind =
+      QUERY_KIND_BY_NODE[(args.node as { kind?: string }).kind ?? '']
+    if (!queryKind) {
+      return args.node
+    }
+
+    if (queryKind === 'select' && this.options.auditReads === false) {
+      return args.node
+    }
+
+    const tables = new Set<string>()
+    collectTableNames(args.node, tables)
+    const queryId = `${this.options.queryIdPrefix ?? 'q'}-${++this.queryCounter}`
+    this.pending.set(args.queryId, {
+      queryKind,
+      queryId,
+      tables: [...tables].sort(),
+      ...extractChangeSet(args.node, queryKind),
+    })
+    return args.node
+  }
+
+  async transformResult(
+    args: PluginTransformResultArgs
+  ): Promise<QueryResult<UnknownRow>> {
+    const pending = this.pending.get(args.queryId)
+    if (!pending) {
+      return args.result
+    }
+
+    this.pending.delete(args.queryId)
+    const rawResult = args.result as QueryResult<UnknownRow> & {
+      numAffectedRows?: bigint
+      numUpdatedOrDeletedRows?: bigint
+    }
+    const rowCount =
+      rawResult.rows.length > 0
+        ? rawResult.rows.length
+        : Number(
+            rawResult.numUpdatedOrDeletedRows ?? rawResult.numAffectedRows ?? 0n
+          )
+
+    await this.options.audit.write({
+      type: this.options.eventType ?? 'db.query',
+      source: 'auto',
+      transactionId: this.options.transactionId ?? null,
+      queryId: pending.queryId,
+      metadata: {
+        queryKind: pending.queryKind,
+        tables: pending.tables,
+        changedColumns: pending.changedColumns,
+        changes: pending.changes,
+        rowCount,
+      },
+    })
+    return rawResult
+  }
+}
+
+export function createAuditedKysely<DB>(
+  db: Kysely<DB>,
+  options: CreateAuditedKyselyOptions
+): Kysely<DB> {
+  return db.withPlugin(new AuditedKyselyPlugin(options))
+}

--- a/packages/services/kysely/src/index.ts
+++ b/packages/services/kysely/src/index.ts
@@ -12,6 +12,10 @@ export type { KyselySecretServiceConfig } from './kysely-secret-service.js'
 export { KyselyCredentialService } from './kysely-credential-service.js'
 export type { KyselyCredentialServiceConfig } from './kysely-credential-service.js'
 export { KyselySessionStore } from './kysely-session-store.js'
+export {
+  createAuditedKysely,
+  type CreateAuditedKyselyOptions,
+} from './create-audited-kysely.js'
 
 export type { KyselyPikkuDB } from './kysely-tables.js'
 export type { WorkflowRunService } from '@pikku/core/workflow'


### PR DESCRIPTION
## Summary
- add audit capture support in core
- add a Kysely audit wrapper and tests
- include follow-up fixes for audit wire restoration and best-effort behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Function-level audit config (best-effort or transactional); invocation context now exposes resolved function id and audit info.
  - Public audit APIs/types and an invocation audit service; Kysely integration to emit/query audit events with optional read-audit control.

* **Tests**
  - New and expanded tests covering audited vs non-audited invocations, nested context preservation, version resolution, DB auditing semantics, and durability flush behavior.

* **Chores**
  - CI matrix updated to run CLI/template tests in a separate no-services job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->