### PR TITLE
feat(assistant-ui): export useFileAttachment and modelSupportsVision

### DIFF
--- a/.changeset/assistant-ui-vision.md
+++ b/.changeset/assistant-ui-vision.md
@@ -1,0 +1,5 @@
+---
+"@pikku/assistant-ui": patch
+---
+
+feat(assistant-ui): export useFileAttachment hook, modelSupportsVision, PendingFile, UploadAttachmentFn, and INLINE_SIZE_LIMIT

--- a/.changeset/isStringLike-type-assertion.md
+++ b/.changeset/isStringLike-type-assertion.md
@@ -1,0 +1,6 @@
+---
+"@pikku/inspector": patch
+"@pikku/cli": patch
+---
+
+Fix `isStringLike` to unwrap type assertion expressions (`as T` / `<T>expr`) so that `workflow.do('step', 'rpcName' as any, data)` is correctly parsed as an RPC step rather than silently dropped as an inline step. Also removes the `as any` cast from the `Emails` step in `all.workflow.ts` now that the inspector handles it, and ensures `pikku all` generates email template artifacts.

--- a/.changeset/pii-classification-semantics.md
+++ b/.changeset/pii-classification-semantics.md
@@ -1,0 +1,14 @@
+---
+"@pikku/cli": patch
+"@pikku/inspector": patch
+---
+
+Fix PKU910 classification semantics and Postgres annotation propagation.
+
+**Inspector (`@pikku/inspector`):**
+- `findPiiPaths()` now returns `ClassifiedField[]` (path + classification level) so `private`/`pii` and `secret` brands are distinguished
+- `Secret<T>` fields are blocked in the output of all exposed functions (sessioned or not)
+- `Private<T>` / `Pii<T>` fields are only blocked in sessionless functions — authenticated (sessioned) functions may return private-classified data to their callers
+
+**CLI (`@pikku/cli`):**
+- Fix missing `rootDir` in the Postgres `generateSchemaTypes` call — the annotations sidecar file (`db/annotations.gen.json`) was silently ignored during Postgres migrations, causing columns annotated `@public` to remain branded as `Private<T>` in the generated schema

--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -11,6 +11,7 @@ rm -rf -- .pikku dist
 echo "Bootstrapping with published @pikku/cli..."
 : "${PIKKU_CLI_VERSION:=latest}"
 _bootstrap_dir=$(mktemp -d)
+trap 'rm -rf "$_bootstrap_dir"' EXIT
 npm install --prefix "$_bootstrap_dir" --no-save --no-package-lock \
   "@pikku/cli@${PIKKU_CLI_VERSION}" "@pikku/auth-js"
 "$_bootstrap_dir/node_modules/.bin/pikku"

--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -10,7 +10,11 @@ rm -rf -- .pikku dist
 # Bootstrap using the published CLI - generates all .pikku files
 echo "Bootstrapping with published @pikku/cli..."
 : "${PIKKU_CLI_VERSION:=latest}"
-npx -y "@pikku/cli@${PIKKU_CLI_VERSION}"
+_bootstrap_dir=$(mktemp -d)
+npm install --prefix "$_bootstrap_dir" --no-save --no-package-lock \
+  "@pikku/cli@${PIKKU_CLI_VERSION}" "@pikku/auth-js"
+"$_bootstrap_dir/node_modules/.bin/pikku"
+rm -rf "$_bootstrap_dir"
 
 # Patch stale forge references from published CLI (renamed to node/)
 rm -rf .pikku/forge

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -29,7 +29,12 @@ import { pikkuWebsocketHandler } from '@pikku/ws'
 import { PikkuNodeHTTPServer } from '@pikku/node-http-server'
 import { WebSocketServer } from 'ws'
 import { InMemorySchedulerService } from '@pikku/schedule'
-import { resolveDb, createKysely, type ResolvedSqliteDb } from '../db/local-db.js'
+import {
+  resolveDb,
+  createKysely,
+  parseDatabaseUrl,
+  type ResolvedSqliteDb,
+} from '../db/local-db.js'
 import { loadUserBootstrap, loadUserModule } from './load-user-project.js'
 
 export const dev = pikkuSessionlessFunc<
