### PR TITLE
feat(secret): add optional rotationPeriod to wireSecret

### DIFF
--- a/packages/core/src/wirings/secret/secret.types.ts
+++ b/packages/core/src/wirings/secret/secret.types.ts
@@ -4,6 +4,12 @@ export type CoreSecret<T = unknown> = {
   description?: string
   secretId: string
   schema: T
+  /**
+   * Optional rotation cadence for this secret, e.g. '1d', '30day', '1w'.
+   * Stored in the generated secrets metadata so consumers can tell when a
+   * secret was last updated and whether it is due for rotation.
+   */
+  rotationPeriod?: string
 }
 
 export type OAuth2CredentialConfig = {
@@ -22,6 +28,7 @@ export type SecretDefinitionMeta = {
   secretId: string
   schema?: Record<string, unknown> | string
   oauth2?: OAuth2CredentialConfig
+  rotationPeriod?: string
   sourceFile?: string
 }
 

--- a/packages/core/src/wirings/secret/validate-secret-definitions.ts
+++ b/packages/core/src/wirings/secret/validate-secret-definitions.ts
@@ -57,6 +57,7 @@ export function validateAndBuildSecretDefinitionsMeta(
           secretId: def.secretId,
           schema: def.schema,
           oauth2: def.oauth2,
+          rotationPeriod: def.rotationPeriod,
           sourceFile: def.sourceFile,
         }
       }
@@ -73,6 +74,7 @@ export function validateAndBuildSecretDefinitionsMeta(
         secretId: def.secretId,
         schema: def.schema,
         oauth2: def.oauth2,
+        rotationPeriod: def.rotationPeriod,
         sourceFile: def.sourceFile,
       }
     }

--- a/packages/inspector/src/add/add-keyed-wiring.ts
+++ b/packages/inspector/src/add/add-keyed-wiring.ts
@@ -6,6 +6,7 @@ import {
 import type { AddWiring, InspectorState } from '../types.js'
 import { ErrorCode } from '../error-codes.js'
 import { detectSchemaVendorOrError } from '../utils/detect-schema-vendor.js'
+import { parseDurationString } from '@pikku/core'
 
 export interface KeyedWiringConfig {
   functionName: string
@@ -50,6 +51,9 @@ export const createAddKeyedWiring = (config: KeyedWiringConfig): AddWiring => {
         | string
         | null
       const descriptionValue = getPropertyValue(obj, 'description') as
+        | string
+        | null
+      const rotationPeriodValue = getPropertyValue(obj, 'rotationPeriod') as
         | string
         | null
       const idValue = getPropertyValue(obj, config.idField) as string | null
@@ -123,6 +127,18 @@ export const createAddKeyedWiring = (config: KeyedWiringConfig): AddWiring => {
         return
       }
 
+      if (rotationPeriodValue) {
+        try {
+          parseDurationString(rotationPeriodValue)
+        } catch {
+          logger.critical(
+            ErrorCode.INVALID_VALUE,
+            `${config.label} '${nameValue}' has an invalid 'rotationPeriod': '${rotationPeriodValue}'. Use a duration like '1d', '30day', or '1w'.`
+          )
+          return
+        }
+      }
+
       const sourceFile = node.getSourceFile().fileName
 
       const wiringState = config.getState(state)
@@ -148,6 +164,7 @@ export const createAddKeyedWiring = (config: KeyedWiringConfig): AddWiring => {
         name: nameValue,
         displayName: displayNameValue,
         description: descriptionValue || undefined,
+        rotationPeriod: rotationPeriodValue || undefined,
         [config.idField]: idValue,
         schema: schemaLookupName,
         sourceFile,

--- a/verifiers/secrets/src/credentials.ts
+++ b/verifiers/secrets/src/credentials.ts
@@ -18,6 +18,7 @@ wireSecret({
   description: 'Credentials for the example external API',
   secretId: 'EXAMPLE_API_CREDENTIALS',
   schema: apiCredentialsSchema,
+  rotationPeriod: '30day',
 })
 
 /**


### PR DESCRIPTION
## What

Adds an optional `rotationPeriod` field to `wireSecret`, e.g.:

```ts
wireSecret({
  name: 'example-api',
  displayName: 'Example API',
  secretId: 'EXAMPLE_API_CREDENTIALS',
  schema: apiCredentialsSchema,
  rotationPeriod: '30day',
})
```

The inspector extracts it, validates the duration string, and stores it in the generated secrets meta JSON so consumers can tell whether a secret is due for rotation.

## How

- `CoreSecret` / `SecretDefinitionMeta` — new optional `rotationPeriod?: string`.
- `add-keyed-wiring.ts` — extracts `rotationPeriod`, validates it via the existing `parseDurationString` util; emits a critical **PKU124** (`INVALID_VALUE`) on a malformed value, otherwise carries it into the definition.
- `validate-secret-definitions.ts` — threads `rotationPeriod` into the built meta (lands in `pikku-secrets-meta.gen.json`).
- Verifier fixture updated with `rotationPeriod: '30day'`.

Meta-JSON only — no runtime `CredentialMeta` / `TypedSecretService` changes.

## Verification

- `tsc -b` clean on `@pikku/core` and `@pikku/inspector`.
- Valid `'30day'` → appears as `"rotationPeriod": "30day"` in the generated meta JSON.
- Malformed `'banana'` → build fails with `[PKU124] Secret 'example-api' has an invalid 'rotationPeriod': 'banana'.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)