### PR TITLE
fix(node-http-server): configurable MCP path + boundary-safe routing

### DIFF
--- a/.changeset/mcp-path-configurable.md
+++ b/.changeset/mcp-path-configurable.md
@@ -1,0 +1,5 @@
+---
+'@pikku/node-http-server': patch
+---
+
+Make the MCP mount path configurable via the `mcpPath` option (default `/mcp`) and route to the MCP handler only on an exact `/mcp` path boundary instead of any `/mcp`-prefixed path.

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.test.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.test.ts
@@ -65,12 +65,27 @@ const createSignedAssetUrl = async (options?: {
 const createCapturingLogger = () => {
   const warnings: string[] = []
   const infos: string[] = []
+  const capture =
+    (sink: string[]) =>
+    (messageOrObj: string | Record<string, any>, ..._meta: any[]) => {
+      sink.push(
+        typeof messageOrObj === 'string'
+          ? messageOrObj
+          : JSON.stringify(messageOrObj)
+      )
+    }
   return {
     logger: {
-      info: (msg: string) => infos.push(msg),
-      warn: (msg: string) => warnings.push(msg),
-      error: (_msg: string | Error) => {},
-      debug: (_msg: string) => {},
+      info: capture(infos),
+      warn: capture(warnings),
+      error: (
+        _messageOrObj: string | Record<string, any> | Error,
+        ..._meta: any[]
+      ) => {},
+      debug: (
+        _messageOrObj: string | Record<string, any>,
+        ..._meta: any[]
+      ) => {},
       setLevel: () => {},
     },
     warnings,
@@ -399,7 +414,10 @@ describe('PikkuNodeHTTPServer MCP mounting', { concurrency: false }, () => {
 
   test('mounts /mcp when mcpJson declares at least one tool', async () => {
     const { logger, infos } = createCapturingLogger()
-    const origin = await startServer({ mcpJson: { tools: [{ name: 'echo' }] } }, logger)
+    const origin = await startServer(
+      { mcpJson: { tools: [{ name: 'echo' }] } },
+      logger
+    )
 
     const response = await getMcp(origin)
     // A GET to /mcp with no session is handled by the MCP server, which
@@ -413,11 +431,54 @@ describe('PikkuNodeHTTPServer MCP mounting', { concurrency: false }, () => {
     )
   })
 
+  test('mounts the MCP server at a configurable path', async () => {
+    const { logger, infos } = createCapturingLogger()
+    const origin = await startServer(
+      { mcpJson: { tools: [{ name: 'echo' }] }, mcpPath: '/api/mcp' },
+      logger
+    )
+
+    const mounted = await fetch(`${origin}/api/mcp`, {
+      headers: { connection: 'close' },
+    })
+    assert.equal(mounted.status, 400)
+    assert.equal((await mounted.text()).includes(MCP_SESSION_ERROR), true)
+    assert.ok(
+      infos.some((msg) => msg.includes('MCP mounted at /api/mcp')),
+      'expected a log line confirming the configured mount path'
+    )
+
+    const defaultPath = await fetch(`${origin}/mcp`, {
+      headers: { connection: 'close' },
+    })
+    assert.equal(
+      (await defaultPath.text()).includes(MCP_SESSION_ERROR),
+      false,
+      'the default /mcp path must not be served when a custom path is set'
+    )
+  })
+
+  test('does not route /mcp-prefixed paths to the MCP handler', async () => {
+    const origin = await startServer({ mcpJson: { tools: [{ name: 'echo' }] } })
+    const response = await fetch(`${origin}/mcpfoo`, {
+      headers: { connection: 'close' },
+    })
+    const body = await response.text()
+    // The MCP handler answers an unmatched path with an empty-body 404; the
+    // normal pikku pipeline always returns a JSON body. A non-empty body proves
+    // /mcpfoo was NOT diverted to the MCP handler.
+    assert.equal(body.includes(MCP_SESSION_ERROR), false)
+    assert.notEqual(body, '', '/mcpfoo must not be routed to the MCP handler')
+  })
+
   test('logs a warning and serves normally when MCP mounting fails', async () => {
     const { logger, warnings } = createCapturingLogger()
     // A null entry makes the registry throw while reading `tool.name`, which
     // exercises the catch branch in initMCP.
-    const origin = await startServer({ mcpJson: { tools: [null] } as any }, logger)
+    const origin = await startServer(
+      { mcpJson: { tools: [null] } as any },
+      logger
+    )
 
     assert.ok(
       warnings.some((msg) => msg.includes('MCP could not be mounted')),

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
@@ -68,10 +68,15 @@ export type PikkuNodeHTTPServerOptions = {
   configureServer?: (server: Server) => void | Promise<void>
   /**
    * Parsed content of `.pikku/mcp/mcp.gen.json`. When provided and non-empty,
-   * `@pikku/modelcontextprotocol` is dynamically imported and `/mcp` is mounted.
+   * `@pikku/modelcontextprotocol` is dynamically imported and the MCP server is
+   * mounted at `mcpPath`.
    * Import the JSON statically so bundlers (esbuild) inline it: no runtime file read needed.
    */
   mcpJson?: { tools?: unknown[]; resources?: unknown[]; prompts?: unknown[] }
+  /**
+   * Path the MCP server is mounted at when `mcpJson` is provided. Default `/mcp`.
+   */
+  mcpPath?: string
 } & RunHTTPWiringOptions
 
 const HARDENING_DEFAULTS = {
@@ -96,6 +101,7 @@ export class PikkuNodeHTTPServer {
   public server: Server
   private listening = false
   private shutdownGracePeriodMs: number
+  private mcpPath: string
   private mcpHandler?: (
     req: IncomingMessage,
     res: ServerResponse
@@ -117,6 +123,7 @@ export class PikkuNodeHTTPServer {
       config.maxRequestsPerSocket ?? HARDENING_DEFAULTS.maxRequestsPerSocket
     this.shutdownGracePeriodMs =
       config.shutdownGracePeriodMs ?? HARDENING_DEFAULTS.shutdownGracePeriodMs
+    this.mcpPath = options.mcpPath ?? '/mcp'
   }
 
   public async init(): Promise<void> {
@@ -149,14 +156,29 @@ export class PikkuNodeHTTPServer {
         this.logger
       )
       await mcpServer.init()
-      const { handler } = mcpServer.createHTTPRequestHandler({ path: '/mcp' })
+      const { handler } = mcpServer.createHTTPRequestHandler({
+        path: this.mcpPath,
+      })
       this.mcpHandler = handler
-      this.logger.info('pikku-node-http-server: MCP mounted at /mcp')
+      this.logger.info(`pikku-node-http-server: MCP mounted at ${this.mcpPath}`)
     } catch (err) {
       this.logger.warn(
         `pikku-node-http-server: MCP could not be mounted — ${err instanceof Error ? err.message : String(err)}`
       )
     }
+  }
+
+  private matchesMcpPath(url: string): boolean {
+    if (!url.startsWith(this.mcpPath)) {
+      return false
+    }
+    const boundary = url.charAt(this.mcpPath.length)
+    return (
+      boundary === '' ||
+      boundary === '/' ||
+      boundary === '?' ||
+      boundary === '#'
+    )
   }
 
   private handleRequest = async (
@@ -175,7 +197,7 @@ export class PikkuNodeHTTPServer {
         return
       }
 
-      if (this.mcpHandler && req.url?.startsWith('/mcp')) {
+      if (this.mcpHandler && req.url && this.matchesMcpPath(req.url)) {
         await this.mcpHandler(req, res)
         return
       }


### PR DESCRIPTION
Follow-up to #679, which merged before this CodeRabbit fix landed on the branch.

## What
- **Boundary-safe `/mcp` routing**: the merged code routes any `/mcp`-prefixed path (e.g. `/mcpfoo`) to the MCP handler via `req.url?.startsWith('/mcp')`. This now matches only the exact `/mcp` path or a `/`, `?`, `#` boundary.
- **Configurable mount path**: new `mcpPath` option on `PikkuNodeHTTPServerOptions` (default `/mcp`), used for the mount, the routing check, and the log line.
- Widened the test capturing-logger signatures to match the `Logger` interface.

## Why
CodeRabbit flagged the prefix-match on #679; the fix commit was pushed ~17 min after that PR was merged, so it never reached main.

## Tests
Two new tests (configurable path + boundary routing) — both fail against the old code and pass with the fix. Full `@pikku/node-http-server` suite green; `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* The MCP server mount path is now configurable via an `mcpPath` option, defaulting to `/mcp`.
* Improved path routing to ensure only exact path matches are routed to the MCP handler, not all `/mcp`-prefixed paths.

## Tests
* Added comprehensive tests for custom MCP path configuration and path boundary matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->