### PR TITLE
feat(cli,better-auth): unified machine + human auth (pikku login + api-key)

### DIFF
--- a/.changeset/cli-betterauth-machine-human-auth.md
+++ b/.changeset/cli-betterauth-machine-human-auth.md
@@ -1,0 +1,21 @@
+---
+'@pikku/cli': minor
+'@pikku/better-auth': minor
+---
+
+feat(cli,better-auth): unified machine + human auth (pikku login + api-key)
+
+A single better-auth-backed model for authenticating CLIs and machines.
+
+- **Human**: `pikku login` / `logout` / `whoami` run a device-authorization flow
+  and persist a session at `~/.pikku/session.json` (0600, keyed by base URL, with
+  expiry).
+- **Machine**: `betterAuthSession()` gains a stateless api-key branch — it resolves
+  scope via `verifyApiKey` (not `getSession`, which drops metadata) and is
+  authoritative when the `x-api-key` header is present.
+- **Auto-wire**: generated channel CLI clients attach the credential on the WS
+  upgrade handshake (`PIKKU_API_KEY` → `x-api-key`, else the stored token →
+  `Bearer`), so `betterAuthSession` resolves before the channel opens.
+
+`@better-auth/api-key` is a separate official package (not in the better-auth
+plugins barrel); peer-requires `better-auth ^1.6.19`.

--- a/.changeset/cli-betterauth-machine-human-auth.md
+++ b/.changeset/cli-betterauth-machine-human-auth.md
@@ -1,6 +1,6 @@
 ---
-'@pikku/cli': minor
-'@pikku/better-auth': minor
+'@pikku/cli': patch
+'@pikku/better-auth': patch
 ---
 
 feat(cli,better-auth): unified machine + human auth (pikku login + api-key)

--- a/.changeset/core-seed-session-when-present.md
+++ b/.changeset/core-seed-session-when-present.md
@@ -1,0 +1,12 @@
+---
+'@pikku/core': patch
+---
+
+fix(workflow): seed sessionService when session already present on wire
+
+When a parent workflow propagates its session to a child workflow via
+`wire.session`, `resolveSession` skipped `setInitial` because `!wire.session`
+was false, so `sessionService.freezeInitial()` returned `undefined` and
+immediately overwrote the propagated session. We now seed the sessionService
+with the existing `wire.session` so `freezeInitial()` returns the correct
+session for `pikkuFunc` steps inside child workflows.

