### PR TITLE
feat(console): add headerRight prop to EmailsPage

### DIFF
--- a/.changeset/cucumber-bump.md
+++ b/.changeset/cucumber-bump.md
@@ -1,0 +1,5 @@
+---
+"@pikku/cucumber": patch
+---
+
+Bumping up

--- a/.changeset/emails-page-header-right.md
+++ b/.changeset/emails-page-header-right.md
@@ -1,0 +1,5 @@
+---
+"@pikku/console": patch
+---
+
+Add `headerRight` prop to `EmailsPage` so callers can inject a refresh button or other controls into the page header.

--- a/.changeset/fabric-validate-required-deps.md
+++ b/.changeset/fabric-validate-required-deps.md
@@ -1,0 +1,9 @@
+---
+"@pikku/cli": patch
+---
+
+`pikku fabric validate` now errors when required Cloudflare deploy dependencies are missing from `packages/functions/dependencies` (not devDependencies):
+
+- `@pikku/schema-cfworker` — always required; injected into every worker entry
+- `@pikku/kysely` — always required; `secretContributor` imports `KyselySecretService` unconditionally
+- `@pikku/ai-vercel` + `@ai-sdk/openai-compatible` — required when the project declares agent units (detected via `.pikku/agent/pikku-agent-wirings-meta.gen.json`)

--- a/.changeset/fix-run-function-tests-dir.md
+++ b/.changeset/fix-run-function-tests-dir.md
@@ -1,0 +1,5 @@
+---
+'@pikku/addon-console': patch
+---
+
+fix(pikku-console): use correct `tests` dir and `.coverage` output path in runFunctionTests

--- a/packages/addon/pikku-console/src/functions/run-function-tests.function.ts
+++ b/packages/addon/pikku-console/src/functions/run-function-tests.function.ts
@@ -29,7 +29,7 @@ export const runFunctionTests = pikkuSessionlessFunc<
     if (!metaService?.basePath) return null
 
     const functionsDir = join(metaService.basePath, '..')
-    const ftestDir = join(functionsDir, 'function-tests')
+    const ftestDir = join(functionsDir, 'tests')
     if (!existsSync(ftestDir)) return null
 
     const pikku = findBin('pikku', functionsDir)
@@ -63,7 +63,7 @@ export const runFunctionTests = pikkuSessionlessFunc<
       proc.on('error', reject)
     })
 
-    const outFile = join(ftestDir, 'coverage', 'function-coverage.json')
+    const outFile = join(ftestDir, '.coverage', 'function-coverage.json')
     if (!existsSync(outFile)) return null
     return JSON.parse(readFileSync(outFile, 'utf-8')) as FunctionCoverageReport
   },

--- a/packages/cli/src/fabric/functions/validate-core.ts
+++ b/packages/cli/src/fabric/functions/validate-core.ts
@@ -193,6 +193,36 @@ export async function runFabricValidate(
       }
     }
 
+    // agent units — require explicit deps rather than CI injection
+    const agentMetaPath = join(
+      fnDir,
+      '.pikku',
+      'agent',
+      'pikku-agent-wirings-meta.gen.json'
+    )
+    const agentMeta = await readJsonSafe<{
+      agentsMeta?: Record<string, unknown>
+    }>(agentMetaPath)
+    if (agentMeta && Object.keys(agentMeta.agentsMeta ?? {}).length > 0) {
+      const fnDeps = { ...fnPkg?.dependencies }
+      if (!fnDeps['@pikku/ai-vercel']) {
+        e(
+          'missing-ai-vercel',
+          'Project declares agent units but @pikku/ai-vercel is not in dependencies',
+          fnPkgPath,
+          'Run `yarn add @pikku/ai-vercel` in packages/functions — must be in dependencies, not devDependencies'
+        )
+      }
+      if (!fnDeps['@ai-sdk/openai-compatible']) {
+        e(
+          'missing-ai-sdk-openai-compatible',
+          'Project declares agent units but @ai-sdk/openai-compatible is not in dependencies',
+          fnPkgPath,
+          'Run `yarn add @ai-sdk/openai-compatible` in packages/functions — must be in dependencies, not devDependencies'
+        )
+      }
+    }
+
     // db/sqlite/ — presence, numbering and SQL dialect
     const migrationsDir = join(fnDir, 'db', 'sqlite')
     if (!existsSync(migrationsDir)) {

--- a/packages/cli/src/fabric/functions/validate-core.ts
+++ b/packages/cli/src/fabric/functions/validate-core.ts
@@ -158,6 +158,15 @@ export async function runFabricValidate(
           'Run `yarn add @pikku/schema-cfworker` in packages/functions — must be in dependencies, not devDependencies'
         )
       }
+
+      if (!fnPkg.dependencies?.['@pikku/kysely']) {
+        e(
+          'missing-pikku-kysely',
+          '@pikku/kysely is not in dependencies — every Cloudflare worker entry requires it (KyselySecretService)',
+          fnPkgPath,
+          'Run `yarn add @pikku/kysely` in packages/functions — must be in dependencies, not devDependencies'
+        )
+      }
     }
 
     const servicesPath = join(fnDir, 'src', 'services.ts')

--- a/packages/cli/src/fabric/functions/validate-core.ts
+++ b/packages/cli/src/fabric/functions/validate-core.ts
@@ -149,6 +149,15 @@ export async function runFabricValidate(
           'Remove @pikku/kysely-postgres and use @pikku/kysely-sqlite with LibsqlWebDialect instead'
         )
       }
