### PR TITLE
feat(react,mantine): i18n brand types + @pikku/mantine zero-runtime overrides

### DIFF
--- a/.changeset/pikku-mantine-i18n.md
+++ b/.changeset/pikku-mantine-i18n.md
@@ -1,0 +1,19 @@
+---
+"@pikku/mantine": minor
+"@pikku/react": minor
+---
+
+feat(react,mantine): i18n brand types + zero-runtime Mantine overrides
+
+`@pikku/react` now exports the i18n brand types `I18nString` / `I18nNode` and the
+`asI18n()` escape hatch from its main entry (pure, no react-i18next dependency).
+The `useI18n` hook and `I18nProvider` move to the new `@pikku/react/i18n` subpath,
+which declares `i18next` / `react-i18next` as optional peers — consumers that only
+need the brand never pull them in.
+
+New package `@pikku/mantine` (`@pikku/mantine/core`) is a drop-in for
+`@mantine/core` (peer `^9`) that adds zero runtime: it re-exports the real Mantine
+component values and only re-casts their types so every string-bearing prop
+(`children`, `label`, `placeholder`, `title`, `aria-label`, …) requires the branded
+`I18nString` / `I18nNode` instead of a bare `string`. Polymorphism (`component=`)
+and compound statics (`Menu.Item`, `Tabs.List`, `Menu.Divider`, …) are preserved.

--- a/.changeset/pikku-mantine-i18n.md
+++ b/.changeset/pikku-mantine-i18n.md
@@ -12,7 +12,8 @@ which declares `i18next` / `react-i18next` as optional peers — consumers that 
 need the brand never pull them in.
 
 New package `@pikku/mantine` (`@pikku/mantine/core`) is a drop-in for
-`@mantine/core` (peer `^9`) that adds zero runtime: it re-exports the real Mantine
+`@mantine/core` (peer `^8 || ^9` — type contract verified against both 8.3.x and
+9.3.x) that adds zero runtime: it re-exports the real Mantine
 component values and only re-casts their types so every string-bearing prop
 (`children`, `label`, `placeholder`, `title`, `aria-label`, …) requires the branded
 `I18nString` / `I18nNode` instead of a bare `string`. Polymorphism (`component=`)

--- a/.changeset/pikku-mantine-i18n.md
+++ b/.changeset/pikku-mantine-i18n.md
@@ -1,6 +1,6 @@
 ---
-"@pikku/mantine": minor
-"@pikku/react": minor
+"@pikku/mantine": patch
+"@pikku/react": patch
 ---
 
 feat(react,mantine): i18n brand types + zero-runtime Mantine overrides

--- a/packages/frontend/mantine/README.md
+++ b/packages/frontend/mantine/README.md
@@ -29,7 +29,7 @@ errors, user content).
 
 ```sh
 yarn add @pikku/mantine @pikku/react
-# peers: @mantine/core@^9, react
+# peers: @mantine/core@^8 || ^9, react
 ```
 
 ## How it works

--- a/packages/frontend/mantine/README.md
+++ b/packages/frontend/mantine/README.md
@@ -1,0 +1,41 @@
+# @pikku/mantine
+
+A drop-in for [`@mantine/core`](https://mantine.dev) with i18n-tightened types —
+**zero runtime added**. Every string-bearing prop (`children`, `label`,
+`placeholder`, `title`, `aria-label`, …) is narrowed from `string` to the branded
+`I18nString` / `I18nNode` from [`@pikku/react`](../react), so untranslated literals
+fail to compile.
+
+```tsx
+// before — plain Mantine compiles this
+import { Button } from '@mantine/core'
+;<Button>Save</Button>
+
+// after — @pikku/mantine rejects the raw string
+import { Button } from '@pikku/mantine/core'
+import { useI18n } from '@pikku/react/i18n'
+
+const { t } = useI18n()
+;<Button>{t('actions.save')}</Button> // ✅ branded
+;<Button>Save</Button> // ❌ type error
+```
+
+Aliasing `@mantine/core` → `@pikku/mantine/core` (e.g. via build-time resolution)
+therefore turns the whole app into a strict translation gate. Use `asI18n()` from
+`@pikku/react` as a deliberate escape hatch for dynamic, non-i18n strings (server
+errors, user content).
+
+## Install
+
+```sh
+yarn add @pikku/mantine @pikku/react
+# peers: @mantine/core@^9, react
+```
+
+## How it works
+
+The package re-exports the real Mantine component *values* and only re-casts their
+*types*. Polymorphism (`component="a"`), compound statics (`Menu.Item`,
+`Tabs.List`, `Menu.Divider`, …) and every other Mantine feature are preserved —
+see `src/core/helpers.ts` for the type machinery and `src/core/i18n.test-d.tsx`
+for the enforced positive/negative contract (`yarn test`).

--- a/packages/frontend/mantine/package.json
+++ b/packages/frontend/mantine/package.json
@@ -19,12 +19,12 @@
     "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
-    "@mantine/core": "^9",
+    "@mantine/core": "^8 || ^9",
     "@pikku/react": "workspace:^",
     "react": "^18 || ^19"
   },
   "devDependencies": {
-    "@mantine/core": "^9",
+    "@mantine/core": "^8.3.8",
     "@pikku/react": "workspace:^",
     "@types/react": "^19",
     "react": "^19",

--- a/packages/frontend/mantine/package.json
+++ b/packages/frontend/mantine/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@pikku/mantine",
+  "version": "0.12.2",
+  "author": "yasser.fadl@gmail.com",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./core": {
+      "import": "./dist/esm/core/index.js",
+      "require": "./dist/cjs/core/index.js"
+    }
+  },
+  "scripts": {
+    "tsc": "tsc",
+    "test": "tsc -p tsconfig.test-d.json",
+    "build:esm": "tsc -b && echo '{\"type\": \"module\"}' > dist/esm/package.json",
+    "build:cjs": "tsc -b tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
+    "build": "yarn build:esm && yarn build:cjs",
+    "prepublishOnly": "yarn build"
+  },
+  "peerDependencies": {
+    "@mantine/core": "^9",
+    "@pikku/react": "workspace:^",
+    "react": "^18 || ^19"
+  },
+  "devDependencies": {
+    "@mantine/core": "^9",
+    "@pikku/react": "workspace:^",
+    "@types/react": "^19",
+    "react": "^19",
+    "typescript": "^5.9"
+  }
+}