--- a/packages/cli/skills/pikku-machine-auth/SKILL.md
+++ b/packages/cli/skills/pikku-machine-auth/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: pikku-machine-auth
+description: 'Use when authenticating a CLI/agent/service against a Pikku server, adding machine-to-machine (M2M) auth, issuing scoped API keys for sandboxes/agents/workers, or wiring better-auth sessions into Pikku middleware. Covers `pikku login` (device-authorization), the better-auth API Key plugin, machine identities, and `betterAuthSession` with the api-key branch.
+TRIGGER when: user asks about CLI login, `pikku login`, machine agents, service-to-service auth, API keys, client credentials, sandbox/worker tokens, or resolving a better-auth session in a Pikku function.
+DO NOT TRIGGER when: user asks about end-user HTTP session/cookie auth only (use pikku-http + the app betterAuth config) or about WebSocket channel mechanics (use pikku-websocket).'
+---
+
+# Pikku Machine Auth
+
+Unified authentication for humans **and** machines against a Pikku + better-auth
+server. Two paths, two headers, one resolver:
+
+| Caller | Credential | Header | Obtained by |
+|---|---|---|---|
+| **Human** (CLI, dev) | better-auth session token | `Authorization: Bearer <token>` | `pikku login` (device flow) → `~/.pikku/session.json` |
+| **Machine** (agent, sandbox, worker) | scoped API key | `x-api-key: <key>` | `createApiKey` (server-side, at provision/spawn) |
+
+Both resolve to a Pikku `UserSession` through one middleware:
+`betterAuthSession({ mapSession, apiKey: { mapKey } })`.
+
+> The literal OAuth `client_credentials` grant is **not** implemented in
+> better-auth's oidc-provider. The API Key plugin gives the same capability (a
+> baked secret a service presents for scoped access), not the wire protocol.
+
+## Agent Operating Procedure
+
+1. Discover before editing — inspect the app's `betterAuth({ plugins: [...] })`
+   config and existing middleware wiring before adding anything.
+2. Server changes go in the auth factory + a middleware wiring file; never put
+   auth checks in a function body (use `permissions`).
+3. The API Key plugin contributes an `apikey` table — add the matching SQL
+   migration and regenerate DB types before relying on it.
+4. Validate with the narrowest command, then `pikku all`.
+
+## Human path — `pikku login`
+
+```bash
+pikku login --url https://app.example.com   # device-authorization flow
+pikku whoami                                  # show current session + expiry
+pikku logout                                  # remove stored session
+```
+
+`pikku login` runs the RFC 8628 device flow: it requests a code, opens the
+browser to the verification URL, polls until you approve, then stores the
+session token (keyed by base URL) at `~/.pikku/session.json` with its expiry.
+
+**Server requirement** — enable the `deviceAuthorization` and `bearer` plugins:
+
+```typescript
+import { deviceAuthorization, bearer } from 'better-auth/plugins'
+
+betterAuth({
+  // ...
+  plugins: [
+    deviceAuthorization({ expiresIn: '5min', interval: '5s', schema: {} }),
+    bearer(), // lets `Authorization: Bearer <session-token>` resolve a session
+  ],
+})
+```
+
+The browser approval is two steps the user's browser does automatically:
+`GET /auth/device?user_code=XXXX` (claims the code while signed in) then
+`POST /auth/device/approve`. The CLI only requests the code and polls
+`POST /auth/device/token`.
+
+## Machine path — API keys
+
+Install the plugin (separate official package) and enable it:
+
+```bash
+yarn add @better-auth/api-key   # peer: better-auth ^1.6.19
+```
+
+```typescript
+import { apiKey } from '@better-auth/api-key'
+
+betterAuth({
+  plugins: [
+    apiKey({
+      enableMetadata: true,          // REQUIRED to store scope on the key
+      enableSessionForAPIKeys: true, // lets a key resolve via getSession too
+    }),
+  ],
+})
+```
+
+### Identity model
+
+A **machine is an API key, not a throwaway user.** Keys are owned by a small set
+of stable **service-user** identities you provision once (e.g. `orchestrator`,
+`machine-agent`, `builder`, `sandbox-runtime`). Per-machine scope rides on the
+key's `metadata`/`permissions`. A key requires a real owning user row — minting
+one for a non-existent `userId` is created but will not resolve.
+
+### Mint a scoped key (server-side, at spawn/provision)
+
+```typescript
+// `auth` is the better-auth instance (injected service)
+const { key } = await auth.api.createApiKey({
+  body: {
+    userId: sandboxRuntimeUserId,        // a stable service user
+    name: `sandbox:${sandboxId}`,
+    expiresIn: 60 * 60,                   // seconds
+    metadata: { sandboxId },             // keep only STABLE ids here
+    permissions: { sandbox: ['read', 'write'] },
+  },
+})
+// inject `key` into the machine's env; it sends it as `x-api-key`.
+```
+
+Rotate by minting a new key and expiring/deleting the old (`deleteApiKey`);
+multiple active keys per identity allow zero-downtime rotation.
+
+### Resolve scope — `verifyApiKey`, not `getSession`
+
+`getSession(x-api-key)` returns only a bare mock session **without** the
+metadata. Scope must come from `verifyApiKey`, which returns
+`{ valid, key: { userId, metadata, permissions } }`. The
+`betterAuthSession` api-key branch does this for you:
+
+```typescript
+import { betterAuthSession } from '@pikku/better-auth'
+import { addHTTPMiddleware } from '@pikku/core/http'
+
+addHTTPMiddleware([
+  betterAuthSession({
+    // human path: getSession result -> app session
+    mapSession: ({ user }) => ({ userId: user.id }),
+    // machine path: verified key -> app session. `services` lets you resolve
+    // CURRENT scope (e.g. look up the owning row) instead of trusting only the
+    // baked metadata.
+    apiKey: {
+      header: 'x-api-key', // default
+      mapKey: async (key, services) => {
+        const sandboxId = key.metadata?.sandboxId
+        if (!sandboxId) return null // reject
+        const row = await services.kysely
+          .selectFrom('sandboxInstance')
+          .innerJoin('sandbox', 'sandbox.id', 'sandboxInstance.sandboxId')
+          .select(['sandbox.orgId', 'sandbox.projectId'])
+          .where('sandboxInstance.sandboxId', '=', sandboxId)
+          .where('sandboxInstance.stoppedAt', 'is', null)
+          .executeTakeFirst()
+        if (!row) return null
+        return { userId: sandboxId, orgId: row.orgId, role: 'sandbox' }
+      },
+    },
+  }),
+])
+```
+
+When the api-key header is present it is authoritative — the middleware never
+falls through to `getSession` (a bare mock session would shadow the scoped one).
+When it is absent, the human `getSession` path runs as normal.
+
+### WebSocket channels authenticate on the upgrade handshake
+
+Generated channel CLI clients attach the credential as a connection header
+(`x-api-key` for `PIKKU_API_KEY`, else `Authorization: Bearer` from
+`~/.pikku/session.json`). The `@pikku/ws` server copies the upgrade-request
+headers into the channel's `http.request` and runs the inherited HTTP `*`
+middleware during `runUpgradeMiddleware`, so `betterAuthSession` resolves the
+session before the channel opens. For this to work the app must register
+`betterAuthSession` via `addHTTPMiddleware([...])` (the `*` group) — not only on
+specific routes — so it is inherited into the channel upgrade. Browser clients
+cannot set WebSocket headers, so header-auth only covers the Node CLI path; a
+browser channel needs a query-param/subprotocol vector instead.
+
+## Gotchas
+
+- `apiKey()` rejects `metadata` unless `enableMetadata: true`.
+- `deviceAuthorization()` requires a `schema` option (pass `schema: {}`).
+- Keep the two paths on **different headers** — `x-api-key` (machine) vs
+  `Authorization: Bearer` (human). One header for both reintroduces ambiguity.
+- The `apikey` table is plugin-contributed — add the SQL migration + regen types.
+- `~/.pikku/session.json` is written `0600` and stores the token + expiry; the
+  CLI uses the expiry to detect when a re-login is needed.

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -14,6 +14,7 @@ import { all } from './functions/commands/all.js'
 import { bootstrap } from './functions/commands/bootstrap.js'
 import { watch } from './functions/commands/watch.js'
 import { consoleCommand } from './functions/commands/console.js'
+import { login, logout, whoami } from './functions/commands/login.js'
 import { dev } from './functions/commands/dev.js'
 import { dbMigrate } from './functions/commands/db-migrate.js'
 import { dbGenerate } from './functions/commands/db-generate.js'
@@ -240,6 +241,51 @@ wireCLI({
         hmr: {
           description: 'Enable hot module reload for registered functions',
           default: false,
+        },
+      },
+    }),
+    login: pikkuCLICommand({
+      func: login,
+      description:
+        'Authenticate the CLI against a pikku server (device-authorization flow)',
+      options: {
+        url: {
+          description: 'Server base URL (default: http://localhost:3000)',
+          short: 'u',
+        },
+        clientId: {
+          description: 'Client identifier sent to the device flow',
+          default: 'pikku-cli',
+        },
+        scope: {
+          description: 'Optional space-separated scopes to request',
+        },
+        authPath: {
+          description: "better-auth base path (default: '/auth')",
+        },
+        open: {
+          description: 'Open the verification URL in a browser',
+          default: true,
+        },
+      },
+    }),
+    logout: pikkuCLICommand({
+      func: logout,
+      description: 'Remove a stored CLI session',
+      options: {
+        url: {
+          description: 'Server base URL to log out of (default: current)',
+          short: 'u',
+        },
+      },
+    }),
+    whoami: pikkuCLICommand({
+      func: whoami,
+      description: 'Show the current CLI session',
+      options: {
+        url: {
+          description: 'Server base URL to inspect (default: current)',
+          short: 'u',
         },
       },
     }),

