### PR TITLE
chore: update lockfile for cli/mantine literal version ranges

### DIFF
--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -7,9 +7,13 @@ echo "Starting Pikku CLI build process..."
 test -f package.json || { echo "Refusing to run outside package root"; exit 1; }
 rm -rf -- .pikku dist
 
-# Bootstrap using the published CLI - generates all .pikku files
+# Bootstrap using the published CLI - generates all .pikku files.
+# Pinned to 0.12.35 (not `latest`): 0.12.36 shipped a `@pikku/better-auth:
+# workspace:*` dependency that leaked verbatim to npm and is uninstallable, so
+# bootstrapping off `latest` self-deadlocks the build. 0.12.35 is the last clean
+# release and still uses @pikku/auth-js (matching the install below).
 echo "Bootstrapping with published @pikku/cli..."
-: "${PIKKU_CLI_VERSION:=latest}"
+: "${PIKKU_CLI_VERSION:=0.12.35}"
 _bootstrap_dir=$(mktemp -d)
 trap 'rm -rf "$_bootstrap_dir"' EXIT
 # The published bootstrap CLI's own auth codegen imports the auth package at

--- a/yarn.lock
+++ b/yarn.lock
@@ -5350,7 +5350,7 @@ __metadata:
   resolution: "@pikku/cli@workspace:packages/cli"
   dependencies:
     "@openapi-contrib/json-schema-to-openapi-schema": "npm:^4.3.1"
-    "@pikku/better-auth": "workspace:*"
+    "@pikku/better-auth": "npm:^0.12.6"
     "@pikku/core": "npm:^0.12.32"
     "@pikku/deploy-cloudflare": "npm:^0.12.3"
     "@pikku/fetch": "npm:^0.12.3"
@@ -5791,7 +5791,7 @@ __metadata:
     typescript: "npm:^5.9"
   peerDependencies:
     "@mantine/core": ^8 || ^9
-    "@pikku/react": "workspace:^"
+    "@pikku/react": ^0.12.3
     react: ^18 || ^19
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Regenerate yarn.lock after replacing the workspace: protocol with literal ranges in @pikku/cli and @pikku/mantine published deps (ee4884815). The --immutable install in CI's setup action failed with YN0028 because the lockfile still pinned the old workspace: descriptors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to pin a dependency to a specific stable version, improving build reliability and preventing potential deployment issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->