### PR TITLE
feat(core): add auditLog service slot for per-invocation audit logs

### DIFF
--- a/.changeset/core-audit-log-service-slot.md
+++ b/.changeset/core-audit-log-service-slot.md
@@ -1,0 +1,17 @@
+---
+"@pikku/core": patch
+---
+
+feat(core): add `auditLog` service slot for per-invocation audit logs
+
+`CoreSingletonServices` now declares `auditLog?: AuditLog`, giving the
+per-request audit log returned by `createInvocationAudit` a typed home in the
+service container. Apps wire it in `createWireServices`
+(`return { auditLog, kysely: createAuditedKysely(kysely, { audit: auditLog }) }`)
+and the runner flushes its buffer via `close()` when the invocation ends.
+
+Previously there was no slot to return it from: `audit` is typed `AuditService`
+(the durable sink, `.audit()`), while `createInvocationAudit` returns an
+`AuditLog` (the request-scoped buffer, `.write/.flush/.close`). Returning the
+buffer under `audit` was a type error, so audited-Kysely wiring could not
+type-check. `auditLog` is distinct from `audit` and never shadows it.

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -40,6 +40,7 @@ import type { MetaService } from '../services/meta-service.js'
 import type { SessionStore } from '../services/session-store.js'
 import type {
   AuditDurability,
+  AuditLog,
   AuditService,
 } from '../services/audit-service.js'
 
@@ -255,6 +256,14 @@ export interface CoreSingletonServices<Config extends CoreConfig = CoreConfig> {
   metaService?: MetaService
   /** Audit service for durable or staged audit event capture */
   audit?: AuditService
+  /**
+   * Per-invocation audit log. Typically created in `createWireServices` via
+   * `createInvocationAudit(audit, wire)` and returned as a wire service so the
+   * runner flushes its buffer (via `close()`) when the invocation ends. Distinct
+   * from `audit` (the durable sink): this is the request-scoped buffer that
+   * writes into it.
+   */
+  auditLog?: AuditLog
   /** Session store for persisting user sessions keyed by pikkuUserId */
   sessionStore?: SessionStore
 }


### PR DESCRIPTION
## What

Adds `auditLog?: AuditLog` to `CoreSingletonServices`, giving the per-request audit log returned by `createInvocationAudit` a typed home in the service container.

## Why

`audit` is typed `AuditService` — the durable sink (`.audit(event)`). `createInvocationAudit(audit, wire)` returns an `AuditLog` — the request-scoped buffer (`.write/.flush/.close`). There was no slot to return that buffer from, so wiring an audited Kysely in `createWireServices` could not type-check (returning the `AuditLog` under the `audit` key collides with `AuditService`).

With this slot, apps wire it cleanly:

```ts
export const createWireServices = pikkuWireServices(async (services, wire) => {
  if (!services.audit) return {}
  const auditLog = createInvocationAudit(services.audit, wire)
  if (!auditLog.config) return {}
  return {
    auditLog,
    kysely: createAuditedKysely(services.kysely, { audit: auditLog }),
  }
})
```

The runner already flushes it: `closeWireServices` calls `.close()` on returned wire services when the invocation ends. `auditLog` is distinct from `audit` and never shadows it.

## Notes

- Type-only addition to `CoreSingletonServices`; no runtime behaviour change.
- `@pikku/core` patch changeset included.
- `packages/core` type-checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved audit logging type compatibility issue, ensuring proper request-scoped audit buffering during invocations.

* **Improvements**
  * Enhanced audit system with clearer distinction between durable and request-scoped audit logs, with automatic buffer cleanup at invocation completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->