### PR TITLE
test(fabric-validate): add .gitignore to makeValidProject fixture

### DIFF
--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -77,6 +77,11 @@ async function makeValidProject(root: string) {
   await mkdir(join(root, 'packages', 'components'), {
     recursive: true,
   })
+  await writeFile(
+    join(root, '.gitignore'),
+    '.pikku\n.pikku-runtime\n.opencode\n*.gen.ts\n*.gen.js\n',
+    'utf8'
+  )
 }
 
 describe('pikku fabric validate', () => {


### PR DESCRIPTION
The new gitignore-missing check in validate-core expects a .gitignore with required entries. The fixture now satisfies that check so the valid-project and all-info-severity tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test project setup with improved configuration fixtures to better replicate production environment conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->