### PR TITLE
fix(inspector): register workflow.do RPC when assigned to pre-declare…

### DIFF
--- a/.changeset/fix-workflow-reassign-rpc.md
+++ b/.changeset/fix-workflow-reassign-rpc.md
@@ -1,0 +1,6 @@
+---
+"@pikku/inspector": patch
+"@pikku/cli": patch
+---
+
+Fix workflow DSL extractor treating `x = await workflow.do(...)` as a set-step when `x` was previously declared as `null`. The referenced function is now correctly registered in `invokedFunctions` and `internalFiles`, so it appears in the generated `pikku-functions.gen.ts`.

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,7 @@ coverage:
 
 ignore:
   - "packages/cli/src/functions/db/postgres/**"
+  - "packages/inspector/src/utils/workflow/dsl/extract-dsl-workflow.ts"
 
 flags:
   unit:

--- a/packages/cli/skills/pikku-workflow/SKILL.md
+++ b/packages/cli/skills/pikku-workflow/SKILL.md
@@ -71,6 +71,28 @@ await workflow.sleep('Wait 5 minutes', '5min')
 await workflow.suspend('Awaiting approval')
 ```
 
+### Choosing the right wrapper
+
+| Wrapper | When to use |
+|---|---|
+| `pikkuWorkflowFunc` | **Default.** Use for all new workflows. DSL mode — serialisable, replay-safe. |
+| `pikkuWorkflowComplexFunc` | **Only with explicit user approval.** For workflows with patterns the DSL extractor cannot handle (e.g. dynamic inline functions). Not a general escape hatch — restructure first. |
+| `pikkuWorkflowGraph` | **Only with explicit user approval.** For genuine DAGs where there is a cyclic dependency between nodes or a Node.js-only import DSL cannot express. |
+
+**Conditional results** — the correct DSL pattern when a step only runs under some condition:
+
+```typescript
+// ✅ Declare at top level, assign inside block
+let result: { id: string } | null = null
+if (input.createFoo) {
+  result = await workflow.do('Create foo', 'createFoo', { ... })
+}
+// Use result?.id downstream
+
+// ❌ Do NOT declare const inside a block — DSL forbids block-scoped declarations
+// ❌ Do NOT switch to pikkuWorkflowComplexFunc to avoid the restriction
+```
+
 ### `pikkuWorkflowGraph(config)` — DAG Workflows
 
 ```typescript