--- a/packages/cli/src/functions/commands/login.ts
+++ b/packages/cli/src/functions/commands/login.ts
@@ -1,0 +1,115 @@
+import open from 'open'
+import { pikkuSessionlessFunc } from '#pikku'
+import { deviceLogin } from '../../utils/device-auth.js'
+import {
+  saveSession,
+  loadSession,
+  clearSession,
+  isSessionExpired,
+  sessionFilePath,
+} from '../../utils/cli-session.js'
+
+const DEFAULT_URL = 'http://localhost:3000'
+
+interface LoginOptions {
+  url?: string
+  clientId?: string
+  scope?: string
+  authPath?: string
+  open?: boolean
+}
+
+/**
+ * `pikku login` — authenticate the CLI against a pikku server using the
+ * better-auth device-authorization flow. Stores a session token at
+ * `~/.pikku/session.json`; generated CLI/websocket clients pick it up
+ * automatically.
+ */
+export const login = pikkuSessionlessFunc<LoginOptions, void>({
+  func: async (
+    { logger },
+    { url, clientId, scope, authPath, open: openBrowser }
+  ) => {
+    const baseURL = (url ?? DEFAULT_URL).trim()
+
+    const session = await deviceLogin({
+      baseURL,
+      clientId,
+      scope,
+      authBasePath: authPath,
+      onPrompt: async ({
+        verificationUri,
+        verificationUriComplete,
+        userCode,
+        expiresAtMs,
+      }) => {
+        const target = verificationUriComplete ?? verificationUri
+        logger.info('')
+        logger.info('  To finish signing in, open:')
+        logger.info(`    ${target}`)
+        logger.info('')
+        logger.info(`  And confirm this code:  ${userCode}`)
+        logger.info(
+          `  (expires ${new Date(expiresAtMs).toLocaleTimeString()})`
+        )
+        logger.info('')
+        logger.info('  Waiting for approval…')
+        // Default to opening the browser unless explicitly disabled.
+        if (openBrowser !== false) {
+          try {
+            await open(target)
+          } catch {
+            // Headless / no browser — the printed URL is the fallback.
+          }
+        }
+      },
+    })
+
+    const path = await saveSession(session)
+    const who = session.user?.email ?? session.user?.id ?? 'authenticated'
+    logger.info(`✓ Logged in as ${who} on ${session.baseURL}`)
+    if (session.expiresAt) {
+      logger.info(`  Session expires ${new Date(session.expiresAt).toLocaleString()}`)
+    }
+    logger.info(`  Saved to ${path}`)
+  },
+})
+
+/**
+ * `pikku logout` — remove a stored session (the given `--url`, or the current
+ * default).
+ */
+export const logout = pikkuSessionlessFunc<{ url?: string }, void>({
+  func: async ({ logger }, { url }) => {
+    const removed = await clearSession(url)
+    if (removed) {
+      logger.info(`✓ Logged out of ${removed}`)
+    } else {
+      logger.info('No active session to log out of.')
+    }
+  },
+})
+
+/**
+ * `pikku whoami` — show the current (or `--url`) stored session and whether it
+ * has expired.
+ */
+export const whoami = pikkuSessionlessFunc<{ url?: string }, void>({
+  func: async ({ logger }, { url }) => {
+    const session = await loadSession(url)
+    if (!session) {
+      logger.info('Not logged in. Run `pikku login` to authenticate.')
+      return
+    }
+    const who = session.user?.email ?? session.user?.id ?? '(unknown user)'
+    logger.info(`Logged in as ${who}`)
+    logger.info(`  Server : ${session.baseURL}`)
+    if (session.expiresAt) {
+      const expired = isSessionExpired(session)
+      logger.info(
+        `  Expires: ${new Date(session.expiresAt).toLocaleString()}${expired ? ' (EXPIRED — run `pikku login` again)' : ''}`
+      )
+    }
+    logger.info(`  Stored : ${sessionFilePath()}`)
+  },
+})

