### PR TITLE
feat(cli): flatten dev config — sqliteDb + content replace dev.db/dev.content

### DIFF
--- a/.changeset/flatten-dev-config.md
+++ b/.changeset/flatten-dev-config.md
@@ -1,0 +1,22 @@
+---
+"@pikku/cli": minor
+---
+
+Flatten `createConfig` dev fields: replace `dev: { db, content }` with top-level `sqliteDb: string` and `content: { contentPath?, uploadUrlPrefix?, assetUrlPrefix?, sizeLimit? }`.
+
+**Migration:** update your `createConfig` export:
+
+```ts
+// before
+export const createConfig = pikkuConfig(async () => ({
+  dev: { db: true, content: true },
+}))
+
+// after
+export const createConfig = pikkuConfig(async () => ({
+  sqliteDb: '.pikku-runtime/dev.db',
+  content: {},
+}))
+```
+
+For test helpers that override the db path, replace `{ ...config, dev: { db: { file: dbFile } } }` with `{ ...config, sqliteDb: dbFile }`.

--- a/.changeset/flatten-dev-config.md
+++ b/.changeset/flatten-dev-config.md
@@ -1,5 +1,5 @@
 ---
-"@pikku/cli": minor
+"@pikku/cli": patch
 ---
 
 Flatten `createConfig` dev fields: replace `dev: { db, content }` with top-level `sqliteDb: string` and `content: { contentPath?, uploadUrlPrefix?, assetUrlPrefix?, sizeLimit? }`.

--- a/packages/cli/src/fabric/functions/validate.function.ts
+++ b/packages/cli/src/fabric/functions/validate.function.ts
@@ -460,7 +460,7 @@ export async function runValidate(
         'config-missing',
         'packages/functions/src/config.ts not found',
         join(fnDir, 'src', 'config.ts'),
-        'Create src/config.ts: export const createConfig = pikkuConfig(async () => ({ dev: { db: true } }))'
+        "Create src/config.ts: export const createConfig = pikkuConfig(async () => ({ sqliteDb: '.pikku-runtime/dev.db' }))"
       )
     }
   }