--- a/packages/frontend/mantine/src/core/helpers.ts
+++ b/packages/frontend/mantine/src/core/helpers.ts
@@ -1,0 +1,35 @@
+import type {
+  FactoryPayload,
+  MantineComponent,
+  MantinePolymorphicComponent,
+} from '@mantine/core'
+
+// Mantine's `PolymorphicFactoryPayload` isn't a public export; reconstruct its
+// shape from the public `FactoryPayload`.
+type PolyPayload = FactoryPayload & { defaultComponent: any; defaultRef: any }
+
+// Homomorphic mapped type: preserves every payload key (defaultComponent,
+// defaultRef, stylesNames, variant, staticComponents…) and rewrites only `props`
+// so the override wins over the original prop types.
+type WithProps<F, O> = {
+  [K in keyof F]: K extends 'props' ? Omit<F[K & 'props'], keyof O> & O : F[K]
+}
+
+/** Narrow a polymorphic Mantine component's props while keeping `component=`. */
+export type OverridePoly<F extends PolyPayload, O> = MantinePolymorphicComponent<
+  WithProps<F, O>
+>
+
+/** Narrow a plain (non-polymorphic) Mantine component's props. */
+export type OverrideFactory<F extends FactoryPayload, O> = MantineComponent<
+  WithProps<F, O>
+>
+
+// For compound components (Menu, Tabs, Stepper…) whose factory doesn't surface
+// `staticComponents`: override only the named statics, KEEP every other static
+// (Menu.Divider, Menu.Sub, Tabs.List…), and preserve the parent's own call
+// signature. `CallSig` keeps callability (mapped types strip it); the mapped
+// type keeps all static keys.
+type CallSig<T> = T extends (...a: infer A) => infer R ? (...a: A) => R : unknown
+type OverrideStatics<T, O> = { [K in keyof T]: K extends keyof O ? O[K] : T[K] }
+export type WithStatics<T, O> = CallSig<T> & OverrideStatics<T, O>

