### PR TITLE
fix(cli): emit global middleware side-effect imports in per-unit codegen

### DIFF
--- a/.changeset/cli-global-middleware-per-unit.md
+++ b/.changeset/cli-global-middleware-per-unit.md
@@ -1,0 +1,16 @@
+---
+"@pikku/cli": patch
+---
+
+fix(cli): emit global middleware side-effect imports in per-unit codegen
+
+`addGlobalMiddleware` registrations live only in `middlewareState.instances`
+(keyed `global:middleware:N`) with no associated wire group. The per-unit
+`--names` deploy filter strips the `state.http.files` fallback that
+`add-middleware` relies on, so a globally-registered middleware was never
+imported into deployed per-unit bundles and silently no-opped at runtime.
+
+`serializeMiddlewareImports` now emits a deduped side-effect import for each
+non-factory global instance into `pikku-middleware.gen.ts`, which the bootstrap
+always imports — guaranteeing global middleware registers in every unit.
+Duplicate imports in full builds are harmless (module bodies evaluate once).

--- a/packages/cli/src/functions/wirings/middleware/serialize-middleware-imports.test.ts
+++ b/packages/cli/src/functions/wirings/middleware/serialize-middleware-imports.test.ts
@@ -1,0 +1,97 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { serializeMiddlewareImports } from './serialize-middleware-imports.js'
+import type {
+  InspectorMiddlewareState,
+  InspectorHTTPState,
+} from '@pikku/inspector'
+
+const emptyMiddlewareState = (
+  instances: InspectorMiddlewareState['instances'] = {}
+): InspectorMiddlewareState =>
+  ({
+    definitions: {},
+    instances,
+    tagMiddleware: new Map(),
+  }) as unknown as InspectorMiddlewareState
+
+const emptyHttpState = (): InspectorHTTPState =>
+  ({
+    routeMiddleware: new Map(),
+  }) as unknown as InspectorHTTPState
+
+describe('serializeMiddlewareImports global middleware', () => {
+  // Regression: addGlobalMiddleware registrations live only in
+  // middlewareState.instances (keyed global:middleware:N) with no associated
+  // wire group. The per-unit --names filter strips the state.http.files
+  // fallback, so without emitting them here a globally-registered middleware
+  // (e.g. the CI-injected fabric telemetry middleware) never imports into a
+  // deployed unit and silently no-ops at runtime.
+  test('emits a side-effect import for a global middleware source file', () => {
+    const state = emptyMiddlewareState({
+      'global:middleware:0': {
+        definitionId: 'telemetryMiddleware',
+        sourceFile: '/project/src/__fabric_telemetry__/telemetry.wiring.ts',
+        position: 0,
+        isFactoryCall: false,
+      },
+    })
+
+    const output = serializeMiddlewareImports(
+      '/project/.pikku/middleware/pikku-middleware.gen.ts',
+      state,
+      emptyHttpState(),
+      {}
+    )
+
+    assert.match(output, /Side-effect imports/)
+    assert.match(output, /__fabric_telemetry__\/telemetry\.wiring/)
+  })
+
+  test('deduplicates a global middleware shared across two instances', () => {
+    const state = emptyMiddlewareState({
+      'global:middleware:0': {
+        definitionId: 'a',
+        sourceFile: '/project/src/mw/global.ts',
+        position: 0,
+        isFactoryCall: false,
+      },
+      'global:middleware:1': {
+        definitionId: 'b',
+        sourceFile: '/project/src/mw/global.ts',
+        position: 1,
+        isFactoryCall: false,
+      },
+    })
+
+    const output = serializeMiddlewareImports(
+      '/project/.pikku/middleware/pikku-middleware.gen.ts',
+      state,
+      emptyHttpState(),
+      {}
+    )
+
+    const occurrences = output.split('mw/global').length - 1
+    assert.equal(occurrences, 1, 'shared global source should import once')
+  })
+
+  test('ignores non-global instances (tag middleware handled elsewhere)', () => {
+    const state = emptyMiddlewareState({
+      'tag:auth:0': {
+        definitionId: 'authMw',
+        sourceFile: '/project/src/mw/auth.ts',
+        position: 0,
+        isFactoryCall: false,
+      },
+    })
+
+    const output = serializeMiddlewareImports(
+      '/project/.pikku/middleware/pikku-middleware.gen.ts',
+      state,
+      emptyHttpState(),
+      {}
+    )
+
+    assert.doesNotMatch(output, /mw\/auth/)
+  })
+})

--- a/packages/cli/src/functions/wirings/middleware/serialize-middleware-imports.ts
+++ b/packages/cli/src/functions/wirings/middleware/serialize-middleware-imports.ts
@@ -78,6 +78,29 @@ export const serializeMiddlewareImports = (
     collectDirectImports(fullState.channelMiddleware.tagMiddleware)
   }
 
+  // Global middleware (addGlobalMiddleware) is registered by a top-level call
+  // at module evaluation, so a side-effect import of its source file runs the
+  // registration. Unlike tag/http middleware it has no associated wire group —
+  // it lives only in `instances` keyed `global:*` — so the per-unit `--names`
+  // filter leaves it out of every deployed unit (the `state.http.files`
+  // fallback that add-middleware adds gets stripped by that filter). Emitting
+  // it here, into the always-bootstrap-imported pikku-middleware.gen.ts,
+  // guarantees global middleware registers in every unit. A duplicate import
+  // in full builds is harmless — module bodies evaluate once.
+  for (const [instanceId, instance] of Object.entries(
+    middlewareState.instances
+  )) {
+    if (instanceId.startsWith('global:') && !instance.isFactoryCall) {
+      directImports.add(
+        getFileImportRelativePath(
+          outputPath,
+          instance.sourceFile,
+          packageMappings
+        )
+      )
+    }
+  }
+
   const allFactories = new Map([
     ...httpFactories,
     ...tagFactories,


### PR DESCRIPTION
## Problem

`addGlobalMiddleware` registrations live only in `middlewareState.instances` (keyed `global:middleware:N`) with no associated wire group. The per-unit `--names` deploy filter strips the `state.http.files` fallback that `add-middleware` relies on, so a globally-registered middleware was never imported into deployed per-unit bundles and silently no-opped at runtime.

This surfaced in Fabric: a CI-injected telemetry middleware (registered via `addGlobalMiddleware`) never bundled into deployed units, so no telemetry was emitted.

## Fix

`serializeMiddlewareImports` now emits a deduped side-effect import for each non-factory global instance into `pikku-middleware.gen.ts`, which the bootstrap always imports — guaranteeing global middleware registers in every unit. Duplicate imports in full builds are harmless (module bodies evaluate once).

Adds a regression test covering emit, dedupe, and non-global exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed global middleware handling in per-unit code generation to ensure middleware registrations are always included in every unit bundle and not inadvertently removed by deploy filters, resolving silent no-op issues at runtime.

## Tests
* Added comprehensive test coverage for global middleware import serialization, including deduplication behavior and proper filtering of non-global middleware instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->