@@ -47,7 +52,9 @@ export const dev = pikkuSessionlessFunc<
     const enableWatch = watch !== false
     const enableHmr = hmr !== false
     const watchDirectories = [
-      ...new Set([config.emailTemplatesDir, ...config.srcDirectories].filter(Boolean)),
+      ...new Set(
+        [config.emailTemplatesDir, ...config.srcDirectories].filter(Boolean)
+      ),
     ] as string[]
     const commandSingletonServices = pikkuState(
       null,
@@ -189,35 +196,41 @@ export const dev = pikkuSessionlessFunc<
 
     const userConfig = await userCreateConfig()
 
-    const resolvedDb = resolveDb(userConfig, config.rootDir, config.outDir, config.runtimeDir)
+    // Resolution priority: DATABASE_URL env var → userConfig.sqliteDb → userConfig.postgresUrl
+    const envDatabaseUrl = process.env.DATABASE_URL
+    const effectiveDbConfig = envDatabaseUrl
+      ? {
+          sqliteDb: userConfig.sqliteDb,
+          postgresUrl: userConfig.postgresUrl,
+          ...parseDatabaseUrl(envDatabaseUrl),
+        }
+      : userConfig
+    const resolvedDb = resolveDb(
+      effectiveDbConfig,
+      config.rootDir,
+      config.outDir,
+      config.runtimeDir
+    )
     const resolvedLocalDb: ResolvedSqliteDb | undefined =
-      resolvedDb?.dialect === 'sqlite'
-        ? resolvedDb
-        : userConfig.sqliteDb
-          ? resolveDb(
-              { sqliteDb: userConfig.sqliteDb },
-              config.rootDir,
-              config.outDir,
-              config.runtimeDir
-            ) as ResolvedSqliteDb
-          : undefined
+      resolvedDb?.dialect === 'sqlite' ? resolvedDb : undefined
     const kysely = resolvedLocalDb
       ? await createKysely(resolvedLocalDb)
       : undefined
 
     const resolvedRuntimeDir =
       config.runtimeDir ?? join(config.rootDir, '.pikku-runtime')
-    const localContentConfig: LocalContentConfig | undefined = userConfig.content
-      ? {
-          localFileUploadPath: userConfig.content.contentPath
-            ? resolve(config.rootDir, userConfig.content.contentPath)
-            : join(resolvedRuntimeDir, 'content'),
-          uploadUrlPrefix: userConfig.content.uploadUrlPrefix ?? '/upload',
-          assetUrlPrefix: userConfig.content.assetUrlPrefix ?? '/assets',
-          server: `http://${hostname}:${resolvedPort}`,
-          sizeLimit: userConfig.content.sizeLimit,
-        }
-      : undefined
+    const localContentConfig: LocalContentConfig | undefined =
+      userConfig.content
+        ? {
+            localFileUploadPath: userConfig.content.contentPath
+              ? resolve(config.rootDir, userConfig.content.contentPath)
+              : join(resolvedRuntimeDir, 'content'),
+            uploadUrlPrefix: userConfig.content.uploadUrlPrefix ?? '/upload',
+            assetUrlPrefix: userConfig.content.assetUrlPrefix ?? '/assets',
+            server: `http://${hostname}:${resolvedPort}`,
+            sizeLimit: userConfig.content.sizeLimit,
+          }
+        : undefined
     const localContent = localContentConfig
       ? new LocalContent(localContentConfig, logger)
       : undefined
@@ -326,7 +339,9 @@ export const dev = pikkuSessionlessFunc<
       const generatorWatcher = () => {
         watcher?.close()
 
-        logger.info(`• Watching directories: \n  - ${watchDirectories.join('\n  - ')}`)
+        logger.info(
+          `• Watching directories: \n  - ${watchDirectories.join('\n  - ')}`
+        )
         watcher = chokidar.watch(watchDirectories, {
           ignoreInitial: true,
           ignored: genIgnore,

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -43,7 +43,7 @@ export const dev = pikkuSessionlessFunc<
 >({
   remote: true,
   func: async (
-    { logger, config, getInspectorState },
+    { logger, config, getInspectorState, variables },
     { port, watch, hmr },
     { rpc }
   ) => {
@@ -196,14 +196,9 @@ export const dev = pikkuSessionlessFunc<
 
     const userConfig = await userCreateConfig()
 
-    // Resolution priority: DATABASE_URL env var → userConfig.sqliteDb → userConfig.postgresUrl
-    const envDatabaseUrl = process.env.DATABASE_URL
+    const envDatabaseUrl = await variables.get('DATABASE_URL')
     const effectiveDbConfig = envDatabaseUrl
-      ? {
-          sqliteDb: userConfig.sqliteDb,
-          postgresUrl: userConfig.postgresUrl,
-          ...parseDatabaseUrl(envDatabaseUrl),
-        }
+      ? parseDatabaseUrl(envDatabaseUrl)
       : userConfig
     const resolvedDb = resolveDb(
       effectiveDbConfig,

--- a/packages/cli/src/functions/db/local-db.test.ts
+++ b/packages/cli/src/functions/db/local-db.test.ts
@@ -1,4 +1,4 @@
-import { test, beforeEach, afterEach } from 'node:test'
+import { test, describe, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   mkdtempSync,
@@ -12,6 +12,7 @@ import { join } from 'node:path'
 
 import {
   resolveDb,
+  parseDatabaseUrl,
   migrateAndCodegen,
   seed as runSeed,
   reset as runReset,
@@ -93,7 +94,11 @@ test('migrateAndCodegen is a no-op on second run', async () => {
   const second = await migrateAndCodegen(resolved)
   assert.deepEqual(second.migrate.applied, [])
   assert.deepEqual(second.migrate.skipped, ['0001-init.sql'])
-  assert.equal(second.codegen.written, false, 'codegen output should be unchanged')
+  assert.equal(
+    second.codegen.written,
+    false,
+    'codegen output should be unchanged'
+  )
   assert.equal(second.zod.written, false, 'zod output should be unchanged')
 })
 
@@ -130,7 +135,9 @@ test('seed applies db/seed.sql once migrate has run', async () => {
   const runtime = await loadSqliteRuntime()
   const db = runtime.open(resolved.dbFile)
   try {
-    const count = db.prepare('SELECT COUNT(*) AS c FROM todos').get() as { c: number }
+    const count = db.prepare('SELECT COUNT(*) AS c FROM todos').get() as {
+      c: number
+    }
     assert.equal(count.c, 2)
   } finally {
     db.close()
@@ -151,7 +158,9 @@ test('reset wipes the dev DB so a follow-up migrate replays from scratch', async
   const runtime = await loadSqliteRuntime()
   const db = runtime.open(resolved.dbFile)
   try {
-    const count = db.prepare('SELECT COUNT(*) AS c FROM todos').get() as { c: number }
+    const count = db.prepare('SELECT COUNT(*) AS c FROM todos').get() as {
+      c: number
+    }
     assert.equal(count.c, 0, 'reset should leave todos empty until seed runs')
   } finally {
     db.close()
@@ -160,8 +169,48 @@ test('reset wipes the dev DB so a follow-up migrate replays from scratch', async
 
 test('reset refuses when resolved DB lives outside the runtime directory', () => {
   const outside = mkdtempSync(join(tmpdir(), 'pikku-db-outside-'))
-  const resolved = resolveDb({ sqliteDb: join(outside, 'evil.db') }, root, root)!
+  const resolved = resolveDb(
+    { sqliteDb: join(outside, 'evil.db') },
+    root,
+    root
+  )!
   assert.equal(resolved.dialect, 'sqlite')
   assert.throws(() => runReset(resolved, root), /outside the runtime directory/)
   rmSync(outside, { recursive: true, force: true })
+})
+
+describe('parseDatabaseUrl', () => {
+  test('postgres URL sets postgresUrl', () => {
+    const url = 'postgres://user:pass@localhost:5432/mydb'
+    assert.deepEqual(parseDatabaseUrl(url), { postgresUrl: url })
+  })
+
+  test('postgresql:// variant also sets postgresUrl', () => {
+    const url = 'postgresql://user:pass@localhost:5432/mydb'
+    assert.deepEqual(parseDatabaseUrl(url), { postgresUrl: url })
+  })
+
+  test('libsql URL returns empty object (remote, CLI does not handle it)', () => {
+    assert.deepEqual(parseDatabaseUrl('libsql://db.turso.io?authToken=abc'), {})
+  })
+
+  test('https URL returns empty object (remote, CLI does not handle it)', () => {
+    assert.deepEqual(parseDatabaseUrl('https://db.turso.io'), {})
+  })
+
+  test('http URL returns empty object', () => {
+    assert.deepEqual(parseDatabaseUrl('http://localhost:8080'), {})
+  })
+
+  test('bare file path sets sqliteDb', () => {
+    assert.deepEqual(parseDatabaseUrl('.pikku-runtime/dev.db'), {
+      sqliteDb: '.pikku-runtime/dev.db',
+    })
+  })
+
+  test('absolute file path sets sqliteDb', () => {
+    assert.deepEqual(parseDatabaseUrl('/var/data/dev.db'), {
+      sqliteDb: '/var/data/dev.db',
+    })
+  })
 })

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -55,6 +55,20 @@ export type ResolvedDb = ResolvedSqliteDb | ResolvedPostgresDb
 // ─── Resolution ───────────────────────────────────────────────────────────────
 
 /**
+ * Parse a DATABASE_URL string into the subset of UserConfigShape that resolveDb understands.
+ * - postgres(ql):// → { postgresUrl }
+ * - libsql:// or http(s):// → {} (remote, not handled by the CLI layer)
+ * - anything else → { sqliteDb } (local file path)
+ */
+export function parseDatabaseUrl(
+  url: string
+): Pick<UserConfigShape, 'sqliteDb' | 'postgresUrl'> {
+  if (/^postgres(ql)?:\/\//.test(url)) return { postgresUrl: url }
+  if (/^(libsql|https?):\/\//.test(url)) return {}
+  return { sqliteDb: url }
+}
+
+/**
  * Resolve a UserConfigShape into an absolute-path descriptor.
  * Returns null when neither sqliteDb nor postgresUrl is configured.
  */

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -176,6 +176,7 @@ export async function migrateAndCodegen(
           manifestFile: resolved.manifestFile,
           classificationMapFile: resolved.classificationMapFile,
           camelCase: resolved.camelCase,
+          rootDir: resolved.rootDir,
           migrationsDir: resolved.migrationsDir,
         })
       } finally {

--- a/packages/cli/src/functions/workflows/all.workflow.ts
+++ b/packages/cli/src/functions/workflows/all.workflow.ts
@@ -165,7 +165,7 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
       workflow.do('Public RPC', 'pikkuPublicRPC', null),
       workflow.do('Console functions', 'pikkuConsoleFunctions', null),
       workflow.do('Events scaffold', 'pikkuEventsScaffold', null),
-      workflow.do('Emails', 'pikkuEmails' as any, null),
+      workflow.do('Emails', 'pikkuEmails', null),
       workflow.do(
         'Secret definition types',
         'pikkuSecretDefinitionTypes',

--- a/packages/core/src/dev/hot-reload.test.ts
+++ b/packages/core/src/dev/hot-reload.test.ts
@@ -308,6 +308,7 @@ describe('pikkuDevReloader', { concurrency: false }, () => {
       pikkuFuncId: 'hotTask',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     }
 
     addFunction('hotTask', {
@@ -375,6 +376,7 @@ describe('pikkuDevReloader', { concurrency: false }, () => {
       pikkuFuncId: 'queue_hot-queue',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     }
 
     addFunction('queue_hot-queue', {

--- a/packages/core/src/function/function-runner.test.ts
+++ b/packages/core/src/function/function-runner.test.ts
@@ -32,6 +32,7 @@ const addTestFunction = (funcName: string, funcConfig: any) => {
     pikkuFuncId: funcName,
     inputSchemaName: null,
     outputSchemaName: null,
+    sessionless: true,
     middleware,
     permissions,
   }
@@ -675,7 +676,7 @@ describe('runPikkuFunc - Integration Tests', () => {
     )
   })
 
-  test('should use backward-compatible auth checks when sessionless metadata is absent', async () => {
+  test('should require auth when sessionless metadata is absent (undefined defaults to session-required)', async () => {
     addTestFunction('legacyAuth', {
       func: async () => 'ok',
       auth: true,

--- a/packages/core/src/function/function-runner.test.ts
+++ b/packages/core/src/function/function-runner.test.ts
@@ -5,7 +5,6 @@ import {
   getAllFunctionNames,
   getFunctionNames,
   runPikkuFunc,
-  runPikkuFuncDirectly,
 } from './function-runner.js'
 import { addTagMiddleware, addTagPermission } from '../index.js'
 import { resetPikkuState, pikkuState } from '../pikku-state.js'
@@ -1227,32 +1226,6 @@ describe('runPikkuFunc - Integration Tests', () => {
 })
 
 describe('function-runner helpers', () => {
-  test('runPikkuFuncDirectly should pass through the provided wire and session helpers', async () => {
-    let receivedWire: any
-    const sessionService = new PikkuSessionService({
-      get: async () => undefined,
-    } as any)
-
-    addTestFunction('directFunc', {
-      func: async (_services: any, _data: any, wire: any) => {
-        receivedWire = wire
-        return 'ok'
-      },
-    })
-
-    const result = await runPikkuFuncDirectly(
-      'directFunc',
-      mockServices,
-      { traceId: 'trace-1' },
-      { hello: 'world' },
-      sessionService
-    )
-
-    assert.equal(result, 'ok')
-    assert.equal(receivedWire.traceId, 'trace-1')
-    assert.equal(typeof receivedWire.getSession, 'function')
-  })
-
   test('getFunctionNames and getAllFunctionNames should include addon namespaces', () => {
     addTestFunction('rootFunc', { func: async () => 'ok' })
     pikkuState(null, 'addons', 'packages').set('stripe', {

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -7,7 +7,6 @@ import { runPermissions } from '../permissions.js'
 import { pikkuState } from '../pikku-state.js'
 import { coerceTopLevelDataFromSchema, validateSchema } from '../schema.js'
 import type {
-  CoreServices,
   CoreUserSession,
   CorePikkuMiddleware,
   PikkuWiringTypes,
@@ -26,10 +25,7 @@ import type {
 } from './functions.types.js'
 import { parseVersionedId } from '../version.js'
 import type { SessionService } from '../services/user-session-service.js'
-import {
-  PikkuSessionService,
-  createFunctionSessionWireProps,
-} from '../services/user-session-service.js'
+import { PikkuSessionService } from '../services/user-session-service.js'
 import { ForbiddenError, ReadonlySessionError } from '../errors/errors.js'
 import {
   PikkuCredentialWireService,
@@ -200,27 +196,6 @@ export const getAllFunctionNames = (): string[] => {
   return functions
 }
 
-export const runPikkuFuncDirectly = async <In, Out>(
-  funcName: string,
-  allServices: CoreServices,
-  wire: PikkuWire,
-  data: In,
-  userSession?: SessionService<CoreUserSession>,
-  packageName: string | null = null
-) => {
-  const funcConfig = pikkuState(packageName, 'function', 'functions').get(
-    funcName
-  )
-  if (!funcConfig) {
-    throw new Error(`Function not found: ${funcName}`)
-  }
-  const wireWithSession = {
-    ...wire,
-    ...(userSession && createFunctionSessionWireProps(userSession)),
-  }
-  return (await funcConfig.func(allServices, data, wireWithSession)) as Out
-}
-
 export const runPikkuFunc = async <In = any, Out = any>(
   wireType: PikkuWiringTypes,
   wireId: string,
@@ -381,7 +356,7 @@ export const runPikkuFunc = async <In = any, Out = any>(
           throw new ForbiddenError('Authentication required')
         }
       }
-    } else if (funcMeta.sessionless === false) {
+    } else {
       if (wiringAuth === false || funcConfig.auth === false) {
         resolvedSingletonServices.logger.warn(
           `Function '${funcName}' requires a session but auth was explicitly disabled — use pikkuSessionlessFunc instead.`
@@ -389,14 +364,6 @@ export const runPikkuFunc = async <In = any, Out = any>(
       }
       if (!session) {
         throw new ForbiddenError('Authentication required')
-      }
-    } else {
-      // TODO: Remove after a couple of releases — backward compat for
-      // generated metadata that doesn't include the `sessionless` field yet.
-      if (wiringAuth === true || funcConfig.auth === true) {
-        if (!session) {
-          throw new ForbiddenError('Authentication required')
-        }
       }
     }
 

--- a/packages/core/src/wirings/ai-agent/ai-agent-prepare.test.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-prepare.test.ts
@@ -178,6 +178,7 @@ describe('ai-agent-prepare', () => {
       description: 'Deploy the service',
       approvalRequired: true,
       inputSchemaName: 'DeployInput',
+      sessionless: true,
     }
     pikkuState(null, 'misc', 'schemas').set('DeployInput', {
       type: 'object',
@@ -254,6 +255,7 @@ describe('ai-agent-prepare', () => {
       description: 'Secret tool',
       permissions: ['admin'],
       inputSchemaName: 'SecretInput',
+      sessionless: true,
     }
     pikkuState(null, 'misc', 'schemas').set('SecretInput', {
       type: 'object',

--- a/packages/core/src/wirings/ai-agent/ai-agent-runner.test.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-runner.test.ts
@@ -560,6 +560,7 @@ describe('runAIAgent', () => {
       description: 'Deploy',
       approvalRequired: true,
       inputSchemaName: 'DeployInput',
+      sessionless: true,
     }
     pikkuState(null, 'misc', 'schemas').set('DeployInput', {
       type: 'object',
@@ -716,6 +717,7 @@ describe('resumeAIAgentSync', () => {
     pikkuState(null, 'function', 'meta').deploy = {
       description: 'Deploy',
       inputSchemaName: 'DeployInput',
+      sessionless: true,
     }
     pikkuState(null, 'misc', 'schemas').set('DeployInput', {
       type: 'object',
@@ -901,6 +903,7 @@ describe('resumeAIAgentSync', () => {
     pikkuState(null, 'function', 'meta').deploy = {
       description: 'Deploy',
       inputSchemaName: 'DeployInput',
+      sessionless: true,
     }
     pikkuState(null, 'misc', 'schemas').set('DeployInput', {
       type: 'object',
@@ -986,7 +989,12 @@ describe('getCredential API key override', () => {
     }
 
     const mockServices = {
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
       aiAgentRunner: {
         run: async (): Promise<AIAgentStepResult> => {
           originalRunCalls.push('original')
@@ -1019,13 +1027,24 @@ describe('getCredential API key override', () => {
     const originalRunCalls: string[] = []
 
     const mockServices = {
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
       aiAgentRunner: {
         run: async (): Promise<AIAgentStepResult> => {
           originalRunCalls.push('original')
           return makeStepResult({ text: 'from-original', finishReason: 'stop' })
         },
-        withApiKey: (_key: string) => ({ run: async () => makeStepResult({ text: 'should-not-be-called', finishReason: 'stop' }) }),
+        withApiKey: (_key: string) => ({
+          run: async () =>
+            makeStepResult({
+              text: 'should-not-be-called',
+              finishReason: 'stop',
+            }),
+        }),
       },
       aiRunState: {
         createRun: async () => 'run-no-cred',
@@ -1051,7 +1070,12 @@ describe('getCredential API key override', () => {
     const originalRunCalls: string[] = []
 
     const mockServices = {
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
       aiAgentRunner: {
         run: async (): Promise<AIAgentStepResult> => {
           originalRunCalls.push('original')

--- a/packages/core/src/wirings/ai-agent/ai-agent-stream.test.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-stream.test.ts
@@ -327,6 +327,7 @@ describe('streamAIAgent', () => {
       description: 'Add a todo',
       approvalRequired: true,
       inputSchemaName: 'AddTodoInput',
+      sessionless: true,
     }
     pikkuState(null, 'misc', 'schemas').set('AddTodoInput', {
       type: 'object',
@@ -428,6 +429,7 @@ describe('streamAIAgent', () => {
       description: 'Add a todo',
       approvalRequired: true,
       inputSchemaName: 'AddTodoInput',
+      sessionless: true,
     }
     pikkuState('@test/addon-todos', 'misc', 'schemas').set('AddTodoInput', {
       type: 'object',
@@ -1287,6 +1289,7 @@ describe('resumeAIAgent', () => {
     pikkuState(null, 'function', 'meta').deploy = {
       description: 'Deploy',
       inputSchemaName: 'DeployInput',
+      sessionless: true,
     }
     pikkuState(null, 'misc', 'schemas').set('DeployInput', {
       type: 'object',

--- a/packages/core/src/wirings/channel/channel-common.ts
+++ b/packages/core/src/wirings/channel/channel-common.ts
@@ -6,7 +6,7 @@ import type {
 } from '../../types/core.types.js'
 import type { CoreChannel, ChannelMessageMeta } from './channel.types.js'
 import { combineMiddleware, runMiddleware } from '../../middleware-runner.js'
-import { runPikkuFuncDirectly } from '../../function/function-runner.js'
+import { runPikkuFunc } from '../../function/function-runner.js'
 import {
   combineChannelMiddleware,
   wrapChannelWithMiddleware,
@@ -79,7 +79,14 @@ export const runChannelLifecycleWithMiddleware = async ({
   }
 
   const runLifecycle = async () => {
-    return await runPikkuFuncDirectly(meta.pikkuFuncId, services, wire, data)
+    return await runPikkuFunc('channel', channelConfig.name, meta.pikkuFuncId, {
+      singletonServices: services,
+      data: () => data as any,
+      wire,
+      tags: meta.tags ?? [],
+      inheritedPermissions: meta.permissions,
+      packageName: meta.packageName ?? null,
+    })
   }
 
   if (allMiddleware.length > 0) {

--- a/packages/core/src/wirings/channel/channel-runner.ts
+++ b/packages/core/src/wirings/channel/channel-runner.ts
@@ -42,30 +42,14 @@ export const wireChannel = <
     return
   }
 
-  const funcMetaMap = pikkuState(null, 'function', 'meta')
-
   // Register onConnect function if provided
   if (channel.onConnect && channelMeta.connect) {
-    const funcId = channelMeta.connect.pikkuFuncId
-    addFunction(funcId, channel.onConnect as any)
-    funcMetaMap[funcId] ??= {
-      pikkuFuncId: funcId,
-      sessionless: true,
-      inputSchemaName: null,
-      outputSchemaName: null,
-    }
+    addFunction(channelMeta.connect.pikkuFuncId, channel.onConnect as any)
   }
 
   // Register onDisconnect function if provided
   if (channel.onDisconnect && channelMeta.disconnect) {
-    const funcId = channelMeta.disconnect.pikkuFuncId
-    addFunction(funcId, channel.onDisconnect as any)
-    funcMetaMap[funcId] ??= {
-      pikkuFuncId: funcId,
-      sessionless: true,
-      inputSchemaName: null,
-      outputSchemaName: null,
-    }
+    addFunction(channelMeta.disconnect.pikkuFuncId, channel.onDisconnect as any)
   }
 
   // Register onMessage function if provided

--- a/packages/core/src/wirings/channel/channel-runner.ts
+++ b/packages/core/src/wirings/channel/channel-runner.ts
@@ -42,14 +42,30 @@ export const wireChannel = <
     return
   }
 
+  const funcMetaMap = pikkuState(null, 'function', 'meta')
+
   // Register onConnect function if provided
   if (channel.onConnect && channelMeta.connect) {
-    addFunction(channelMeta.connect.pikkuFuncId, channel.onConnect as any)
+    const funcId = channelMeta.connect.pikkuFuncId
+    addFunction(funcId, channel.onConnect as any)
+    funcMetaMap[funcId] ??= {
+      pikkuFuncId: funcId,
+      sessionless: true,
+      inputSchemaName: null,
+      outputSchemaName: null,
+    }
   }
 
   // Register onDisconnect function if provided
   if (channel.onDisconnect && channelMeta.disconnect) {
-    addFunction(channelMeta.disconnect.pikkuFuncId, channel.onDisconnect as any)
+    const funcId = channelMeta.disconnect.pikkuFuncId
+    addFunction(funcId, channel.onDisconnect as any)
+    funcMetaMap[funcId] ??= {
+      pikkuFuncId: funcId,
+      sessionless: true,
+      inputSchemaName: null,
+      outputSchemaName: null,
+    }
   }
 
   // Register onMessage function if provided

--- a/packages/core/src/wirings/channel/local/local-channel-handler.ts
+++ b/packages/core/src/wirings/channel/local/local-channel-handler.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '../../../services/logger.js'
 import type { BinaryData } from '../channel.types.js'
 import { PikkuAbstractChannelHandler } from '../pikku-abstract-channel-handler.js'
 
@@ -11,6 +12,17 @@ export class PikkuLocalChannelHandler<
   private closeCallbacks: (() => Promise<void> | void)[] = []
   private sendCallback?: (message: Out, isBinary?: boolean) => void
   private sendBinaryCallback?: (data: BinaryData) => void
+  private logger?: Logger
+
+  constructor(
+    channelId: string,
+    channelName: string,
+    openingData: OpeningData,
+    logger?: Logger
+  ) {
+    super(channelId, channelName, openingData)
+    this.logger = logger
+  }
 
   public registerOnOpen(callback: () => Promise<void> | void): void {
     this.openCallBack = callback
@@ -52,8 +64,11 @@ export class PikkuLocalChannelHandler<
       return
     }
     super.close()
-    for (const cb of this.closeCallbacks) {
-      await cb()
+    const results = await Promise.allSettled(this.closeCallbacks.map((cb) => cb()))
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        this.logger?.error('Error in channel close callback:', result.reason)
+      }
     }
   }
 

--- a/packages/core/src/wirings/channel/local/local-channel-handler.ts
+++ b/packages/core/src/wirings/channel/local/local-channel-handler.ts
@@ -7,19 +7,19 @@ export class PikkuLocalChannelHandler<
 > extends PikkuAbstractChannelHandler<OpeningData, Out> {
   private onMessageCallback?: (message: unknown) => void
   private onBinaryMessageCallback?: (data: BinaryData) => void
-  private openCallBack?: () => void
-  private closeCallbacks: (() => void)[] = []
+  private openCallBack?: () => Promise<void> | void
+  private closeCallbacks: (() => Promise<void> | void)[] = []
   private sendCallback?: (message: Out, isBinary?: boolean) => void
   private sendBinaryCallback?: (data: BinaryData) => void
 
-  public registerOnOpen(callback: () => void): void {
+  public registerOnOpen(callback: () => Promise<void> | void): void {
     this.openCallBack = callback
   }
 
-  public open() {
+  public async open(): Promise<void> {
     this.getChannel().state = 'open'
     if (this.openCallBack) {
-      this.openCallBack()
+      await this.openCallBack()
     }
   }
 
@@ -43,17 +43,17 @@ export class PikkuLocalChannelHandler<
     return this.onBinaryMessageCallback?.(data)
   }
 
-  public registerOnClose(callback: () => void): void {
+  public registerOnClose(callback: () => Promise<void> | void): void {
     this.closeCallbacks.push(callback)
   }
 
-  public close() {
+  public async close(): Promise<void> {
     if (this.getChannel().state === 'closed') {
       return
     }
     super.close()
     for (const cb of this.closeCallbacks) {
-      cb()
+      await cb()
     }
   }
 

--- a/packages/core/src/wirings/channel/local/local-channel-runner.ts
+++ b/packages/core/src/wirings/channel/local/local-channel-runner.ts
@@ -119,7 +119,8 @@ export const runLocalChannel = async ({
       channelHandler = new PikkuLocalChannelHandler(
         channelId,
         channelConfig.name,
-        openingData
+        openingData,
+        singletonServices.logger
       )
       const channel = channelHandler.getChannel()
       const wire: PikkuWire = {

--- a/packages/core/src/wirings/cli/cli-runner.test.ts
+++ b/packages/core/src/wirings/cli/cli-runner.test.ts
@@ -622,7 +622,6 @@ describe('CLI Runner', () => {
           inputSchemaName: null,
           outputSchemaName: null,
           sessionless: true,
-          sessionless: true,
         },
       })
 

--- a/packages/core/src/wirings/cli/cli-runner.test.ts
+++ b/packages/core/src/wirings/cli/cli-runner.test.ts
@@ -128,6 +128,7 @@ describe('CLI Runner', () => {
           pikkuFuncId: 'greetFunc',
           inputSchemaName: null,
           outputSchemaName: null,
+          sessionless: true,
         },
       })
 
@@ -192,6 +193,7 @@ describe('CLI Runner', () => {
           pikkuFuncId: 'testFunc',
           inputSchemaName: null,
           outputSchemaName: null,
+          sessionless: true,
         },
       })
 
@@ -252,6 +254,7 @@ describe('CLI Runner', () => {
           pikkuFuncId: 'greetFunc',
           inputSchemaName: null,
           outputSchemaName: null,
+          sessionless: true,
         },
       })
 
@@ -296,6 +299,7 @@ describe('CLI Runner', () => {
           pikkuFuncId: 'secureFunc',
           inputSchemaName: null,
           outputSchemaName: null,
+          sessionless: true,
         },
       })
 
@@ -617,6 +621,7 @@ describe('CLI Runner', () => {
           pikkuFuncId: 'greetFunc',
           inputSchemaName: null,
           outputSchemaName: null,
+          sessionless: true,
           sessionless: true,
         },
       })

--- a/packages/core/src/wirings/http/http-runner.test.ts
+++ b/packages/core/src/wirings/http/http-runner.test.ts
@@ -129,6 +129,7 @@ const setRouteMeta = (
     inputSchemaName: null,
     outputSchemaName: null,
     sessionless: true,
+    sessionless: true,
     permissions: undefined,
     middleware: undefined,
   } as any

--- a/packages/core/src/wirings/queue/queue-runner.test.ts
+++ b/packages/core/src/wirings/queue/queue-runner.test.ts
@@ -43,6 +43,7 @@ const addTestQueueFunction = (pikkuFuncId: string) => {
     pikkuFuncId,
     inputSchemaName: null,
     outputSchemaName: null,
+    sessionless: true,
     middleware: undefined,
     permissions: undefined,
   }

--- a/packages/core/src/wirings/scheduler/scheduler-runner.test.ts
+++ b/packages/core/src/wirings/scheduler/scheduler-runner.test.ts
@@ -157,6 +157,7 @@ describe('runScheduledTask', () => {
       pikkuFuncId: 'scheduler_simple-task',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     }
     wireScheduler(mockTask)
 
@@ -199,6 +200,7 @@ describe('runScheduledTask', () => {
       pikkuFuncId: 'scheduler_task-with-session',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     }
     wireScheduler(mockTask)
 
@@ -287,6 +289,7 @@ describe('runScheduledTask', () => {
       pikkuFuncId: 'scheduler_skipped-task',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     }
     wireScheduler(mockTask)
 
@@ -332,6 +335,7 @@ describe('runScheduledTask', () => {
       pikkuFuncId: 'scheduler_skipped-task-no-reason',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     }
     wireScheduler(mockTask)
 
@@ -380,6 +384,7 @@ describe('runScheduledTask', () => {
       pikkuFuncId: 'scheduler_wire-task',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     }
     wireScheduler(mockTask)
 
@@ -420,6 +425,7 @@ describe('runScheduledTask', () => {
       pikkuFuncId: 'scheduler_session-services-task',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     }
     wireScheduler(mockTask)
 
@@ -469,6 +475,7 @@ describe('runScheduledTask', () => {
       pikkuFuncId: 'scheduler_cleanup-task',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     }
     wireScheduler(mockTask)
 
@@ -517,6 +524,7 @@ describe('runScheduledTask', () => {
       pikkuFuncId: 'scheduler_error-cleanup-task',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     }
     wireScheduler(mockTask)
 
@@ -558,6 +566,7 @@ describe('runScheduledTask', () => {
       pikkuFuncId: 'scheduler_error-task',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     }
     wireScheduler(mockTask)
 
@@ -607,6 +616,7 @@ describe('runScheduledTask', () => {
       pikkuFuncId: 'scheduler_middleware-task',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     }
     wireScheduler(mockTask)
 

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
@@ -22,7 +22,6 @@ describe('pikku-workflow-service worker registration', () => {
       functionType: 'helper',
       inputSchemaName: null,
       outputSchemaName: null,
-      sessionless: true,
     })
   })
 })

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
@@ -22,6 +22,7 @@ describe('pikku-workflow-service worker registration', () => {
       functionType: 'helper',
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
     })
   })
 })

--- a/packages/inspector/src/add/add-channel.ts
+++ b/packages/inspector/src/add/add-channel.ts
@@ -630,6 +630,25 @@ export const addChannel: AddWiring = (
     state.serviceAggregation.usedFunctions.add(disconnectFuncId)
   }
 
+  // Synthesize function meta for connect/disconnect handlers that are defined
+  // with pikkuChannelConnectionFunc/pikkuChannelDisconnectionFunc (not pikkuFunc/
+  // pikkuSessionlessFunc), so the runtime has correct sessionless info without
+  // needing to inject it at runtime.
+  {
+    const routeAuth = getPropertyValue(obj, 'auth')
+    const sessionless = routeAuth === false ? true : undefined
+    for (const funcId of [connectFuncId, disconnectFuncId]) {
+      if (funcId && !state.functions.meta[funcId]) {
+        state.functions.meta[funcId] = {
+          pikkuFuncId: funcId,
+          sessionless,
+          inputSchemaName: null,
+          outputSchemaName: null,
+        }
+      }
+    }
+  }
+
   if (message) {
     state.serviceAggregation.usedFunctions.add(message.pikkuFuncId)
   }

--- a/packages/inspector/src/add/add-functions.ts
+++ b/packages/inspector/src/add/add-functions.ts
@@ -883,24 +883,50 @@ export const addFunctions: AddWiring = (
     }
   }
 
-  // ── PII brand check ───────────────────────────────────────────────────────
-  // Walk the function body's ACTUAL inferred return type looking for Private<T>
-  // / Pii<T> / Secret<T> brands (__classification__ property).  This runs for every function,
-  // including those with a Zod output schema, because the TS return type
-  // reflects what the body actually returns before any Zod coercion.
+  const sessionless = expression.text !== 'pikkuFunc'
+
+  // ── Classification brand check ─────────────────────────────────────────────
+  // Walk the function body's ACTUAL inferred return type looking for classification
+  // brands (__classification__ property on Private<T>, Pii<T>, Secret<T>).
+  //
+  // Semantics:
+  //   secret  → never returned by any exposed function (sessioned or not)
+  //   private → only visible to authenticated (sessioned) users; ok for pikkuFunc
+  //   public  → safe for sessionless functions
   {
     const sig = checker.getSignatureFromDeclaration(handler)
     if (sig) {
       const rawRet = checker.getReturnTypeOfSignature(sig)
       const unwrapped = unwrapPromise(checker, rawRet)
-      const piiPaths = findPiiPaths(checker, unwrapped)
-      if (piiPaths.length > 0) {
+      const classifiedFields = findPiiPaths(checker, unwrapped)
+
+      const secretPaths = classifiedFields
+        .filter((f) => f.classification === 'secret')
+        .map((f) => f.path)
+
+      const privatePaths = classifiedFields
+        .filter(
+          (f) => f.classification === 'private' || f.classification === 'pii'
+        )
+        .map((f) => f.path)
+
+      if (secretPaths.length > 0) {
         logger.critical(
           ErrorCode.PII_IN_OUTPUT,
-          `Function '${name}' exposes PII-classified field(s) in its return type: ` +
-            piiPaths.map((p) => `'${p}'`).join(', ') +
-            `.\n  Either strip these fields before returning or mark the column ` +
-            `@public in the migration if it is safe to expose.`
+          `Function '${name}' exposes secret-classified field(s) in its return type: ` +
+            secretPaths.map((p) => `'${p}'`).join(', ') +
+            `.\n  Secret fields must never appear in function output. ` +
+            `Strip these fields before returning or change the column classification.`
+        )
+      }
+
+      if (sessionless && privatePaths.length > 0) {
+        logger.critical(
+          ErrorCode.PII_IN_OUTPUT,
+          `Sessionless function '${name}' exposes private-classified field(s) in its return type: ` +
+            privatePaths.map((p) => `'${p}'`).join(', ') +
+            `.\n  Private fields are only safe to return from authenticated (sessioned) functions. ` +
+            `Either require a session (use pikkuFunc) or mark the column @public if it is safe to expose publicly.`
         )
       }
     }
@@ -946,7 +972,6 @@ export const addFunctions: AddWiring = (
     }
   }
 
-  const sessionless = expression.text !== 'pikkuFunc'
   const implementationHash = computeImplementationHash({
     wrapper: expression.text,
     handler,

--- a/packages/inspector/src/add/add-http-route.ts
+++ b/packages/inspector/src/add/add-http-route.ts
@@ -248,6 +248,31 @@ export function registerHTTPRoute({
     extracted.isHelper
   )
 
+  // Propagate sessionless from the addon target so the runtime can correctly
+  // determine whether a session is required for ref()-based routes.
+  if (refAddonTarget) {
+    const targetMeta = resolveFunctionMeta(state, refAddonTarget)
+    const inlineMeta = state.functions.meta[funcName]
+    if (targetMeta && inlineMeta && targetMeta.sessionless !== undefined) {
+      inlineMeta.sessionless = targetMeta.sessionless
+    }
+  }
+
+  // For inline functions (e.g. oauth2 handlers), propagate sessionless: true
+  // when auth is explicitly disabled at the route or group level — the
+  // developer opted out of auth so no session is required.
+  {
+    const inlineMeta = state.functions.meta[funcName]
+    if (inlineMeta && inlineMeta.sessionless === undefined) {
+      const routeAuth = getPropertyValue(obj, 'auth')
+      const resolvedAuth =
+        routeAuth === true || routeAuth === false ? routeAuth : inheritedAuth
+      if (resolvedAuth === false) {
+        inlineMeta.sessionless = true
+      }
+    }
+  }
+
   // Lookup existing function metadata
   const fnMeta = resolveFunctionMeta(state, funcName)
   if (!fnMeta) {

--- a/packages/inspector/src/add/pii-check.test.ts
+++ b/packages/inspector/src/add/pii-check.test.ts
@@ -46,26 +46,15 @@ async function runInspect(sourceCode: string) {
   return criticals
 }
 
-// ── findPiiPaths unit tests via full inspect() round-trip ────────────────────
+// ── classification semantics:
+//   secret  → never returned by any function (sessioned or not)
+//   private → only blocked in sessionless functions (pikkuSessionlessFunc)
+//   public  → safe for sessionless functions
 
 describe('PII output check — PKU910', () => {
-  test('flags a top-level Private<string> field', async () => {
-    const criticals = await runInspect(`
-${BRAND_TYPES}
-import { pikkuFunc } from '@pikku/core'
-export const getUser = pikkuFunc({
-  func: async () => {
-    const email = 'test@example.com' as Private<string>
-    return { id: 1, email }
-  }
-})
-`)
-    const hit = criticals.find((c) => c.code === ErrorCode.PII_IN_OUTPUT)
-    assert.ok(hit, `Expected PKU910 but got: ${JSON.stringify(criticals)}`)
-    assert.match(hit.message, /email/)
-  })
+  // ── Secret<T>: always blocked ──────────────────────────────────────────────
 
-  test('flags a top-level Secret<string> field', async () => {
+  test('flags a top-level Secret<string> field in a sessioned function', async () => {
     const criticals = await runInspect(`
 ${BRAND_TYPES}
 import { pikkuFunc } from '@pikku/core'
@@ -81,11 +70,64 @@ export const getToken = pikkuFunc({
     assert.match(hit.message, /token/)
   })
 
-  test('flags a nested Private field', async () => {
+  test('flags a top-level Secret<string> field in a sessionless function', async () => {
+    const criticals = await runInspect(`
+${BRAND_TYPES}
+import { pikkuSessionlessFunc } from '@pikku/core'
+export const getToken = pikkuSessionlessFunc({
+  func: async () => {
+    const token = 'abc' as Secret<string>
+    return { token }
+  }
+})
+`)
+    const hit = criticals.find((c) => c.code === ErrorCode.PII_IN_OUTPUT)
+    assert.ok(hit)
+    assert.match(hit.message, /token/)
+  })
+
+  // ── Private<T>: only blocked in sessionless functions ─────────────────────
+
+  test('flags a top-level Private<string> field in a sessionless function', async () => {
+    const criticals = await runInspect(`
+${BRAND_TYPES}
+import { pikkuSessionlessFunc } from '@pikku/core'
+export const getUser = pikkuSessionlessFunc({
+  func: async () => {
+    const email = 'test@example.com' as Private<string>
+    return { id: 1, email }
+  }
+})
+`)
+    const hit = criticals.find((c) => c.code === ErrorCode.PII_IN_OUTPUT)
+    assert.ok(hit, `Expected PKU910 but got: ${JSON.stringify(criticals)}`)
+    assert.match(hit.message, /email/)
+  })
+
+  test('does not flag a Private<string> field in a sessioned function', async () => {
     const criticals = await runInspect(`
 ${BRAND_TYPES}
 import { pikkuFunc } from '@pikku/core'
-export const getProfile = pikkuFunc({
+export const getUser = pikkuFunc({
+  func: async () => {
+    const email = 'test@example.com' as Private<string>
+    return { id: 1, email }
+  }
+})
+`)
+    const hit = criticals.find((c) => c.code === ErrorCode.PII_IN_OUTPUT)
+    assert.equal(
+      hit,
+      undefined,
+      `Expected no PKU910 (sessioned function may return Private fields) but got: ${JSON.stringify(hit)}`
+    )
+  })
+
+  test('flags a nested Private field in a sessionless function', async () => {
+    const criticals = await runInspect(`
+${BRAND_TYPES}
+import { pikkuSessionlessFunc } from '@pikku/core'
+export const getProfile = pikkuSessionlessFunc({
   func: async () => {
     const email = 'x@y.com' as Private<string>
     return { user: { id: 1, email } }
@@ -123,12 +165,12 @@ export const doWork = pikkuFunc({
     assert.equal(hit, undefined)
   })
 
-  test('flags a function that returns a typed alias with Private field', async () => {
+  test('flags a sessionless function that returns a typed alias with Private field', async () => {
     const criticals = await runInspect(`
 ${BRAND_TYPES}
-import { pikkuFunc } from '@pikku/core'
+import { pikkuSessionlessFunc } from '@pikku/core'
 type UserRow = { id: number; email: Private<string> }
-export const getUser = pikkuFunc({
+export const getUser = pikkuSessionlessFunc({
   func: async (): Promise<UserRow> => {
     return { id: 1, email: 'x' as Private<string> }
   }
@@ -139,17 +181,17 @@ export const getUser = pikkuFunc({
     assert.match(hit.message, /email/)
   })
 
-  test('flags across multiple functions in the same file', async () => {
+  test('flags across multiple sessionless functions in the same file', async () => {
     const criticals = await runInspect(`
 ${BRAND_TYPES}
-import { pikkuFunc } from '@pikku/core'
-export const getEmail = pikkuFunc({
+import { pikkuSessionlessFunc } from '@pikku/core'
+export const getEmail = pikkuSessionlessFunc({
   func: async () => ({ email: 'x' as Private<string> })
 })
-export const getPhone = pikkuFunc({
+export const getPhone = pikkuSessionlessFunc({
   func: async () => ({ phone: '555' as Private<string> })
 })
-export const getSafe = pikkuFunc({
+export const getSafe = pikkuSessionlessFunc({
   func: async () => ({ name: 'Alice' })
 })
 `)
@@ -157,11 +199,11 @@ export const getSafe = pikkuFunc({
     assert.equal(hits.length, 2, `Expected 2 PKU910 but got ${hits.length}`)
   })
 
-  test('flags branded values inside arrays', async () => {
+  test('flags branded values inside arrays (sessionless)', async () => {
     const criticals = await runInspect(`
 ${BRAND_TYPES}
-import { pikkuFunc } from '@pikku/core'
-export const getEmails = pikkuFunc({
+import { pikkuSessionlessFunc } from '@pikku/core'
+export const getEmails = pikkuSessionlessFunc({
   func: async () => ({ emails: ['x@y.com' as Private<string>] })
 })
 `)
@@ -170,11 +212,11 @@ export const getEmails = pikkuFunc({
     assert.match(hit.message, /emails/)
   })
 
-  test('flags branded values inside string-indexed records', async () => {
+  test('flags branded values inside string-indexed records (sessionless)', async () => {
     const criticals = await runInspect(`
 ${BRAND_TYPES}
-import { pikkuFunc } from '@pikku/core'
-export const getMap = pikkuFunc({
+import { pikkuSessionlessFunc } from '@pikku/core'
+export const getMap = pikkuSessionlessFunc({
   func: async () => ({ byId: { a: 'x@y.com' as Private<string> } as Record<string, Private<string>> })
 })
 `)
@@ -186,8 +228,8 @@ export const getMap = pikkuFunc({
   test('does not flag when branded field is stripped before return', async () => {
     const criticals = await runInspect(`
 ${BRAND_TYPES}
-import { pikkuFunc } from '@pikku/core'
-export const getUser = pikkuFunc({
+import { pikkuSessionlessFunc } from '@pikku/core'
+export const getUser = pikkuSessionlessFunc({
   func: async () => {
     const raw: { email: Private<string> } = { email: 'x' as Private<string> }
     const safe: { email: string } = { email: raw.email as string }

--- a/packages/inspector/src/utils/check-pii-output.ts
+++ b/packages/inspector/src/utils/check-pii-output.ts
@@ -1,16 +1,22 @@
 import * as ts from 'typescript'
 
+export type ClassifiedField = {
+  path: string
+  classification: 'private' | 'pii' | 'secret' | string
+}
+
 /**
  * Recursively walks a resolved TypeScript type looking for `__classification__` brands —
- * the structural marker emitted by `Private<T>` and `Secret<T>`.
+ * the structural marker emitted by `Private<T>`, `Pii<T>`, and `Secret<T>`.
  *
  * `Private<T> = T & { readonly __classification__: 'private' }` shows up in the TS type
  * system as an intersection whose constituents include a type with a `__classification__`
  * property.  We detect that by checking whether any constituent of an
  * intersection exposes a property named `__classification__`.
  *
- * Returns the list of dotted field paths where a brand was found
- * (e.g. `['email', 'address.phone']`).  An empty array means clean.
+ * Returns the list of classified fields found, each with its dotted path and
+ * classification level (e.g. `[{ path: 'email', classification: 'private' }]`).
+ * An empty array means clean.
  */
 export function findPiiPaths(
   checker: ts.TypeChecker,
@@ -18,23 +24,33 @@ export function findPiiPaths(
   path = '',
   depth = 0,
   seen = new Set<ts.Type>()
-): string[] {
+): ClassifiedField[] {
   if (depth > 8 || seen.has(type)) return []
   seen.add(type)
 
   // ── Is this type itself branded? ─────────────────────────────────────────
   // Private<T> = T & { readonly __classification__: 'private' }  →  isIntersection()
-  // where one constituent has a `__classification__` property.
+  // where one constituent has a `__classification__` property whose type is a string literal.
   if (type.isIntersection()) {
-    const branded = type.types.some((t) =>
-      t.getProperties().some((p) => p.name === '__classification__')
-    )
-    if (branded) {
-      return [path || '<return value>']
+    for (const t of type.types) {
+      const classificationProp = t
+        .getProperties()
+        .find((p) => p.name === '__classification__')
+      if (classificationProp) {
+        const decl =
+          classificationProp.valueDeclaration ??
+          classificationProp.declarations?.[0]
+        const classification = decl
+          ? ((
+              checker.getTypeOfSymbolAtLocation(classificationProp, decl) as any
+            )?.value ?? 'private')
+          : 'private'
+        return [{ path: path || '<return value>', classification }]
+      }
     }
   }
 
-  const violations: string[] = []
+  const violations: ClassifiedField[] = []
 
   // ── Union: check every branch ─────────────────────────────────────────────
   if (type.isUnion()) {

--- a/packages/inspector/src/utils/extract-node-value.ts
+++ b/packages/inspector/src/utils/extract-node-value.ts
@@ -52,13 +52,17 @@ export function extractStringLiteral(
 /**
  * Check if node is string-like (string literal or template expression)
  */
-export function isStringLike(node: ts.Node, _checker: ts.TypeChecker): boolean {
+export function isStringLike(node: ts.Node, checker: ts.TypeChecker): boolean {
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
     return true
   }
   // Check if it's a template string with substitutions
   if (ts.isTemplateExpression(node)) {
     return true
+  }
+  // Unwrap type assertions: `expr as Type` or `<Type>expr`
+  if (ts.isAsExpression(node) || ts.isTypeAssertionExpression(node)) {
+    return isStringLike(node.expression, checker)
   }
   return false
 }

--- a/packages/services/auth-js/src/auth-routes.ts
+++ b/packages/services/auth-js/src/auth-routes.ts
@@ -46,6 +46,7 @@ function registerAuthMeta(basePath: string): void {
       pikkuFuncId,
       inputSchemaName: null,
       outputSchemaName: null,
+      sessionless: true,
       services: { optimized: false, services: [] },
     }
   }

--- a/verifiers/middleware-and-permissions/src/functions/channel-local.assert.ts
+++ b/verifiers/middleware-and-permissions/src/functions/channel-local.assert.ts
@@ -44,7 +44,7 @@ export async function testChannelWiring(
       })
 
       // Open the channel
-      channelHandler.open()
+      await channelHandler.open()
 
       // Send a message
       await channelHandler.message(
@@ -55,7 +55,7 @@ export async function testChannelWiring(
       )
 
       // Close the channel
-      channelHandler.close()
+      await channelHandler.close()
     },
     singletonServices.logger
   )


### PR DESCRIPTION
## Summary
- Adds changeset for `@pikku/assistant-ui` patch release
- Exports `useFileAttachment`, `modelSupportsVision`, `PendingFile`, `UploadAttachmentFn`, and `INLINE_SIZE_LIMIT` from the package index

## Test plan
- [ ] Merge triggers changeset version + publish pipeline → `0.12.6` on npm
- [ ] Fabric console can then bump to `^0.12.6` to fix the `modelSupportsVision` import error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exports vision and file-attachment utilities for assistant integration
  * Refines data protection rules: Secret fields blocked universally; Private/PII fields blocked in sessionless functions only
  * Adds DATABASE_URL environment variable support to dev command

* **Bug Fixes**
  * Fixed Postgres schema annotation propagation in code generation

* **Refactor**
  * Simplified function authentication pipeline
  * Updated channel lifecycle callbacks to support asynchronous operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->