--- a/packages/cli/src/functions/wirings/cli/serialize-channel-cli-client.ts
+++ b/packages/cli/src/functions/wirings/cli/serialize-channel-cli-client.ts
@@ -188,17 +188,48 @@ export default ${capitalizedName}CLIClient
 if (import.meta.url === \`file://\${process.argv[1]}\`) {
   const url = process.env.PIKKU_WS_URL || 'ws://localhost:4002${finalChannelRoute}'
 
-  // Create WebSocket instance
-  let WebSocketImpl: any
-  if (typeof WebSocket !== 'undefined') {
-    WebSocketImpl = WebSocket
+  // Attach credentials so the channel authenticates like any other pikku client.
+  // A machine API key (PIKKU_API_KEY -> x-api-key) takes precedence; otherwise
+  // the human session token saved by \`pikku login\` (~/.pikku/session.json ->
+  // Authorization: Bearer) is used. This block only runs under Node (direct
+  // execution), so reading the session file and using the 'ws' headers option
+  // is safe — the browser WebSocket cannot set custom headers anyway.
+  const headers: Record<string, string> = {}
+  if (process.env.PIKKU_API_KEY) {
+    headers['x-api-key'] = process.env.PIKKU_API_KEY
   } else {
-    // Node.js environment - dynamically import 'ws'
+    try {
+      const { homedir } = await import('os')
+      const { readFileSync } = await import('fs')
+      const { join } = await import('path')
+      const store = JSON.parse(
+        readFileSync(join(homedir(), '.pikku', 'session.json'), 'utf8')
+      ) as {
+        current?: string
+        sessions?: Record<string, { accessToken?: string }>
+      }
+      const token = store.current
+        ? store.sessions?.[store.current]?.accessToken
+        : undefined
+      if (token) {
+        headers['authorization'] = \`Bearer \${token}\`
+      }
+    } catch {
+      // No saved session — connect unauthenticated (the server may reject).
+    }
+  }
+  const hasAuth = Object.keys(headers).length > 0
+
+  // Custom headers require the Node 'ws' module — the global/browser WebSocket
+  // cannot set them — so prefer 'ws' whenever we have credentials to send.
+  let ws: WebSocket
+  if (hasAuth || typeof WebSocket === 'undefined') {
     const wsModule = await import('ws')
-    WebSocketImpl = wsModule.default
+    ws = new wsModule.default(url, { headers }) as unknown as WebSocket
+  } else {
+    ws = new WebSocket(url)
   }
 
-  const ws = new WebSocketImpl(url) as WebSocket
   ${capitalizedName}CLIClient(ws, process.argv.slice(2)).catch(error => {
     console.error('Fatal channel CLI error:', error)
     // TODO: We get an error code even when it exists cleanly, investigate

--- a/packages/cli/src/utils/cli-session.ts
+++ b/packages/cli/src/utils/cli-session.ts
@@ -1,0 +1,118 @@
+import { homedir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { readFile, writeFile, mkdir, rm } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+
+/**
+ * A locally-persisted CLI session obtained via `pikku login` (the better-auth
+ * device-authorization flow). Stored at `~/.pikku/session.json`, keyed by the
+ * server's base URL so a single user can be logged into multiple pikku servers.
+ *
+ * `accessToken` is a better-auth session token — present it as
+ * `Authorization: Bearer <accessToken>` (requires the `bearer` plugin on the
+ * server). This is the HUMAN path; machine agents use scoped API keys
+ * (`x-api-key`) instead and never read this file.
+ */
+export interface PikkuCliSession {
+  baseURL: string
+  accessToken: string
+  tokenType: string
+  /** ISO timestamp; absent when the server did not report an expiry. */
+  expiresAt?: string
+  user?: { id: string; email?: string | null; name?: string | null }
+  obtainedAt: string
+}
+
+interface SessionFile {
+  /** Sessions keyed by normalized base URL. */
+  sessions: Record<string, PikkuCliSession>
+  /** Most-recently used base URL — the default target when none is given. */
+  current?: string
+}
+
+const SESSION_DIR = join(homedir(), '.pikku')
+const SESSION_FILE = join(SESSION_DIR, 'session.json')
+
+export const sessionFilePath = (): string => SESSION_FILE
+
+/** Drop a trailing slash so `https://x/` and `https://x` share one entry. */
+export const normalizeBaseURL = (url: string): string =>
+  url.trim().replace(/\/+$/, '')
+
+const readSessionFile = async (): Promise<SessionFile> => {
+  if (!existsSync(SESSION_FILE)) {
+    return { sessions: {} }
+  }
+  try {
+    const parsed = JSON.parse(await readFile(SESSION_FILE, 'utf-8'))
+    return { sessions: parsed.sessions ?? {}, current: parsed.current }
+  } catch {
+    // Corrupt file — treat as empty rather than crashing every command.
+    return { sessions: {} }
+  }
+}
+
+const writeSessionFile = async (file: SessionFile): Promise<void> => {
+  await mkdir(dirname(SESSION_FILE), { recursive: true })
+  // 0600 — the file holds bearer tokens.
+  await writeFile(SESSION_FILE, JSON.stringify(file, null, 2), { mode: 0o600 })
+}
+
+/** Persist a session and mark it the current default target. */
+export const saveSession = async (
+  session: PikkuCliSession
+): Promise<string> => {
+  const file = await readSessionFile()
+  const key = normalizeBaseURL(session.baseURL)
+  file.sessions[key] = { ...session, baseURL: key }
+  file.current = key
+  await writeSessionFile(file)
+  return SESSION_FILE
+}
+
+/**
+ * Load a stored session. With no `baseURL`, returns the current default. Returns
+ * `null` if none is stored.
+ */
+export const loadSession = async (
+  baseURL?: string
+): Promise<PikkuCliSession | null> => {
+  const file = await readSessionFile()
+  const key = baseURL ? normalizeBaseURL(baseURL) : file.current
+  if (!key) {
+    return null
+  }
+  return file.sessions[key] ?? null
+}
+
+/**
+ * Remove a stored session (the given one, or the current default). Returns the
+ * base URL that was removed, or `null` if nothing matched.
+ */
+export const clearSession = async (
+  baseURL?: string
+): Promise<string | null> => {
+  const file = await readSessionFile()
+  const key = baseURL ? normalizeBaseURL(baseURL) : file.current
+  if (!key || !file.sessions[key]) {
+    return null
+  }
+  delete file.sessions[key]
+  if (file.current === key) {
+    file.current = Object.keys(file.sessions)[0]
+  }
+  if (Object.keys(file.sessions).length === 0) {
+    // Nothing left — remove the file entirely rather than leaving an empty husk.
+    await rm(SESSION_FILE, { force: true })
+  } else {
+    await writeSessionFile(file)
+  }
+  return key
+}
+
+/** True when the session has a known expiry that is in the past. */
+export const isSessionExpired = (
+  session: PikkuCliSession,
+  nowMs: number = Date.now()
+): boolean =>
+  session.expiresAt ? new Date(session.expiresAt).getTime() <= nowMs : false

--- a/packages/cli/src/utils/device-auth.ts
+++ b/packages/cli/src/utils/device-auth.ts
@@ -1,0 +1,183 @@
+import type { PikkuCliSession } from './cli-session.js'
+import { normalizeBaseURL } from './cli-session.js'
+
+/** RFC 8628 device-authorization grant type. */
+const DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code'
+
+interface DeviceCodeResponse {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  verification_uri_complete?: string
+  expires_in: number
+  interval: number
+}
+
+interface DeviceTokenSuccess {
+  access_token: string
+  token_type?: string
+  expires_in?: number
+}
+
+interface DeviceTokenPending {
+  error: 'authorization_pending' | 'slow_down' | 'access_denied' | 'expired_token'
+  error_description?: string
+}
+
+export interface DevicePrompt {
+  /** Where the user approves the request. */
+  verificationUri: string
+  /** Same as above with the code pre-filled (open this if present). */
+  verificationUriComplete?: string
+  userCode: string
+  /** Absolute ms timestamp when the code expires. */
+  expiresAtMs: number
+}
+
+export interface DeviceLoginOptions {
+  /** Server origin, e.g. `https://app.example.com`. */
+  baseURL: string
+  /** better-auth basePath. Defaults to `/auth`. */
+  authBasePath?: string
+  /** Logical client identifier (no OIDC registration required). */
+  clientId?: string
+  /** Optional space-separated scopes to request. */
+  scope?: string
+  /** Called once the device code is issued, so the caller can prompt the user. */
+  onPrompt: (prompt: DevicePrompt) => void | Promise<void>
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+const joinUrl = (base: string, path: string) =>
+  `${base}${path.startsWith('/') ? '' : '/'}${path}`
+
+/**
+ * Run the better-auth device-authorization flow against `baseURL` and return a
+ * persisted-shaped session (token + best-effort expiry/user). The human
+ * approves in the browser; this only requests a code and polls for the token.
+ */
+export const deviceLogin = async (
+  opts: DeviceLoginOptions
+): Promise<PikkuCliSession> => {
+  const baseURL = normalizeBaseURL(opts.baseURL)
+  const authBase = `${baseURL}${opts.authBasePath ?? '/auth'}`
+  const clientId = opts.clientId ?? 'pikku-cli'
+
+  // 1. Request a device + user code.
+  const codeRes = await fetch(joinUrl(authBase, '/device/code'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ client_id: clientId, scope: opts.scope }),
+  })
+  if (!codeRes.ok) {
+    throw new Error(
+      `device/code failed (${codeRes.status}): ${await codeRes.text()}`
+    )
+  }
+  const code = (await codeRes.json()) as DeviceCodeResponse
+  const expiresAtMs = Date.now() + code.expires_in * 1000
+
+  await opts.onPrompt({
+    verificationUri: code.verification_uri,
+    verificationUriComplete: code.verification_uri_complete,
+    userCode: code.user_code,
+    expiresAtMs,
+  })
+
+  // 2. Poll the token endpoint until approved, denied, or expired.
+  let intervalMs = Math.max(1, code.interval) * 1000
+  while (Date.now() < expiresAtMs) {
+    await sleep(intervalMs)
+    const tokenRes = await fetch(joinUrl(authBase, '/device/token'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: DEVICE_GRANT_TYPE,
+        device_code: code.device_code,
+        client_id: clientId,
+      }),
+    })
+    const body = (await tokenRes.json().catch(() => ({}))) as
+      | DeviceTokenSuccess
+      | DeviceTokenPending
+
+    if (tokenRes.ok && 'access_token' in body && body.access_token) {
+      return finalizeSession(baseURL, authBase, body)
+    }
+
+    const error = (body as DeviceTokenPending).error
+    if (error === 'authorization_pending') {
+      continue
+    }
+    if (error === 'slow_down') {
+      // Back off as the spec requires.
+      intervalMs += 5000
+      continue
+    }
+    if (error === 'access_denied') {
+      throw new Error('Login was denied in the browser.')
+    }
+    if (error === 'expired_token') {
+      break
+    }
+    // Unknown non-pending error — surface it rather than spinning.
+    throw new Error(
+      `device/token failed (${tokenRes.status}): ${JSON.stringify(body)}`
+    )
+  }
+  throw new Error('Login timed out before it was approved.')
+}
+
+/**
+ * Turn a token response into a stored session. Best-effort enriches it with the
+ * server-reported expiry + user by calling `/auth/get-session` with the bearer
+ * token (works when the `bearer` plugin is enabled); falls back to the token's
+ * own `expires_in` if that call is unavailable.
+ */
+const finalizeSession = async (
+  baseURL: string,
+  authBase: string,
+  token: DeviceTokenSuccess
+): Promise<PikkuCliSession> => {
+  const obtainedAt = new Date().toISOString()
+  let expiresAt: string | undefined
+  let user: PikkuCliSession['user']
+
+  if (typeof token.expires_in === 'number') {
+    expiresAt = new Date(Date.now() + token.expires_in * 1000).toISOString()
+  }
+
+  try {
+    const res = await fetch(joinUrl(authBase, '/get-session'), {
+      headers: { authorization: `Bearer ${token.access_token}` },
+    })
+    if (res.ok) {
+      const data = (await res.json()) as {
+        session?: { expiresAt?: string }
+        user?: { id: string; email?: string; name?: string }
+      } | null
+      if (data?.session?.expiresAt) {
+        expiresAt = new Date(data.session.expiresAt).toISOString()
+      }
+      if (data?.user) {
+        user = {
+          id: data.user.id,
+          email: data.user.email,
+          name: data.user.name,
+        }
+      }
+    }
+  } catch {
+    // get-session not reachable — keep whatever expiry we already have.
+  }
+
+  return {
+    baseURL,
+    accessToken: token.access_token,
+    tokenType: token.token_type ?? 'Bearer',
+    expiresAt,
+    user,
+    obtainedAt,
+  }
+}

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -58,6 +58,10 @@ async function resolveSession(
       wire.session = stored
       sessionService?.setInitial(stored)
     }
