### PR TITLE
fix(secret+variable api): revert getSecretJSON/setSecretJSON and getJ…

### DIFF
--- a/.changeset/fix-secret-variable-api-revert.md
+++ b/.changeset/fix-secret-variable-api-revert.md
@@ -1,0 +1,10 @@
+---
+"@pikku/core": patch
+"@pikku/kysely": patch
+"@pikku/kysely-postgres": patch
+"@pikku/services-redis": patch
+"@pikku/services-mongodb": patch
+"@pikku/services-aws": patch
+---
+
+Revert getSecretJSON/setSecretJSON and getJSON/setJSON — use generic getSecret<T>/setSecret and get<T>/set instead

--- a/e2e/src/services.ts
+++ b/e2e/src/services.ts
@@ -129,12 +129,12 @@ export const createSingletonServices = pikkuServices(
     ])
     await jwt.init()
 
-    await secrets.setSecretJSON('MOCK_OAUTH_APP', {
+    await secrets.setSecret('MOCK_OAUTH_APP', {
       clientId: 'mock-client-id',
       clientSecret: 'mock-client-secret',
     })
 
-    await secrets.setSecretJSON('SLACK_OAUTH_APP', {
+    await secrets.setSecret('SLACK_OAUTH_APP', {
       clientId: '00512a03116f14d0000000003',
       clientSecret: 'K005p2Yl6t9kDmAppyq0vsKlxcW1Y7I',
     })

--- a/packages/addon/pikku-console/src/functions/oauth-exchange-tokens.function.ts
+++ b/packages/addon/pikku-console/src/functions/oauth-exchange-tokens.function.ts
@@ -27,7 +27,7 @@ export const oauthExchangeTokens = pikkuSessionlessFunc<
     if (credentialService) {
       await credentialService.set(flow.credentialName, tokens, flow.userId)
     } else {
-      await secrets.setSecretJSON(flow.oauth2.tokenSecretId, tokens)
+      await secrets.setSecret(flow.oauth2.tokenSecretId, tokens)
     }
 
     logger.info(

--- a/packages/addon/pikku-console/src/functions/oauth-status.function.ts
+++ b/packages/addon/pikku-console/src/functions/oauth-status.function.ts
@@ -52,7 +52,7 @@ export const oauthStatus = pikkuSessionlessFunc<
       }
 
       if (!token) {
-        token = await secrets.getSecretJSON<{
+        token = await secrets.getSecret<{
           accessToken: string
           refreshToken?: string
           expiresAt?: number

--- a/packages/addon/pikku-console/src/tests/test-oauth2-client.ts
+++ b/packages/addon/pikku-console/src/tests/test-oauth2-client.ts
@@ -12,22 +12,18 @@ import { LocalSecretService } from '@pikku/core/services'
 class TestVariablesService implements VariablesService {
   private store: Record<string, string> = {}
 
-  set(key: string, value: string) {
-    this.store[key] = value
+  set(name: string, value: unknown): void {
+    this.store[name] = typeof value === 'string' ? value : JSON.stringify(value)
   }
 
-  setJSON(name: string, value: unknown): void {
-    this.store[name] = JSON.stringify(value)
-  }
-
-  get(key: string): string | undefined {
-    return this.store[key]
-  }
-
-  getJSON<T = unknown>(name: string): T | undefined {
-    const value = this.store[name]
-    if (value === undefined) return undefined
-    return JSON.parse(value)
+  get<T = string>(name: string): T | undefined {
+    const raw = this.store[name]
+    if (raw === undefined) return undefined
+    try {
+      return JSON.parse(raw) as T
+    } catch {
+      return raw as unknown as T
+    }
   }
 
   getAll(): Record<string, string> {

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -274,7 +274,7 @@ export const createSingletonServices = pikkuAddonServices(async (
   config,
   { secrets, variables }
 ) => {
-  const creds = await secrets.getSecretJSON<${pascalName}Secrets>('${screamingName}_CREDENTIALS')
+  const creds = await secrets.getSecret<${pascalName}Secrets>('${screamingName}_CREDENTIALS')
   const ${camelName} = new ${pascalName}Service(creds, variables)
 
   return { ${camelName} }
@@ -794,7 +794,7 @@ import { createSingletonServices } from './services.js'
 test('${name} addon', async () => {
   const secrets = new LocalSecretService()
   // Set up secrets for the service
-  // await secrets.setSecretJSON('${screamingName}_CREDENTIALS', { ... })
+  // await secrets.setSecret('${screamingName}_CREDENTIALS', { ... })
 
   const singletonServices = await createSingletonServices({}, { secrets })
   const rpc = rpcService.getContextRPCService(singletonServices as any, {})

--- a/packages/cli/src/functions/wirings/console/serialize-console-functions.ts
+++ b/packages/cli/src/functions/wirings/console/serialize-console-functions.ts
@@ -16,7 +16,7 @@ export const pikkuConsoleSetSecret = pikkuSessionlessFunc<{
   expose: true,
   auth: false,
   func: async ({ secrets }, { secretId, value }) => {
-    await secrets.setSecretJSON(secretId, value)
+    await secrets.setSecret(secretId, value)
     return { success: true }
   },
 })
@@ -35,7 +35,7 @@ export const pikkuConsoleGetVariable = pikkuSessionlessFunc<
       return { exists: false, value: null }
     }
     try {
-      const value = await variables.getJSON(variableId)
+      const value = await variables.get(variableId)
       return { exists: true, value }
     } catch {
       const value = await variables.get(variableId)
@@ -56,7 +56,7 @@ export const pikkuConsoleSetVariable = pikkuSessionlessFunc<
     if (typeof value === 'string') {
       await variables.set(variableId, value)
     } else {
-      await variables.setJSON(variableId, value)
+      await variables.set(variableId, value)
     }
     return { success: true }
   },
@@ -89,7 +89,7 @@ export const pikkuConsoleGetSecret = pikkuSessionlessFunc<
     if (!exists) {
       return { exists: false, value: null }
     }
-    const value = await secrets.getSecretJSON(secretId)
+    const value = await secrets.getSecret(secretId)
     return { exists: true, value }
   },
 })

--- a/packages/cli/src/functions/wirings/functions/serialize-addon-types.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-addon-types.ts
@@ -60,7 +60,7 @@ export const pikkuAddonConfig = <ExistingServices extends Omit<Partial<Singleton
  *   config,
  *   { secrets }
  * ) => {
- *   const creds = await secrets.getSecretJSON<GithubCredentials>('GITHUB_CREDENTIALS')
+ *   const creds = await secrets.getSecret<GithubCredentials>('GITHUB_CREDENTIALS')
  *   const github = new GithubService(creds)
  *   return { github }
  * })

--- a/packages/core/src/services/gopass-secrets.ts
+++ b/packages/core/src/services/gopass-secrets.ts
@@ -6,10 +6,6 @@ import type { SecretService } from './secret-service.js'
  * Requires gopass to be installed and configured on the system.
  */
 export class GopassSecretService implements SecretService {
-  /**
-   * Creates an instance of GopassSecretService.
-   * @param prefix - Optional prefix for all secret keys (e.g., 'pikku/' will look up 'pikku/mykey' for key 'mykey')
-   */
   constructor(private prefix: string = '') {}
 
   private getFullKey(key: string): string {
@@ -19,39 +15,22 @@ export class GopassSecretService implements SecretService {
     return this.prefix ? `${this.prefix}${key}` : key
   }
 
-  /**
-   * Retrieves a secret by key and parses it as JSON.
-   * @param key - The key of the secret to retrieve.
-   * @returns A promise that resolves to the parsed secret value.
-   * @throws {Error} If the secret is not found or gopass fails.
-   */
-  public async getSecretJSON<R>(key: string): Promise<R> {
-    const value = await this.getSecret(key)
-    return JSON.parse(value)
-  }
-
-  /**
-   * Retrieves a secret by key as a string.
-   * @param key - The key of the secret to retrieve.
-   * @returns A promise that resolves to the secret value.
-   * @throws {Error} If the secret is not found or gopass fails.
-   */
-  public async getSecret(key: string): Promise<string> {
+  public async getSecret<T = string>(key: string): Promise<T> {
     const fullKey = this.getFullKey(key)
     try {
-      return execFileSync('gopass', ['show', '-o', fullKey], {
+      const raw = execFileSync('gopass', ['show', '-o', fullKey], {
         encoding: 'utf8',
       }).trim()
+      try {
+        return JSON.parse(raw) as T
+      } catch {
+        return raw as unknown as T
+      }
     } catch (error: any) {
       throw new Error(`Secret Not Found: ${key}`, { cause: error })
     }
   }
 
-  /**
-   * Checks if a secret exists without throwing.
-   * @param key - The key of the secret to check.
-   * @returns A promise that resolves to true if the secret exists.
-   */
   public async hasSecret(key: string): Promise<boolean> {
     const fullKey = this.getFullKey(key)
     try {
@@ -62,19 +41,13 @@ export class GopassSecretService implements SecretService {
     }
   }
 
-  /**
-   * Stores a JSON value as a secret in gopass.
-   * @param key - The key to store the secret under.
-   * @param value - The JSON value to store.
-   * @returns A promise that resolves when the secret is stored.
-   */
-  public async setSecretJSON(key: string, value: unknown): Promise<void> {
+  public async setSecret(key: string, value: unknown): Promise<void> {
     const fullKey = this.getFullKey(key)
-    const jsonValue = JSON.stringify(value)
+    const encoded = typeof value === 'string' ? value : JSON.stringify(value)
     try {
       execFileSync('gopass', ['insert', '-f', fullKey], {
         encoding: 'utf8',
-        input: jsonValue,
+        input: encoded,
         stdio: ['pipe', 'pipe', 'pipe'],
       })
     } catch (error: any) {
@@ -82,11 +55,6 @@ export class GopassSecretService implements SecretService {
     }
   }
 
-  /**
-   * Deletes a secret from gopass.
-   * @param key - The key of the secret to delete.
-   * @returns A promise that resolves when the secret is deleted.
-   */
   public async deleteSecret(key: string): Promise<void> {
     const fullKey = this.getFullKey(key)
     try {

--- a/packages/core/src/services/local-secrets.test.ts
+++ b/packages/core/src/services/local-secrets.test.ts
@@ -6,7 +6,7 @@ import { LocalVariablesService } from './local-variables.js'
 describe('LocalSecretService', () => {
   test('should get secret from local storage', async () => {
     const service = new LocalSecretService()
-    await service.setSecretJSON('MY_KEY', { token: 'abc' })
+    await service.setSecret('MY_KEY', { token: 'abc' })
     const result = await service.getSecret('MY_KEY')
     assert.strictEqual(result, '{"token":"abc"}')
   })
@@ -28,22 +28,22 @@ describe('LocalSecretService', () => {
 
   test('should get JSON secret from local storage', async () => {
     const service = new LocalSecretService()
-    await service.setSecretJSON('JSON_KEY', { data: 42 })
-    const result = await service.getSecretJSON('JSON_KEY')
+    await service.setSecret('JSON_KEY', { data: 42 })
+    const result = await service.getSecret('JSON_KEY')
     assert.deepStrictEqual(result, { data: 42 })
   })
 
   test('should get JSON secret from environment variables', async () => {
     const vars = new LocalVariablesService({ CONFIG: '{"port":3000}' })
     const service = new LocalSecretService(vars)
-    const result = await service.getSecretJSON('CONFIG')
+    const result = await service.getSecret('CONFIG')
     assert.deepStrictEqual(result, { port: 3000 })
   })
 
   test('should throw when JSON secret not found', async () => {
     const vars = new LocalVariablesService({})
     const service = new LocalSecretService(vars)
-    await assert.rejects(() => service.getSecretJSON('MISSING'), {
+    await assert.rejects(() => service.getSecret('MISSING'), {
       message: 'Requested secret not found',
     })
   })
@@ -51,7 +51,7 @@ describe('LocalSecretService', () => {
   test('should prefer local storage over env variables', async () => {
     const vars = new LocalVariablesService({ KEY: 'env-value' })
     const service = new LocalSecretService(vars)
-    await service.setSecretJSON('KEY', 'local-value')
+    await service.setSecret('KEY', 'local-value')
     const result = await service.getSecret('KEY')
     assert.strictEqual(result, '"local-value"')
   })
@@ -59,7 +59,7 @@ describe('LocalSecretService', () => {
   test('should check hasSecret in local storage', async () => {
     const vars = new LocalVariablesService({})
     const service = new LocalSecretService(vars)
-    await service.setSecretJSON('EXISTS', 'yes')
+    await service.setSecret('EXISTS', 'yes')
     assert.strictEqual(await service.hasSecret('EXISTS'), true)
     assert.strictEqual(await service.hasSecret('NOPE'), false)
   })
@@ -72,7 +72,7 @@ describe('LocalSecretService', () => {
 
   test('should delete secret from local storage', async () => {
     const service = new LocalSecretService()
-    await service.setSecretJSON('DEL_KEY', 'value')
+    await service.setSecret('DEL_KEY', 'value')
     assert.strictEqual(await service.hasSecret('DEL_KEY'), true)
     await service.deleteSecret('DEL_KEY')
     assert.strictEqual(await service.hasSecret('DEL_KEY'), false)

--- a/packages/core/src/services/local-secrets.test.ts
+++ b/packages/core/src/services/local-secrets.test.ts
@@ -8,7 +8,7 @@ describe('LocalSecretService', () => {
     const service = new LocalSecretService()
     await service.setSecret('MY_KEY', { token: 'abc' })
     const result = await service.getSecret('MY_KEY')
-    assert.strictEqual(result, '{"token":"abc"}')
+    assert.deepStrictEqual(result, { token: 'abc' })
   })
 
   test('should get secret from environment variables', async () => {
@@ -53,7 +53,7 @@ describe('LocalSecretService', () => {
     const service = new LocalSecretService(vars)
     await service.setSecret('KEY', 'local-value')
     const result = await service.getSecret('KEY')
-    assert.strictEqual(result, '"local-value"')
+    assert.strictEqual(result, 'local-value')
   })
 
   test('should check hasSecret in local storage', async () => {

--- a/packages/core/src/services/local-secrets.ts
+++ b/packages/core/src/services/local-secrets.ts
@@ -9,81 +9,38 @@ import type { VariablesService } from './variables-service.js'
 export class LocalSecretService implements SecretService {
   private localSecrets: Map<string, string> = new Map()
 
-  // TODO: Drop this fallback once secrets and variables expose aligned typed/raw access paths again.
-  private parseSecret<R>(raw: string): R {
+  private parseSecret<T>(raw: string): T {
     try {
-      return JSON.parse(raw) as R
+      return JSON.parse(raw) as T
     } catch {
-      return raw as unknown as R
+      return raw as unknown as T
     }
   }
 
-  /**
-   * Creates an instance of LocalSecretService.
-   */
   constructor(
     private variables: VariablesService = new LocalVariablesService()
   ) {}
 
-  /**
-   * Retrieves a secret by key.
-   * Checks local storage first, then falls back to environment variables.
-   * @param key - The key of the secret to retrieve.
-   * @returns A promise that resolves to the secret value.
-   * @throws {Error} If the secret is not found.
-   */
-  public async getSecretJSON<R>(key: string): Promise<R> {
-    // Check local storage first
+  public async getSecret<T = string>(key: string): Promise<T> {
     const localValue = this.localSecrets.get(key)
     if (localValue) {
-      return this.parseSecret(localValue)
+      return this.parseSecret<T>(localValue)
     }
 
-    // Fall back to environment variables
     const value = await this.variables.get(key)
     if (value) {
-      return this.parseSecret(value)
+      return this.parseSecret<T>(value)
     }
     throw new Error('Requested secret not found')
   }
 
-  /**
-   * Retrieves a secret by key.
-   * Checks local storage first, then falls back to environment variables.
-   * @param key - The key of the secret to retrieve.
-   * @returns A promise that resolves to the secret value.
-   * @throws {Error} If the secret is not found.
-   */
-  public async getSecret(key: string): Promise<string> {
-    // Check local storage first
-    const localValue = this.localSecrets.get(key)
-    if (localValue) {
-      return localValue
-    }
-
-    // Fall back to environment variables
-    const value = await this.variables.get(key)
-    if (value) {
-      return value
-    }
-    throw new Error('Requested secret not found')
+  public async setSecret(key: string, value: unknown): Promise<void> {
+    this.localSecrets.set(
+      key,
+      typeof value === 'string' ? value : JSON.stringify(value)
+    )
   }
 
-  /**
-   * Stores a JSON value as a secret in local storage.
-   * @param key - The key to store the secret under.
-   * @param value - The JSON value to store.
-   * @returns A promise that resolves when the secret is stored.
-   */
-  public async setSecretJSON(key: string, value: unknown): Promise<void> {
-    this.localSecrets.set(key, JSON.stringify(value))
-  }
-
-  /**
-   * Checks if a secret exists without throwing.
-   * @param key - The key of the secret to check.
-   * @returns A promise that resolves to true if the secret exists.
-   */
   public async hasSecret(key: string): Promise<boolean> {
     if (this.localSecrets.has(key)) {
       return true
@@ -92,11 +49,6 @@ export class LocalSecretService implements SecretService {
     return value !== undefined && value !== null && value !== ''
   }
 
-  /**
-   * Deletes a secret from local storage.
-   * @param key - The key of the secret to delete.
-   * @returns A promise that resolves when the secret is deleted.
-   */
   public async deleteSecret(key: string): Promise<void> {
     this.localSecrets.delete(key)
   }

--- a/packages/core/src/services/local-variables.test.ts
+++ b/packages/core/src/services/local-variables.test.ts
@@ -51,7 +51,7 @@ describe('LocalVariablesService', () => {
   test('should set JSON variable', () => {
     const service = new LocalVariablesService({})
     service.set('DATA', { key: 'val' })
-    assert.strictEqual(service.get('DATA'), '{"key":"val"}')
+    assert.deepStrictEqual(service.get('DATA'), { key: 'val' })
   })
 
   test('should handle has with undefined value', () => {

--- a/packages/core/src/services/local-variables.test.ts
+++ b/packages/core/src/services/local-variables.test.ts
@@ -39,18 +39,18 @@ describe('LocalVariablesService', () => {
 
   test('should get JSON variable', () => {
     const service = new LocalVariablesService({ DATA: '{"key":"val"}' })
-    const result = service.getJSON('DATA')
+    const result = service.get('DATA')
     assert.deepStrictEqual(result, { key: 'val' })
   })
 
   test('should return undefined for missing JSON variable', () => {
     const service = new LocalVariablesService({})
-    assert.strictEqual(service.getJSON('MISSING'), undefined)
+    assert.strictEqual(service.get('MISSING'), undefined)
   })
 
   test('should set JSON variable', () => {
     const service = new LocalVariablesService({})
-    service.setJSON('DATA', { key: 'val' })
+    service.set('DATA', { key: 'val' })
     assert.strictEqual(service.get('DATA'), '{"key":"val"}')
   })
 

--- a/packages/core/src/services/local-variables.ts
+++ b/packages/core/src/services/local-variables.ts
@@ -5,28 +5,23 @@ export class LocalVariablesService implements VariablesService {
     private variables: Record<string, string | undefined> = process.env
   ) {}
 
-  public getAll():
-    | Promise<Record<string, string | undefined>>
-    | Record<string, string | undefined> {
+  public getAll(): Record<string, string | undefined> {
     return this.variables || {}
   }
 
-  public get(name: string): Promise<string | undefined> | string | undefined {
-    return this.variables[name]
+  public get<T = string>(name: string): T | undefined {
+    const raw = this.variables[name]
+    if (raw === undefined) return undefined
+    try {
+      return JSON.parse(raw) as T
+    } catch {
+      return raw as unknown as T
+    }
   }
 
-  public getJSON<T = unknown>(name: string): T | undefined {
-    const value = this.variables[name]
-    if (value === undefined) return undefined
-    return JSON.parse(value)
-  }
-
-  public set(name: string, value: string): void {
-    this.variables[name] = value
-  }
-
-  public setJSON(name: string, value: unknown): void {
-    this.variables[name] = JSON.stringify(value)
+  public set(name: string, value: unknown): void {
+    this.variables[name] =
+      typeof value === 'string' ? value : JSON.stringify(value)
   }
 
   public has(name: string): boolean {

--- a/packages/core/src/services/scoped-secret-service.test.ts
+++ b/packages/core/src/services/scoped-secret-service.test.ts
@@ -3,10 +3,9 @@ import assert from 'node:assert'
 import { ScopedSecretService } from './scoped-secret-service.js'
 
 const createMockSecrets = () => ({
-  getSecret: async (key: string) => `value-of-${key}`,
-  getSecretJSON: async (key: string) => ({ key }),
+  getSecret: async <T>(key: string) => ({ key }) as T,
   hasSecret: async () => true,
-  setSecretJSON: async () => {},
+  setSecret: async () => {},
   deleteSecret: async () => {},
 })
 
@@ -15,7 +14,7 @@ describe('ScopedSecretService', () => {
     const mock = createMockSecrets()
     const scoped = new ScopedSecretService(mock, new Set(['KEY1', 'KEY2']))
     const result = await scoped.getSecret('KEY1')
-    assert.strictEqual(result, 'value-of-KEY1')
+    assert.deepStrictEqual(result, { key: 'KEY1' })
   })
 
   test('should deny access to non-allowed keys', async () => {
@@ -26,17 +25,17 @@ describe('ScopedSecretService', () => {
     })
   })
 
-  test('should allow getSecretJSON for allowed keys', async () => {
+  test('should allow getSecret for allowed keys', async () => {
     const mock = createMockSecrets()
     const scoped = new ScopedSecretService(mock, new Set(['KEY1']))
-    const result = await scoped.getSecretJSON('KEY1')
+    const result = await scoped.getSecret('KEY1')
     assert.deepStrictEqual(result, { key: 'KEY1' })
   })
 
-  test('should deny getSecretJSON for non-allowed keys', async () => {
+  test('should deny getSecret for non-allowed keys', async () => {
     const mock = createMockSecrets()
     const scoped = new ScopedSecretService(mock, new Set(['KEY1']))
-    await assert.rejects(() => scoped.getSecretJSON('FORBIDDEN'), {
+    await assert.rejects(() => scoped.getSecret('FORBIDDEN'), {
       message: 'Access denied to secret key: FORBIDDEN',
     })
   })
@@ -56,11 +55,11 @@ describe('ScopedSecretService', () => {
     })
   })
 
-  test('should always throw on setSecretJSON', async () => {
+  test('should always throw on setSecret', async () => {
     const mock = createMockSecrets()
     const scoped = new ScopedSecretService(mock, new Set(['KEY1']))
-    await assert.rejects(() => scoped.setSecretJSON('KEY1', 'val'), {
-      message: 'setSecretJSON is not allowed in scoped secret service',
+    await assert.rejects(() => scoped.setSecret('KEY1', 'val'), {
+      message: 'setSecret is not allowed in scoped secret service',
     })
   })
 

--- a/packages/core/src/services/scoped-secret-service.ts
+++ b/packages/core/src/services/scoped-secret-service.ts
@@ -16,14 +16,9 @@ export class ScopedSecretService implements SecretService {
     }
   }
 
-  async getSecret(key: string): Promise<string> {
+  async getSecret<T = string>(key: string): Promise<T> {
     this.assertAllowed(key)
-    return this.secrets.getSecret(key)
-  }
-
-  async getSecretJSON<T = {}>(key: string): Promise<T> {
-    this.assertAllowed(key)
-    return this.secrets.getSecretJSON<T>(key)
+    return this.secrets.getSecret<T>(key)
   }
 
   async hasSecret(key: string): Promise<boolean> {
@@ -31,8 +26,8 @@ export class ScopedSecretService implements SecretService {
     return this.secrets.hasSecret(key)
   }
 
-  async setSecretJSON(_key: string, _value: unknown): Promise<void> {
-    throw new Error('setSecretJSON is not allowed in scoped secret service')
+  async setSecret(_key: string, _value: unknown): Promise<void> {
+    throw new Error('setSecret is not allowed in scoped secret service')
   }
 
   async deleteSecret(_key: string): Promise<void> {

--- a/packages/core/src/services/secret-service.ts
+++ b/packages/core/src/services/secret-service.ts
@@ -3,19 +3,12 @@
  */
 export interface SecretService {
   /**
-   * Retrieves a secret by key and parses it as JSON.
-   * @param key - The key of the secret to retrieve.
-   * @returns A promise that resolves to the parsed secret value.
-   * @throws If the secret is not found.
-   */
-  getSecretJSON<Return = {}>(key: string): Promise<Return>
-  /**
-   * Retrieves a secret by key as a string.
+   * Retrieves a secret by key, typed as T (defaults to string).
    * @param key - The key of the secret to retrieve.
    * @returns A promise that resolves to the secret value.
    * @throws If the secret is not found.
    */
-  getSecret(key: string): Promise<string>
+  getSecret<T = string>(key: string): Promise<T>
   /**
    * Checks if a secret exists without throwing.
    * @param key - The key of the secret to check.
@@ -23,12 +16,12 @@ export interface SecretService {
    */
   hasSecret(key: string): Promise<boolean>
   /**
-   * Stores a JSON value as a secret.
+   * Stores a secret value.
    * @param key - The key to store the secret under.
-   * @param value - The JSON value to store.
+   * @param value - The value to store.
    * @returns A promise that resolves when the secret is stored.
    */
-  setSecretJSON(key: string, value: unknown): Promise<void>
+  setSecret(key: string, value: unknown): Promise<void>
   /**
    * Deletes a secret by key.
    * @param key - The key of the secret to delete.

--- a/packages/core/src/services/typed-secret-service.test.ts
+++ b/packages/core/src/services/typed-secret-service.test.ts
@@ -3,18 +3,17 @@ import assert from 'node:assert'
 import { TypedSecretService } from './typed-secret-service.js'
 
 const createMockSecrets = (store: Map<string, string> = new Map()) => ({
-  getSecret: async (key: string) => {
+  getSecret: async <T = string>(key: string): Promise<T> => {
     const val = store.get(key)
     if (!val) throw new Error(`Not found: ${key}`)
-    return val
-  },
-  getSecretJSON: async (key: string) => {
-    const val = store.get(key)
-    if (!val) throw new Error(`Not found: ${key}`)
-    return JSON.parse(val)
+    try {
+      return JSON.parse(val) as T
+    } catch {
+      return val as unknown as T
+    }
   },
   hasSecret: async (key: string) => store.has(key),
-  setSecretJSON: async (key: string, value: unknown) => {
+  setSecret: async (key: string, value: unknown) => {
     store.set(key, JSON.stringify(value))
   },
   deleteSecret: async (key: string) => {
@@ -24,42 +23,42 @@ const createMockSecrets = (store: Map<string, string> = new Map()) => ({
 
 describe('TypedSecretService', () => {
   test('should delegate getSecret to underlying service', async () => {
-    const store = new Map([['API_KEY', 'sk-123']])
+    const store = new Map([['API_KEY', '"sk-123"']])
     const service = new TypedSecretService(createMockSecrets(store), {})
     const result = await service.getSecret('API_KEY')
     assert.strictEqual(result, 'sk-123')
   })
 
-  test('should delegate getSecretJSON to underlying service', async () => {
+  test('should delegate getSecret with type to underlying service', async () => {
     const store = new Map([['CONFIG', '{"port":3000}']])
     const service = new TypedSecretService(createMockSecrets(store), {})
-    const result = await service.getSecretJSON('CONFIG')
+    const result = await service.getSecret<{ port: number }>('CONFIG')
     assert.deepStrictEqual(result, { port: 3000 })
   })
 
   test('should delegate hasSecret to underlying service', async () => {
-    const store = new Map([['EXISTS', 'val']])
+    const store = new Map([['EXISTS', '"val"']])
     const service = new TypedSecretService(createMockSecrets(store), {})
     assert.strictEqual(await service.hasSecret('EXISTS'), true)
     assert.strictEqual(await service.hasSecret('MISSING'), false)
   })
 
-  test('should delegate setSecretJSON to underlying service', async () => {
+  test('should delegate setSecret to underlying service', async () => {
     const store = new Map<string, string>()
     const service = new TypedSecretService(createMockSecrets(store), {})
-    await service.setSecretJSON('NEW_KEY', { data: 'val' })
+    await service.setSecret('NEW_KEY', { data: 'val' })
     assert.strictEqual(store.get('NEW_KEY'), '{"data":"val"}')
   })
 
   test('should delegate deleteSecret to underlying service', async () => {
-    const store = new Map([['KEY', 'val']])
+    const store = new Map([['KEY', '"val"']])
     const service = new TypedSecretService(createMockSecrets(store), {})
     await service.deleteSecret('KEY')
     assert.strictEqual(store.has('KEY'), false)
   })
 
   test('should get all status for credentials', async () => {
-    const store = new Map([['STRIPE_KEY', 'sk-123']])
+    const store = new Map([['STRIPE_KEY', '"sk-123"']])
     const meta = {
       STRIPE_KEY: { name: 'stripe', displayName: 'Stripe' },
       GITHUB_TOKEN: {
@@ -80,7 +79,7 @@ describe('TypedSecretService', () => {
   })
 
   test('should get missing credentials', async () => {
-    const store = new Map([['STRIPE_KEY', 'sk-123']])
+    const store = new Map([['STRIPE_KEY', '"sk-123"']])
     const meta = {
       STRIPE_KEY: { name: 'stripe', displayName: 'Stripe' },
       GITHUB_TOKEN: { name: 'github', displayName: 'GitHub' },

--- a/packages/core/src/services/typed-secret-service.ts
+++ b/packages/core/src/services/typed-secret-service.ts
@@ -22,13 +22,9 @@ export class TypedSecretService<
     private credentialsMeta: Record<string, CredentialMeta>
   ) {}
 
-  async getSecretJSON<K extends keyof TMap & string>(key: K): Promise<TMap[K]>
-  async getSecretJSON<T = unknown>(key: string): Promise<T>
-  async getSecretJSON(key: string): Promise<unknown> {
-    return this.secrets.getSecretJSON(key)
-  }
-
-  async getSecret(key: string): Promise<string> {
+  async getSecret<K extends keyof TMap & string>(key: K): Promise<TMap[K]>
+  async getSecret<T = string>(key: string): Promise<T>
+  async getSecret(key: string): Promise<unknown> {
     return this.secrets.getSecret(key)
   }
 
@@ -36,11 +32,11 @@ export class TypedSecretService<
     return this.secrets.hasSecret(key)
   }
 
-  async setSecretJSON<K extends string>(
+  async setSecret<K extends string>(
     key: K,
     value: K extends keyof TMap ? TMap[K] : unknown
   ): Promise<void> {
-    return this.secrets.setSecretJSON(key, value)
+    return this.secrets.setSecret(key, value)
   }
 
   async deleteSecret(key: string): Promise<void> {

--- a/packages/core/src/services/typed-variables-service.test.ts
+++ b/packages/core/src/services/typed-variables-service.test.ts
@@ -36,14 +36,14 @@ describe('TypedVariablesService', () => {
     assert.strictEqual(service.has('DB_URL'), false)
   })
 
-  test('should delegate getJSON to underlying service', () => {
+  test('should delegate get to underlying service', () => {
     const service = createService({ DATA: '{"key":"val"}' })
-    assert.deepStrictEqual(service.getJSON('DATA'), { key: 'val' })
+    assert.deepStrictEqual(service.get('DATA'), { key: 'val' })
   })
 
-  test('should delegate setJSON to underlying service', () => {
+  test('should delegate set to underlying service', () => {
     const service = createService()
-    service.setJSON('DATA', { key: 'val' })
+    service.set('DATA', { key: 'val' })
     assert.strictEqual(service.get('DATA'), '{"key":"val"}')
   })
 

--- a/packages/core/src/services/typed-variables-service.test.ts
+++ b/packages/core/src/services/typed-variables-service.test.ts
@@ -44,7 +44,7 @@ describe('TypedVariablesService', () => {
   test('should delegate set to underlying service', () => {
     const service = createService()
     service.set('DATA', { key: 'val' })
-    assert.strictEqual(service.get('DATA'), '{"key":"val"}')
+    assert.deepStrictEqual(service.get('DATA'), { key: 'val' })
   })
 
   test('should get all status for configured variables', async () => {

--- a/packages/core/src/services/typed-variables-service.ts
+++ b/packages/core/src/services/typed-variables-service.ts
@@ -20,20 +20,12 @@ export class TypedVariablesService<
     private variablesMeta: Record<string, VariableMeta>
   ) {}
 
-  get(
-    name: keyof TMap & string
-  ): Promise<string | undefined> | string | undefined
-  get(name: string): Promise<string | undefined> | string | undefined
-  get(name: string): Promise<string | undefined> | string | undefined {
-    return this.variables.get(name)
-  }
-
-  getJSON<K extends keyof TMap & string>(
+  get<K extends keyof TMap & string>(
     name: K
   ): Promise<TMap[K] | undefined> | TMap[K] | undefined
-  getJSON<T = unknown>(name: string): Promise<T | undefined> | T | undefined
-  getJSON(name: string): Promise<unknown> | unknown {
-    return this.variables.getJSON(name)
+  get<T = string>(name: string): Promise<T | undefined> | T | undefined
+  get(name: string): Promise<unknown> | unknown {
+    return this.variables.get(name)
   }
 
   getAll():
@@ -42,12 +34,8 @@ export class TypedVariablesService<
     return this.variables.getAll()
   }
 
-  set(name: string, value: string): Promise<void> | void {
+  set(name: string, value: unknown): Promise<void> | void {
     return this.variables.set(name, value)
-  }
-
-  setJSON(name: string, value: unknown): Promise<void> | void {
-    return this.variables.setJSON(name, value)
   }
 
   has(name: string): Promise<boolean> | boolean {

--- a/packages/core/src/services/variables-service.ts
+++ b/packages/core/src/services/variables-service.ts
@@ -1,11 +1,9 @@
 export interface VariablesService {
-  get: (name: string) => Promise<string | undefined> | string | undefined
-  getJSON: <T = unknown>(name: string) => Promise<T | undefined> | T | undefined
+  get<T = string>(name: string): Promise<T | undefined> | T | undefined
   getAll: () =>
     | Promise<Record<string, string | undefined>>
     | Record<string, string | undefined>
-  set: (name: string, value: string) => Promise<void> | void
-  setJSON: (name: string, value: unknown) => Promise<void> | void
+  set: (name: string, value: unknown) => Promise<void> | void
   has: (name: string) => Promise<boolean> | boolean
   delete: (name: string) => Promise<void> | void
 }

--- a/packages/core/src/testing/service-tests.ts
+++ b/packages/core/src/testing/service-tests.ts
@@ -782,13 +782,13 @@ export function defineServiceTests(config: ServiceTestConfig): void {
     const kek = 'test-key-encryption-key-32chars!'
 
     describe(`SecretService [${name}]`, () => {
-      test('setSecretJSON and getSecretJSON', async () => {
+      test('setSecret and getSecret', async () => {
         const service = await factory({ key: kek })
-        await service.setSecretJSON('api-key', {
+        await service.setSecret('api-key', {
           token: 'sk-123',
           endpoint: 'https://api.example.com',
         })
-        const result = await service.getSecretJSON<{
+        const result = await service.getSecret<{
           token: string
           endpoint: string
         }>('api-key')
@@ -800,7 +800,7 @@ export function defineServiceTests(config: ServiceTestConfig): void {
 
       test('getSecret returns raw string', async () => {
         const service = await factory({ key: kek })
-        await service.setSecretJSON('string-secret', 'plain-value')
+        await service.setSecret('string-secret', 'plain-value')
         const result = await service.getSecret('string-secret')
         assert.strictEqual(result, '"plain-value"')
       })
@@ -818,17 +818,17 @@ export function defineServiceTests(config: ServiceTestConfig): void {
         })
       })
 
-      test('setSecretJSON upserts existing key', async () => {
+      test('setSecret upserts existing key', async () => {
         const service = await factory({ key: kek })
-        await service.setSecretJSON('upsert-key', { v: 1 })
-        await service.setSecretJSON('upsert-key', { v: 2 })
-        const result = await service.getSecretJSON<{ v: number }>('upsert-key')
+        await service.setSecret('upsert-key', { v: 1 })
+        await service.setSecret('upsert-key', { v: 2 })
+        const result = await service.getSecret<{ v: number }>('upsert-key')
         assert.deepEqual(result, { v: 2 })
       })
 
       test('deleteSecret removes the key', async () => {
         const service = await factory({ key: kek })
-        await service.setSecretJSON('to-delete', 'bye')
+        await service.setSecret('to-delete', 'bye')
         assert.strictEqual(await service.hasSecret('to-delete'), true)
         await service.deleteSecret('to-delete')
         assert.strictEqual(await service.hasSecret('to-delete'), false)
@@ -837,7 +837,7 @@ export function defineServiceTests(config: ServiceTestConfig): void {
       test('rotateKEK re-wraps all secrets', async () => {
         const newKEK = 'new-key-encryption-key-rotated!'
         const oldService = await factory({ key: kek })
-        await oldService.setSecretJSON('rotate-test', { important: 'data' })
+        await oldService.setSecret('rotate-test', { important: 'data' })
 
         const rotatedService = await factory({
           key: newKEK,
@@ -845,7 +845,7 @@ export function defineServiceTests(config: ServiceTestConfig): void {
           previousKey: kek,
         })
 
-        const before = await rotatedService.getSecretJSON<{
+        const before = await rotatedService.getSecret<{
           important: string
         }>('rotate-test')
         assert.deepEqual(before, { important: 'data' })
@@ -858,7 +858,7 @@ export function defineServiceTests(config: ServiceTestConfig): void {
           key: newKEK,
           keyVersion: 2,
         })
-        const after = await newOnlyService.getSecretJSON<{
+        const after = await newOnlyService.getSecret<{
           important: string
         }>('rotate-test')
         assert.deepEqual(after, { important: 'data' })

--- a/packages/core/src/testing/service-tests.ts
+++ b/packages/core/src/testing/service-tests.ts
@@ -802,7 +802,7 @@ export function defineServiceTests(config: ServiceTestConfig): void {
         const service = await factory({ key: kek })
         await service.setSecret('string-secret', 'plain-value')
         const result = await service.getSecret('string-secret')
-        assert.strictEqual(result, '"plain-value"')
+        assert.strictEqual(result, 'plain-value')
       })
 
       test('hasSecret returns true/false', async () => {

--- a/packages/core/src/wirings/oauth2/oauth2-client.test.ts
+++ b/packages/core/src/wirings/oauth2/oauth2-client.test.ts
@@ -14,9 +14,8 @@ function createMockSecretService(
 ): SecretService & { getStoredSecrets: () => Map<string, unknown> } {
   const secrets = new Map<string, unknown>(Object.entries(initialSecrets))
   return {
-    getSecret: async (key: string) => secrets.get(key) as string,
-    getSecretJSON: async <T>(key: string) => secrets.get(key) as T,
-    setSecretJSON: async (key: string, value: unknown) => {
+    getSecret: async <T = string>(key: string) => secrets.get(key) as T,
+    setSecret: async (key: string, value: unknown) => {
       secrets.set(key, value)
     },
     deleteSecret: async (_key: string) => {

--- a/packages/core/src/wirings/oauth2/oauth2-client.ts
+++ b/packages/core/src/wirings/oauth2/oauth2-client.ts
@@ -124,7 +124,7 @@ export class OAuth2Client {
     }
 
     // Load from secrets
-    const token = await this.secrets.getSecretJSON<OAuth2Token>(
+    const token = await this.secrets.getSecret<OAuth2Token>(
       this.oauth2Config.tokenSecretId
     )
     this.cachedToken = token
@@ -209,7 +209,7 @@ export class OAuth2Client {
       scope: data.scope,
     }
 
-    await this.secrets.setSecretJSON(this.oauth2Config.tokenSecretId, token)
+    await this.secrets.setSecret(this.oauth2Config.tokenSecretId, token)
     this.cachedToken = token
 
     return token
@@ -233,7 +233,7 @@ export class OAuth2Client {
       return this.cachedAppCredential
     }
     this.cachedAppCredential =
-      await this.secrets.getSecretJSON<OAuth2AppCredential>(
+      await this.secrets.getSecret<OAuth2AppCredential>(
         this.appCredentialSecretId
       )
     return this.cachedAppCredential

--- a/packages/services/aws-services/src/aws-secrets.ts
+++ b/packages/services/aws-services/src/aws-secrets.ts
@@ -13,20 +13,17 @@ export class AWSSecrets implements SecretService {
     this.client = new SecretsManagerClient({ region: config.awsRegion })
   }
 
-  public async getSecretJSON<Result = string>(
-    SecretId: string
-  ): Promise<Result> {
-    const secretValue = await this.getSecret(SecretId)
-    return JSON.parse(secretValue)
-  }
-
-  public async getSecret<Result = string>(SecretId: string): Promise<Result> {
+  public async getSecret<T = string>(SecretId: string): Promise<T> {
     try {
       const result = await this.client.send(
         new GetSecretValueCommand({ SecretId })
       )
       if (result.SecretString) {
-        return result.SecretString as any
+        try {
+          return JSON.parse(result.SecretString) as T
+        } catch {
+          return result.SecretString as unknown as T
+        }
       }
       throw new Error(`Secret '${SecretId}' has no string value`)
     } catch (e: any) {
@@ -47,8 +44,8 @@ export class AWSSecrets implements SecretService {
     }
   }
 
-  public async setSecretJSON(_key: string, _value: unknown): Promise<void> {
-    throw new Error('setSecretJSON is not implemented for AWSSecrets')
+  public async setSecret(_key: string, _value: unknown): Promise<void> {
+    throw new Error('setSecret is not implemented for AWSSecrets')
   }
 
   public async deleteSecret(_key: string): Promise<void> {

--- a/packages/services/kysely/src/kysely-secret-service.ts
+++ b/packages/services/kysely/src/kysely-secret-service.ts
@@ -93,7 +93,7 @@ export class KyselySecretService implements SecretService {
     throw new Error(`No KEK available for key_version ${version}`)
   }
 
-  async getSecret(key: string): Promise<string> {
+  async getSecret<T = string>(key: string): Promise<T> {
     const row = await this.db
       .selectFrom('secrets')
       .select(['ciphertext', 'wrappedDek', 'keyVersion'])
@@ -103,18 +103,9 @@ export class KyselySecretService implements SecretService {
     if (!row) throw new Error('Requested secret not found')
 
     const kek = this.getKEK(row.keyVersion)
-    const result = await envelopeDecrypt<string>(
-      kek,
-      row.ciphertext,
-      row.wrappedDek
-    )
+    const result = await envelopeDecrypt<T>(kek, row.ciphertext, row.wrappedDek)
     await this.logAudit(key, 'read')
     return result
-  }
-
-  async getSecretJSON<R = {}>(key: string): Promise<R> {
-    const raw = await this.getSecret(key)
-    return JSON.parse(raw) as R
   }
 
   async hasSecret(key: string): Promise<boolean> {
@@ -126,12 +117,8 @@ export class KyselySecretService implements SecretService {
     return !!row
   }
 
-  async setSecretJSON(key: string, value: unknown): Promise<void> {
-    const plaintext = JSON.stringify(value)
-    const { ciphertext, wrappedDEK } = await envelopeEncrypt(
-      this.key,
-      plaintext
-    )
+  async setSecret(key: string, value: unknown): Promise<void> {
+    const { ciphertext, wrappedDEK } = await envelopeEncrypt(this.key, value)
     const now = new Date().toISOString()
 
     await this.db

--- a/packages/services/kysely/src/kysely-services.test.ts
+++ b/packages/services/kysely/src/kysely-services.test.ts
@@ -128,7 +128,7 @@ function registerTests(
         auditReads: true,
       })
       await service.init()
-      await service.setSecretJSON('audit-test', 'value')
+      await service.setSecret('audit-test', 'value')
       await service.getSecret('audit-test')
       await service.deleteSecret('audit-test')
 
@@ -152,7 +152,7 @@ function registerTests(
         auditReads: false,
       })
       await service.init()
-      await service.setSecretJSON('no-read-audit', 'value')
+      await service.setSecret('no-read-audit', 'value')
       await service.getSecret('no-read-audit')
 
       const logs = await getDb()

--- a/packages/services/mongodb/src/mongodb-secret-service.ts
+++ b/packages/services/mongodb/src/mongodb-secret-service.ts
@@ -87,23 +87,14 @@ export class MongoDBSecretService implements SecretService {
     throw new Error(`No KEK available for key_version ${version}`)
   }
 
-  async getSecret(key: string): Promise<string> {
+  async getSecret<T = string>(key: string): Promise<T> {
     const row = await this.secrets.findOne({ _id: key })
     if (!row) throw new Error('Requested secret not found')
 
     const kek = this.getKEK(row.keyVersion)
-    const result = await envelopeDecrypt<string>(
-      kek,
-      row.ciphertext,
-      row.wrappedDek
-    )
+    const result = await envelopeDecrypt<T>(kek, row.ciphertext, row.wrappedDek)
     await this.logAudit(key, 'read')
     return result
-  }
-
-  async getSecretJSON<R = {}>(key: string): Promise<R> {
-    const raw = await this.getSecret(key)
-    return JSON.parse(raw) as R
   }
 
   async hasSecret(key: string): Promise<boolean> {
@@ -111,12 +102,8 @@ export class MongoDBSecretService implements SecretService {
     return count > 0
   }
 
-  async setSecretJSON(key: string, value: unknown): Promise<void> {
-    const plaintext = JSON.stringify(value)
-    const { ciphertext, wrappedDEK } = await envelopeEncrypt(
-      this.key,
-      plaintext
-    )
+  async setSecret(key: string, value: unknown): Promise<void> {
+    const { ciphertext, wrappedDEK } = await envelopeEncrypt(this.key, value)
     const now = new Date()
 
     await this.secrets.updateOne(

--- a/packages/services/mongodb/src/mongodb-services.test.ts
+++ b/packages/services/mongodb/src/mongodb-services.test.ts
@@ -71,7 +71,7 @@ function registerTests(name: string, getDb: () => Db) {
         auditReads: true,
       })
       await service.init()
-      await service.setSecretJSON('audit-test', 'value')
+      await service.setSecret('audit-test', 'value')
       await service.getSecret('audit-test')
       await service.deleteSecret('audit-test')
 
@@ -94,7 +94,7 @@ function registerTests(name: string, getDb: () => Db) {
         auditReads: false,
       })
       await service.init()
-      await service.setSecretJSON('no-read-audit', 'value')
+      await service.setSecret('no-read-audit', 'value')
       await service.getSecret('no-read-audit')
 
       const logs = await getDb()

--- a/packages/services/redis/src/redis-secret-service.test.ts
+++ b/packages/services/redis/src/redis-secret-service.test.ts
@@ -35,11 +35,11 @@ describe('RedisSecretService', () => {
       keyPrefix: 'app2',
     })
 
-    await s1.setSecretJSON('shared-name', { from: 'app1' })
-    await s2.setSecretJSON('shared-name', { from: 'app2' })
+    await s1.setSecret('shared-name', { from: 'app1' })
+    await s2.setSecret('shared-name', { from: 'app2' })
 
-    const r1 = await s1.getSecretJSON<{ from: string }>('shared-name')
-    const r2 = await s2.getSecretJSON<{ from: string }>('shared-name')
+    const r1 = await s1.getSecret<{ from: string }>('shared-name')
+    const r2 = await s2.getSecret<{ from: string }>('shared-name')
 
     assert.deepEqual(r1, { from: 'app1' })
     assert.deepEqual(r2, { from: 'app2' })

--- a/packages/services/redis/src/redis-secret-service.ts
+++ b/packages/services/redis/src/redis-secret-service.ts
@@ -56,17 +56,12 @@ export class RedisSecretService implements SecretService {
     throw new Error(`No KEK available for key_version ${version}`)
   }
 
-  async getSecret(key: string): Promise<string> {
+  async getSecret<T = string>(key: string): Promise<T> {
     const data = await this.redis.hgetall(this.secretKey(key))
     if (!data.ciphertext) throw new Error('Requested secret not found')
 
     const kek = this.getKEK(Number(data.key_version))
-    return envelopeDecrypt<string>(kek, data.ciphertext!, data.wrapped_dek!)
-  }
-
-  async getSecretJSON<R = {}>(key: string): Promise<R> {
-    const raw = await this.getSecret(key)
-    return JSON.parse(raw) as R
+    return envelopeDecrypt<T>(kek, data.ciphertext!, data.wrapped_dek!)
   }
 
   async hasSecret(key: string): Promise<boolean> {
@@ -74,12 +69,8 @@ export class RedisSecretService implements SecretService {
     return exists === 1
   }
 
-  async setSecretJSON(key: string, value: unknown): Promise<void> {
-    const plaintext = JSON.stringify(value)
-    const { ciphertext, wrappedDEK } = await envelopeEncrypt(
-      this.key,
-      plaintext
-    )
+  async setSecret(key: string, value: unknown): Promise<void> {
+    const { ciphertext, wrappedDEK } = await envelopeEncrypt(this.key, value)
 
     await this.redis.hset(this.secretKey(key), {
       ciphertext,

--- a/verifiers/secrets/src/test-secrets.ts
+++ b/verifiers/secrets/src/test-secrets.ts
@@ -30,22 +30,21 @@ void ({
 
 // Inline VariablesService that reads from process.env
 class EnvVariablesService implements VariablesService {
-  get(key: string): string | undefined {
-    return process.env[key]
-  }
-  getJSON<T = unknown>(name: string): T | undefined {
-    const value = process.env[name]
-    if (value === undefined) return undefined
-    return JSON.parse(value)
+  get<T = string>(key: string): T | undefined {
+    const raw = process.env[key]
+    if (raw === undefined) return undefined
+    try {
+      return JSON.parse(raw) as T
+    } catch {
+      return raw as unknown as T
+    }
   }
   getAll(): Record<string, string> {
     return process.env as Record<string, string>
   }
-  set(name: string, value: string): void {
-    process.env[name] = value
-  }
-  setJSON(name: string, value: unknown): void {
-    process.env[name] = JSON.stringify(value)
+  set(name: string, value: unknown): void {
+    process.env[name] =
+      typeof value === 'string' ? value : JSON.stringify(value)
   }
   has(name: string): boolean {
     return process.env[name] !== undefined
@@ -70,10 +69,10 @@ async function testTypedSecretService() {
   const secretService = new LocalSecretService(variablesService)
   const secrets = new TypedSecretService(secretService)
 
-  // Test 1: getSecretJSON() returns correct types
-  console.log('Test 1: Type inference for getSecretJSON()')
+  // Test 1: getSecret() returns correct types
+  console.log('Test 1: Type inference for getSecret()')
 
-  const apiCreds = await secrets.getSecretJSON('EXAMPLE_API_CREDENTIALS')
+  const apiCreds = await secrets.getSecret('EXAMPLE_API_CREDENTIALS')
   console.log(`  EXAMPLE_API_CREDENTIALS.apiKey: ${apiCreds.apiKey}`)
   console.log(`  EXAMPLE_API_CREDENTIALS.apiSecret: ${apiCreds.apiSecret}`)
   console.log(`  EXAMPLE_API_CREDENTIALS.baseUrl: ${apiCreds.baseUrl}`)
@@ -123,15 +122,15 @@ async function testTypedSecretService() {
     throw new Error(`Expected 1 missing secret, got ${missingCreds.length}`)
   }
 
-  // Test 6: setSecretJSON() type enforcement
-  console.log('\nTest 6: setSecretJSON() type enforcement')
-  await secrets.setSecretJSON('EXAMPLE_API_CREDENTIALS', {
+  // Test 6: setSecret() type enforcement
+  console.log('\nTest 6: setSecret() type enforcement')
+  await secrets.setSecret('EXAMPLE_API_CREDENTIALS', {
     apiKey: 'new-key',
     apiSecret: 'new-secret',
     // @ts-expect-error - extra properties should cause type error
     extraProperty: 5,
   })
-  console.log('  setSecretJSON() rejects extra properties at compile time')
+  console.log('  setSecret() rejects extra properties at compile time')
 
   console.log('\n✓ All TypedSecretService tests passed!')
 }


### PR DESCRIPTION
…SON/setJSON

Remove JSON-suffix methods from SecretService and VariablesService. The correct API is generic getSecret<T>/get<T> with value: unknown setters. Envelope-encrypted stores pass value directly to envelopeEncrypt (no pre-stringify). Non-crypto stores: strings pass through as-is, objects get JSON.stringify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Revert**
  * Restored the unified generic secret and variable get/set APIs (with automatic JSON (de)serialization) by reverting the prior JSON-specific helpers.
  * Updated console helpers, generated addon templates, CLI wirings, and service integrations to use the restored generic APIs.
  * Adjusted test suites and end-to-end seeding to match the reverted API surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->