--- a/packages/frontend/mantine/src/core/i18n.test-d.tsx
+++ b/packages/frontend/mantine/src/core/i18n.test-d.tsx
@@ -4,6 +4,8 @@
 
 import {
   Button,
+  Text,
+  Title,
   ActionIcon,
   TextInput,
   Select,
@@ -38,6 +40,10 @@ const _ok_mixed = (
     {t('save')}
   </Button>
 )
+const _ok_text = <Text>{t('greeting')}</Text>
+// Text is polymorphic too
+const _ok_text_poly = <Text component="span">{t('greeting')}</Text>
+const _ok_title = <Title order={2}>{t('page.title')}</Title>
 const _ok_icon = <ActionIcon aria-label={t('close')} />
 const _ok_input = <TextInput label={t('email')} placeholder={asI18n('you@x.com')} />
 const _ok_select = (
@@ -93,6 +99,10 @@ const _bad_button2 = <Button>{'Save'}</Button>
 // prettier-ignore
 // @ts-expect-error — raw string child on polymorphic usage
 const _bad_poly = <Button component="a" href="/x">Go</Button>;
+// @ts-expect-error — raw string child on Text
+const _bad_text = <Text>Hello</Text>
+// @ts-expect-error — raw string child on Title
+const _bad_title = <Title order={1}>Page</Title>
 // @ts-expect-error — raw string aria-label
 const _bad_icon = <ActionIcon aria-label="close" />
 // @ts-expect-error — raw string label
@@ -109,6 +119,9 @@ void [
   _ok_button_jsx,
   _ok_poly,
   _ok_mixed,
+  _ok_text,
+  _ok_text_poly,
+  _ok_title,
   _ok_icon,
   _ok_input,
   _ok_select,
@@ -120,6 +133,8 @@ void [
   _bad_button,
   _bad_button2,
   _bad_poly,
+  _bad_text,
+  _bad_title,
   _bad_icon,
   _bad_input,
   _bad_modal,

--- a/packages/frontend/mantine/src/core/i18n.test-d.tsx
+++ b/packages/frontend/mantine/src/core/i18n.test-d.tsx
@@ -43,6 +43,12 @@ const _ok_mixed = (
 const _ok_text = <Text>{t('greeting')}</Text>
 // Text is polymorphic too
 const _ok_text_poly = <Text component="span">{t('greeting')}</Text>
+// aria-label / title on children components are branded too
+const _ok_button_attrs = (
+  <Button aria-label={t('save')} title={t('save')}>
+    {t('save')}
+  </Button>
+)
 const _ok_title = <Title order={2}>{t('page.title')}</Title>
 const _ok_icon = <ActionIcon aria-label={t('close')} />
 const _ok_input = <TextInput label={t('email')} placeholder={asI18n('you@x.com')} />
@@ -99,6 +105,10 @@ const _bad_button2 = <Button>{'Save'}</Button>
 // prettier-ignore
 // @ts-expect-error — raw string child on polymorphic usage
 const _bad_poly = <Button component="a" href="/x">Go</Button>;
+// @ts-expect-error — raw string aria-label on a children component
+const _bad_button_aria = <Button aria-label="save">{t('save')}</Button>
+// @ts-expect-error — raw string title on a children component
+const _bad_button_title = <Button title="save">{t('save')}</Button>
 // @ts-expect-error — raw string child on Text
 const _bad_text = <Text>Hello</Text>
 // @ts-expect-error — raw string child on Title
@@ -121,6 +131,7 @@ void [
   _ok_mixed,
   _ok_text,
   _ok_text_poly,
+  _ok_button_attrs,
   _ok_title,
   _ok_icon,
   _ok_input,
@@ -133,6 +144,8 @@ void [
   _bad_button,
   _bad_button2,
   _bad_poly,
+  _bad_button_aria,
+  _bad_button_title,
   _bad_text,
   _bad_title,
   _bad_icon,

--- a/packages/frontend/mantine/src/core/i18n.test-d.tsx
+++ b/packages/frontend/mantine/src/core/i18n.test-d.tsx
@@ -1,0 +1,128 @@
+// Type-level tests. A clean `tsc --noEmit` over this file proves both that the
+// brand is enforced (negatives fail) and that polymorphism + statics survive.
+// Run standalone — it is excluded from the package build.
+
+import {
+  Button,
+  ActionIcon,
+  TextInput,
+  Select,
+  Modal,
+  Tooltip,
+  Menu,
+  Tabs,
+  Stepper,
+} from './index.js'
+import { asI18n } from '@pikku/react'
+import type { I18nString } from '@pikku/react'
+
+declare const t: (k: string) => I18nString
+
+// ── positives: branded text + JSX structure compile ──────────────────────────
+const _ok_button = <Button onClick={() => {}}>{t('save')}</Button>
+const _ok_button_jsx = (
+  <Button leftSection={<span />} variant="filled">
+    {t('save')}
+  </Button>
+)
+// polymorphism preserved — component="a" + anchor-only href
+const _ok_poly = (
+  <Button component="a" href="/x" target="_blank">
+    {t('go')}
+  </Button>
+)
+// mixed / multiple children allowed (array I18nNode), bare string still not
+const _ok_mixed = (
+  <Button>
+    <span />
+    {t('save')}
+  </Button>
+)
+const _ok_icon = <ActionIcon aria-label={t('close')} />
+const _ok_input = <TextInput label={t('email')} placeholder={asI18n('you@x.com')} />
+const _ok_select = (
+  <Select data={[]} label={t('country')} nothingFoundMessage={t('none')} />
+)
+const _ok_modal = (
+  <Modal opened onClose={() => {}} title={t('confirm')}>
+    <span>structural body is fine</span>
+  </Modal>
+)
+const _ok_tooltip = (
+  <Tooltip label={t('hint')}>
+    <span />
+  </Tooltip>
+)
+const _ok_menu = (
+  <Menu>
+    <Menu.Target>
+      <Button>{t('open')}</Button>
+    </Menu.Target>
+    <Menu.Dropdown>
+      <Menu.Label>{t('section')}</Menu.Label>
+      <Menu.Item onClick={() => {}}>{t('rename')}</Menu.Item>
+      {/* preserved static we never overrode */}
+      <Menu.Divider />
+    </Menu.Dropdown>
+  </Menu>
+)
+const _ok_tabs = (
+  <Tabs defaultValue="a">
+    <Tabs.List>
+      <Tabs.Tab value="a">{t('first')}</Tabs.Tab>
+    </Tabs.List>
+    <Tabs.Panel value="a">
+      <span />
+    </Tabs.Panel>
+  </Tabs>
+)
+const _ok_stepper = (
+  <Stepper active={0}>
+    <Stepper.Step label={t('step1')} />
+    <Stepper.Completed>
+      <span />
+    </Stepper.Completed>
+  </Stepper>
+)
+
+// ── negatives: raw unbranded strings MUST fail ───────────────────────────────
+// @ts-expect-error — raw string child
+const _bad_button = <Button>Save</Button>
+// @ts-expect-error — raw string expression child
+const _bad_button2 = <Button>{'Save'}</Button>
+// prettier-ignore
+// @ts-expect-error — raw string child on polymorphic usage
+const _bad_poly = <Button component="a" href="/x">Go</Button>;
+// @ts-expect-error — raw string aria-label
+const _bad_icon = <ActionIcon aria-label="close" />
+// @ts-expect-error — raw string label
+const _bad_input = <TextInput label="Email" />
+// @ts-expect-error — raw string title
+const _bad_modal = <Modal opened onClose={() => {}} title="Confirm" />
+// @ts-expect-error — raw string child on Menu.Item
+const _bad_menu_item = <Menu.Item>Rename</Menu.Item>
+// @ts-expect-error — raw string child on Tabs.Tab
+const _bad_tab = <Tabs.Tab value="a">First</Tabs.Tab>
+
+void [
+  _ok_button,
+  _ok_button_jsx,
+  _ok_poly,
+  _ok_mixed,
+  _ok_icon,
+  _ok_input,
+  _ok_select,
+  _ok_modal,
+  _ok_tooltip,
+  _ok_menu,
+  _ok_tabs,
+  _ok_stepper,
+  _bad_button,
+  _bad_button2,
+  _bad_poly,
+  _bad_icon,
+  _bad_input,
+  _bad_modal,
+  _bad_menu_item,
+  _bad_tab,
+]

--- a/packages/frontend/mantine/src/core/index.ts
+++ b/packages/frontend/mantine/src/core/index.ts
@@ -1,0 +1,290 @@
+// @pikku/mantine/core — a drop-in for `@mantine/core` with i18n-tightened types.
+//
+// The VALUES below are the untouched Mantine components — this package adds ZERO
+// runtime. We only re-cast each component's TYPE so that string-bearing props
+// (children, label, placeholder, title, aria-label…) accept the branded
+// `I18nString` / `I18nNode` from `@pikku/react` instead of a bare `string`.
+//
+// Aliasing `@mantine/core` -> `@pikku/mantine/core` over code written against
+// plain Mantine (`<Button>Save</Button>`) is therefore a STRICT GATE: untranslated
+// raw strings fail to compile. Pass text through `t()` / `asI18n()`.
+
+export * from '@mantine/core'
+
+import {
+  // polymorphic (children)
+  Button as MantineButton,
+  Anchor as MantineAnchor,
+  Badge as MantineBadge,
+  // polymorphic (aria-label only)
+  ActionIcon as MantineActionIcon,
+  CloseButton as MantineCloseButton,
+  // polymorphic (label/description)
+  NavLink as MantineNavLink,
+  // polymorphic (input)
+  InputBase as MantineInputBase,
+  // plain (children)
+  Chip as MantineChip,
+  // plain (single label-ish prop)
+  Tooltip as MantineTooltip,
+  Divider as MantineDivider,
+  Indicator as MantineIndicator,
+  Progress as MantineProgress,
+  Fieldset as MantineFieldset,
+  Breadcrumbs as MantineBreadcrumbs,
+  Spoiler as MantineSpoiler,
+  // plain (title + children body)
+  Modal as MantineModal,
+  Drawer as MantineDrawer,
+  Alert as MantineAlert,
+  Notification as MantineNotification,
+  // plain (inputs)
+  TextInput as MantineTextInput,
+  PasswordInput as MantinePasswordInput,
+  Textarea as MantineTextarea,
+  NumberInput as MantineNumberInput,
+  Select as MantineSelect,
+  MultiSelect as MantineMultiSelect,
+  Checkbox as MantineCheckbox,
+  Switch as MantineSwitch,
+  Radio as MantineRadio,
+  Autocomplete as MantineAutocomplete,
+  TagsInput as MantineTagsInput,
+  NativeSelect as MantineNativeSelect,
+  FileInput as MantineFileInput,
+  JsonInput as MantineJsonInput,
+  ColorInput as MantineColorInput,
+  PinInput as MantinePinInput,
+  // compound
+  Menu as MantineMenu,
+  Tabs as MantineTabs,
+  Stepper as MantineStepper,
+  // factories (top-level components)
+  type ButtonFactory,
+  type AnchorFactory,
+  type BadgeFactory,
+  type ActionIconFactory,
+  type CloseButtonFactory,
+  type NavLinkFactory,
+  type InputBaseFactory,
+  type ChipFactory,
+  type TooltipFactory,
+  type DividerFactory,
+  type IndicatorFactory,
+  type ProgressFactory,
+  type FieldsetFactory,
+  type BreadcrumbsFactory,
+  type SpoilerFactory,
+  type ModalFactory,
+  type DrawerFactory,
+  type AlertFactory,
+  type NotificationFactory,
+  type TextInputFactory,
+  type PasswordInputFactory,
+  type TextareaFactory,
+  type NumberInputFactory,
+  type SelectFactory,
+  type MultiSelectFactory,
+  type CheckboxFactory,
+  type SwitchFactory,
+  type RadioFactory,
+  type AutocompleteFactory,
+  type TagsInputFactory,
+  type NativeSelectFactory,
+  type FileInputFactory,
+  type JsonInputFactory,
+  type ColorInputFactory,
+  type PinInputFactory,
+  // props for sub-components (their factories aren't root-exported)
+  type MenuItemProps,
+  type MenuLabelProps,
+  type TabsTabProps,
+  type StepperStepProps,
+} from '@mantine/core'
+
+import type { I18nNode, I18nString } from '@pikku/react'
+import type { OverrideFactory, OverridePoly, WithStatics } from './helpers.js'
+
+// shared override shapes
+type Children = { children?: I18nNode }
+type AriaLabel = { 'aria-label'?: I18nString }
+type Input = {
+  label?: I18nNode
+  placeholder?: I18nString
+  description?: I18nNode
+}
+
+// ── Polymorphic: children ────────────────────────────────────────────────────
+export const Button = MantineButton as OverridePoly<ButtonFactory, Children>
+export const Anchor = MantineAnchor as OverridePoly<AnchorFactory, Children>
+export const Badge = MantineBadge as OverridePoly<BadgeFactory, Children>
+
+// ── Polymorphic: icon-only buttons (aria-label is the only visible text) ──────
+export const ActionIcon = MantineActionIcon as OverridePoly<
+  ActionIconFactory,
+  AriaLabel
+>
+export const CloseButton = MantineCloseButton as OverridePoly<
+  CloseButtonFactory,
+  AriaLabel
+>
+
+// ── Polymorphic: label + description ──────────────────────────────────────────
+export const NavLink = MantineNavLink as OverridePoly<
+  NavLinkFactory,
+  { label?: I18nNode; description?: I18nNode }
+>
+
+// ── Polymorphic: generic input wrapper ───────────────────────────────────────
+export const InputBase = MantineInputBase as OverridePoly<InputBaseFactory, Input>
+
+// ── Plain: children ───────────────────────────────────────────────────────────
+export const Chip = MantineChip as OverrideFactory<ChipFactory, Children>
+
+// ── Plain: single label-ish prop ─────────────────────────────────────────────
+export const Tooltip = MantineTooltip as OverrideFactory<
+  TooltipFactory,
+  { label: I18nNode }
+>
+export const Divider = MantineDivider as OverrideFactory<
+  DividerFactory,
+  { label?: I18nNode }
+>
+export const Indicator = MantineIndicator as OverrideFactory<
+  IndicatorFactory,
+  { label?: I18nNode }
+>
+export const Progress = MantineProgress as OverrideFactory<
+  ProgressFactory,
+  { label?: I18nString }
+>
+export const Fieldset = MantineFieldset as OverrideFactory<
+  FieldsetFactory,
+  { legend?: I18nNode }
+>
+export const Breadcrumbs = MantineBreadcrumbs as OverrideFactory<
+  BreadcrumbsFactory,
+  { separator?: I18nNode }
+>
+export const Spoiler = MantineSpoiler as OverrideFactory<
+  SpoilerFactory,
+  { showLabel: I18nNode; hideLabel: I18nNode }
+>
+
+// ── Plain: title + structural children body ──────────────────────────────────
+export const Modal = MantineModal as OverrideFactory<
+  ModalFactory,
+  { title?: I18nNode }
+>
+export const Drawer = MantineDrawer as OverrideFactory<
+  DrawerFactory,
+  { title?: I18nNode }
+>
+export const Alert = MantineAlert as OverrideFactory<
+  AlertFactory,
+  { title?: I18nNode; children?: I18nNode }
+>
+export const Notification = MantineNotification as OverrideFactory<
+  NotificationFactory,
+  { title?: I18nNode; children?: I18nNode }
+>
+
+// ── Plain: inputs (label / placeholder / description, plus extras) ────────────
+export const TextInput = MantineTextInput as OverrideFactory<TextInputFactory, Input>
+export const PasswordInput = MantinePasswordInput as OverrideFactory<
+  PasswordInputFactory,
+  Input
+>
+export const Textarea = MantineTextarea as OverrideFactory<TextareaFactory, Input>
+export const JsonInput = MantineJsonInput as OverrideFactory<JsonInputFactory, Input>
+export const NativeSelect = MantineNativeSelect as OverrideFactory<
+  NativeSelectFactory,
+  Input
+>
+export const NumberInput = MantineNumberInput as OverrideFactory<
+  NumberInputFactory,
+  Input & { prefix?: I18nString; suffix?: I18nString }
+>
+export const Select = MantineSelect as OverrideFactory<
+  SelectFactory,
+  Input & { nothingFoundMessage?: I18nNode }
+>
+export const MultiSelect = MantineMultiSelect as OverrideFactory<
+  MultiSelectFactory,
+  Input & { nothingFoundMessage?: I18nNode }
+>
+export const Autocomplete = MantineAutocomplete as OverrideFactory<
+  AutocompleteFactory,
+  Input & { nothingFoundMessage?: I18nNode }
+>
+export const TagsInput = MantineTagsInput as OverrideFactory<
+  TagsInputFactory,
+  Input & { nothingFoundMessage?: I18nNode }
+>
+export const ColorInput = MantineColorInput as OverrideFactory<
+  ColorInputFactory,
+  Input & { swatchesLabel?: I18nString }
+>
+export const FileInput = MantineFileInput as OverrideFactory<
+  FileInputFactory,
+  { label?: I18nNode; placeholder?: I18nNode; description?: I18nNode }
+>
+export const PinInput = MantinePinInput as OverrideFactory<
+  PinInputFactory,
+  { placeholder?: I18nString }
+>
+export const Checkbox = MantineCheckbox as OverrideFactory<
+  CheckboxFactory,
+  { label?: I18nNode; description?: I18nNode }
+>
+export const Switch = MantineSwitch as OverrideFactory<
+  SwitchFactory,
+  { label?: I18nNode; description?: I18nNode }
+>
+export const Radio = MantineRadio as OverrideFactory<
+  RadioFactory,
+  { label?: I18nNode; description?: I18nNode }
+>
+
+// ── Compound components ───────────────────────────────────────────────────────
+// Override the text-bearing statics; WithStatics preserves every OTHER static
+// (Menu.Divider, Menu.Sub, Tabs.List, Tabs.Panel, Stepper.Completed…) and the
+// parent's own call signature automatically.
+export const Menu = MantineMenu as unknown as WithStatics<
+  typeof MantineMenu,
+  {
+    Item: OverridePoly<
+      {
+        props: MenuItemProps
+        defaultComponent: 'button'
+        defaultRef: HTMLButtonElement
+      },
+      Children
+    >
+    Label: OverrideFactory<{ props: MenuLabelProps }, Children>
+  }
+>
+
+export const Tabs = MantineTabs as unknown as WithStatics<
+  typeof MantineTabs,
+  {
+    Tab: OverridePoly<
+      {
+        props: TabsTabProps
+        defaultComponent: 'button'
+        defaultRef: HTMLButtonElement
+      },
+      Children
+    >
+  }
+>
+
+export const Stepper = MantineStepper as unknown as WithStatics<
+  typeof MantineStepper,
+  {
+    Step: OverrideFactory<
+      { props: StepperStepProps },
+      { label?: I18nNode; description?: I18nNode }
+    >
+  }
+>

--- a/packages/frontend/mantine/src/core/index.ts
+++ b/packages/frontend/mantine/src/core/index.ts
@@ -112,17 +112,21 @@ import type { OverrideFactory, OverridePoly, WithStatics } from './helpers.js'
 // shared override shapes
 type Children = { children?: I18nNode }
 type AriaLabel = { 'aria-label'?: I18nString }
+// Global string attributes present on every host element that still carry
+// user-visible text. Both are native DOM string attributes, so I18nString —
+// never I18nNode (they can't hold elements).
+type Labelled = { 'aria-label'?: I18nString; title?: I18nString }
 type Input = {
   label?: I18nNode
   placeholder?: I18nString
   description?: I18nNode
 }
 
-// ── Polymorphic: children ────────────────────────────────────────────────────
-export const Button = MantineButton as OverridePoly<ButtonFactory, Children>
-export const Anchor = MantineAnchor as OverridePoly<AnchorFactory, Children>
-export const Badge = MantineBadge as OverridePoly<BadgeFactory, Children>
-export const Text = MantineText as OverridePoly<TextFactory, Children>
+// ── Polymorphic: children (+ branded aria-label / title) ─────────────────────
+export const Button = MantineButton as OverridePoly<ButtonFactory, Children & Labelled>
+export const Anchor = MantineAnchor as OverridePoly<AnchorFactory, Children & Labelled>
+export const Badge = MantineBadge as OverridePoly<BadgeFactory, Children & Labelled>
+export const Text = MantineText as OverridePoly<TextFactory, Children & Labelled>
 
 // ── Polymorphic: icon-only buttons (aria-label is the only visible text) ──────
 export const ActionIcon = MantineActionIcon as OverridePoly<

--- a/packages/frontend/mantine/src/core/index.ts
+++ b/packages/frontend/mantine/src/core/index.ts
@@ -16,6 +16,7 @@ import {
   Button as MantineButton,
   Anchor as MantineAnchor,
   Badge as MantineBadge,
+  Text as MantineText,
   // polymorphic (aria-label only)
   ActionIcon as MantineActionIcon,
   CloseButton as MantineCloseButton,
@@ -25,6 +26,7 @@ import {
   InputBase as MantineInputBase,
   // plain (children)
   Chip as MantineChip,
+  Title as MantineTitle,
   // plain (single label-ish prop)
   Tooltip as MantineTooltip,
   Divider as MantineDivider,
@@ -63,6 +65,8 @@ import {
   type ButtonFactory,
   type AnchorFactory,
   type BadgeFactory,
+  type TextFactory,
+  type TitleFactory,
   type ActionIconFactory,
   type CloseButtonFactory,
   type NavLinkFactory,
@@ -118,6 +122,7 @@ type Input = {
 export const Button = MantineButton as OverridePoly<ButtonFactory, Children>
 export const Anchor = MantineAnchor as OverridePoly<AnchorFactory, Children>
 export const Badge = MantineBadge as OverridePoly<BadgeFactory, Children>
+export const Text = MantineText as OverridePoly<TextFactory, Children>
 
 // ── Polymorphic: icon-only buttons (aria-label is the only visible text) ──────
 export const ActionIcon = MantineActionIcon as OverridePoly<
@@ -140,6 +145,7 @@ export const InputBase = MantineInputBase as OverridePoly<InputBaseFactory, Inpu
 
 // ── Plain: children ───────────────────────────────────────────────────────────
 export const Chip = MantineChip as OverrideFactory<ChipFactory, Children>
+export const Title = MantineTitle as OverrideFactory<TitleFactory, Children>
 
 // ── Plain: single label-ish prop ─────────────────────────────────────────────
 export const Tooltip = MantineTooltip as OverrideFactory<

--- a/packages/frontend/mantine/tsconfig.cjs.json
+++ b/packages/frontend/mantine/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "es2015",
+    "moduleResolution": "node"
+  },
+  "exclude": ["**/*.test-d.tsx", "**/*.test.ts", "node_modules", "dist"]
+}

--- a/packages/frontend/mantine/tsconfig.json
+++ b/packages/frontend/mantine/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "module": "Node18",
+    "outDir": "dist/esm",
+    "target": "esnext",
+    "declaration": true,
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["**/*.test-d.tsx", "**/*.test.ts", "node_modules"]
+}

--- a/packages/frontend/mantine/tsconfig.test-d.json
+++ b/packages/frontend/mantine/tsconfig.test-d.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.test-d.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/packages/frontend/react/package.json
+++ b/packages/frontend/react/package.json
@@ -10,6 +10,10 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
+    },
+    "./i18n": {
+      "import": "./dist/esm/i18n.js",
+      "require": "./dist/cjs/i18n.js"
     }
   },
   "scripts": {
@@ -23,12 +27,24 @@
     "@pikku/fetch": "^0.12.2"
   },
   "peerDependencies": {
+    "i18next": "^23 || ^24 || ^25",
     "react": "^18 || ^19",
-    "react-dom": "^18 || ^19"
+    "react-dom": "^18 || ^19",
+    "react-i18next": "^14 || ^15"
+  },
+  "peerDependenciesMeta": {
+    "i18next": {
+      "optional": true
+    },
+    "react-i18next": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "i18next": "^25",
+    "react-i18next": "^15",
     "typescript": "^5.9"
   }
 }

--- a/packages/frontend/react/src/i18n-types.ts
+++ b/packages/frontend/react/src/i18n-types.ts
@@ -1,0 +1,35 @@
+import type { ReactElement, ReactPortal } from 'react'
+
+declare const _i18nBrand: unique symbol
+
+/**
+ * A plain string that has been explicitly passed through `t()` or `asI18n()`.
+ * Compile-time brand only — at runtime this is just a string.
+ */
+export type I18nString = string & { readonly [_i18nBrand]: true }
+
+/**
+ * Drop-in for `ReactNode` in props that should carry translated text: anything
+ * `ReactNode` allows, EXCEPT a bare, unbranded `string`.
+ *
+ * We use `ReadonlyArray` (not `Iterable`) for the multiple-children case on
+ * purpose. A `string` IS structurally an `Iterable<…>` — TypeScript resolves the
+ * recursion co-inductively and would let plain strings back in through that
+ * backdoor — but a `string` is NOT assignable to a readonly array. So arrays /
+ * multiple children pass while bare strings stay blocked.
+ */
+export type I18nNode =
+  | I18nString
+  | ReactElement
+  | ReactPortal
+  | number
+  | boolean
+  | null
+  | undefined
+  | ReadonlyArray<I18nNode>
+
+/**
+ * Escape hatch for dynamic strings that legitimately come from outside i18n
+ * (server errors, user-supplied content, etc.). Use deliberately.
+ */
+export const asI18n = (s: string): I18nString => s as I18nString

--- a/packages/frontend/react/src/i18n.tsx
+++ b/packages/frontend/react/src/i18n.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next'
+import type { I18nString } from './i18n-types.js'
+
+export type { I18nString, I18nNode } from './i18n-types.js'
+export { asI18n } from './i18n-types.js'
+
+/** The i18n provider. Re-exported so consumers wire i18n from one place. */
+export { I18nextProvider as I18nProvider } from 'react-i18next'
+
+/**
+ * Drop-in for `useTranslation()` — same API, but `t()` is typed to return
+ * {@link I18nString} so the compiler can enforce that every user-visible string
+ * went through i18n. Pairs with `@pikku/mantine`, whose components only accept
+ * branded text.
+ */
+export function useI18n() {
+  const result = useTranslation()
+  return {
+    ...result,
+    t: result.t as unknown as (
+      ...args: Parameters<typeof result.t>
+    ) => I18nString,
+  }
+}

--- a/packages/frontend/react/src/index.ts
+++ b/packages/frontend/react/src/index.ts
@@ -9,3 +9,9 @@ export {
 export type { PikkuInstance } from './pikku-provider.js'
 export { createPikku } from './create-pikku.js'
 export type { CreatePikkuOptions } from './create-pikku.js'
+
+// i18n brand types — pure, no react-i18next dependency. The `useI18n` hook and
+// provider live on the `@pikku/react/i18n` subpath so consumers that only use
+// the brand (e.g. `@pikku/mantine`) never pull in react-i18next.
+export type { I18nString, I18nNode } from './i18n-types.js'
+export { asI18n } from './i18n-types.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,6 +2178,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.27.6, @babel/runtime@npm:^7.29.2":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10/9883b4951787779fd382b121f22f92966d85f19434841f65fb00b2dfec232107e139683f47c6f252891826ad8ee18317b46c3a0e4819116a9885f47b46d7126a
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.28.6":
   version: 7.28.6
   resolution: "@babel/template@npm:7.28.6"
@@ -5661,6 +5668,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@pikku/mantine@workspace:packages/frontend/mantine":
+  version: 0.0.0-use.local
+  resolution: "@pikku/mantine@workspace:packages/frontend/mantine"
+  dependencies:
+    "@mantine/core": "npm:^8.3.8"
+    "@pikku/react": "workspace:^"
+    "@types/react": "npm:^19"
+    react: "npm:^19"
+    typescript: "npm:^5.9"
+  peerDependencies:
+    "@mantine/core": ^8 || ^9
+    "@pikku/react": "workspace:^"
+    react: ^18 || ^19
+  languageName: unknown
+  linkType: soft
+
 "@pikku/modelcontextprotocol@npm:^0.12.1, @pikku/modelcontextprotocol@npm:^0.12.4, @pikku/modelcontextprotocol@workspace:*, @pikku/modelcontextprotocol@workspace:packages/runtimes/modelcontextprotocol":
   version: 0.0.0-use.local
   resolution: "@pikku/modelcontextprotocol@workspace:packages/runtimes/modelcontextprotocol"
@@ -5788,17 +5811,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pikku/react@workspace:*, @pikku/react@workspace:packages/frontend/react":
+"@pikku/react@workspace:*, @pikku/react@workspace:^, @pikku/react@workspace:packages/frontend/react":
   version: 0.0.0-use.local
   resolution: "@pikku/react@workspace:packages/frontend/react"
   dependencies:
     "@pikku/fetch": "npm:^0.12.2"
     "@types/react": "npm:^19"
     "@types/react-dom": "npm:^19"
+    i18next: "npm:^25"
+    react-i18next: "npm:^15"
     typescript: "npm:^5.9"
   peerDependencies:
+    i18next: ^23 || ^24 || ^25
     react: ^18 || ^19
     react-dom: ^18 || ^19
+    react-i18next: ^14 || ^15
+  peerDependenciesMeta:
+    i18next:
+      optional: true
+    react-i18next:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -15554,6 +15586,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-parse-stringify@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "html-parse-stringify@npm:3.0.1"
+  dependencies:
+    void-elements: "npm:3.1.0"
+  checksum: 10/8743b76cc50e46d1956c1ad879d18eb9613b0d2d81e24686d633f9f69bb26b84676f64a926973de793cca479997017a63219278476d617b6c42d68246d7c07fe
+  languageName: node
+  linkType: hard
+
 "html-url-attributes@npm:^3.0.0":
   version: 3.0.1
   resolution: "html-url-attributes@npm:3.0.1"
@@ -15688,6 +15729,20 @@ __metadata:
   dependencies:
     hyperscript-attribute-to-property: "npm:^1.0.0"
   checksum: 10/cc171afd77716d0e5e05212abae93d2302d368afb22095c4560eb40f6b54cfb4a3aea04ad51b15a90b247d157e4a5a360eadfdc13ca7c4082b045a3266a4521b
+  languageName: node
+  linkType: hard
+
+"i18next@npm:^25":
+  version: 25.10.10
+  resolution: "i18next@npm:25.10.10"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+  peerDependencies:
+    typescript: ^5 || ^6
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/ee4f6ba360902a2f0550cfeef234c9e68a67487b575d204e89bdf2f2db647934aa3900a39c64174b9201a8979e455d0bf8f56b57934c34fc8f9aa3b430cb152d
   languageName: node
   linkType: hard
 
@@ -20439,6 +20494,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-i18next@npm:^15":
+  version: 15.7.4
+  resolution: "react-i18next@npm:15.7.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.27.6"
+    html-parse-stringify: "npm:^3.0.1"
+  peerDependencies:
+    i18next: ">= 23.4.0"
+    react: ">= 16.8.0"
+    typescript: ^5
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+    typescript:
+      optional: true
+  checksum: 10/bda66694f159e6874b090997e6fe99a3cd112f535ec8f7d7b04ec8766444a2842fc6688b1f8ed7513a167a94dbeb4aa3d487368d166e41c03d7998dc8b09eac4
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -23665,6 +23741,13 @@ __metadata:
   version: 1.1.2
   resolution: "vm-browserify@npm:1.1.2"
   checksum: 10/ad5b17c9f7a9d9f1ed0e24c897782ab7a587c1fd40f370152482e1af154c7cf0b0bacc45c5ae76a44289881e083ae4ae127808fdff864aa9b562192aae8b5c3b
+  languageName: node
+  linkType: hard
+
+"void-elements@npm:3.1.0":
+  version: 3.1.0
+  resolution: "void-elements@npm:3.1.0"
+  checksum: 10/0390f818107fa8fce55bb0a5c3f661056001c1d5a2a48c28d582d4d847347c2ab5b7f8272314cac58acf62345126b6b09bea623a185935f6b1c3bbce0dfd7f7f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds two things to standardise i18n across Pikku frontends:

- **`@pikku/react`** — exports the i18n brand types `I18nString` / `I18nNode` and the `asI18n()` escape hatch from its main entry (pure, no `react-i18next` dependency). The `useI18n` hook and `I18nProvider` move to a new **`@pikku/react/i18n`** subpath, which declares `i18next` / `react-i18next` as **optional** peers — consumers that only need the brand (e.g. `@pikku/mantine`) never pull them in.
- **`@pikku/mantine`** (new, `@pikku/mantine/core`) — a drop-in for `@mantine/core` that adds **zero runtime**: it re-exports the real Mantine component *values* and only re-casts their *types* so every string-bearing prop (`children`, `label`, `placeholder`, `title`, `aria-label`, …) requires the branded `I18nString` / `I18nNode` instead of a bare `string`. Aliasing `@mantine/core` → `@pikku/mantine/core` therefore turns the app into a strict translation gate: untranslated literals fail to compile.

## Guarantees verified

- **Zero runtime** — emitted JS is `export const Button = MantineButton` (casts erased); `helpers.js` is `export {}`.
- **Mantine 8 *and* 9** — peer `^8 || ^9`; full ~40-component build + type contract verified against both 8.3.x and 9.3.x. Lets the Fabric console (on 8.3.x) adopt it without a Mantine 8→9 upgrade first.
- **Polymorphism preserved** (`component="a"`) and **compound statics preserved** (`Menu.Item`, `Tabs.List`, `Menu.Divider`, `Stepper.Completed`, …) via a `WithStatics` helper that overrides only named statics.
- **Gate covers the common carriers** — incl. `Text` and `Title`. Other text-bearing components (`Code`, `Kbd`, `Blockquote`, `List.Item`, `Timeline.Item`, `Accordion`, table cells) still pass through and can be added the same way later.
- Type contract (positives compile / negatives `@ts-expect-error`) enforced in `packages/frontend/mantine/src/core/i18n.test-d.tsx` (`yarn workspace @pikku/mantine test`).

## Release

`patch` changeset for `@pikku/react` + `@pikku/mantine` — both go out at **0.12.3** with the rest of the 0.12.x line via the normal CI changeset release. No manual publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `@pikku/mantine` as a type-enforced drop-in for Mantine Core that requires i18n-branded strings
  * Exported i18n brand types and escape hatch from main `@pikku/react` entry
  * Reorganized i18n utilities to `@pikku/react/i18n` subpath with optional peer dependencies

* **Documentation**
  * Added guide for Mantine i18n integration and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->