+  } else {
+    // Session already present on wire (e.g. propagated from parent workflow).
+    // Seed the sessionService so freezeInitial() returns it instead of undefined.
+    sessionService?.setInitial(wire.session as CoreUserSession)
   }
 }
 

--- a/packages/services/better-auth/package.json
+++ b/packages/services/better-auth/package.json
@@ -21,7 +21,8 @@
     "better-auth": "^1.6.0"
   },
   "devDependencies": {
-    "better-auth": "^1.6.18",
+    "@better-auth/api-key": "^1.6.19",
+    "better-auth": "^1.6.19",
     "typescript": "^5.9"
   },
   "exports": {

--- a/packages/services/better-auth/src/auth-session.ts
+++ b/packages/services/better-auth/src/auth-session.ts
@@ -1,43 +1,120 @@
-import type { CoreUserSession, CorePikkuMiddleware } from '@pikku/core'
+import type {
+  CoreUserSession,
+  CorePikkuMiddleware,
+  CoreServices,
+} from '@pikku/core'
 import { pikkuMiddleware } from '@pikku/core'
 import type { BetterAuthInstance } from './define-auth.js'
 
 type BetterAuthSessionResult = { user: any; session: any }
 
+/**
+ * The shape returned by the API Key plugin's `verifyApiKey` endpoint. `key`
+ * carries the machine identity and its scope (`userId`, `metadata`,
+ * `permissions`) — this is the channel scope rides on for the machine path,
+ * because better-auth's `getSession()` returns only a bare mock session for an
+ * API key and drops the metadata.
+ */
+type VerifiedApiKey = { valid: boolean; error: unknown; key: any }
+
 type BetterAuthSessionOptions = {
+  /**
+   * Map a human/cookie/bearer session (from `getSession`) to the app session.
+   */
   mapSession?: (result: BetterAuthSessionResult) => CoreUserSession
+  /**
+   * Resolve machine (API key) callers statelessly. When the configured header
+   * is present the middleware calls `verifyApiKey` and, if valid, maps the
+   * verified key to the app session. Scope must be derived here (not from
+   * `getSession`) — see {@link VerifiedApiKey}.
+   */
+  apiKey?: {
+    /** Header carrying the raw API key. Defaults to `x-api-key`. */
+    header?: string
+    /**
+     * Map a verified API key to the app session. Receives the singleton
+     * services so callers can resolve current scope (e.g. look up the owning
+     * resource row) rather than trusting only what is baked into the key.
+     * Return `null`/`undefined` to reject the caller.
+     */
+    mapKey: (
+      key: any,
+      services: CoreServices
+    ) =>
+      | CoreUserSession
+      | null
+      | undefined
+      | Promise<CoreUserSession | null | undefined>
+  }
 }
 
 export const betterAuthSession = (
   options: BetterAuthSessionOptions = {}
 ): CorePikkuMiddleware => {
-  const { mapSession } = options
-  return pikkuMiddleware(async (services, { http, setSession, session }, next) => {
-    if (!http?.request || !setSession || session) {
+  const { mapSession, apiKey } = options
+  const apiKeyHeader = apiKey?.header ?? 'x-api-key'
+
+  return pikkuMiddleware(
+    async (services, { http, setSession, session }, next) => {
+      if (!http?.request || !setSession || session) {
+        return next()
+      }
+
+      // --- Machine path: stateless API key resolution -----------------------
+      // Handled before getSession because getSession would otherwise return a
+      // metadata-less mock session for the same key, masking the scoped one.
+      if (apiKey) {
+        const rawKey = http.request.header(apiKeyHeader)
+        if (rawKey) {
+          try {
+            const auth = (await (services as any).auth()) as BetterAuthInstance
+            const verified = (await auth.api.verifyApiKey({
+              body: { key: rawKey },
+            })) as VerifiedApiKey | null
+
+            if (verified?.valid && verified.key) {
+              const mapped = await apiKey.mapKey(
+                verified.key,
+                services as CoreServices
+              )
+              if (mapped) {
+                setSession(mapped)
+              }
+            }
+          } catch (e: any) {
+            services.logger?.warn(
+              `better-auth api-key verify failed: ${e?.message}`
+            )
+          }
+          // The api-key header is authoritative for this request — never fall
+          // through to getSession (a bare mock session would shadow our scope).
+          return next()
+        }
+      }
+
+      // --- Human path: cookie / bearer session ------------------------------
+      try {
+        const auth = (await (services as any).auth()) as BetterAuthInstance
+        // getSession only needs the request headers — build them directly
+        // instead of going through toWebRequest(), which (for a POST) would
+        // otherwise read the single-use request body just to discard it,
+        // starving the route handler that actually needs it.
+        const result = (await auth.api.getSession({
+          headers: new Headers(http.request.headers()),
+        })) as BetterAuthSessionResult | null
+
+        if (result?.user) {
+          setSession(
+            mapSession
+              ? mapSession(result)
+              : ({ userId: result.user.id } as CoreUserSession)
+          )
+        }
+      } catch (e: any) {
+        services.logger?.warn(`better-auth session read failed: ${e?.message}`)
+      }
+
       return next()
     }
-
-    try {
-      const auth = (await (services as any).auth()) as BetterAuthInstance
-      // getSession only needs the request headers — build them directly instead
-      // of going through toWebRequest(), which (for a POST) would otherwise read
-      // the single-use request body just to discard it, starving the route
-      // handler that actually needs it.
-      const result = (await auth.api.getSession({
-        headers: new Headers(http.request.headers()),
-      })) as BetterAuthSessionResult | null
-
-      if (result?.user) {
-        setSession(
-          mapSession
-            ? mapSession(result)
-            : ({ userId: result.user.id } as CoreUserSession)
-        )
-      }
-    } catch (e: any) {
-      services.logger?.warn(`better-auth session read failed: ${e?.message}`)
-    }
-
-    return next()
-  })
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,6 +2204,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@better-auth/api-key@npm:^1.6.19":
+  version: 1.6.19
+  resolution: "@better-auth/api-key@npm:1.6.19"
+  dependencies:
+    zod: "npm:^4.3.6"
+  peerDependencies:
+    "@better-auth/core": ^1.6.19
+    "@better-auth/utils": 0.4.2
+    better-auth: ^1.6.19
+    better-call: 1.3.6
+  checksum: 10/698a98951459388bff002b50efd65dd7a62a377a2b8e025c8fcff14f2837aa6ee514ae57568c49f5edc62390a4af6c1c0dcff16fc0ca8dbc782b4fcb12523f53
+  languageName: node
+  linkType: hard
+
 "@better-auth/core@npm:1.6.18":
   version: 1.6.18
   resolution: "@better-auth/core@npm:1.6.18"
@@ -2229,6 +2243,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@better-auth/core@npm:1.6.19":
+  version: 1.6.19
+  resolution: "@better-auth/core@npm:1.6.19"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:^1.39.0"
+    "@standard-schema/spec": "npm:^1.1.0"
+    zod: "npm:^4.3.6"
+  peerDependencies:
+    "@better-auth/utils": 0.4.2
+    "@better-fetch/fetch": 1.3.1
+    "@cloudflare/workers-types": ">=4"
+    "@opentelemetry/api": ^1.9.0
+    better-call: 1.3.6
+    jose: ^6.1.0
+    kysely: ^0.28.5 || ^0.29.0
+    nanostores: ^1.0.1
+  peerDependenciesMeta:
+    "@cloudflare/workers-types":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+  checksum: 10/95f5ec43b2a93b1e16b9740e00efd05c14eb7ebd1c5d2f766214104add50b18b237a1eb484bdb2667938cd5102d6599ec8384f503a5b9e0fb784b6db8f7460b3
+  languageName: node
+  linkType: hard
+
 "@better-auth/drizzle-adapter@npm:1.6.18":
   version: 1.6.18
   resolution: "@better-auth/drizzle-adapter@npm:1.6.18"
@@ -2240,6 +2279,20 @@ __metadata:
     drizzle-orm:
       optional: true
   checksum: 10/8a7a866e8361fa5830364370e38100c46c0db56e3dd6eab51e17d277b3aeabbc241d6316b87291ab792b3eb536d37eb6d7635df9fc4c492346074d10be7ae054
+  languageName: node
+  linkType: hard
+
+"@better-auth/drizzle-adapter@npm:1.6.19":
+  version: 1.6.19
+  resolution: "@better-auth/drizzle-adapter@npm:1.6.19"
+  peerDependencies:
+    "@better-auth/core": ^1.6.19
+    "@better-auth/utils": 0.4.2
+    drizzle-orm: ^0.45.2
+  peerDependenciesMeta:
+    drizzle-orm:
+      optional: true
+  checksum: 10/6e0eaa4e51e95ac904f0d8a90d34a83f1def9e90c0eff57577dd9beafc261b2a85bd19cf68a4423e027725a08f537d6d5448eb8c1a8c5d1b854e8bdb06aff43c
   languageName: node
   linkType: hard
 
@@ -2257,6 +2310,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@better-auth/kysely-adapter@npm:1.6.19":
+  version: 1.6.19
+  resolution: "@better-auth/kysely-adapter@npm:1.6.19"
+  peerDependencies:
+    "@better-auth/core": ^1.6.19
+    "@better-auth/utils": 0.4.2
+    kysely: ^0.28.17 || ^0.29.0
+  peerDependenciesMeta:
+    kysely:
+      optional: true
+  checksum: 10/2530d1270b2bfbc4be9c4751e0c24de70d3127906cc1f522fc36cfe81075705a2f84ef2afcc68bb905824a491a0d688ab5e352efb6a9d970c31a50fb54d49e99
+  languageName: node
+  linkType: hard
+
 "@better-auth/memory-adapter@npm:1.6.18":
   version: 1.6.18
   resolution: "@better-auth/memory-adapter@npm:1.6.18"
@@ -2264,6 +2331,16 @@ __metadata:
     "@better-auth/core": ^1.6.18
     "@better-auth/utils": 0.4.1
   checksum: 10/85be406cfb2a0e99ea2d7180bb381e08adcda9aeecb10109aba3407c7f2ccc24dbcd7bb42d6f003a66578d2e7752f2135e0c9ab5e04b6e45864f4cff32f536d4
+  languageName: node
+  linkType: hard
+
+"@better-auth/memory-adapter@npm:1.6.19":
+  version: 1.6.19
+  resolution: "@better-auth/memory-adapter@npm:1.6.19"
+  peerDependencies:
+    "@better-auth/core": ^1.6.19
+    "@better-auth/utils": 0.4.2
+  checksum: 10/09235a884193d356f5bd5371abbaf980dab2defa30fcebaff28df55c90a25e329629d99c63450954969210d99e6274527591d921be88dcbe8cb51b43d1af37f5
   languageName: node
   linkType: hard
 
@@ -2278,6 +2355,20 @@ __metadata:
     mongodb:
       optional: true
   checksum: 10/003fdf6e66ea6f2b18e9a3d2160ad6cf04a75e681cb8a52de9ea809f49ba10d4dc64844c1ce41109cb5eef0c4eedf267e3c39f37f07379d02eb4bb9489428493
+  languageName: node
+  linkType: hard
+
+"@better-auth/mongo-adapter@npm:1.6.19":
+  version: 1.6.19
+  resolution: "@better-auth/mongo-adapter@npm:1.6.19"
+  peerDependencies:
+    "@better-auth/core": ^1.6.19
+    "@better-auth/utils": 0.4.2
+    mongodb: ^6.0.0 || ^7.0.0
+  peerDependenciesMeta:
+    mongodb:
+      optional: true
+  checksum: 10/df0a636b0c379c62fc87530acf4feda426c0f2ea249ae32102c0a1a741a273b874333a12551af0f8e5781d3b590c71dc83d33392044c7a43c269d9ac69466749
   languageName: node
   linkType: hard
 
@@ -2298,6 +2389,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@better-auth/prisma-adapter@npm:1.6.19":
+  version: 1.6.19
+  resolution: "@better-auth/prisma-adapter@npm:1.6.19"
+  peerDependencies:
+    "@better-auth/core": ^1.6.19
+    "@better-auth/utils": 0.4.2
+    "@prisma/client": ^5.0.0 || ^6.0.0 || ^7.0.0
+    prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+  peerDependenciesMeta:
+    "@prisma/client":
+      optional: true
+    prisma:
+      optional: true
+  checksum: 10/6cc948d57ae002b4179561014c1bcea749cfbb2982cb54e057378827257ab79efda9e3fcf1af1cfe8490e9d2a92de265b8ff45bfe6e45173735635fffad6390d
+  languageName: node
+  linkType: hard
+
 "@better-auth/telemetry@npm:1.6.18":
   version: 1.6.18
   resolution: "@better-auth/telemetry@npm:1.6.18"
@@ -2306,6 +2414,17 @@ __metadata:
     "@better-auth/utils": 0.4.1
     "@better-fetch/fetch": 1.3.0
   checksum: 10/a1da12f98f39ccd440442eb2f1d825caa718603b02f6d1387af829b7e9301f1b12f2864857a49c154436c759fc36b5195aacee9f3242e41980182b21f2e08d56
+  languageName: node
+  linkType: hard
+
+"@better-auth/telemetry@npm:1.6.19":
+  version: 1.6.19
+  resolution: "@better-auth/telemetry@npm:1.6.19"
+  peerDependencies:
+    "@better-auth/core": ^1.6.19
+    "@better-auth/utils": 0.4.2
+    "@better-fetch/fetch": 1.3.1
+  checksum: 10/76a138ba7ced322ede822f3f91ca6f8e3712f480eb292d1dcdded9cdc79162b2262f63cf4800130db4619fc8b588d6972778bf7bc911f9bef0074c4be6900074
   languageName: node
   linkType: hard
 
@@ -2318,10 +2437,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@better-auth/utils@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@better-auth/utils@npm:0.4.2"
+  dependencies:
+    "@noble/hashes": "npm:^2.0.1"
+  checksum: 10/27c78bcd9ef14c8049681660d459a0c50891b74bcb4899d96d3d535f9be883b1e2d1432da3d2dfd072e8b695fff522f0461c94b021c695f4d81fc26bb41aa1af
+  languageName: node
+  linkType: hard
+
 "@better-fetch/fetch@npm:1.3.0, @better-fetch/fetch@npm:^1.1.21":
   version: 1.3.0
   resolution: "@better-fetch/fetch@npm:1.3.0"
   checksum: 10/c1190be172ec72218cc9a30ae70d2edcad7e2bf56857d91601d868f9472702684b6d6ec1f0b38d95ff0fbd7de6464965f03ace4d9ed83df56c7effd06cbb870f
+  languageName: node
+  linkType: hard
+
+"@better-fetch/fetch@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@better-fetch/fetch@npm:1.3.1"
+  checksum: 10/9031913794cb23893e63984b00f26780ee2cfb3ba318bbc8e15ca01e5c635c737811eecb6ddcb1c22f93c5b0e693082907d2998ab02fcd199a7d8c381f8002f5
   languageName: node
   linkType: hard
 
@@ -5337,7 +5472,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/better-auth@workspace:packages/services/better-auth"
   dependencies:
-    better-auth: "npm:^1.6.18"
+    "@better-auth/api-key": "npm:^1.6.19"
+    better-auth: "npm:^1.6.19"
     typescript: "npm:^5.9"
   peerDependencies:
     "@pikku/core": ^0.12.32
@@ -12121,6 +12257,90 @@ __metadata:
     vue:
       optional: true
   checksum: 10/3ac38cbe2c42691548b336d7cb93cc71be6a53b8941f6bb9fec7acdf6e373cfe294a0d779bfc8e4bae7a595d0fc75ce3294890ead9be0494af18e121cea0421d
+  languageName: node
+  linkType: hard
+
+"better-auth@npm:^1.6.19":
+  version: 1.6.19
+  resolution: "better-auth@npm:1.6.19"
+  dependencies:
+    "@better-auth/core": "npm:1.6.19"
+    "@better-auth/drizzle-adapter": "npm:1.6.19"
+    "@better-auth/kysely-adapter": "npm:1.6.19"
+    "@better-auth/memory-adapter": "npm:1.6.19"
+    "@better-auth/mongo-adapter": "npm:1.6.19"
+    "@better-auth/prisma-adapter": "npm:1.6.19"
+    "@better-auth/telemetry": "npm:1.6.19"
+    "@better-auth/utils": "npm:0.4.2"
+    "@better-fetch/fetch": "npm:1.3.1"
+    "@noble/ciphers": "npm:^2.1.1"
+    "@noble/hashes": "npm:^2.0.1"
+    better-call: "npm:1.3.6"
+    defu: "npm:^6.1.4"
+    jose: "npm:^6.1.3"
+    kysely: "npm:^0.28.17 || ^0.29.0"
+    nanostores: "npm:^1.1.1"
+    zod: "npm:^4.3.6"
+  peerDependencies:
+    "@lynx-js/react": "*"
+    "@prisma/client": ^5.0.0 || ^6.0.0 || ^7.0.0
+    "@sveltejs/kit": ^2.0.0
+    "@tanstack/react-start": ^1.0.0
+    "@tanstack/solid-start": ^1.0.0
+    better-sqlite3: ^12.0.0
+    drizzle-kit: ">=0.31.4"
+    drizzle-orm: ^0.45.2
+    mongodb: ^6.0.0 || ^7.0.0
+    mysql2: ^3.0.0
+    next: ^14.0.0 || ^15.0.0 || ^16.0.0
+    pg: ^8.0.0
+    prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    solid-js: ^1.0.0
+    svelte: ^4.0.0 || ^5.0.0
+    vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+    vue: ^3.0.0
+  peerDependenciesMeta:
+    "@lynx-js/react":
+      optional: true
+    "@prisma/client":
+      optional: true
+    "@sveltejs/kit":
+      optional: true
+    "@tanstack/react-start":
+      optional: true
+    "@tanstack/solid-start":
+      optional: true
+    better-sqlite3:
+      optional: true
+    drizzle-kit:
+      optional: true
+    drizzle-orm:
+      optional: true
+    mongodb:
+      optional: true
+    mysql2:
+      optional: true
+    next:
+      optional: true
+    pg:
+      optional: true
+    prisma:
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+    solid-js:
+      optional: true
+    svelte:
+      optional: true
+    vitest:
+      optional: true
+    vue:
+      optional: true
+  checksum: 10/06d4af7f72b3a73926089ecb2f9f5328e14ec69c54f4261cd76975c91eb5432ea67f4abeeba475525e945ed06ee1888f0d4950a44a515fc399f5c259836e3ab7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

OSS foundation for replacing fabric's bespoke machine/sandbox JWTs with a single better-auth-backed model. Two paths, two headers, one resolver.

### Human auth — `pikku login` / `logout` / `whoami`
Device-authorization flow with a session store at `~/.pikku/session.json` (0600, keyed by base URL, with expiry). Verified end-to-end (14/14 integration assertions against a real better-auth `deviceAuthorization` + bearer server).

### Machine auth — api-key branch in `betterAuthSession()`
Stateless: resolves scope via `verifyApiKey` (**not** `getSession`, which drops metadata) and is authoritative when the `x-api-key` header is present.

### Auto-wire
Generated channel CLI clients attach the credential on the WS upgrade handshake (`PIKKU_API_KEY` → `x-api-key`, else stored token → `Bearer`), so `betterAuthSession` resolves before the channel opens.

Adds the `pikku-machine-auth` skill documenting both paths + the identity model.

> `@better-auth/api-key` is a separate official package (not in the better-auth plugins barrel); peer-requires `better-auth ^1.6.19`.

## Also included
- **fix(workflow): seed sessionService when session already present on wire** (`@pikku/core` patch) — when a parent workflow propagates its session to a child via `wire.session`, `resolveSession` skipped `setInitial`, so `freezeInitial()` returned `undefined` and overwrote the propagated session. Now seeds the sessionService with the existing wire session so `pikkuFunc` steps inside child workflows resolve it.

## Changesets
- `@pikku/cli`: minor — `login`/`logout`/`whoami` + credential auto-wire
- `@pikku/better-auth`: minor — api-key auth branch
- `@pikku/core`: patch — workflow child-session seed fix

## Related
- Follow-up #725 — generalize this into `cli.login` / `cli.machine2machine` config flags (deferred; design captured there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)