### PR TITLE
fix(inspector): support string concatenation (+) in description/title/summary fields

### DIFF
--- a/.changeset/inspector-string-concat-descriptions.md
+++ b/.changeset/inspector-string-concat-descriptions.md
@@ -1,0 +1,5 @@
+---
+"@pikku/inspector": patch
+---
+
+Fix inspector failing to extract descriptions written as string concatenation (`+`). Descriptions like `'line one ' + 'line two'` are now correctly resolved to their full value. The `checker` parameter is also threaded through `getCommonWireMetaData` so all wiring types benefit from static string evaluation.

--- a/packages/inspector/src/add/add-ai-agent.ts
+++ b/packages/inspector/src/add/add-ai-agent.ts
@@ -252,7 +252,7 @@ export const addAIAgent: AddWiring = (
 
     const nameValue = getPropertyValue(obj, 'name') as string | null
     const { disabled, tags, summary, description, errors } =
-      getCommonWireMetaData(obj, 'AI agent', nameValue, logger)
+      getCommonWireMetaData(obj, 'AI agent', nameValue, logger, checker)
 
     if (disabled) return
 

--- a/packages/inspector/src/add/add-channel.ts
+++ b/packages/inspector/src/add/add-channel.ts
@@ -238,7 +238,8 @@ export function addMessagesRoutes(
                             init,
                             'Channel message',
                             routeKey,
-                            logger
+                            logger,
+                            checker
                           ).tags
                         : undefined
                       const routeMiddleware = ts.isObjectLiteralExpression(init)
@@ -270,7 +271,8 @@ export function addMessagesRoutes(
                           init,
                           'Channel message',
                           routeKey,
-                          logger
+                          logger,
+                          checker
                         ).tags
                       : undefined
                     const routeMiddleware = ts.isObjectLiteralExpression(init)
@@ -319,7 +321,8 @@ export function addMessagesRoutes(
                                 init,
                                 'Channel message',
                                 routeKey,
-                                logger
+                                logger,
+                                checker
                               ).tags
                             : undefined
                           const routeMiddleware = ts.isObjectLiteralExpression(
@@ -350,7 +353,8 @@ export function addMessagesRoutes(
                                 init,
                                 'Channel message',
                                 routeKey,
-                                logger
+                                logger,
+                                checker
                               ).tags
                             : undefined
                           const routeMiddleware = ts.isObjectLiteralExpression(
@@ -438,7 +442,8 @@ export function addMessagesRoutes(
                       init,
                       'Channel message',
                       routeKey,
-                      logger
+                      logger,
+                      checker
                     ).tags
                   : undefined
                 const routeMiddleware = ts.isObjectLiteralExpression(init)
@@ -481,7 +486,13 @@ export function addMessagesRoutes(
       // Resolve middleware and permissions for this route
       // Check if the route config is an object literal with middleware/permissions
       const routeTags = ts.isObjectLiteralExpression(init)
-        ? getCommonWireMetaData(init, 'Channel message', routeKey, logger).tags
+        ? getCommonWireMetaData(
+            init,
+            'Channel message',
+            routeKey,
+            logger,
+            checker
+          ).tags
         : undefined
       const routeMiddleware = ts.isObjectLiteralExpression(init)
         ? resolveMiddleware(state, init, routeTags, checker)
@@ -540,7 +551,7 @@ export const addChannel: AddWiring = (
     : []
 
   const { disabled, tags, summary, description, errors } =
-    getCommonWireMetaData(obj, 'Channel', name, logger)
+    getCommonWireMetaData(obj, 'Channel', name, logger, checker)
 
   if (disabled) return
 

--- a/packages/inspector/src/add/add-functions.ts
+++ b/packages/inspector/src/add/add-functions.ts
@@ -462,7 +462,13 @@ export const addFunctions: AddWiring = (
   // Extract config properties if using object form
   if (ts.isObjectLiteralExpression(firstArg)) {
     objectNode = firstArg
-    const metadata = getCommonWireMetaData(firstArg, 'Function', name, logger)
+    const metadata = getCommonWireMetaData(
+      firstArg,
+      'Function',
+      name,
+      logger,
+      checker
+    )
     if (metadata.disabled) return
     title = metadata.title
     tags = metadata.tags

--- a/packages/inspector/src/add/add-gateway.ts
+++ b/packages/inspector/src/add/add-gateway.ts
@@ -45,7 +45,7 @@ export const addGateway: AddWiring = (
   const typeValue = getPropertyValue(obj, 'type') as GatewayTransportType | null
   const routeValue = getPropertyValue(obj, 'route') as string | undefined
   const { disabled, tags, summary, description, errors } =
-    getCommonWireMetaData(obj, 'Gateway', nameValue, logger)
+    getCommonWireMetaData(obj, 'Gateway', nameValue, logger, checker)
 
   if (disabled) return
 

--- a/packages/inspector/src/add/add-http-route.ts
+++ b/packages/inspector/src/add/add-http-route.ts
@@ -175,7 +175,7 @@ export function registerHTTPRoute({
     summary,
     description,
     errors,
-  } = getCommonWireMetaData(obj, 'HTTP route', fullRoute, logger)
+  } = getCommonWireMetaData(obj, 'HTTP route', fullRoute, logger, checker)
 
   if (disabled) return
 

--- a/packages/inspector/src/add/add-mcp-prompt.ts
+++ b/packages/inspector/src/add/add-mcp-prompt.ts
@@ -45,7 +45,7 @@ export const addMCPPrompt: AddWiring = (
 
     const nameValue = getPropertyValue(obj, 'name') as string | null
     const { disabled, tags, summary, description, errors } =
-      getCommonWireMetaData(obj, 'MCP prompt', nameValue, logger)
+      getCommonWireMetaData(obj, 'MCP prompt', nameValue, logger, checker)
 
     if (disabled) return
 

--- a/packages/inspector/src/add/add-mcp-resource.ts
+++ b/packages/inspector/src/add/add-mcp-resource.ts
@@ -46,7 +46,7 @@ export const addMCPResource: AddWiring = (
     const uriValue = getPropertyValue(obj, 'uri') as string | null
     const titleValue = getPropertyValue(obj, 'title') as string | null
     const { disabled, tags, summary, description, errors } =
-      getCommonWireMetaData(obj, 'MCP resource', uriValue, logger)
+      getCommonWireMetaData(obj, 'MCP resource', uriValue, logger, checker)
 
     if (disabled) return
 

--- a/packages/inspector/src/add/add-queue-worker.ts
+++ b/packages/inspector/src/add/add-queue-worker.ts
@@ -37,7 +37,7 @@ export const addQueueWorker: AddWiring = (logger, node, checker, state) => {
 
     const name = getPropertyValue(obj, 'name') as string | null
     const { disabled, tags, summary, description, errors } =
-      getCommonWireMetaData(obj, 'Queue worker', name, logger)
+      getCommonWireMetaData(obj, 'Queue worker', name, logger, checker)
 
     if (disabled) return
 

--- a/packages/inspector/src/add/add-schedule.ts
+++ b/packages/inspector/src/add/add-schedule.ts
@@ -44,7 +44,7 @@ export const addSchedule: AddWiring = (
     const nameValue = getPropertyValue(obj, 'name') as string | null
     const scheduleValue = getPropertyValue(obj, 'schedule') as string | null
     const { disabled, tags, summary, description, errors } =
-      getCommonWireMetaData(obj, 'Scheduler', nameValue, logger)
+      getCommonWireMetaData(obj, 'Scheduler', nameValue, logger, checker)
 
     if (disabled) return
 

--- a/packages/inspector/src/add/add-trigger.ts
+++ b/packages/inspector/src/add/add-trigger.ts
@@ -55,7 +55,7 @@ const addWireTrigger: (
 
   const nameValue = getPropertyValue(obj, 'name') as string | null
   const { disabled, tags, summary, description, errors } =
-    getCommonWireMetaData(obj, 'Trigger', nameValue, logger)
+    getCommonWireMetaData(obj, 'Trigger', nameValue, logger, checker)
 
   if (disabled) return
 

--- a/packages/inspector/src/add/add-workflow.ts
+++ b/packages/inspector/src/add/add-workflow.ts
@@ -217,7 +217,8 @@ export const addWorkflow: AddWiring = (logger, node, checker, state) => {
       firstArg,
       'Workflow',
       workflowName,
-      logger
+      logger,
+      checker
     )
     if (metadata.disabled) return
     tags = metadata.tags

--- a/packages/inspector/src/utils/ensure-function-metadata.ts
+++ b/packages/inspector/src/utils/ensure-function-metadata.ts
@@ -280,7 +280,9 @@ export function ensureFunctionMetadata(
           const { tags } = getCommonWireMetaData(
             firstArg,
             'Function',
-            fallbackName || pikkuFuncId
+            fallbackName || pikkuFuncId,
+            undefined,
+            checker
           )
           if (tags) {
             meta.tags = tags

--- a/packages/inspector/src/utils/extract-node-value.test.ts
+++ b/packages/inspector/src/utils/extract-node-value.test.ts
@@ -46,18 +46,20 @@ describe('extractDescription', () => {
     assert.equal(extractDescription(obj, checker), 'my step')
   })
 
-  test('returns null for non-literal description value without crashing', () => {
+  test('extracts concatenated string literals in description', () => {
     const { checker, sourceFile } = createChecker(
-      `const name = 'test'; const data = { description: name + ' addon' }`
+      `const data = { description: 'line one ' + 'line two' }`
     )
-    const objs: ts.ObjectLiteralExpression[] = []
-    const visit = (node: ts.Node) => {
-      if (ts.isObjectLiteralExpression(node)) objs.push(node)
-      ts.forEachChild(node, visit)
-    }
-    ts.forEachChild(sourceFile, visit)
-    const dataObj = objs[objs.length - 1]!
-    assert.equal(extractDescription(dataObj, checker), null)
+    const obj = findObjectLiteral(sourceFile)!
+    assert.equal(extractDescription(obj, checker), 'line one line two')
+  })
+
+  test('extracts deeply nested concatenation in description', () => {
+    const { checker, sourceFile } = createChecker(
+      `const data = { description: 'a' + 'b' + 'c' }`
+    )
+    const obj = findObjectLiteral(sourceFile)!
+    assert.equal(extractDescription(obj, checker), 'abc')
   })
 
   test('returns null for non-object node', () => {

--- a/packages/inspector/src/utils/extract-node-value.ts
+++ b/packages/inspector/src/utils/extract-node-value.ts
@@ -32,6 +32,16 @@ export function extractStringLiteral(
     return extractStringLiteral(node.expression, checker)
   }
 
+  if (
+    ts.isBinaryExpression(node) &&
+    node.operatorToken.kind === ts.SyntaxKind.PlusToken
+  ) {
+    return (
+      extractStringLiteral(node.left, checker) +
+      extractStringLiteral(node.right, checker)
+    )
+  }
+
   // Try to evaluate constant identifiers
   if (ts.isIdentifier(node)) {
     const symbol = checker.getSymbolAtLocation(node)

--- a/packages/inspector/src/utils/get-property-value.ts
+++ b/packages/inspector/src/utils/get-property-value.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript'
 import { ErrorCode } from '../error-codes.js'
+import { extractStringLiteral } from './extract-node-value.js'
 
 /**
  * Extracts an array of strings from an object property.
@@ -137,7 +138,8 @@ export const getCommonWireMetaData = (
   obj: ts.ObjectLiteralExpression,
   wiringType: string,
   wiringName: string | null,
-  logger?: { critical: (code: ErrorCode, message: string) => void }
+  logger?: { critical: (code: ErrorCode, message: string) => void },
+  checker?: ts.TypeChecker
 ): {
   disabled?: true
   title?: string
@@ -166,18 +168,36 @@ export const getCommonWireMetaData = (
         prop.initializer.kind === ts.SyntaxKind.TrueKeyword
       ) {
         metadata.disabled = true
-      } else if (propName === 'title' && ts.isStringLiteral(prop.initializer)) {
-        metadata.title = prop.initializer.text
-      } else if (
-        propName === 'summary' &&
-        ts.isStringLiteral(prop.initializer)
-      ) {
-        metadata.summary = prop.initializer.text
-      } else if (
-        propName === 'description' &&
-        ts.isStringLiteral(prop.initializer)
-      ) {
-        metadata.description = prop.initializer.text
+      } else if (propName === 'title') {
+        try {
+          metadata.title = checker
+            ? extractStringLiteral(prop.initializer, checker)
+            : ts.isStringLiteral(prop.initializer)
+              ? prop.initializer.text
+              : undefined
+        } catch {
+          // non-static title — skip
+        }
+      } else if (propName === 'summary') {
+        try {
+          metadata.summary = checker
+            ? extractStringLiteral(prop.initializer, checker)
+            : ts.isStringLiteral(prop.initializer)
+              ? prop.initializer.text
+              : undefined
+        } catch {
+          // non-static summary — skip
+        }
+      } else if (propName === 'description') {
+        try {
+          metadata.description = checker
+            ? extractStringLiteral(prop.initializer, checker)
+            : ts.isStringLiteral(prop.initializer)
+              ? prop.initializer.text
+              : undefined
+        } catch {
+          // non-static description — skip
+        }
       } else if (propName === 'tags') {
         if (ts.isArrayLiteralExpression(prop.initializer)) {
           metadata.tags = prop.initializer.elements


### PR DESCRIPTION
## Summary

- Extends `extractStringLiteral` to handle `BinaryExpression` nodes with `+`, recursively evaluating both sides so `'line one ' + 'line two'` → `'line one line two'`
- Threads `checker` through `getCommonWireMetaData` as an optional param (fully backwards-compatible) so all wiring types benefit from static string evaluation
- Updates all call sites in `add-*.ts` and `ensure-function-metadata.ts` to pass `checker`

## Test plan

- [x] `packages/inspector` tests: 218 pass, 0 fail
- [x] Two new test cases cover literal concat (`'a' + 'b'`) and deeply nested concat (`'a' + 'b' + 'c'`)
- [x] TypeScript clean in `packages/inspector`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the inspector's handling of description values created through string concatenation. Descriptions combining multiple string expressions are now correctly evaluated and displayed across all component types (channels, functions, gateways, routes, prompts, and more).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->