### PR TITLE
feat(mcp): auto-mount MCP server in PikkuNodeHTTPServer

### DIFF
--- a/.changeset/mcp-auto-mount.md
+++ b/.changeset/mcp-auto-mount.md
@@ -1,0 +1,6 @@
+---
+'@pikku/node-http-server': patch
+'@pikku/cli': patch
+---
+
+Auto-mount the MCP server in PikkuNodeHTTPServer

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -116,6 +116,46 @@ jobs:
           name: verifier-coverage
         continue-on-error: true
 
+  unit-coverage:
+    name: Unit Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - name: Run package unit tests with coverage
+        # --enable-source-maps so tsx-transpiled line numbers map back to the
+        # original .ts before lcov is written. A single package's test failure
+        # must not halt the sweep, so each run is isolated with `|| warning`.
+        env:
+          NODE_OPTIONS: --enable-source-maps
+        run: |
+          while IFS= read -r script; do
+            dir=$(dirname "$script")
+            echo "::group::coverage ${dir}"
+            (cd "$dir" && bash run-tests.sh --coverage) || echo "::warning::unit tests failed in ${dir}"
+            echo "::endgroup::"
+          done < <(find packages -name run-tests.sh -not -path '*/node_modules/*' | sort)
+      - name: Merge lcov reports and re-root paths to repo root
+        # Each package writes lcov.info with package-relative SF paths (src/...).
+        # Prefix them with the package directory so Codecov maps them to the
+        # correct file in a monorepo where many packages share src/index.ts.
+        run: |
+          : > unit-lcov.info
+          while IFS= read -r f; do
+            dir=$(dirname "$f")
+            sed "s#^SF:#SF:${dir}/#" "$f" >> unit-lcov.info
+          done < <(find packages -name lcov.info -not -path '*/node_modules/*' | sort)
+          echo "Merged $(grep -c '^SF:' unit-lcov.info || echo 0) source files into unit-lcov.info"
+      - name: Upload unit coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: unit-lcov.info
+          flags: unit
+          name: unit-coverage
+        continue-on-error: true
+
   templates:
     name: Templates (${{ matrix.version }}, ${{ matrix.template }}, ${{ matrix.package-manager }})
     runs-on: ubuntu-latest