--- a/packages/cli/src/functions/commands/db-migrate.ts
+++ b/packages/cli/src/functions/commands/db-migrate.ts
@@ -12,16 +12,16 @@ export const dbMigrate = pikkuSessionlessFunc<{}, void>({
     if (!userConfig) return
 
     const resolved = resolveLocalDb(
-      userConfig.dev?.db,
+      userConfig.sqliteDb,
       config.rootDir,
       config.outDir,
       config.runtimeDir
     )
     if (!resolved) {
       logger.error(
-        'pikku db migrate: dev.db is not configured in your pikku config.'
+        'pikku db migrate: sqliteDb is not configured in your createConfig.'
       )
-      throw new Error('dev.db not configured')
+      throw new Error('sqliteDb not configured')
     }
 
     const { migrate, codegen, zod } = await migrateAndCodegen(resolved)

--- a/packages/cli/src/functions/commands/db-reset.ts
+++ b/packages/cli/src/functions/commands/db-reset.ts
@@ -17,16 +17,16 @@ export const dbReset = pikkuSessionlessFunc<{}, void>({
     if (!userConfig) return
 
     const resolved = resolveLocalDb(
-      userConfig.dev?.db,
+      userConfig.sqliteDb,
       config.rootDir,
       config.outDir,
       config.runtimeDir
     )
     if (!resolved) {
       logger.error(
-        'pikku db reset: dev.db is not configured in your pikku config.'
+        'pikku db reset: sqliteDb is not configured in your createConfig.'
       )
-      throw new Error('dev.db not configured')
+      throw new Error('sqliteDb not configured')
     }
 
     reset(resolved, config.rootDir)

--- a/packages/cli/src/functions/commands/db-seed.ts
+++ b/packages/cli/src/functions/commands/db-seed.ts
@@ -12,16 +12,16 @@ export const dbSeed = pikkuSessionlessFunc<{}, void>({
     if (!userConfig) return
 
     const resolved = resolveLocalDb(
-      userConfig.dev?.db,
+      userConfig.sqliteDb,
       config.rootDir,
       config.outDir,
       config.runtimeDir
     )
     if (!resolved) {
       logger.error(
-        'pikku db seed: dev.db is not configured in your pikku config.'
+        'pikku db seed: sqliteDb is not configured in your createConfig.'
       )
-      throw new Error('dev.db not configured')
+      throw new Error('sqliteDb not configured')
     }
 
     const result = await seed(resolved)

--- a/packages/cli/src/functions/commands/db-shared.ts
+++ b/packages/cli/src/functions/commands/db-shared.ts
@@ -4,12 +4,6 @@ import { loadUserModule } from './load-user-project.js'
 
 export interface UserConfigShape {
   sqliteDb?: string
-  content?: {
-    contentPath?: string
-    uploadUrlPrefix?: string
-    assetUrlPrefix?: string
-    sizeLimit?: string
-  }
   [key: string]: unknown
 }
 

--- a/packages/cli/src/functions/commands/db-shared.ts
+++ b/packages/cli/src/functions/commands/db-shared.ts
@@ -44,7 +44,7 @@ export async function loadUserConfigForDb(
   )
   if (!configFactoryFile) {
     if (hasConventionalDbAssets) {
-      return { sqliteDb: join(config.rootDir, '.pikku-runtime', 'dev.db') }
+      return { sqliteDb: '.pikku-runtime/dev.db' }
     }
     logger.error('createConfig must be defined in your project')
     return null
@@ -58,7 +58,7 @@ export async function loadUserConfigForDb(
       logger.warn(
         `Falling back to default local db config because '${configFactoryFile}' could not be loaded: ${error.message}`
       )
-      return { sqliteDb: join(config.rootDir, '.pikku-runtime', 'dev.db') }
+      return { sqliteDb: '.pikku-runtime/dev.db' }
     }
     throw error
   }
@@ -69,7 +69,7 @@ export async function loadUserConfigForDb(
       logger.warn(
         `Falling back to default local db config because '${configFactoryFile}' does not export createConfig`
       )
-      return { sqliteDb: join(config.rootDir, '.pikku-runtime', 'dev.db') }
+      return { sqliteDb: '.pikku-runtime/dev.db' }
     }
     logger.error(
       `Expected 'createConfig' in '${configFactoryFile}' to be a function`

--- a/packages/cli/src/functions/commands/db-shared.ts
+++ b/packages/cli/src/functions/commands/db-shared.ts
@@ -1,11 +1,14 @@
 import { existsSync } from 'fs'
 import { resolve, join } from 'path'
 import { loadUserModule } from './load-user-project.js'
-import type { DevDbConfig } from '../db/local-db.js'
 
 export interface UserConfigShape {
-  dev?: {
-    db?: DevDbConfig
+  sqliteDb?: string
+  content?: {
+    contentPath?: string
+    uploadUrlPrefix?: string
+    assetUrlPrefix?: string
+    sizeLimit?: string
   }
   [key: string]: unknown
 }
@@ -47,7 +50,7 @@ export async function loadUserConfigForDb(
   )
   if (!configFactoryFile) {
     if (hasConventionalDbAssets) {
-      return { dev: { db: true } }
+      return { sqliteDb: join(config.rootDir, '.pikku-runtime', 'dev.db') }
     }
     logger.error('createConfig must be defined in your project')
     return null
@@ -61,7 +64,7 @@ export async function loadUserConfigForDb(
       logger.warn(
         `Falling back to default local db config because '${configFactoryFile}' could not be loaded: ${error.message}`
       )
-      return { dev: { db: true } }
+      return { sqliteDb: join(config.rootDir, '.pikku-runtime', 'dev.db') }
     }
     throw error
   }
@@ -72,7 +75,7 @@ export async function loadUserConfigForDb(
       logger.warn(
         `Falling back to default local db config because '${configFactoryFile}' does not export createConfig`
       )
-      return { dev: { db: true } }
+      return { sqliteDb: join(config.rootDir, '.pikku-runtime', 'dev.db') }
     }
     logger.error(
       `Expected 'createConfig' in '${configFactoryFile}' to be a function`

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -190,7 +190,7 @@ export const dev = pikkuSessionlessFunc<
     const userConfig = await userCreateConfig()
 
     const resolvedLocalDb = resolveLocalDb(
-      userConfig.dev?.db ?? true,
+      userConfig.sqliteDb,
       config.rootDir,
       config.outDir,
       config.runtimeDir
@@ -201,14 +201,15 @@ export const dev = pikkuSessionlessFunc<
 
     const resolvedRuntimeDir =
       config.runtimeDir ?? join(config.rootDir, '.pikku-runtime')
-    const localContentConfig: LocalContentConfig | undefined = userConfig.dev
-      ?.content
+    const localContentConfig: LocalContentConfig | undefined = userConfig.content
       ? {
-          localFileUploadPath: join(resolvedRuntimeDir, 'content'),
-          uploadUrlPrefix: '/upload',
-          assetUrlPrefix: '/assets',
+          localFileUploadPath: userConfig.content.contentPath
+            ? resolve(config.rootDir, userConfig.content.contentPath)
+            : join(resolvedRuntimeDir, 'content'),
+          uploadUrlPrefix: userConfig.content.uploadUrlPrefix ?? '/upload',
+          assetUrlPrefix: userConfig.content.assetUrlPrefix ?? '/assets',
           server: `http://${hostname}:${resolvedPort}`,
-          ...(userConfig.dev.content !== true ? userConfig.dev.content : {}),
+          sizeLimit: userConfig.content.sizeLimit,
         }
       : undefined
     const localContent = localContentConfig

--- a/packages/cli/src/functions/commands/workspace-validate.test.ts
+++ b/packages/cli/src/functions/commands/workspace-validate.test.ts
@@ -215,6 +215,11 @@ describe('pikku workspace validate', () => {
     try {
       await makeValidWorkspace(tmp)
       await writeFile(
+        join(tmp, 'packages', 'functions', 'src', 'config.ts'),
+        "export const createConfig = () => ({ sqliteDb: '.pikku-runtime/dev.db' })\n",
+        'utf8'
+      )
+      await writeFile(
         join(
           tmp,
           'packages',

--- a/packages/cli/src/functions/db/local-db.test.ts
+++ b/packages/cli/src/functions/db/local-db.test.ts
@@ -53,7 +53,7 @@ test('resolveLocalDb returns null when config is undefined', () => {
 test(
   'migrateAndCodegen applies pending migrations and writes schema.d.ts',
   async () => {
-    const resolved = resolveLocalDb(true, root, root)!
+    const resolved = resolveLocalDb('.pikku-runtime/dev.db', root, root)!
     const { migrate, codegen, zod } = await migrateAndCodegen(resolved)
 
     assert.deepEqual(migrate.applied, ['0001-init.sql'])
@@ -89,7 +89,7 @@ test(
 )
 
 test('migrateAndCodegen is a no-op on second run', async () => {
-  const resolved = resolveLocalDb(true, root, root)!
+  const resolved = resolveLocalDb('.pikku-runtime/dev.db', root, root)!
   await migrateAndCodegen(resolved)
   const second = await migrateAndCodegen(resolved)
   assert.deepEqual(second.migrate.applied, [])
@@ -105,7 +105,7 @@ test('migrateAndCodegen is a no-op on second run', async () => {
 test(
   'migrateAndCodegen throws MigrationDriftError when applied file changes',
   async () => {
-    const resolved = resolveLocalDb(true, root, root)!
+    const resolved = resolveLocalDb('.pikku-runtime/dev.db', root, root)!
     await migrateAndCodegen(resolved)
 
     const migPath = join(root, 'db', 'migrations', '0001-init.sql')
@@ -127,7 +127,7 @@ test(
 )
 
 test('seed applies db/seed.sql once migrate has run', async () => {
-  const resolved = resolveLocalDb(true, root, root)!
+  const resolved = resolveLocalDb('.pikku-runtime/dev.db', root, root)!
   await migrateAndCodegen(resolved)
 
   const result = await runSeed(resolved)
@@ -149,7 +149,7 @@ test('seed applies db/seed.sql once migrate has run', async () => {
 test(
   'reset wipes the dev DB so a follow-up migrate replays from scratch',
   async () => {
-    const resolved = resolveLocalDb(true, root, root)!
+    const resolved = resolveLocalDb('.pikku-runtime/dev.db', root, root)!
     await migrateAndCodegen(resolved)
     await runSeed(resolved)
 
@@ -173,11 +173,7 @@ test(
 
 test('reset refuses when resolved DB lives outside the runtime directory', () => {
   const outside = mkdtempSync(join(tmpdir(), 'pikku-db-outside-'))
-  const resolved = resolveLocalDb(
-    { file: join(outside, 'evil.db') },
-    root,
-    root
-  )!
+  const resolved = resolveLocalDb(join(outside, 'evil.db'), root, root)!
   assert.throws(() => runReset(resolved, root), /outside the runtime directory/)
   rmSync(outside, { recursive: true, force: true })
 })

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -21,8 +21,9 @@ export interface ResolvedLocalDb {
 }
 
 /**
- * Resolve a DevDbConfig into absolute paths.
- * - dbFile lives under runtimeDir (default: <rootDir>/.pikku-runtime)
+ * Resolve a sqliteDb path into absolute paths.
+ * - sqliteDb is the file path (relative to rootDir or absolute); if undefined, returns null
+ * - dbFile resolves to the absolute path of the SQLite file
  * - schema/coercion/zod are generated into outDir/db
  * - migrations and seed are authored source under rootDir/db
  */

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -9,8 +9,6 @@ import { createCoercionPlugin, type CoercionMap } from './coercion-plugin.js'
 import { createSqliteKysely } from './sqlite-kysely.js'
 import { loadSqliteRuntime } from './sqlite-runtime.js'
 
-export type DevDbConfig = true | { file?: string }
-
 export interface ResolvedLocalDb {
   dbFile: string
   runtimeDir: string
@@ -29,18 +27,15 @@ export interface ResolvedLocalDb {
  * - migrations and seed are authored source under rootDir/db
  */
 export function resolveLocalDb(
-  config: DevDbConfig | undefined,
+  sqliteDb: string | undefined,
   rootDir: string,
   outDir: string,
   runtimeDir?: string
 ): ResolvedLocalDb | null {
-  if (!config) return null
-  const file = config === true ? undefined : config.file
+  if (!sqliteDb) return null
   const resolvedRuntimeDir = runtimeDir ?? join(rootDir, '.pikku-runtime')
   return {
-    dbFile: file
-      ? resolveAgainst(rootDir, file)
-      : join(resolvedRuntimeDir, 'dev.db'),
+    dbFile: resolveAgainst(rootDir, sqliteDb),
     runtimeDir: resolvedRuntimeDir,
     migrationsDir: resolveAgainst(rootDir, 'db/migrations'),
     seedFile: resolveAgainst(rootDir, 'db/seed.sql'),
@@ -113,7 +108,7 @@ export function reset(resolved: ResolvedLocalDb, rootDir: string): void {
   const rel = relative(resolved.runtimeDir, resolved.dbFile)
   if (rel.startsWith('..') || isAbsolute(rel)) {
     throw new Error(
-      `pikku db reset refused: resolved DB file (${resolved.dbFile}) is outside the runtime directory (${resolved.runtimeDir}). Override dev.db.file or set runtimeDir correctly.`
+      `pikku db reset refused: resolved DB file (${resolved.dbFile}) is outside the runtime directory (${resolved.runtimeDir}). Override sqliteDb or set runtimeDir correctly.`
     )
   }
   if (existsSync(resolved.dbFile)) {

--- a/packages/cli/src/functions/validate/workspace-validate.ts
+++ b/packages/cli/src/functions/validate/workspace-validate.ts
@@ -155,9 +155,7 @@ export async function runWorkspaceValidate(
     }
   }
 
-  const hasConfiguredDevDb = Boolean(
-    (pikkuConfig as { sqliteDb?: unknown } | null)?.sqliteDb
-  )
+  const hasConfiguredDevDb = existsSync(join(root, 'db', 'migrations'))
 
   type RootPkg = {
     workspaces?: unknown

--- a/packages/cli/src/functions/validate/workspace-validate.ts
+++ b/packages/cli/src/functions/validate/workspace-validate.ts
@@ -156,7 +156,7 @@ export async function runWorkspaceValidate(
   }
 
   const hasConfiguredDevDb = Boolean(
-    (pikkuConfig as { dev?: { db?: unknown } } | null)?.dev?.db
+    (pikkuConfig as { sqliteDb?: unknown } | null)?.sqliteDb
   )
 
   type RootPkg = {
@@ -297,9 +297,9 @@ export async function runWorkspaceValidate(
     if (authEnabled && !hasConfiguredDevDb) {
       e(
         'auth-dev-db-missing',
-        'Auth middleware is registered, but pikku.config.json is missing dev.db so local auth schema validation and db migrate cannot run',
+        'Auth middleware is registered, but createConfig is missing sqliteDb so local auth schema validation and db migrate cannot run',
         pikkuConfigPath,
-        'Add dev.db to pikku.config.json so `pikku db migrate` can create and validate the local auth schema'
+        'Add sqliteDb to createConfig so `pikku db migrate` can create and validate the local auth schema'
       )
     }
 

--- a/packages/cli/src/functions/validate/workspace-validate.ts
+++ b/packages/cli/src/functions/validate/workspace-validate.ts
@@ -155,8 +155,6 @@ export async function runWorkspaceValidate(
     }
   }
 
-  const hasConfiguredDevDb = existsSync(join(root, 'db', 'migrations'))
-
   type RootPkg = {
     workspaces?: unknown
     dependencies?: Record<string, string>
@@ -254,6 +252,8 @@ export async function runWorkspaceValidate(
 
     const migrationsDir = join(fnDir, 'db', 'migrations')
     const authEnabled = await hasAuthSessionMiddleware(fnDir)
+    const configText = await readTextSafe(join(fnDir, 'src', 'config.ts'))
+    const hasConfiguredDevDb = /sqliteDb/.test(configText ?? '')
     let createsAppUser = false
     let createsAuthVerificationToken = false
     if (existsSync(migrationsDir)) {


### PR DESCRIPTION
## Summary

- Replaces `dev: { db, content }` in `createConfig` with flat top-level `sqliteDb: string` and `content: { contentPath?, ... }`
- Removes the `DevDbConfig = true | { file? }` type; `resolveLocalDb` now takes the file path string directly
- All db commands (`db migrate`, `db seed`, `db reset`) and `pikku dev` updated to read the new shape
- Fallback in `loadUserConfigForDb` (no config file but migrations present) defaults to `.pikku-runtime/dev.db`

## Why

`dev.db` was named after the SQLite filename, not a meaningful grouping. The `dev` wrapper added confusion without value — in production the DB is injected through services, so there's nothing else that would go under `dev`. Flat top-level fields are clearer and easier to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified DB config to use a top-level sqliteDb field and removed nested dev.db.
  * Reworked content settings to a top-level content object with explicit defaults.

* **Bug Fixes**
  * Updated validation and DB command messages to reference sqliteDb and content correctly.

* **Documentation**
  * Changeset with migration guidance for updating createConfig and test helpers.

* **Tests**
  * Updated tests to use explicit sqliteDb paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->