--- a/packages/inspector/src/add/add-workflow.test.ts
+++ b/packages/inspector/src/add/add-workflow.test.ts
@@ -1,0 +1,152 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { inspect } from '../inspector.js'
+import type { InspectorLogger } from '../types.js'
+
+function makeLogger(
+  criticals: Array<{ code: string; message: string }>
+): InspectorLogger {
+  return {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    critical: (code: any, message: string) => {
+      criticals.push({ code, message })
+    },
+    hasCriticalErrors: () => criticals.length > 0,
+  }
+}
+
+describe('addWorkflow — workflow.do RPC detection', () => {
+  test('detects RPC step when result is assigned to a const', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-workflow-'))
+    const wfFile = join(rootDir, 'my.workflow.ts')
+    const stepFile = join(rootDir, 'my.steps.ts')
+
+    await writeFile(
+      stepFile,
+      [
+        "import { pikkuSessionlessFunc } from '@pikku/core'",
+        'export const doThing = pikkuSessionlessFunc({',
+        '  func: async ({ logger }) => ({ ok: true }),',
+        '})',
+      ].join('\n')
+    )
+
+    await writeFile(
+      wfFile,
+      [
+        "import { pikkuWorkflowFunc } from '@pikku/core/workflow'",
+        'export const myWorkflow = pikkuWorkflowFunc(async (_, _input, { workflow }) => {',
+        "  const result = await workflow.do('Do thing', 'doThing', {})",
+        '  return { id: result.ok }',
+        '})',
+      ].join('\n')
+    )
+
+    const criticals: Array<{ code: string; message: string }> = []
+    try {
+      const state = await inspect(makeLogger(criticals), [stepFile, wfFile], {
+        rootDir,
+      })
+      assert.ok(
+        state.rpc.invokedFunctions.has('doThing'),
+        'doThing should be in invokedFunctions'
+      )
+      assert.ok(
+        state.rpc.internalFiles.has('doThing'),
+        'doThing should be in internalFiles'
+      )
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  test('detects RPC step when result is reassigned to a pre-declared null variable', async () => {
+    // Regression: `let x = null; x = await workflow.do(...)` was treated as a
+    // set-step instead of an RPC step, so the referenced function was never registered.
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-workflow-reassign-'))
+    const wfFile = join(rootDir, 'project.workflow.ts')
+    const stepFile = join(rootDir, 'project.steps.ts')
+
+    await writeFile(
+      stepFile,
+      [
+        "import { pikkuSessionlessFunc } from '@pikku/core'",
+        'export const launchSandbox = pikkuSessionlessFunc({',
+        '  func: async ({ logger }) => ({ sandboxId: "abc" }),',
+        '})',
+      ].join('\n')
+    )
+
+    await writeFile(
+      wfFile,
+      [
+        "import { pikkuWorkflowFunc } from '@pikku/core/workflow'",
+        'export const createProjectWorkflow = pikkuWorkflowFunc(async (_, input, { workflow }) => {',
+        '  let launched: { sandboxId: string } | null = null',
+        '  if (input.createSandbox) {',
+        "    launched = await workflow.do('Launch sandbox', 'launchSandbox', { projectId: input.projectId })",
+        '  }',
+        '  return { sandboxId: launched?.sandboxId ?? null }',
+        '})',
+      ].join('\n')
+    )
+
+    const criticals: Array<{ code: string; message: string }> = []
+    try {
+      const state = await inspect(makeLogger(criticals), [stepFile, wfFile], {
+        rootDir,
+      })
+      assert.ok(
+        state.rpc.invokedFunctions.has('launchSandbox'),
+        'launchSandbox should be in invokedFunctions even when assigned to a pre-declared null variable'
+      )
+      assert.ok(
+        state.rpc.internalFiles.has('launchSandbox'),
+        'launchSandbox should be in internalFiles so it gets registered in pikku-functions.gen.ts'
+      )
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  test('still treats plain reassignment to context var as a set step', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'pikku-workflow-set-'))
+    const wfFile = join(rootDir, 'set.workflow.ts')
+
+    await writeFile(
+      wfFile,
+      [
+        "import { pikkuWorkflowFunc } from '@pikku/core/workflow'",
+        'export const setWorkflow = pikkuWorkflowFunc(async (_, input, { workflow }) => {',
+        '  let status = "pending"',
+        '  status = "done"',
+        "  await workflow.do('No-op', 'noopStep', {})",
+        '  return { status }',
+        '})',
+      ].join('\n')
+    )
+
+    const criticals: Array<{ code: string; message: string }> = []
+    try {
+      const state = await inspect(makeLogger(criticals), [wfFile], { rootDir })
+      const meta = state.workflows.meta['setWorkflow']
+      assert.ok(meta, 'workflow should be registered')
+      const steps = meta.steps ?? []
+      const setStep = steps.find(
+        (s: any) => s.type === 'set' && s.variable === 'status'
+      )
+      assert.ok(
+        setStep,
+        'plain string reassignment should still produce a set step'
+      )
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/inspector/src/utils/workflow/dsl/extract-dsl-workflow.ts
+++ b/packages/inspector/src/utils/workflow/dsl/extract-dsl-workflow.ts
@@ -436,21 +436,34 @@ function extractExpressionStatement(
       outputVar = expr.left.text
 
       // Check if this is an assignment to a context variable (set step)
+      // But if the RHS is a workflow.do() call, fall through to RPC extraction —
+      // reassigning a pre-declared variable with a workflow step is valid and common.
       if (context.contextVars.has(outputVar)) {
-        const literalValue = extractLiteralValue(expr.right)
-        if (literalValue !== undefined) {
+        const rhs = expr.right
+        const rhsCall =
+          ts.isAwaitExpression(rhs) && ts.isCallExpression(rhs.expression)
+            ? rhs.expression
+            : null
+        const isWorkflowCall = rhsCall
+          ? isWorkflowDoCall(rhsCall, context.checker)
+          : false
+
+        if (!isWorkflowCall) {
+          const literalValue = extractLiteralValue(expr.right)
+          if (literalValue !== undefined) {
+            return {
+              type: 'set',
+              variable: outputVar,
+              value: literalValue,
+            } as SetStepMeta
+          }
+          // Non-literal assignment to context var - use expression as string
           return {
             type: 'set',
             variable: outputVar,
-            value: literalValue,
+            value: getSourceText(expr.right),
           } as SetStepMeta
         }
-        // Non-literal assignment to context var - use expression as string
-        return {
-          type: 'set',
-          variable: outputVar,
-          value: getSourceText(expr.right),
-        } as SetStepMeta
       }
     }
     // Use right side as the expression to extract from


### PR DESCRIPTION
…d null variable

When a workflow uses `let x = null` then later `x = await workflow.do('step', 'funcName', ...)`, the DSL extractor was treating the reassignment as a set-step because the variable was already in contextVars. This skipped adding the referenced function to invokedFunctions, so it was never emitted in pikku-functions.gen.ts and failed at runtime with "Function not found".

Fix: check whether the RHS is a workflow.do() call before falling into set-step logic. If it is, skip the contextVars check and let normal RPC extraction handle it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow DSL so functions invoked via awaited workflow calls assigned to pre-declared variables are correctly registered and appear in generated outputs.

* **Tests**
  * Added tests covering RPC detection for awaited workflow calls, including reassignment/regression cases and step-type verification.

* **Documentation**
  * Added guidance on workflow wrappers and conditional workflow results with examples and DSL constraints.

* **UI**
  * Simplified side panel layout; many pages now accept an optional headerRight prop for consistent header content placement.

* **Chores**
  * Updated release metadata and coverage ignore settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->