--- a/packages/cli/src/functions/wirings/mcp/pikku-command-mcp-json.ts
+++ b/packages/cli/src/functions/wirings/mcp/pikku-command-mcp-json.ts
@@ -6,7 +6,7 @@ import { serializeMCPJson } from '@pikku/inspector'
 export const pikkuMCPJSON = pikkuSessionlessFunc<void, void>({
   func: async ({ logger, config, getInspectorState }) => {
     const state = await getInspectorState()
-    const mcpJsonFile = config.clientFiles?.mcpJsonFile
+    const mcpJsonFile = config.mcpJsonFile ?? config.clientFiles?.mcpJsonFile
 
     if (mcpJsonFile) {
       const mcpJson = serializeMCPJson(logger, state)

--- a/packages/cli/src/functions/workflows/all.workflow.ts
+++ b/packages/cli/src/functions/workflows/all.workflow.ts
@@ -308,8 +308,8 @@ export const allWorkflow = pikkuWorkflowComplexFunc<void, void>({
         allImports.push(config.gatewaysWiringFile)
       }
 
+      await workflow.do('MCP JSON', 'pikkuMCPJSON', null)
       if (mcp) {
-        await workflow.do('MCP JSON', 'pikkuMCPJSON', null)
         allImports.push(config.mcpWiringsMetaFile, config.mcpWiringsFile)
       }
 

--- a/packages/cli/src/utils/pikku-cli-config.ts
+++ b/packages/cli/src/utils/pikku-cli-config.ts
@@ -476,6 +476,9 @@ const _getPikkuCLIConfig = async (
     if (!result.mcpTypesFile) {
       result.mcpTypesFile = join(mcpDir, 'pikku-mcp-types.gen.ts')
     }
+    if (!result.mcpJsonFile) {
+      result.mcpJsonFile = join(mcpDir, 'mcp.gen.json')
+    }
 
     // AI Agent
     const agentDir = join(result.outDir, 'agent')

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -87,6 +87,7 @@ export interface PikkuCLICoreOutputFiles {
   mcpWiringsMetaFile: string
   mcpWiringsMetaJsonFile: string
   mcpTypesFile: string
+  mcpJsonFile: string
 
   // AI Agent
   agentWiringsFile: string

--- a/packages/runtimes/node-http-server/package.json
+++ b/packages/runtimes/node-http-server/package.json
@@ -18,10 +18,17 @@
     "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
-    "@pikku/core": "^0.12.21"
+    "@pikku/core": "^0.12.21",
+    "@pikku/modelcontextprotocol": "^0.12.4"
+  },
+  "peerDependenciesMeta": {
+    "@pikku/modelcontextprotocol": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@pikku/core": "^0.12.21",
+    "@pikku/modelcontextprotocol": "^0.12.4",
     "typescript": "^5.9.3"
   },
   "engines": {

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.test.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.test.ts
@@ -62,6 +62,22 @@ const createSignedAssetUrl = async (options?: {
   return url
 }
 
+const createCapturingLogger = () => {
+  const warnings: string[] = []
+  const infos: string[] = []
+  return {
+    logger: {
+      info: (msg: string) => infos.push(msg),
+      warn: (msg: string) => warnings.push(msg),
+      error: (_msg: string | Error) => {},
+      debug: (_msg: string) => {},
+      setLevel: () => {},
+    },
+    warnings,
+    infos,
+  }
+}
+
 const skipContentRouteSuite = Number.parseInt(process.versions.node, 10) >= 24
 
 describe(
@@ -317,3 +333,102 @@ describe(
     })
   }
 )
+
+const MCP_SESSION_ERROR = 'Invalid or missing session ID'
+
+describe('PikkuNodeHTTPServer MCP mounting', { concurrency: false }, () => {
+  let server: PikkuNodeHTTPServer | undefined
+
+  beforeEach(() => {
+    resetPikkuState()
+    pikkuState(null, 'package', 'singletonServices', {
+      schema: {
+        compileSchema: async () => {},
+        getSchemaNames: () => new Set<string>(),
+      },
+    } as any)
+  })
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop()
+      server = undefined
+    }
+  })
+
+  const startServer = async (
+    options?: ConstructorParameters<typeof PikkuNodeHTTPServer>[2],
+    logger = createMockLogger()
+  ) => {
+    server = new PikkuNodeHTTPServer(
+      { hostname: '127.0.0.1', port: 0 } as any,
+      logger as any,
+      options
+    )
+    await server.init()
+    await server.start()
+    const address = server.server.address()
+    assert.ok(address && typeof address === 'object')
+    return `http://127.0.0.1:${address.port}`
+  }
+
+  const getMcp = (origin: string) =>
+    fetch(`${origin}/mcp`, { headers: { connection: 'close' } })
+
+  test('does not mount /mcp when mcpJson is absent', async () => {
+    const origin = await startServer()
+    const response = await getMcp(origin)
+    assert.equal(
+      (await response.text()).includes(MCP_SESSION_ERROR),
+      false,
+      '/mcp should not be handled by the MCP server when mcpJson is absent'
+    )
+  })
+
+  test('does not mount /mcp when mcpJson has no tools, resources, or prompts', async () => {
+    const origin = await startServer({
+      mcpJson: { tools: [], resources: [], prompts: [] },
+    })
+    const response = await getMcp(origin)
+    assert.equal(
+      (await response.text()).includes(MCP_SESSION_ERROR),
+      false,
+      'empty mcpJson should not mount the MCP server'
+    )
+  })
+
+  test('mounts /mcp when mcpJson declares at least one tool', async () => {
+    const { logger, infos } = createCapturingLogger()
+    const origin = await startServer({ mcpJson: { tools: [{ name: 'echo' }] } }, logger)
+
+    const response = await getMcp(origin)
+    // A GET to /mcp with no session is handled by the MCP server, which
+    // responds with a JSON-RPC "missing session" error — proving the request
+    // was routed to the mounted handler rather than the normal pikku pipeline.
+    assert.equal(response.status, 400)
+    assert.equal((await response.text()).includes(MCP_SESSION_ERROR), true)
+    assert.ok(
+      infos.some((msg) => msg.includes('MCP mounted at /mcp')),
+      'expected a log line confirming the mount'
+    )
+  })
+
+  test('logs a warning and serves normally when MCP mounting fails', async () => {
+    const { logger, warnings } = createCapturingLogger()
+    // A null entry makes the registry throw while reading `tool.name`, which
+    // exercises the catch branch in initMCP.
+    const origin = await startServer({ mcpJson: { tools: [null] } as any }, logger)
+
+    assert.ok(
+      warnings.some((msg) => msg.includes('MCP could not be mounted')),
+      'expected a warning when the MCP server fails to initialize'
+    )
+
+    const response = await getMcp(origin)
+    assert.equal(
+      (await response.text()).includes(MCP_SESSION_ERROR),
+      false,
+      'a failed mount must not leave a partial /mcp handler installed'
+    )
+  })
+})

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
@@ -135,8 +135,8 @@ export class PikkuNodeHTTPServer {
       const { handler } = mcpServer.createHTTPRequestHandler({ path: '/mcp' })
       this.mcpHandler = handler
       this.logger.info('pikku-node-http-server: MCP tools mounted at /mcp')
-    } catch {
-      // @pikku/modelcontextprotocol not installed or mcp.gen.json not yet generated — skip
+    } catch (err) {
+      this.logger.warn(`pikku-node-http-server: MCP tools registered but /mcp could not be mounted — ${err instanceof Error ? err.message : String(err)}`)
     }
   }
 

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
@@ -5,8 +5,8 @@ import {
   type ServerResponse,
 } from 'node:http'
 import { createReadStream } from 'node:fs'
-import { mkdir, stat, writeFile } from 'node:fs/promises'
-import { normalize, resolve } from 'node:path'
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { join, normalize, resolve } from 'node:path'
 
 import type { CoreConfig } from '@pikku/core'
 import { stopSingletonServices } from '@pikku/core'
@@ -20,6 +20,7 @@ import {
   type RunHTTPWiringOptions,
 } from '@pikku/core/http'
 import { compileAllSchemas } from '@pikku/core/schema'
+import { getMCPToolsMeta } from '@pikku/core/mcp'
 
 import { incomingMessageToRequest } from './request-converter.js'
 import { writeResponse } from './response-writer.js'
@@ -90,6 +91,7 @@ export class PikkuNodeHTTPServer {
   public server: Server
   private listening = false
   private shutdownGracePeriodMs: number
+  private mcpHandler?: (req: IncomingMessage, res: ServerResponse) => Promise<void>
 
   constructor(
     private readonly config: NodeHTTPServerConfig,
@@ -115,6 +117,27 @@ export class PikkuNodeHTTPServer {
       await this.options.configureServer(this.server)
     }
     logRegisterRoutes(this.logger)
+    await this.initMCP()
+  }
+
+  private async initMCP(): Promise<void> {
+    const toolsMeta = getMCPToolsMeta()
+    if (Object.keys(toolsMeta).length === 0) return
+    try {
+      const { PikkuMCPServer } = await import('@pikku/modelcontextprotocol')
+      const mcpJsonPath = join(process.cwd(), '.pikku', 'mcp', 'mcp.gen.json')
+      const mcpJson = JSON.parse(await readFile(mcpJsonPath, 'utf8'))
+      const mcpServer = new PikkuMCPServer(
+        { name: 'pikku', version: '1.0.0', mcpJSON: mcpJson, capabilities: { tools: {} } },
+        this.logger
+      )
+      await mcpServer.init()
+      const { handler } = mcpServer.createHTTPRequestHandler({ path: '/mcp' })
+      this.mcpHandler = handler
+      this.logger.info('pikku-node-http-server: MCP tools mounted at /mcp')
+    } catch {
+      // @pikku/modelcontextprotocol not installed or mcp.gen.json not yet generated — skip
+    }
   }
 
   private handleRequest = async (
@@ -130,6 +153,11 @@ export class PikkuNodeHTTPServer {
       }
 
       if (await this.handleContentRequest(req, res)) {
+        return
+      }
+
+      if (this.mcpHandler && req.url?.startsWith('/mcp')) {
+        await this.mcpHandler(req, res)
         return
       }
 

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
@@ -5,8 +5,8 @@ import {
   type ServerResponse,
 } from 'node:http'
 import { createReadStream } from 'node:fs'
-import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
-import { join, normalize, resolve } from 'node:path'
+import { mkdir, stat, writeFile } from 'node:fs/promises'
+import { normalize, resolve } from 'node:path'
 
 import type { CoreConfig } from '@pikku/core'
 import { stopSingletonServices } from '@pikku/core'
@@ -20,7 +20,6 @@ import {
   type RunHTTPWiringOptions,
 } from '@pikku/core/http'
 import { compileAllSchemas } from '@pikku/core/schema'
-import { getMCPToolsMeta } from '@pikku/core/mcp'
 
 import { incomingMessageToRequest } from './request-converter.js'
 import { writeResponse } from './response-writer.js'
@@ -67,6 +66,12 @@ export type PikkuNodeHTTPServerOptions = {
    * starts (e.g. WebSocket upgrades). Called once during `init()`.
    */
   configureServer?: (server: Server) => void | Promise<void>
+  /**
+   * Parsed content of `.pikku/mcp/mcp.gen.json`. When provided and non-empty,
+   * `@pikku/modelcontextprotocol` is dynamically imported and `/mcp` is mounted.
+   * Import the JSON statically so bundlers (esbuild) inline it: no runtime file read needed.
+   */
+  mcpJson?: { tools?: unknown[]; resources?: unknown[]; prompts?: unknown[] }
 } & RunHTTPWiringOptions
 
 const HARDENING_DEFAULTS = {
@@ -91,7 +96,10 @@ export class PikkuNodeHTTPServer {
   public server: Server
   private listening = false
   private shutdownGracePeriodMs: number
-  private mcpHandler?: (req: IncomingMessage, res: ServerResponse) => Promise<void>
+  private mcpHandler?: (
+    req: IncomingMessage,
+    res: ServerResponse
+  ) => Promise<void>
 
   constructor(
     private readonly config: NodeHTTPServerConfig,
@@ -121,22 +129,33 @@ export class PikkuNodeHTTPServer {
   }
 
   private async initMCP(): Promise<void> {
-    const toolsMeta = getMCPToolsMeta()
-    if (Object.keys(toolsMeta).length === 0) return
+    const mcpJson = this.options.mcpJson
+    if (!mcpJson) return
+    const { tools = [], resources = [], prompts = [] } = mcpJson
+    if (tools.length + resources.length + prompts.length === 0) return
     try {
       const { PikkuMCPServer } = await import('@pikku/modelcontextprotocol')
-      const mcpJsonPath = join(process.cwd(), '.pikku', 'mcp', 'mcp.gen.json')
-      const mcpJson = JSON.parse(await readFile(mcpJsonPath, 'utf8'))
       const mcpServer = new PikkuMCPServer(
-        { name: 'pikku', version: '1.0.0', mcpJSON: mcpJson, capabilities: { tools: {} } },
+        {
+          name: 'pikku',
+          version: '1.0.0',
+          mcpJSON: mcpJson,
+          capabilities: {
+            ...(tools.length > 0 && { tools: {} }),
+            ...(resources.length > 0 && { resources: {} }),
+            ...(prompts.length > 0 && { prompts: {} }),
+          },
+        },
         this.logger
       )
       await mcpServer.init()
       const { handler } = mcpServer.createHTTPRequestHandler({ path: '/mcp' })
       this.mcpHandler = handler
-      this.logger.info('pikku-node-http-server: MCP tools mounted at /mcp')
+      this.logger.info('pikku-node-http-server: MCP mounted at /mcp')
     } catch (err) {
-      this.logger.warn(`pikku-node-http-server: MCP tools registered but /mcp could not be mounted — ${err instanceof Error ? err.message : String(err)}`)
+      this.logger.warn(
+        `pikku-node-http-server: MCP could not be mounted — ${err instanceof Error ? err.message : String(err)}`
+      )
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5661,7 +5661,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pikku/modelcontextprotocol@npm:^0.12.1, @pikku/modelcontextprotocol@workspace:*, @pikku/modelcontextprotocol@workspace:packages/runtimes/modelcontextprotocol":
+"@pikku/modelcontextprotocol@npm:^0.12.1, @pikku/modelcontextprotocol@npm:^0.12.4, @pikku/modelcontextprotocol@workspace:*, @pikku/modelcontextprotocol@workspace:packages/runtimes/modelcontextprotocol":
   version: 0.0.0-use.local
   resolution: "@pikku/modelcontextprotocol@workspace:packages/runtimes/modelcontextprotocol"
   dependencies:
@@ -5726,9 +5726,14 @@ __metadata:
   resolution: "@pikku/node-http-server@workspace:packages/runtimes/node-http-server"
   dependencies:
     "@pikku/core": "npm:^0.12.21"
+    "@pikku/modelcontextprotocol": "npm:^0.12.4"
     typescript: "npm:^5.9.3"
   peerDependencies:
     "@pikku/core": ^0.12.21
+    "@pikku/modelcontextprotocol": ^0.12.4
+  peerDependenciesMeta:
+    "@pikku/modelcontextprotocol":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Auto-mounts an MCP server inside `PikkuNodeHTTPServer` when MCP tools are registered, with an optional `mcpJson` mount option and a warn-on-mount-failure path.

Commits (rebased onto current `main`):
- `feat(mcp): auto-mount MCP server in PikkuNodeHTTPServer when tools are registered`
- `fix(mcp): warn instead of silently skip when /mcp mount fails`
- `feat(node-http-server): optional MCP mount via mcpJson option`

Touches `runtimes/node-http-server` (mount logic + dep) and `cli` config (`mcpJson` field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node HTTP Server runtime supports optional Model Context Protocol (MCP) auto-mounting and routes requests to `/mcp` when enabled.

* **Refactor**
  * MCP JSON generation now runs unconditionally in the MCP workflow.
  * MCP JSON output path now defaults when not set, and MCP JSON wiring prioritizes the configured output path with a fallback.

* **Tests**
  * Added coverage for MCP mounting, routing behavior, and warning logging on mount failures.

* **Chores**
  * Added optional peer/dev dependency for MCP and updated CI coverage reporting via a new unit-coverage job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->