+
+      if (!fnPkg.dependencies?.['@pikku/schema-cfworker']) {
+        e(
+          'missing-schema-cfworker',
+          '@pikku/schema-cfworker is not in dependencies — every Cloudflare worker entry requires it',
+          fnPkgPath,
+          'Run `yarn add @pikku/schema-cfworker` in packages/functions — must be in dependencies, not devDependencies'
+        )
+      }
     }
 
     const servicesPath = join(fnDir, 'src', 'services.ts')

--- a/packages/cli/src/fabric/functions/validate-core.ts
+++ b/packages/cli/src/fabric/functions/validate-core.ts
@@ -222,8 +222,7 @@ export async function runFabricValidate(
       agentsMeta?: Record<string, unknown>
     }>(agentMetaPath)
     if (agentMeta && Object.keys(agentMeta.agentsMeta ?? {}).length > 0) {
-      const fnDeps = { ...fnPkg?.dependencies }
-      if (!fnDeps['@pikku/ai-vercel']) {
+      if (!fnPkg?.dependencies?.['@pikku/ai-vercel']) {
         e(
           'missing-ai-vercel',
           'Project declares agent units but @pikku/ai-vercel is not in dependencies',
@@ -231,7 +230,7 @@ export async function runFabricValidate(
           'Run `yarn add @pikku/ai-vercel` in packages/functions — must be in dependencies, not devDependencies'
         )
       }
-      if (!fnDeps['@ai-sdk/openai-compatible']) {
+      if (!fnPkg?.dependencies?.['@ai-sdk/openai-compatible']) {
         e(
           'missing-ai-sdk-openai-compatible',
           'Project declares agent units but @ai-sdk/openai-compatible is not in dependencies',

--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -45,6 +45,10 @@ async function makeValidProject(root: string) {
   })
   await writeJson(join(root, 'packages', 'functions', 'package.json'), {
     type: 'module',
+    dependencies: {
+      '@pikku/schema-cfworker': '^0.12.0',
+      '@pikku/kysely': '^0.12.0',
+    },
   })
   await writeFile(
     join(root, 'packages', 'functions', 'src', 'services.ts'),
@@ -360,7 +364,11 @@ describe('pikku fabric validate', () => {
       try {
         await makeValidProject(tmp)
         await writeJson(join(tmp, 'packages', 'functions', 'package.json'), {
-          dependencies: { '@pikku/cloudflare': '^0.12.6' },
+          dependencies: {
+            '@pikku/cloudflare': '^0.12.6',
+            '@pikku/schema-cfworker': '^0.12.0',
+            '@pikku/kysely': '^0.12.0',
+          },
           // no type: 'module'
         })
         const result = await runValidate(tmp)

--- a/packages/console/src/pages/EmailsPage.tsx
+++ b/packages/console/src/pages/EmailsPage.tsx
@@ -135,7 +135,7 @@ const EmailsOverview: React.FC<{
   )
 }
 
-export const EmailsPage: React.FC<{ hero?: React.ReactNode }> = ({ hero }) => {
+export const EmailsPage: React.FC<{ hero?: React.ReactNode; headerRight?: React.ReactNode }> = ({ hero, headerRight }) => {
   const { meta, loading } = usePikkuMeta()
   const [searchParams, setSearchParams] = useSearchParams()
   const [previewInput, setPreviewInput] = useState<
@@ -213,7 +213,7 @@ export const EmailsPage: React.FC<{ hero?: React.ReactNode }> = ({ hero }) => {
   if (loading) {
     return (
       <PanelProvider>
-        <ResizablePanelLayout hidePanel header={<ListPageHeader title="Email Templates" description="Preview and inspect email templates with live variable rendering" />}>
+        <ResizablePanelLayout hidePanel header={<ListPageHeader title="Email Templates" description="Preview and inspect email templates with live variable rendering" lead={headerRight} />}>
           <Center h="100%">
             <Loader />
           </Center>
@@ -225,7 +225,7 @@ export const EmailsPage: React.FC<{ hero?: React.ReactNode }> = ({ hero }) => {
   if (templateNames.length === 0) {
     return (
       <PanelProvider>
-        <ResizablePanelLayout hidePanel header={<ListPageHeader title="Email Templates" description="Preview and inspect email templates with live variable rendering" />}>
+        <ResizablePanelLayout hidePanel header={<ListPageHeader title="Email Templates" description="Preview and inspect email templates with live variable rendering" lead={headerRight} />}>
           <EmptyStatePlaceholder
             icon={Mail}
             hero={hero}
@@ -244,7 +244,7 @@ export const EmailsPage: React.FC<{ hero?: React.ReactNode }> = ({ hero }) => {
       <PanelProvider>
         <ResizablePanelLayout
           hidePanel
-          header={<ListPageHeader title="Email Templates" description="Preview and inspect email templates with live variable rendering" />}
+          header={<ListPageHeader title="Email Templates" description="Preview and inspect email templates with live variable rendering" lead={headerRight} />}
         >
           <EmailsOverview
             templateNames={templateNames}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EmailsPage header can now accept custom right-side elements (e.g., refresh controls).
  * CLI validation now enforces required dependencies for cloud function deployments and agent-related features.
* **Tests**
  * Updated test fixtures to include the newly required dependencies.
* **Documentation**
  * Added/updated changeset entries documenting the above patch releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->