### PR TITLE
Add PGlite local Postgres support

### DIFF
--- a/.changeset/core-temporary-file-service.md
+++ b/.changeset/core-temporary-file-service.md
@@ -1,0 +1,5 @@
+---
+'@pikku/core': patch
+---
+
+Add a dedicated `@pikku/core/services/temporary-file-service` export for the Node filesystem-backed temporary file service without routing it through the `services` barrel.

--- a/.changeset/pglite-dev-postgres.md
+++ b/.changeset/pglite-dev-postgres.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Add embedded PGlite-backed Postgres support for local dev and DB commands when `db/postgres` is present without a configured `postgresUrl`, while keeping real Postgres as the explicit path when `postgresUrl` is set.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
+    "@electric-sql/pglite": "^0.5.1",
     "@openapi-contrib/json-schema-to-openapi-schema": "^4.3.1",
     "@pikku/better-auth": "^0.12.6",
     "@pikku/core": "^0.12.32",

--- a/packages/cli/src/functions/commands/db-generate.ts
+++ b/packages/cli/src/functions/commands/db-generate.ts
@@ -30,16 +30,13 @@ export const dbGenerate = pikkuSessionlessFunc<{}, void>({
 
     switch (result.status) {
       case 'no-auth':
-        logger.info('db generate: no pikkuBetterAuth found — nothing to generate')
+        logger.info(
+          'db generate: no pikkuBetterAuth found — nothing to generate'
+        )
         return
       case 'up-to-date':
         logger.info(
           'db generate: Better Auth schema already covered by existing migrations — nothing to generate'
-        )
-        return
-      case 'unsupported-dialect':
-        logger.warn(
-          'db generate: automatic Better Auth migration generation is currently SQLite-only. Run Better Auth schema generation manually for postgres.'
         )
         return
       case 'incremental-unsupported': {

--- a/packages/cli/src/functions/commands/db-reset.ts
+++ b/packages/cli/src/functions/commands/db-reset.ts
@@ -5,24 +5,37 @@ import { loadUserConfigForDb } from './db-shared.js'
 export const dbReset = pikkuSessionlessFunc<{}, void>({
   remote: true,
   func: async ({ logger, config }) => {
+    if (process.env.NODE_ENV === 'production') {
+      logger.error(
+        'pikku db reset refused: NODE_ENV=production. This command only runs in dev.'
+      )
+      throw new Error('pikku db reset refused: NODE_ENV=production')
+    }
+
     const userConfig = await loadUserConfigForDb({ config, logger })
     if (!userConfig) return
 
-    const resolved = resolveDb(userConfig, config.rootDir, config.outDir, config.runtimeDir)
+    const resolved = resolveDb(
+      userConfig,
+      config.rootDir,
+      config.outDir,
+      config.runtimeDir
+    )
     if (!resolved) {
       logger.error(
-        'pikku db reset: no database configured — set sqliteDb in your createConfig.'
+        'pikku db reset: no database configured — set sqliteDb or postgresUrl in your createConfig.'
       )
       throw new Error('no database configured')
     }
 
-    if (resolved.dialect !== 'sqlite') {
-      logger.error('pikku db reset: reset is only supported for SQLite databases.')
-      throw new Error('reset not supported for postgres')
-    }
-
-    reset(resolved, config.rootDir)
-    logger.info(`db reset: removed ${resolved.dbFile}`)
+    await reset(resolved, config.rootDir)
+    logger.info(
+      resolved.dialect === 'sqlite'
+        ? `db reset: removed ${resolved.dbFile}`
+        : resolved.mode === 'pglite'
+          ? `db reset: removed ${resolved.pgliteDir}`
+          : 'db reset: cleared non-system Postgres schemas'
+    )
 
     const { migrate, codegen, zod } = await migrateAndCodegen(resolved)
     for (const name of migrate.applied) {
@@ -41,7 +54,9 @@ export const dbReset = pikkuSessionlessFunc<{}, void>({
 
     const seedResult = await seed(resolved)
     if (seedResult.applied) {
-      logger.info(`db reset: seeded ${resolved.seedFile} (${seedResult.bytes} bytes)`)
+      logger.info(
+        `db reset: seeded ${resolved.seedFile} (${seedResult.bytes} bytes)`
+      )
     }
   },
 })

--- a/packages/cli/src/functions/commands/db-seed.ts
+++ b/packages/cli/src/functions/commands/db-seed.ts
@@ -8,24 +8,25 @@ export const dbSeed = pikkuSessionlessFunc<{}, void>({
     const userConfig = await loadUserConfigForDb({ config, logger })
     if (!userConfig) return
 
-    const resolved = resolveDb(userConfig, config.rootDir, config.outDir, config.runtimeDir)
+    const resolved = resolveDb(
+      userConfig,
+      config.rootDir,
+      config.outDir,
+      config.runtimeDir
+    )
     if (!resolved) {
       logger.error(
-        'pikku db seed: no database configured — set sqliteDb in your createConfig.'
+        'pikku db seed: no database configured — set sqliteDb or postgresUrl in your createConfig.'
       )
       throw new Error('no database configured')
     }
 
-    if (resolved.dialect !== 'sqlite') {
-      logger.error('pikku db seed: seed is only supported for SQLite databases.')
-      throw new Error('seed not supported for postgres')
-    }
-
     const result = await seed(resolved)
+    const seedFile = resolved.seedFile
     if (!result.applied) {
-      logger.info(`db seed: no ${resolved.seedFile} found, nothing to do`)
+      logger.info(`db seed: no ${seedFile} found, nothing to do`)
     } else {
-      logger.info(`db seed: applied ${resolved.seedFile} (${result.bytes} bytes)`)
+      logger.info(`db seed: applied ${seedFile} (${result.bytes} bytes)`)
     }
   },
 })

--- a/packages/cli/src/functions/commands/db-shared.ts
+++ b/packages/cli/src/functions/commands/db-shared.ts
@@ -42,12 +42,7 @@ export async function loadUserConfigForDb(
 
   const getFallbackConfig = (): UserConfigShape | null => {
     if (hasSqliteDbAssets) return { sqliteDb: '.pikku-runtime/dev.db' }
-    if (hasPostgresDbAssets) {
-      logger.error(
-        'Postgres assets detected but postgresUrl is not configured in createConfig.'
-      )
-      return null
-    }
+    if (hasPostgresDbAssets) return {}
     return null
   }
 

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -32,7 +32,7 @@ import {
   resolveDb,
   createKysely,
   parseDatabaseUrl,
-  type ResolvedSqliteDb,
+  type ResolvedDb,
 } from '../db/local-db.js'
 import { loadUserBootstrap, loadUserModule } from './load-user-project.js'
 
@@ -196,8 +196,7 @@ export const dev = pikkuSessionlessFunc<
       config.outDir,
       config.runtimeDir
     )
-    const resolvedLocalDb: ResolvedSqliteDb | undefined =
-      resolvedDb?.dialect === 'sqlite' ? resolvedDb : undefined
+    const resolvedLocalDb: ResolvedDb | undefined = resolvedDb ?? undefined
     const kysely = resolvedLocalDb
       ? await createKysely(resolvedLocalDb)
       : undefined

--- a/packages/cli/src/functions/db/local-db.test.ts
+++ b/packages/cli/src/functions/db/local-db.test.ts
@@ -16,11 +16,40 @@ import {
   migrateAndCodegen,
   seed as runSeed,
   reset as runReset,
+  createKysely,
 } from './local-db.js'
 import { MigrationDriftError } from './db-migrator.js'
 import { loadSqliteRuntime } from './sqlite/sqlite-runtime.js'
 
 let root: string
+
+function usePostgresProject(options?: {
+  migrationSql?: string
+  seedSql?: string
+}) {
+  rmSync(join(root, 'db', 'sqlite'), { recursive: true, force: true })
+  mkdirSync(join(root, 'db', 'postgres'), { recursive: true })
+  writeFileSync(
+    join(root, 'db', 'postgres', '0001-init.sql'),
+    options?.migrationSql ??
+      `CREATE TABLE todos (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  done BOOLEAN NOT NULL DEFAULT FALSE
+);
+`
+  )
+  if (options?.seedSql !== undefined) {
+    writeFileSync(join(root, 'db', 'postgres-seed.sql'), options.seedSql)
+  } else {
+    writeFileSync(
+      join(root, 'db', 'postgres-seed.sql'),
+      `INSERT INTO todos (title, done) VALUES ('walk dog', FALSE);
+INSERT INTO todos (title, done) VALUES ('buy milk', TRUE);
+`
+    )
+  }
+}
 
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), 'pikku-db-test-'))
@@ -53,6 +82,21 @@ test('resolveDb auto-detects sqlite when db/sqlite dir exists and no config', ()
   assert.equal(resolved!.dialect, 'sqlite')
 })
 
+test('resolveDb throws when both postgresUrl and sqliteDb are configured', () => {
+  assert.throws(
+    () =>
+      resolveDb(
+        {
+          postgresUrl: 'postgres://user:pass@localhost:5432/mydb',
+          sqliteDb: '.pikku-runtime/dev.db',
+        },
+        root,
+        root
+      ),
+    /Configure exactly one database dialect/
+  )
+})
+
 test('resolveDb returns null when no db settings and no db/sqlite dir', () => {
   const emptyRoot = mkdtempSync(join(tmpdir(), 'pikku-db-empty-'))
   try {
@@ -60,6 +104,62 @@ test('resolveDb returns null when no db settings and no db/sqlite dir', () => {
   } finally {
     rmSync(emptyRoot, { recursive: true, force: true })
   }
+})
+
+test('resolveDb auto-detects local PGlite postgres when db/postgres exists and no config', () => {
+  rmSync(join(root, 'db', 'sqlite'), { recursive: true, force: true })
+  mkdirSync(join(root, 'db', 'postgres'), { recursive: true })
+
+  const resolved = resolveDb({}, root, root)
+  assert.ok(resolved !== null)
+  assert.equal(resolved!.dialect, 'postgres')
+  if (resolved!.dialect !== 'postgres') throw new Error('expected postgres')
+  assert.equal(resolved.mode, 'pglite')
+  assert.equal(resolved.pgliteDir, join(root, '.pikku-runtime', 'dev-postgres'))
+})
+
+test('resolveDb honors explicit sqliteDb even when db/postgres exists', () => {
+  mkdirSync(join(root, 'db', 'postgres'), { recursive: true })
+
+  const resolved = resolveDb(
+    { sqliteDb: '.pikku-runtime/explicit.db' },
+    root,
+    root
+  )
+  assert.ok(resolved !== null)
+  assert.equal(resolved!.dialect, 'sqlite')
+  if (resolved!.dialect !== 'sqlite') throw new Error('expected sqlite')
+  assert.equal(resolved.dbFile, join(root, '.pikku-runtime', 'explicit.db'))
+})
+
+test('resolveDb honors explicit postgresUrl over inferred local assets', () => {
+  mkdirSync(join(root, 'db', 'postgres'), { recursive: true })
+
+  const resolved = resolveDb(
+    { postgresUrl: 'postgres://user:pass@localhost:5432/mydb' },
+    root,
+    root
+  )
+  assert.ok(resolved !== null)
+  assert.equal(resolved!.dialect, 'postgres')
+  if (resolved!.dialect !== 'postgres') throw new Error('expected postgres')
+  assert.equal(resolved.mode, 'url')
+  assert.equal(
+    resolved.connectionString,
+    'postgres://user:pass@localhost:5432/mydb'
+  )
+})
+
+test('resolveDb uses custom runtimeDir for local PGlite postgres', () => {
+  rmSync(join(root, 'db', 'sqlite'), { recursive: true, force: true })
+  mkdirSync(join(root, 'db', 'postgres'), { recursive: true })
+
+  const resolved = resolveDb({}, root, root, 'custom-runtime')
+  assert.ok(resolved !== null)
+  assert.equal(resolved!.dialect, 'postgres')
+  if (resolved!.dialect !== 'postgres') throw new Error('expected postgres')
+  assert.equal(resolved.runtimeDir, join(root, 'custom-runtime'))
+  assert.equal(resolved.pgliteDir, join(root, 'custom-runtime', 'dev-postgres'))
 })
 
 test('migrateAndCodegen applies pending migrations and writes schema.d.ts', async () => {
@@ -161,7 +261,7 @@ test('reset wipes the dev DB so a follow-up migrate replays from scratch', async
   await migrateAndCodegen(resolved)
   await runSeed(resolved)
 
-  runReset(resolved, root)
+  await runReset(resolved, root)
 
   const after = await migrateAndCodegen(resolved)
   assert.deepEqual(after.migrate.applied, ['0001-init.sql'])
@@ -178,7 +278,7 @@ test('reset wipes the dev DB so a follow-up migrate replays from scratch', async
   }
 })
 
-test('reset refuses when resolved DB lives outside the runtime directory', () => {
+test('reset refuses when resolved DB lives outside the runtime directory', async () => {
   const outside = mkdtempSync(join(tmpdir(), 'pikku-db-outside-'))
   const resolved = resolveDb(
     { sqliteDb: join(outside, 'evil.db') },
@@ -186,8 +286,138 @@ test('reset refuses when resolved DB lives outside the runtime directory', () =>
     root
   )!
   assert.equal(resolved.dialect, 'sqlite')
-  assert.throws(() => runReset(resolved, root), /outside the runtime directory/)
+  await assert.rejects(
+    () => runReset(resolved, root),
+    /outside the runtime directory/
+  )
   rmSync(outside, { recursive: true, force: true })
+})
+
+test('reset refuses in NODE_ENV=production for local Postgres too', async () => {
+  usePostgresProject()
+  const resolved = resolveDb({}, root, root)!
+  const previous = process.env.NODE_ENV
+  process.env.NODE_ENV = 'production'
+  try {
+    await assert.rejects(() => runReset(resolved, root), /NODE_ENV=production/)
+  } finally {
+    if (previous === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = previous
+    }
+  }
+})
+
+test('reset refuses when resolved PGlite dir lives outside the runtime directory', async () => {
+  usePostgresProject()
+  const outside = mkdtempSync(join(tmpdir(), 'pikku-pg-outside-'))
+  const resolved = resolveDb({}, root, root)!
+  assert.equal(resolved.dialect, 'postgres')
+  if (resolved.dialect !== 'postgres') throw new Error('expected postgres')
+
+  await assert.rejects(
+    () =>
+      runReset(
+        {
+          ...resolved,
+          pgliteDir: join(outside, 'dev-postgres'),
+        },
+        root
+      ),
+    /outside the runtime directory/
+  )
+  rmSync(outside, { recursive: true, force: true })
+})
+
+test('postgres PGlite seed is a no-op when the seed file is missing', async () => {
+  usePostgresProject()
+  rmSync(join(root, 'db', 'postgres-seed.sql'), { force: true })
+
+  const resolved = resolveDb({}, root, root)!
+  assert.equal(resolved.dialect, 'postgres')
+
+  const result = await runSeed(resolved)
+  assert.deepEqual(result, { applied: false, bytes: 0 })
+})
+
+test('postgres PGlite seed is a no-op when the seed file is blank', async () => {
+  usePostgresProject({ seedSql: '   \n\t  ' })
+
+  const resolved = resolveDb({}, root, root)!
+  assert.equal(resolved.dialect, 'postgres')
+
+  const result = await runSeed(resolved)
+  assert.deepEqual(result, { applied: false, bytes: 0 })
+})
+
+test('postgres PGlite migrations support multi-statement SQL files', async () => {
+  usePostgresProject({
+    migrationSql: `CREATE TABLE todos (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  done BOOLEAN NOT NULL DEFAULT FALSE
+);
+CREATE INDEX todos_title_idx ON todos (title);
+INSERT INTO todos (title, done) VALUES ('seed from migration', FALSE);
+`,
+    seedSql: '',
+  })
+
+  const resolved = resolveDb({}, root, root)!
+  assert.equal(resolved.dialect, 'postgres')
+
+  const result = await migrateAndCodegen(resolved)
+  assert.deepEqual(result.migrate.applied, ['0001-init.sql'])
+
+  const kysely = await createKysely<{ todos: { title: string } }>(resolved)
+  try {
+    const rows = await kysely.selectFrom('todos').select('title').execute()
+    assert.deepEqual(rows, [{ title: 'seed from migration' }])
+  } finally {
+    await kysely.destroy()
+  }
+})
+
+test('postgres PGlite migrate, seed, createKysely, and reset work end-to-end', async () => {
+  usePostgresProject()
+
+  const resolved = resolveDb({}, root, root)!
+  assert.equal(resolved.dialect, 'postgres')
+  assert.equal(resolved.mode, 'pglite')
+
+  const first = await migrateAndCodegen(resolved)
+  assert.deepEqual(first.migrate.applied, ['0001-init.sql'])
+  assert.equal(first.codegen.written, true)
+  assert.equal(first.zod.written, true)
+
+  const seedResult = await runSeed(resolved)
+  assert.equal(seedResult.applied, true)
+
+  const kysely = await createKysely<{
+    todos: { title: string; done: boolean }
+  }>(resolved)
+  try {
+    const rows = await kysely.selectFrom('todos').selectAll().execute()
+    assert.equal(rows.length, 2)
+  } finally {
+    await kysely.destroy()
+  }
+
+  await runReset(resolved, root)
+
+  const after = await migrateAndCodegen(resolved)
+  assert.deepEqual(after.migrate.applied, ['0001-init.sql'])
+
+  const freshKysely = await createKysely<{
+    todos: { title: string; done: boolean }
+  }>(resolved)
+  try {
+    const rows = await freshKysely.selectFrom('todos').selectAll().execute()
+    assert.equal(rows.length, 0)
+  } finally {
+    await freshKysely.destroy()
+  }
 })
 
 describe('parseDatabaseUrl', () => {

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -10,7 +10,8 @@ import { resolve, isAbsolute, relative, dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
 import { runInNewContext } from 'node:vm'
 import { transformSync } from 'esbuild'
-import { CamelCasePlugin, CompiledQuery, Kysely, PostgresDialect } from 'kysely'
+import { CamelCasePlugin, Kysely, PostgresDialect } from 'kysely'
+import type { PGlite } from '@electric-sql/pglite'
 import { migrate, type MigrateResult } from './db-migrator.js'
 import type { DbIntrospector } from './db-introspector.js'
 import { loadAuthOptions, getAuthMigrations } from './better-auth-schema.js'
@@ -23,6 +24,7 @@ import { createSqliteKysely } from './sqlite/sqlite-kysely.js'
 import { loadSqliteRuntime } from './sqlite/sqlite-runtime.js'
 import { seed as runSeed, type SeedResult } from './sqlite/seed.js'
 import { PostgresMigrationExecutor } from './postgres/postgres-migrator.js'
+import { createPGliteKysely } from './postgres/pglite-kysely.js'
 import { PostgresIntrospector } from './postgres/postgres-introspector.js'
 import type { UserConfigShape } from '../commands/db-shared.js'
 
@@ -51,7 +53,11 @@ export interface ResolvedSqliteDb extends ResolvedDbBase {
 
 export interface ResolvedPostgresDb extends ResolvedDbBase {
   dialect: 'postgres'
-  connectionString: string
+  mode: 'url' | 'pglite'
+  connectionString?: string
+  pgliteDir?: string
+  runtimeDir: string
+  seedFile: string
 }
 
 export type ResolvedDb = ResolvedSqliteDb | ResolvedPostgresDb
@@ -82,6 +88,9 @@ export function resolveDb(
   outDir: string,
   runtimeDir?: string
 ): ResolvedDb | null {
+  const resolvedRuntimeDir = runtimeDir
+    ? resolveAgainst(rootDir, runtimeDir)
+    : join(rootDir, '.pikku-runtime')
   const base = (sub: string): ResolvedDbBase => ({
     rootDir,
     migrationsDir: resolveAgainst(rootDir, sub),
@@ -109,7 +118,10 @@ export function resolveDb(
   if (userConfig.postgresUrl) {
     return {
       dialect: 'postgres',
+      mode: 'url',
       connectionString: userConfig.postgresUrl,
+      runtimeDir: resolvedRuntimeDir,
+      seedFile: resolveAgainst(rootDir, 'db/postgres-seed.sql'),
       ...base('db/postgres'),
     }
   }
@@ -121,15 +133,23 @@ export function resolveDb(
       : undefined)
 
   if (sqliteDb) {
-    const resolvedRuntimeDir = runtimeDir
-      ? resolveAgainst(rootDir, runtimeDir)
-      : join(rootDir, '.pikku-runtime')
     return {
       dialect: 'sqlite',
       dbFile: resolveAgainst(rootDir, sqliteDb),
       runtimeDir: resolvedRuntimeDir,
       seedFile: resolveAgainst(rootDir, 'db/sqlite-seed.sql'),
       ...base('db/sqlite'),
+    }
+  }
+
+  if (existsSync(join(rootDir, 'db/postgres'))) {
+    return {
+      dialect: 'postgres',
+      mode: 'pglite',
+      pgliteDir: join(resolvedRuntimeDir, 'dev-postgres'),
+      runtimeDir: resolvedRuntimeDir,
+      seedFile: resolveAgainst(rootDir, 'db/postgres-seed.sql'),
+      ...base('db/postgres'),
     }
   }
 
@@ -152,6 +172,73 @@ function resolveAgainst(root: string, p: string): string {
   return isAbsolute(p) ? p : resolve(root, p)
 }
 
+interface PostgresQueryClient {
+  query<T = unknown>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>
+  connect?(): Promise<unknown>
+  end(): Promise<void>
+  exec?(sql: string): Promise<unknown>
+  __connectionString?: string
+  __pglite?: PGlite
+}
+
+async function createPostgresClient(
+  resolved: ResolvedPostgresDb
+): Promise<PostgresQueryClient> {
+  if (resolved.mode === 'url') {
+    const { Client } = await import('pg')
+    const client = new Client({ connectionString: resolved.connectionString })
+    await client.connect()
+    return Object.assign(client, {
+      __connectionString: resolved.connectionString,
+    })
+  }
+
+  if (!resolved.pgliteDir) {
+    throw new Error('PGlite Postgres resolution is missing pgliteDir.')
+  }
+
+  mkdirSync(dirname(resolved.pgliteDir), { recursive: true })
+  const { PGlite } = await import('@electric-sql/pglite')
+  const db = new PGlite(resolved.pgliteDir)
+  return pgliteAsClient(db)
+}
+
+function pgliteAsClient(db: PGlite): PostgresQueryClient {
+  return {
+    query: (sql: string, params?: unknown[]) => db.query(sql, params),
+    exec: (sql: string) => db.exec(sql),
+    __pglite: db,
+    end: async () => {
+      if (!db.closed) {
+        await db.close()
+      }
+    },
+  }
+}
+
+async function withPostgresClient<T>(
+  resolved: ResolvedPostgresDb,
+  run: (client: PostgresQueryClient) => Promise<T>
+): Promise<T> {
+  const client = await createPostgresClient(resolved)
+  try {
+    return await run(client)
+  } finally {
+    await client.end()
+  }
+}
+
+async function loadCoercionPlugin(
+  coercionFile: string
+): Promise<CoercionMap | undefined> {
+  try {
+    const mod = await import(coercionFile)
+    return mod.coercionMap as CoercionMap
+  } catch {
+    return undefined
+  }
+}
+
 // ─── Migrate + codegen ────────────────────────────────────────────────────────
 
 export interface MigrateAndCodegenOutcome {
@@ -165,8 +252,8 @@ export interface MigrateAndCodegenOutcome {
 export async function migrateAndCodegen(
   resolved: ResolvedDb
 ): Promise<MigrateAndCodegenOutcome> {
-  let migrateResult: MigrateResult
-  let codegenResult: CodegenResult
+  let migrateResult!: MigrateResult
+  let codegenResult!: CodegenResult
 
   // Compile any authored db/annotations.ts → sidecar BEFORE codegen so edits
   // reflect in a single `db migrate` (codegen reads the sidecar).
@@ -197,13 +284,9 @@ export async function migrateAndCodegen(
       db.close()
     }
   } else {
-    // Postgres
-    const introspector = new PostgresIntrospector(resolved.connectionString)
-    await introspector.connect()
-    try {
-      const { Client } = await import('pg')
-      const client = new Client({ connectionString: resolved.connectionString })
-      await client.connect()
+    await withPostgresClient(resolved, async (client) => {
+      const introspector = new PostgresIntrospector(client)
+      await introspector.connect()
       try {
         const executor = new PostgresMigrationExecutor(client)
         migrateResult = await migrate(executor, resolved.migrationsDir)
@@ -218,11 +301,9 @@ export async function migrateAndCodegen(
           dialect: 'postgres',
         })
       } finally {
-        await client.end()
+        await introspector.close()
       }
-    } finally {
-      await introspector.close()
-    }
+    })
   }
 
   const zodResult = generateZodTypes({
@@ -254,31 +335,92 @@ export async function migrateAndCodegen(
 
 // ─── SQLite-only operations ───────────────────────────────────────────────────
 
-export async function seed(resolved: ResolvedSqliteDb): Promise<SeedResult> {
-  const runtime = await loadSqliteRuntime()
-  const db = runtime.open(resolved.dbFile)
-  try {
-    return runSeed(db, resolved.seedFile)
-  } finally {
-    db.close()
+export async function seed(resolved: ResolvedDb): Promise<SeedResult> {
+  if (resolved.dialect === 'sqlite') {
+    const runtime = await loadSqliteRuntime()
+    const db = runtime.open(resolved.dbFile)
+    try {
+      return runSeed(db, resolved.seedFile)
+    } finally {
+      db.close()
+    }
   }
+
+  if (!existsSync(resolved.seedFile)) {
+    return { applied: false, bytes: 0 }
+  }
+
+  const sql = readFileSync(resolved.seedFile, 'utf8')
+  if (sql.trim().length === 0) {
+    return { applied: false, bytes: 0 }
+  }
+
+  await withPostgresClient(resolved, async (client) => {
+    if (typeof client.exec === 'function') {
+      await client.exec(sql)
+    } else {
+      await client.query(sql)
+    }
+  })
+
+  return { applied: true, bytes: Buffer.byteLength(sql) }
 }
 
-export function reset(resolved: ResolvedSqliteDb, rootDir: string): void {
+export async function reset(
+  resolved: ResolvedDb,
+  rootDir: string
+): Promise<void> {
   if (process.env.NODE_ENV === 'production') {
     throw new Error(
       `pikku db reset refused: NODE_ENV=production. This command only runs in dev.`
     )
   }
-  const rel = relative(resolved.runtimeDir, resolved.dbFile)
-  if (rel.startsWith('..') || isAbsolute(rel)) {
-    throw new Error(
-      `pikku db reset refused: resolved DB file (${resolved.dbFile}) is outside the runtime directory (${resolved.runtimeDir}). Override sqliteDb or set runtimeDir correctly.`
-    )
+
+  if (resolved.dialect === 'sqlite') {
+    const rel = relative(resolved.runtimeDir, resolved.dbFile)
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      throw new Error(
+        `pikku db reset refused: resolved DB file (${resolved.dbFile}) is outside the runtime directory (${resolved.runtimeDir}). Override sqliteDb or set runtimeDir correctly.`
+      )
+    }
+    if (existsSync(resolved.dbFile)) {
+      rmSync(resolved.dbFile)
+    }
+    return
   }
-  if (existsSync(resolved.dbFile)) {
-    rmSync(resolved.dbFile)
+
+  if (resolved.mode === 'pglite') {
+    if (!resolved.pgliteDir) {
+      throw new Error('PGlite Postgres resolution is missing pgliteDir.')
+    }
+    const rel = relative(resolved.runtimeDir, resolved.pgliteDir)
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      throw new Error(
+        `pikku db reset refused: resolved PGlite dir (${resolved.pgliteDir}) is outside the runtime directory (${resolved.runtimeDir}).`
+      )
+    }
+    if (existsSync(resolved.pgliteDir)) {
+      rmSync(resolved.pgliteDir, { recursive: true, force: true })
+    }
+    return
   }
+
+  await withPostgresClient(resolved, async (client) => {
+    const result = await client.query<{ schema_name: string }>(`
+      SELECT schema_name
+      FROM information_schema.schemata
+      WHERE schema_name NOT IN ('information_schema', 'pg_catalog')
+        AND schema_name NOT LIKE 'pg_toast%'
+        AND schema_name NOT LIKE 'pg_temp_%'
+    `)
+
+    for (const { schema_name: schemaName } of result.rows) {
+      const quoted = `"${schemaName.replace(/"/g, '""')}"`
+      await client.query(`DROP SCHEMA IF EXISTS ${quoted} CASCADE`)
+    }
+
+    await client.query('CREATE SCHEMA IF NOT EXISTS public')
+  })
 }
 
 // ── Classification sync ───────────────────────────────────────────────────────
@@ -388,21 +530,47 @@ function compileClassifications(
 }
 
 export async function createKysely<DB>(
-  resolved: ResolvedSqliteDb
+  resolved: ResolvedDb
 ): Promise<Kysely<DB>> {
-  mkdirSync(dirname(resolved.dbFile), { recursive: true })
-  const runtime = await loadSqliteRuntime()
-  let coercionMap: CoercionMap | undefined
-  try {
-    const mod = await import(resolved.coercionFile)
-    coercionMap = mod.coercionMap as CoercionMap
-  } catch {
-    // coercion.gen.ts not yet generated — run `pikku db migrate` first
+  const coercionMap = await loadCoercionPlugin(resolved.coercionFile)
+  const plugins = coercionMap
+    ? [createCoercionPlugin({ map: coercionMap })]
+    : []
+
+  if (resolved.dialect === 'sqlite') {
+    mkdirSync(dirname(resolved.dbFile), { recursive: true })
+    const runtime = await loadSqliteRuntime()
+    return createSqliteKysely<DB>({
+      db: runtime.open(resolved.dbFile),
+      camelCase: resolved.camelCase,
+      plugins,
+    })
   }
-  return createSqliteKysely<DB>({
-    db: runtime.open(resolved.dbFile),
+
+  if (resolved.mode === 'url') {
+    const { Pool } = await import('pg')
+    const pool = new Pool({
+      connectionString: resolved.connectionString,
+      max: 10,
+    })
+    return new Kysely<DB>({
+      dialect: new PostgresDialect({ pool }),
+      plugins: resolved.camelCase
+        ? [new CamelCasePlugin(), ...plugins]
+        : plugins,
+    })
+  }
+
+  if (!resolved.pgliteDir) {
+    throw new Error('PGlite Postgres resolution is missing pgliteDir.')
+  }
+
+  mkdirSync(dirname(resolved.pgliteDir), { recursive: true })
+  const { PGlite } = await import('@electric-sql/pglite')
+  return createPGliteKysely<DB>({
+    db: new PGlite(resolved.pgliteDir),
     camelCase: resolved.camelCase,
-    plugins: coercionMap ? [createCoercionPlugin({ map: coercionMap })] : [],
+    plugins,
   })
 }
 
@@ -460,42 +628,107 @@ function isPostgresAuthDatabase(options: {
   return options.database?.type === 'postgres'
 }
 
-function createScratchPostgresSchemaName(): string {
+function createScratchPostgresDatabaseName(prefix: string): string {
   const random = Math.random().toString(36).slice(2, 10)
-  return `pikku_auth_${Date.now().toString(36)}_${random}`
+  return `${prefix}_${Date.now().toString(36)}_${random}`.slice(0, 63)
 }
 
-async function postgresSchemaToMap(
+function quotePgIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`
+}
+
+function withPostgresDatabase(
   connectionString: string,
-  schema: string
-): Promise<SchemaMap> {
-  const { Client } = await import('pg')
-  const client = new Client({ connectionString })
-  await client.connect()
-  try {
-    const tablesResult = await client.query<{ table_name: string }>(
-      `SELECT table_name
-       FROM information_schema.tables
-       WHERE table_schema = $1
-         AND table_type = 'BASE TABLE'
-       ORDER BY table_name`,
-      [schema]
-    )
-    const map: SchemaMap = new Map()
-    for (const { table_name } of tablesResult.rows) {
-      const columnsResult = await client.query<{ column_name: string }>(
-        `SELECT column_name
-         FROM information_schema.columns
-         WHERE table_schema = $1
-           AND table_name = $2
-         ORDER BY ordinal_position`,
-        [schema, table_name]
-      )
-      map.set(table_name, new Set(columnsResult.rows.map((c) => c.column_name)))
+  databaseName: string
+): string {
+  const url = new URL(connectionString)
+  url.pathname = `/${databaseName}`
+  return url.toString()
+}
+
+function getPostgresAdminConnectionString(connectionString: string): string {
+  return withPostgresDatabase(connectionString, 'postgres')
+}
+
+async function withScratchPostgresDatabase<T>(
+  resolved: ResolvedPostgresDb,
+  prefix: string,
+  run: (scratchDb: PostgresQueryClient) => Promise<T>
+): Promise<T> {
+  if (resolved.mode === 'pglite') {
+    const { PGlite } = await import('@electric-sql/pglite')
+    const scratchDb = new PGlite()
+    try {
+      return await run(pgliteAsClient(scratchDb))
+    } finally {
+      if (!scratchDb.closed) {
+        await scratchDb.close()
+      }
     }
-    return map
+  }
+
+  const { Client } = await import('pg')
+  const databaseName = createScratchPostgresDatabaseName(prefix)
+  const adminConnectionString = getPostgresAdminConnectionString(
+    resolved.connectionString!
+  )
+  const adminClient = new Client({ connectionString: adminConnectionString })
+  await adminClient.connect()
+  try {
+    await adminClient.query(
+      `CREATE DATABASE ${quotePgIdentifier(databaseName)}`
+    )
   } finally {
-    await client.end()
+    await adminClient.end()
+  }
+
+  const scratchConnectionString = withPostgresDatabase(
+    resolved.connectionString!,
+    databaseName
+  )
+
+  try {
+    const scratchClient = Object.assign(
+      new Client({ connectionString: scratchConnectionString }),
+      { __connectionString: scratchConnectionString }
+    )
+    await scratchClient.connect()
+    try {
+      return await run(scratchClient)
+    } finally {
+      await scratchClient.end()
+    }
+  } finally {
+    const cleanupClient = new Client({
+      connectionString: adminConnectionString,
+    })
+    await cleanupClient.connect()
+    try {
+      await cleanupClient.query(
+        `SELECT pg_terminate_backend(pid)
+         FROM pg_stat_activity
+         WHERE datname = $1
+           AND pid <> pg_backend_pid()`,
+        [databaseName]
+      )
+      await cleanupClient.query(
+        `DROP DATABASE IF EXISTS ${quotePgIdentifier(databaseName)}`
+      )
+    } finally {
+      await cleanupClient.end()
+    }
+  }
+}
+
+async function postgresDatabaseToMap(
+  client: PostgresQueryClient
+): Promise<SchemaMap> {
+  const intro = new PostgresIntrospector(client)
+  await intro.connect()
+  try {
+    return await introspectorToMap(intro)
+  } finally {
+    await intro.close()
   }
 }
 
@@ -505,65 +738,47 @@ async function desiredPostgresAuthSchema(
   srcDirectories: string[],
   logger: { error: (msg: string) => void }
 ): Promise<DesiredAuthSchema | null> {
-  const { Pool } = await import('pg')
-  const schema = createScratchPostgresSchemaName()
-  const pool = new Pool({
-    connectionString: resolved.connectionString,
-    max: 1,
-  })
-  try {
-    const admin = await pool.connect()
-    try {
-      await admin.query(`CREATE SCHEMA "${schema}"`)
-      await admin.query(`SET search_path TO "${schema}"`)
-    } finally {
-      admin.release()
-    }
+  return withScratchPostgresDatabase(
+    resolved,
+    'pikku_auth',
+    async (scratchDb) => {
+      const { Pool } = await import('pg')
+      const kysely =
+        resolved.mode === 'url'
+          ? new Kysely<any>({
+              dialect: new PostgresDialect({
+                pool: new Pool({
+                  connectionString: scratchDb.__connectionString,
+                  max: 1,
+                }),
+              }),
+              plugins: [new CamelCasePlugin()],
+            })
+          : createPGliteKysely<any>({
+              db: scratchDb.__pglite!,
+              camelCase: true,
+            })
 
-    const kysely = new Kysely<any>({
-      dialect: new PostgresDialect({
-        pool,
-        onReserveConnection: async (connection) => {
-          await connection.executeQuery(
-            CompiledQuery.raw(`SET search_path TO "${schema}"`)
-          )
-        },
-      }),
-      plugins: [new CamelCasePlugin()],
-    }).withSchema(schema)
+      try {
+        const options = await loadAuthOptions({
+          rootDir,
+          srcDirectories,
+          kysely,
+          logger,
+        })
+        if (!options) return null
 
-    try {
-      const options = await loadAuthOptions({
-        rootDir,
-        srcDirectories,
-        kysely,
-        logger,
-      })
-      if (!options) return null
-
-      const { runMigrations, compileMigrations } =
-        await getAuthMigrations(options)
-      await runMigrations()
-      const tables = await postgresSchemaToMap(
-        resolved.connectionString,
-        schema
-      )
-      const sql = await compileMigrations()
-      return { tables, sql }
-    } finally {
-      await kysely.destroy()
+        const { runMigrations, compileMigrations } =
+          await getAuthMigrations(options)
+        await runMigrations()
+        const tables = await postgresDatabaseToMap(scratchDb)
+        const sql = await compileMigrations()
+        return { tables, sql }
+      } finally {
+        await kysely.destroy()
+      }
     }
-  } finally {
-    const cleanup = new Pool({
-      connectionString: resolved.connectionString,
-      max: 1,
-    })
-    try {
-      await cleanup.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
-    } finally {
-      await cleanup.end()
-    }
-  }
+  )
 }
 
 export async function desiredAuthSchema(
@@ -619,13 +834,15 @@ export async function introspectSchema(
       db.close()
     }
   }
-  const intro = new PostgresIntrospector(resolved.connectionString)
-  await intro.connect()
-  try {
-    return await introspectorToMap(intro)
-  } finally {
-    await intro.close()
-  }
+  return withPostgresClient(resolved, async (client) => {
+    const intro = new PostgresIntrospector(client)
+    await intro.connect()
+    try {
+      return await introspectorToMap(intro)
+    } finally {
+      await intro.close()
+    }
+  })
 }
 
 async function coveredSqliteSchema(migrationsDir: string): Promise<SchemaMap> {
@@ -637,6 +854,20 @@ async function coveredSqliteSchema(migrationsDir: string): Promise<SchemaMap> {
   } finally {
     db.close()
   }
+}
+
+async function coveredPostgresSchema(
+  resolved: ResolvedPostgresDb,
+  migrationsDir: string
+): Promise<SchemaMap> {
+  return withScratchPostgresDatabase(
+    resolved,
+    'pikku_migrate',
+    async (client) => {
+      await migrate(new PostgresMigrationExecutor(client), migrationsDir)
+      return postgresDatabaseToMap(client)
+    }
+  )
 }
 
 export interface AuthDriftResult {
@@ -692,12 +923,7 @@ function nextMigrationFile(migrationsDir: string, label: string): string {
 }
 
 export interface GenerateAuthResult {
-  status:
-    | 'no-auth'
-    | 'up-to-date'
-    | 'written'
-    | 'incremental-unsupported'
-    | 'unsupported-dialect'
+  status: 'no-auth' | 'up-to-date' | 'written' | 'incremental-unsupported'
   file?: string
   missingTables?: string[]
   missingColumns?: { table: string; columns: string[] }[]
@@ -709,8 +935,6 @@ export async function generateAuthMigration(
   srcDirectories: string[],
   logger: { error: (msg: string) => void }
 ): Promise<GenerateAuthResult> {
-  if (resolved.dialect !== 'sqlite') return { status: 'unsupported-dialect' }
-
   const desired = await desiredAuthSchema(
     resolved,
     rootDir,
@@ -719,7 +943,10 @@ export async function generateAuthMigration(
   )
   if (!desired) return { status: 'no-auth' }
 
-  const covered = await coveredSqliteSchema(resolved.migrationsDir)
+  const covered =
+    resolved.dialect === 'sqlite'
+      ? await coveredSqliteSchema(resolved.migrationsDir)
+      : await coveredPostgresSchema(resolved, resolved.migrationsDir)
   const { missingTables, missingColumns } = diffSchemas(desired.tables, covered)
   if (missingTables.length === 0 && missingColumns.length === 0) {
     return { status: 'up-to-date' }

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -198,9 +198,22 @@ async function createPostgresClient(
   }
 
   mkdirSync(dirname(resolved.pgliteDir), { recursive: true })
-  const { PGlite } = await import('@electric-sql/pglite')
-  const db = new PGlite(resolved.pgliteDir)
+  const db = await createEmbeddedPostgres(resolved.pgliteDir)
   return pgliteAsClient(db)
+}
+
+async function createEmbeddedPostgres(dataDir?: string): Promise<PGlite> {
+  const [{ PGlite }, { pgcrypto }] = await Promise.all([
+    import('@electric-sql/pglite'),
+    import('@electric-sql/pglite/contrib/pgcrypto'),
+  ])
+
+  return new PGlite({
+    ...(dataDir ? { dataDir } : {}),
+    extensions: {
+      pgcrypto,
+    },
+  })
 }
 
 function pgliteAsClient(db: PGlite): PostgresQueryClient {
@@ -566,9 +579,8 @@ export async function createKysely<DB>(
   }
 
   mkdirSync(dirname(resolved.pgliteDir), { recursive: true })
-  const { PGlite } = await import('@electric-sql/pglite')
   return createPGliteKysely<DB>({
-    db: new PGlite(resolved.pgliteDir),
+    db: await createEmbeddedPostgres(resolved.pgliteDir),
     camelCase: resolved.camelCase,
     plugins,
   })
@@ -656,8 +668,7 @@ async function withScratchPostgresDatabase<T>(
   run: (scratchDb: PostgresQueryClient) => Promise<T>
 ): Promise<T> {
   if (resolved.mode === 'pglite') {
-    const { PGlite } = await import('@electric-sql/pglite')
-    const scratchDb = new PGlite()
+    const scratchDb = await createEmbeddedPostgres()
     try {
       return await run(pgliteAsClient(scratchDb))
     } finally {

--- a/packages/cli/src/functions/db/postgres/pglite-kysely.ts
+++ b/packages/cli/src/functions/db/postgres/pglite-kysely.ts
@@ -1,0 +1,120 @@
+import {
+  CamelCasePlugin,
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  type CompiledQuery,
+  type DatabaseConnection,
+  type DatabaseIntrospector,
+  type Dialect,
+  type DialectAdapter,
+  type Driver,
+  type KyselyPlugin,
+  type QueryCompiler,
+  type QueryResult,
+} from 'kysely'
+import type { Kysely as KyselyInstance } from 'kysely'
+import type { PGlite } from '@electric-sql/pglite'
+
+export interface CreatePGliteKyselyOptions {
+  db: PGlite
+  camelCase?: boolean
+  plugins?: KyselyPlugin[]
+}
+
+export function createPGliteKysely<DB>(
+  options: CreatePGliteKyselyOptions
+): Kysely<DB> {
+  const plugins: KyselyPlugin[] = []
+  if (options.camelCase ?? true) plugins.push(new CamelCasePlugin())
+  if (options.plugins) plugins.push(...options.plugins)
+
+  return new Kysely<DB>({
+    dialect: new PGliteDialect(options.db),
+    plugins,
+  })
+}
+
+class PGliteDialect implements Dialect {
+  constructor(private readonly db: PGlite) {}
+
+  createAdapter(): DialectAdapter {
+    return new PostgresAdapter()
+  }
+
+  createDriver(): Driver {
+    return new PGliteDriver(this.db)
+  }
+
+  createQueryCompiler(): QueryCompiler {
+    return new PostgresQueryCompiler()
+  }
+
+  createIntrospector(db: KyselyInstance<unknown>): DatabaseIntrospector {
+    return new PostgresIntrospector(db)
+  }
+}
+
+class PGliteDriver implements Driver {
+  private readonly connection: PGliteConnection
+
+  constructor(db: PGlite) {
+    this.connection = new PGliteConnection(db)
+  }
+
+  async init(): Promise<void> {}
+
+  async acquireConnection(): Promise<DatabaseConnection> {
+    return this.connection
+  }
+
+  async beginTransaction(conn: DatabaseConnection): Promise<void> {
+    await (conn as PGliteConnection).executeRaw('BEGIN')
+  }
+
+  async commitTransaction(conn: DatabaseConnection): Promise<void> {
+    await (conn as PGliteConnection).executeRaw('COMMIT')
+  }
+
+  async rollbackTransaction(conn: DatabaseConnection): Promise<void> {
+    await (conn as PGliteConnection).executeRaw('ROLLBACK')
+  }
+
+  async releaseConnection(): Promise<void> {}
+
+  async destroy(): Promise<void> {
+    await this.connection.close()
+  }
+}
+
+class PGliteConnection implements DatabaseConnection {
+  constructor(private readonly db: PGlite) {}
+
+  async executeQuery<R>(query: CompiledQuery): Promise<QueryResult<R>> {
+    const result = await this.db.query<R>(query.sql, [...query.parameters])
+    return {
+      rows: result.rows,
+      numAffectedRows:
+        result.affectedRows !== undefined
+          ? BigInt(result.affectedRows)
+          : undefined,
+    }
+  }
+
+  async *streamQuery<R>(
+    query: CompiledQuery
+  ): AsyncIterableIterator<QueryResult<R>> {
+    yield await this.executeQuery<R>(query)
+  }
+
+  async executeRaw(sql: string): Promise<void> {
+    await this.db.exec(sql)
+  }
+
+  async close(): Promise<void> {
+    if (!this.db.closed) {
+      await this.db.close()
+    }
+  }
+}

--- a/packages/cli/src/functions/db/postgres/postgres-introspector.ts
+++ b/packages/cli/src/functions/db/postgres/postgres-introspector.ts
@@ -1,5 +1,10 @@
 import { Pool } from 'pg'
-import type { DbIntrospector, ColumnInfo, ForeignKeyInfo, EnumInfo } from '../db-introspector.js'
+import type {
+  DbIntrospector,
+  ColumnInfo,
+  ForeignKeyInfo,
+  EnumInfo,
+} from '../db-introspector.js'
 
 interface PgColumnRow {
   column_name: string
@@ -18,6 +23,7 @@ interface QueryClient {
 
 export class PostgresIntrospector implements DbIntrospector {
   private client: QueryClient
+  private ownsClient: boolean
 
   constructor(clientOrConnectionString: QueryClient | string) {
     if (typeof clientOrConnectionString === 'string') {
@@ -25,8 +31,10 @@ export class PostgresIntrospector implements DbIntrospector {
         connectionString: clientOrConnectionString,
         max: 10,
       })
+      this.ownsClient = true
     } else {
       this.client = clientOrConnectionString
+      this.ownsClient = false
     }
   }
 
@@ -158,6 +166,8 @@ export class PostgresIntrospector implements DbIntrospector {
   }
 
   async close(): Promise<void> {
-    await this.client.end()
+    if (this.ownsClient) {
+      await this.client.end()
+    }
   }
 }

--- a/packages/cli/src/functions/db/postgres/postgres-migrator.ts
+++ b/packages/cli/src/functions/db/postgres/postgres-migrator.ts
@@ -1,10 +1,14 @@
-import type { Client } from 'pg'
 import type { MigrationExecutor, AppliedMigration } from '../db-migrator.js'
 
 const TRACKING_TABLE = 'sql_migrations'
 
+export interface PostgresMigrationClient {
+  query<T = unknown>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>
+  exec?(sql: string): Promise<unknown>
+}
+
 export class PostgresMigrationExecutor implements MigrationExecutor {
-  constructor(private readonly client: Client) {}
+  constructor(private readonly client: PostgresMigrationClient) {}
 
   async ensureTrackingTable(): Promise<void> {
     await this.client.query(`
@@ -26,7 +30,11 @@ export class PostgresMigrationExecutor implements MigrationExecutor {
   async runMigration(sql: string, name: string, hash: string): Promise<void> {
     await this.client.query('BEGIN')
     try {
-      await this.client.query(sql)
+      if (typeof this.client.exec === 'function') {
+        await this.client.exec(sql)
+      } else {
+        await this.client.query(sql)
+      }
       await this.client.query(
         `INSERT INTO ${TRACKING_TABLE} (name, hash) VALUES ($1, $2)`,
         [name, hash]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,7 @@
     "./services": "./dist/services/index.js",
     "./services/local-meta": "./dist/services/meta-service.js",
     "./services/local-content": "./dist/services/local-content.js",
+    "./services/temporary-file-service": "./dist/services/temporary-file-service.js",
     "./services/gopass-secrets": "./dist/services/gopass-secrets.js",
     "./crypto-utils": "./dist/crypto-utils.js",
     "./internal": "./dist/internal.js",

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -58,6 +58,10 @@ async function resolveSession(
       wire.session = stored
       sessionService?.setInitial(stored)
     }
+  } else {
+    // Session already present on wire (e.g. propagated from parent workflow).
+    // Seed the sessionService so freezeInitial() returns it instead of undefined.
+    sessionService?.setInitial(wire.session as CoreUserSession)
   }
 }
 

--- a/packages/core/src/services/temporary-file-service.ts
+++ b/packages/core/src/services/temporary-file-service.ts
@@ -1,8 +1,8 @@
 import { createReadStream, createWriteStream } from 'fs'
 import { mkdir, rm, stat } from 'fs/promises'
 import { resolve } from 'path'
-import { Readable } from 'stream'
 import { pipeline } from 'stream/promises'
+import type { Readable } from 'stream'
 import type { Logger } from './logger.js'
 
 export class TemporaryFileInstance {

--- a/packages/core/src/services/temporary-file-service.ts
+++ b/packages/core/src/services/temporary-file-service.ts
@@ -1,0 +1,76 @@
+import { createReadStream, createWriteStream } from 'fs'
+import { mkdir, rm, stat } from 'fs/promises'
+import { resolve } from 'path'
+import { Readable } from 'stream'
+import { pipeline } from 'stream/promises'
+import type { Logger } from './logger.js'
+
+export class TemporaryFileInstance {
+  private files: string[] = []
+
+  constructor(
+    private logger: Logger,
+    private tempDir: string
+  ) {
+    this.tempDir = resolve(tempDir)
+    logger.debug(`Using temp dir ${this.tempDir}`)
+  }
+
+  public getFile(key: string): ReadableStream | NodeJS.ReadableStream {
+    return createReadStream(`${this.tempDir}/${key}`)
+  }
+
+  public async writeFile(
+    key: string,
+    stream: ReadableStream | NodeJS.ReadableStream
+  ): Promise<void> {
+    await this.createDir(key)
+    const filePath = `${this.tempDir}/${key}`
+    const fileStream = createWriteStream(filePath)
+    await pipeline(stream as Readable, fileStream)
+    this.files.push(filePath)
+    this.logger.debug(`Wrote file: ${filePath}`)
+  }
+
+  public async deleteFile(key: string): Promise<void> {
+    await rm(`${this.tempDir}/${key}`)
+    this.logger.debug(`Deleted file ${this.tempDir}/${key}`)
+  }
+
+  public async hasFile(key: string): Promise<boolean> {
+    try {
+      return !!(await stat(`${this.tempDir}/${key}`))
+    } catch {
+      return false
+    }
+  }
+
+  public async getTempFileAbsolutePath(key: string): Promise<string> {
+    await this.createDir(key)
+    return `${this.tempDir}/${key}`
+  }
+
+  private async createDir(key: string) {
+    const dir = `${this.tempDir}/${key}`.split('/').slice(0, -1).join('/')
+    if (!(await this.hasFile(dir))) {
+      await mkdir(dir, { recursive: true })
+    }
+  }
+
+  public async cleanup() {
+    await Promise.all(this.files.map((file) => rm(file)))
+  }
+}
+
+export class TemporaryFileService {
+  constructor(
+    private logger: Logger,
+    private tempDir: string
+  ) {
+    this.tempDir = resolve(tempDir)
+  }
+
+  public createInstance() {
+    return new TemporaryFileInstance(this.logger, this.tempDir)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5349,6 +5349,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/cli@workspace:packages/cli"
   dependencies:
+    "@electric-sql/pglite": "npm:^0.5.1"
     "@openapi-contrib/json-schema-to-openapi-schema": "npm:^4.3.1"
     "@pikku/better-auth": "npm:^0.12.6"
     "@pikku/core": "npm:^0.12.32"


### PR DESCRIPTION
## Summary
- add embedded PGlite-backed Postgres support for local dev and DB commands when a project uses `db/postgres` without a configured `postgresUrl`
- add a dedicated `@pikku/core/services/temporary-file-service` export without routing it through the services barrel
- seed `sessionService` when a session is already present on the wire in workflow execution paths

## Details
- `pikku dev` can now boot Postgres projects locally without requiring a real Postgres instance when `postgresUrl` is unset
- `db reset`, `db seed`, and `db generate` now handle Postgres projects in the local CLI flow
- embedded Postgres preloads `pgcrypto` so common migrations work under PGlite
- local DB tests were expanded around the embedded Postgres path and edge cases

## Validation
- added/updated local DB tests in `packages/cli/src/functions/db/local-db.test.ts`
- built local `@pikku/core`
- did not run the full repo test suite locally