### PR TITLE
feat(cli): pikku fabric publish + add for the community registry

### DIFF
--- a/.changeset/fabric-publish-add-npm-pack.md
+++ b/.changeset/fabric-publish-add-npm-pack.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+`pikku fabric publish` now packs with `npm pack` (honouring the package's `files` field and matching a normal install's layout) instead of a hand-rolled tar. `pikku fabric add` installs the artifact into the project's `node_modules/<package-name>/` — the location `wireAddon({ package })` resolves via `require.resolve` — stripping npm's `package/` prefix, instead of copying source into `src/addons/<id>/` where it could not be wired.

--- a/.changeset/fabric-registry-publish-add.md
+++ b/.changeset/fabric-registry-publish-add.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Add `pikku fabric publish [dir]` and `pikku fabric add <id>` for the Fabric community registry. `publish` packs a package directory into an artifact and uploads it via a short-lived presigned URL (authenticated; attributed to the publisher's org or person). `add` resolves a public presigned download and copies the package source shadcn-style into `addons.addonDir` (new `pikku.config.json` config, default `src/addons`).

--- a/.changeset/inspector-skip-node-modules.md
+++ b/.changeset/inspector-skip-node-modules.md
@@ -1,0 +1,5 @@
+---
+'@pikku/inspector': patch
+---
+
+Exclude `node_modules` from inspector source scanning. A locally-installed addon (under the project's `node_modules`) is a dependency, not project source — scanning it double-counted the addon's own application types (`CoreConfig`/`CoreServices`/`CoreSingletonServices`) and failed `pikku all` with "More than one … found". Addons still contribute via their generated metadata, not by being re-scanned as source.

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,7 @@ packages/cli/release/
 **/.better-auth*.sqlite
 **/.better-auth*.sqlite-shm
 **/.better-auth*.sqlite-wal
+
+# addon-registry verifier install artifacts (shadcn copy + provenance)
+verifiers/addon-registry/consumer/addons/
+verifiers/addon-registry/consumer/pikku-addons.json

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -59,10 +59,7 @@ import {
   FabricValidate,
   renderValidate,
 } from './functions/validate.function.js'
-import {
-  FabricSmoke,
-  renderSmoke,
-} from './functions/smoke.function.js'
+import { FabricSmoke, renderSmoke } from './functions/smoke.function.js'
 import { FabricPublish } from './functions/publish.function.js'
 import { FabricAdd } from './functions/add.function.js'
 
@@ -133,27 +130,33 @@ export const fabricCommands = defineCLICommands({
       },
     },
   }),
-  publish: pikkuCLICommand({
-    parameters: '[dir]',
-    func: FabricPublish,
-    description:
-      'Publish a package directory to the Fabric community registry (pack + upload)',
-    options: {
-      apiUrl: { description: 'Override the fabric-api URL for this call' },
+  addon: {
+    description: 'Publish and install Fabric community-registry addons',
+    subcommands: {
+      publish: pikkuCLICommand({
+        parameters: '[dir]',
+        func: FabricPublish,
+        description:
+          'Publish the addon in this directory to the community registry (pack + upload)',
+        options: {
+          apiUrl: { description: 'Override the fabric-api URL for this call' },
+        },
+      }),
+      add: pikkuCLICommand({
+        parameters: '<id>',
+        func: FabricAdd,
+        description:
+          'Install an addon from the community registry into addons/ (shadcn-style)',
+        options: {
+          dir: {
+            description:
+              'Addon dir (overrides pikku.config.json addons.addonDir, default addons/)',
+          },
+          apiUrl: { description: 'Override the fabric-api URL for this call' },
+        },
+      }),
     },
-  }),
-  add: pikkuCLICommand({
-    parameters: '<id>',
-    func: FabricAdd,
-    description:
-      'Install a package from the Fabric community registry into the project',
-    options: {
-      dir: {
-        description: 'Install dir (overrides pikku.config.json addons.addonDir)',
-      },
-      apiUrl: { description: 'Override the fabric-api URL for this call' },
-    },
-  }),
+  },
   deploy: {
     description: 'Plan and apply deploys for a named branch or production',
     subcommands: {

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -63,6 +63,8 @@ import {
   FabricSmoke,
   renderSmoke,
 } from './functions/smoke.function.js'
+import { FabricPublish } from './functions/publish.function.js'
+import { FabricAdd } from './functions/add.function.js'
 
 export const fabricCommands = defineCLICommands({
   validate: pikkuCLICommand({
@@ -129,6 +131,27 @@ export const fabricCommands = defineCLICommands({
       apiUrl: {
         description: 'Override the fabric-api URL stored in fabric.config.json',
       },
+    },
+  }),
+  publish: pikkuCLICommand({
+    parameters: '[dir]',
+    func: FabricPublish,
+    description:
+      'Publish a package directory to the Fabric community registry (pack + upload)',
+    options: {
+      apiUrl: { description: 'Override the fabric-api URL for this call' },
+    },
+  }),
+  add: pikkuCLICommand({
+    parameters: '<id>',
+    func: FabricAdd,
+    description:
+      'Install a package from the Fabric community registry into the project',
+    options: {
+      dir: {
+        description: 'Install dir (overrides pikku.config.json addons.addonDir)',
+      },
+      apiUrl: { description: 'Override the fabric-api URL for this call' },
     },
   }),
   deploy: {

--- a/packages/cli/src/fabric/functions/add.function.ts
+++ b/packages/cli/src/fabric/functions/add.function.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { readFile, mkdir, rm, writeFile } from 'node:fs/promises'
+import { readFile, mkdir, rm, writeFile, rename } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { dirname, isAbsolute, join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -18,33 +18,25 @@ export const FabricAddOutput = z.object({
   path: z.string(),
 })
 
-const DEFAULT_ADDON_DIR = 'src/addons'
-
-/** Walk up from cwd to find pikku.config.json and read its addons.addonDir. */
-async function resolveAddonDir(): Promise<string> {
+/** Walk up from cwd to find the project root (the dir with package.json). */
+function resolveProjectRoot(): string {
   let dir = process.cwd()
   while (true) {
-    const candidate = join(dir, 'pikku.config.json')
-    if (existsSync(candidate)) {
-      const cfg = JSON.parse(await readFile(candidate, 'utf8')) as {
-        rootDir?: string
-        addons?: { addonDir?: string }
-      }
-      const addonDir = cfg.addons?.addonDir ?? DEFAULT_ADDON_DIR
-      return isAbsolute(addonDir) ? addonDir : join(dir, addonDir)
-    }
+    if (existsSync(join(dir, 'package.json'))) return dir
     const parent = dirname(dir)
-    if (parent === dir) return join(process.cwd(), DEFAULT_ADDON_DIR)
+    if (parent === dir) return process.cwd()
     dir = parent
   }
 }
 
 /**
- * Install a community-registry package into the project. Resolves a presigned
- * download URL (public — no auth needed), fetches the artifact, and extracts it
- * shadcn-style into `<addonDir>/<id>/` so the source is copied into the
- * codebase. `addonDir` comes from pikku.config.json `addons.addonDir`
- * (default `src/addons`), or `--dir`.
+ * Install a community-registry package into the project's `node_modules` so it
+ * resolves by package name — the location `wireAddon({ package })` looks it up
+ * (`require.resolve('<package>/.pikku/...')`). Resolves a presigned download URL
+ * (public — no auth), fetches the artifact, and unpacks it into
+ * `<root>/node_modules/<package-name>/`. The package name comes from the
+ * artifact's own package.json (npm-pack nests contents under `package/`, which
+ * `--strip-components=1` removes). `--dir` overrides the node_modules root.
  */
 export const FabricAdd = pikkuSessionlessFunc({
   description:
@@ -69,22 +61,40 @@ export const FabricAdd = pikkuSessionlessFunc({
     if (!dl.ok) throw new Error(`artifact fetch failed → ${dl.status}`)
     const artifact = Buffer.from(await dl.arrayBuffer())
 
-    // 3. extract into <addonDir>/<id> (replace any prior copy)
-    const baseDir = dir
+    // 3. unpack into a staging dir *inside* the install root (so the final
+    //    move is same-filesystem — no EXDEV), stripping the npm `package/`
+    //    prefix. The root is known up front; the package subdir isn't (its
+    //    name lives in the artifact's package.json).
+    const root = dir
       ? isAbsolute(dir)
         ? dir
         : join(process.cwd(), dir)
-      : await resolveAddonDir()
-    const target = join(baseDir, id)
-    await rm(target, { recursive: true, force: true })
-    await mkdir(target, { recursive: true })
-
+      : join(resolveProjectRoot(), 'node_modules')
+    const staging = join(root, `.pikku-add-${id}-${Date.now()}`)
+    await mkdir(staging, { recursive: true })
     const tmp = join(tmpdir(), `pikku-add-${Date.now()}.tgz`)
     await writeFile(tmp, artifact)
-    execFileSync('tar', ['-xzf', tmp, '-C', target])
-    await rm(tmp, { force: true })
+    try {
+      execFileSync('tar', ['-xzf', tmp, '-C', staging, '--strip-components=1'])
+      await rm(tmp, { force: true })
 
-    console.log(`[fabric] installed ${id} → ${target}`)
-    return { id, path: target }
+      // 4. read the package name and move into <root>/<name>
+      const pkg = JSON.parse(
+        await readFile(join(staging, 'package.json'), 'utf8')
+      ) as { name?: string }
+      if (!pkg.name)
+        throw new Error('artifact package.json is missing a "name" field')
+
+      const target = join(root, ...pkg.name.split('/'))
+      await rm(target, { recursive: true, force: true })
+      await mkdir(dirname(target), { recursive: true })
+      await rename(staging, target)
+
+      console.log(`[fabric] installed ${pkg.name} → ${target}`)
+      return { id, path: target }
+    } finally {
+      await rm(staging, { recursive: true, force: true })
+      await rm(tmp, { force: true })
+    }
   },
 })

--- a/packages/cli/src/fabric/functions/add.function.ts
+++ b/packages/cli/src/fabric/functions/add.function.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod'
+import { readFile, mkdir, rm, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { dirname, isAbsolute, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { execFileSync } from 'node:child_process'
+import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
+import { resolveApiContext } from '../lib/config.js'
+
+export const FabricAddInput = z.object({
+  id: z.string(),
+  dir: z.string().optional(),
+  apiUrl: z.string().optional(),
+})
+
+export const FabricAddOutput = z.object({
+  id: z.string(),
+  path: z.string(),
+})
+
+const DEFAULT_ADDON_DIR = 'src/addons'
+
+/** Walk up from cwd to find pikku.config.json and read its addons.addonDir. */
+async function resolveAddonDir(): Promise<string> {
+  let dir = process.cwd()
+  while (true) {
+    const candidate = join(dir, 'pikku.config.json')
+    if (existsSync(candidate)) {
+      const cfg = JSON.parse(await readFile(candidate, 'utf8')) as {
+        rootDir?: string
+        addons?: { addonDir?: string }
+      }
+      const addonDir = cfg.addons?.addonDir ?? DEFAULT_ADDON_DIR
+      return isAbsolute(addonDir) ? addonDir : join(dir, addonDir)
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return join(process.cwd(), DEFAULT_ADDON_DIR)
+    dir = parent
+  }
+}
+
+/**
+ * Install a community-registry package into the project. Resolves a presigned
+ * download URL (public — no auth needed), fetches the artifact, and extracts it
+ * shadcn-style into `<addonDir>/<id>/` so the source is copied into the
+ * codebase. `addonDir` comes from pikku.config.json `addons.addonDir`
+ * (default `src/addons`), or `--dir`.
+ */
+export const FabricAdd = pikkuSessionlessFunc({
+  description:
+    'Install a package from the Fabric community registry into the project.',
+  input: FabricAddInput,
+  output: FabricAddOutput,
+  func: async (_services, { id, dir, apiUrl: apiUrlOverride }) => {
+    const ctx = await resolveApiContext({ apiUrlOverride })
+
+    // 1. resolve a presigned download URL (public read)
+    const metaRes = await fetch(
+      `${ctx.apiUrl}/registry/packages/${encodeURIComponent(id)}/download`
+    )
+    if (!metaRes.ok)
+      throw new Error(
+        `download lookup failed → ${metaRes.status}: ${await metaRes.text()}`
+      )
+    const { url } = (await metaRes.json()) as { url: string }
+
+    // 2. fetch the artifact
+    const dl = await fetch(url)
+    if (!dl.ok) throw new Error(`artifact fetch failed → ${dl.status}`)
+    const artifact = Buffer.from(await dl.arrayBuffer())
+
+    // 3. extract into <addonDir>/<id> (replace any prior copy)
+    const baseDir = dir
+      ? isAbsolute(dir)
+        ? dir
+        : join(process.cwd(), dir)
+      : await resolveAddonDir()
+    const target = join(baseDir, id)
+    await rm(target, { recursive: true, force: true })
+    await mkdir(target, { recursive: true })
+
+    const tmp = join(tmpdir(), `pikku-add-${Date.now()}.tgz`)
+    await writeFile(tmp, artifact)
+    execFileSync('tar', ['-xzf', tmp, '-C', target])
+    await rm(tmp, { force: true })
+
+    console.log(`[fabric] installed ${id} → ${target}`)
+    return { id, path: target }
+  },
+})

--- a/packages/cli/src/fabric/functions/add.function.ts
+++ b/packages/cli/src/fabric/functions/add.function.ts
@@ -15,6 +15,8 @@ export const FabricAddInput = z.object({
 
 export const FabricAddOutput = z.object({
   id: z.string(),
+  name: z.string(),
+  version: z.string(),
   path: z.string(),
 })
 
@@ -29,18 +31,78 @@ function resolveProjectRoot(): string {
   }
 }
 
+/** Read `addons.addonDir` from pikku.config.json if present (json only). */
+async function readAddonDirFromConfig(
+  root: string
+): Promise<string | undefined> {
+  const cfgPath = join(root, 'pikku.config.json')
+  if (!existsSync(cfgPath)) return undefined
+  try {
+    const cfg = JSON.parse(await readFile(cfgPath, 'utf8')) as {
+      addons?: { addonDir?: string }
+    }
+    return cfg.addons?.addonDir
+  } catch {
+    return undefined
+  }
+}
+
+/** Ensure the root package.json `workspaces` glob covers `<addonDir>/*`, so a
+ *  later `yarn install` symlinks the addon into node_modules and `wireAddon`
+ *  resolves it by package name. */
+async function ensureWorkspaceGlob(
+  root: string,
+  addonDir: string
+): Promise<void> {
+  const pkgPath = join(root, 'package.json')
+  const pkg = JSON.parse(await readFile(pkgPath, 'utf8')) as {
+    workspaces?: string[] | { packages?: string[] }
+  }
+  const glob = `${addonDir}/*`
+  const objectForm = !Array.isArray(pkg.workspaces) && pkg.workspaces != null
+  const list = Array.isArray(pkg.workspaces)
+    ? pkg.workspaces
+    : (pkg.workspaces?.packages ?? [])
+  if (list.includes(glob)) return
+  list.push(glob)
+  if (objectForm) (pkg.workspaces as { packages?: string[] }).packages = list
+  else pkg.workspaces = list
+  await writeFile(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
+}
+
+/** Record install provenance in pikku-addons.json — CLI-owned, so we know which
+ *  registry package + version a folder came from even after the user forks it. */
+async function recordInstall(
+  root: string,
+  name: string,
+  rec: { id: string; version: string }
+): Promise<void> {
+  const p = join(root, 'pikku-addons.json')
+  let data: Record<string, { id: string; version: string }> = {}
+  if (existsSync(p)) {
+    try {
+      data = JSON.parse(await readFile(p, 'utf8'))
+    } catch {
+      data = {}
+    }
+  }
+  data[name] = rec
+  await writeFile(p, JSON.stringify(data, null, 2) + '\n')
+}
+
 /**
- * Install a community-registry package into the project's `node_modules` so it
- * resolves by package name — the location `wireAddon({ package })` looks it up
- * (`require.resolve('<package>/.pikku/...')`). Resolves a presigned download URL
- * (public — no auth), fetches the artifact, and unpacks it into
- * `<root>/node_modules/<package-name>/`. The package name comes from the
- * artifact's own package.json (npm-pack nests contents under `package/`, which
- * `--strip-components=1` removes). `--dir` overrides the node_modules root.
+ * Install a community-registry addon shadcn-style: the source is copied into
+ * `<addonDir>/<name>/` (default `addons/`, top-level so it sits outside the
+ * app's TS scan and never collides with the project's own CoreConfig). The dir
+ * is registered as a yarn workspace, so `yarn install` symlinks it into
+ * node_modules and `wireAddon({ package })` resolves it by name unchanged.
+ *
+ * Provenance (registry id + version) is recorded in pikku-addons.json, which is
+ * CLI-owned and survives the user editing/forking the copied source.
  */
 export const FabricAdd = pikkuSessionlessFunc({
   description:
-    'Install a package from the Fabric community registry into the project.',
+    'Install an addon from the Fabric community registry into addons/ (shadcn-style).',
   input: FabricAddInput,
   output: FabricAddOutput,
   func: async (_services, { id, dir, apiUrl: apiUrlOverride }) => {
@@ -61,37 +123,43 @@ export const FabricAdd = pikkuSessionlessFunc({
     if (!dl.ok) throw new Error(`artifact fetch failed → ${dl.status}`)
     const artifact = Buffer.from(await dl.arrayBuffer())
 
-    // 3. unpack into a staging dir *inside* the install root (so the final
-    //    move is same-filesystem — no EXDEV), stripping the npm `package/`
-    //    prefix. The root is known up front; the package subdir isn't (its
-    //    name lives in the artifact's package.json).
-    const root = dir
-      ? isAbsolute(dir)
-        ? dir
-        : join(process.cwd(), dir)
-      : join(resolveProjectRoot(), 'node_modules')
-    const staging = join(root, `.pikku-add-${id}-${Date.now()}`)
+    const root = resolveProjectRoot()
+    const addonDir = dir ?? (await readAddonDirFromConfig(root)) ?? 'addons'
+    const addonRoot = isAbsolute(addonDir) ? addonDir : join(root, addonDir)
+
+    // 3. stage inside addonRoot (same filesystem — no EXDEV on the final move)
+    //    and strip npm-pack's `package/` prefix. The dir name isn't known until
+    //    we read the artifact's package.json.
+    await mkdir(addonRoot, { recursive: true })
+    const staging = join(addonRoot, `.pikku-add-${id}-${Date.now()}`)
     await mkdir(staging, { recursive: true })
-    const tmp = join(tmpdir(), `pikku-add-${Date.now()}.tgz`)
+    const tmp = join(tmpdir(), `pikku-add-${id}.tgz`)
     await writeFile(tmp, artifact)
     try {
       execFileSync('tar', ['-xzf', tmp, '-C', staging, '--strip-components=1'])
       await rm(tmp, { force: true })
 
-      // 4. read the package name and move into <root>/<name>
       const pkg = JSON.parse(
         await readFile(join(staging, 'package.json'), 'utf8')
-      ) as { name?: string }
+      ) as { name?: string; version?: string }
       if (!pkg.name)
         throw new Error('artifact package.json is missing a "name" field')
+      const version = pkg.version ?? '0.0.0'
 
-      const target = join(root, ...pkg.name.split('/'))
+      // shadcn copy: folder is the last segment of the (scoped) package name
+      const folder = pkg.name.split('/').pop()!
+      const target = join(addonRoot, folder)
       await rm(target, { recursive: true, force: true })
-      await mkdir(dirname(target), { recursive: true })
       await rename(staging, target)
 
-      console.log(`[fabric] installed ${pkg.name} → ${target}`)
-      return { id, path: target }
+      // 4. register the workspace glob + record provenance (skip glob for an
+      //    absolute --dir override — it can't be a relative workspace pattern)
+      if (!isAbsolute(addonDir)) await ensureWorkspaceGlob(root, addonDir)
+      await recordInstall(root, pkg.name, { id, version })
+
+      console.log(`[fabric] installed ${pkg.name}@${version} → ${target}`)
+      console.log('[fabric] run `yarn install` to link it into node_modules')
+      return { id, name: pkg.name, version, path: target }
     } finally {
       await rm(staging, { recursive: true, force: true })
       await rm(tmp, { force: true })

--- a/packages/cli/src/fabric/functions/publish.function.ts
+++ b/packages/cli/src/fabric/functions/publish.function.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod'
+import { readFile } from 'node:fs/promises'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { execFileSync } from 'node:child_process'
+import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
+import { resolveApiContext } from '../lib/config.js'
+
+export const FabricPublishInput = z.object({
+  dir: z.string().optional(),
+  apiUrl: z.string().optional(),
+})
+
+export const FabricPublishOutput = z.object({
+  id: z.string(),
+  name: z.string(),
+  version: z.string(),
+  publisher: z.string().nullable(),
+})
+
+/**
+ * Publish a package to the Fabric community registry. Packs the directory into
+ * a gzipped tar, requests a short-lived presigned upload URL, PUTs the artifact
+ * to R2, then finalizes the publish so the catalogue indexes it. Authenticated
+ * as the logged-in user (the package is attributed to their org or person).
+ *
+ * Generating the package contents (`.pikku/` meta etc.) is a separate step;
+ * this command only packages + uploads what's already in the directory.
+ */
+export const FabricPublish = pikkuSessionlessFunc({
+  description: 'Publish a package directory to the Fabric community registry.',
+  input: FabricPublishInput,
+  output: FabricPublishOutput,
+  func: async (_services, { dir, apiUrl: apiUrlOverride }) => {
+    const ctx = await resolveApiContext({ apiUrlOverride })
+    if (!ctx.token)
+      throw new Error('Not logged in. Run `pikku fabric login` first.')
+
+    const packageDir = dir ?? process.cwd()
+    const pkgPath = join(packageDir, 'package.json')
+    if (!existsSync(pkgPath))
+      throw new Error(`No package.json found in ${packageDir}`)
+    const pkg = JSON.parse(await readFile(pkgPath, 'utf8')) as {
+      name?: string
+      version?: string
+    }
+    if (!pkg.name || !pkg.version)
+      throw new Error('package.json must have a name and version')
+
+    // Pack the directory into a gzipped tar (artifact). Excludes are the usual
+    // build/VCS noise; everything else ships so consumers can copy it in.
+    const artifactPath = join(tmpdir(), `pikku-publish-${Date.now()}.tgz`)
+    execFileSync('tar', [
+      '-czf',
+      artifactPath,
+      '-C',
+      packageDir,
+      '--exclude=node_modules',
+      '--exclude=.git',
+      '--exclude=dist',
+      '.',
+    ])
+    const artifact = readFileSync(artifactPath)
+
+    const headers = {
+      authorization: `Bearer ${ctx.token}`,
+      'content-type': 'application/json',
+    }
+    const post = async (path: string, body: unknown) => {
+      const r = await fetch(`${ctx.apiUrl}${path}`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      })
+      if (!r.ok) throw new Error(`POST ${path} → ${r.status}: ${await r.text()}`)
+      return r.json() as Promise<any>
+    }
+
+    // 1. presigned upload URL (short-lived)
+    const { uploadUrl, artifactKey } = await post(
+      '/registry/packages/publish-url',
+      { packageName: pkg.name, version: pkg.version }
+    )
+
+    // 2. PUT the artifact to the exact signed URL (no extra headers — the URL
+    //    is signed over host only; mismatched headers break the signature).
+    const put = await fetch(uploadUrl, { method: 'PUT', body: artifact })
+    if (!put.ok)
+      throw new Error(`upload failed → ${put.status}: ${await put.text()}`)
+
+    // 3. finalize — server reads the artifact back, extracts meta, indexes it
+    const entry = await post('/registry/packages/publish', { artifactKey })
+
+    const publisher: string | null = entry.publisher?.name ?? null
+    console.log(
+      `[fabric] published ${entry.name}@${entry.version} (id=${entry.id})` +
+        (publisher ? ` as ${publisher}` : '')
+    )
+
+    return {
+      id: entry.id,
+      name: entry.name,
+      version: entry.version,
+      publisher,
+    }
+  },
+})

--- a/packages/cli/src/fabric/functions/publish.function.ts
+++ b/packages/cli/src/fabric/functions/publish.function.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { readFile } from 'node:fs/promises'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { execFileSync } from 'node:child_process'
@@ -48,20 +48,19 @@ export const FabricPublish = pikkuSessionlessFunc({
     if (!pkg.name || !pkg.version)
       throw new Error('package.json must have a name and version')
 
-    // Pack the directory into a gzipped tar (artifact). Excludes are the usual
-    // build/VCS noise; everything else ships so consumers can copy it in.
-    const artifactPath = join(tmpdir(), `pikku-publish-${Date.now()}.tgz`)
-    execFileSync('tar', [
-      '-czf',
-      artifactPath,
-      '-C',
-      packageDir,
-      '--exclude=node_modules',
-      '--exclude=.git',
-      '--exclude=dist',
-      '.',
-    ])
-    const artifact = readFileSync(artifactPath)
+    // Pack via `npm pack` so the artifact honours the package's `files` field
+    // (ship src/.pikku/types, not build/VCS noise) and matches the layout a
+    // normal install produces. npm nests contents under `package/`; the
+    // registry ingestion and `pikku fabric add` both handle that prefix.
+    const packDir = join(tmpdir(), `pikku-publish-${Date.now()}`)
+    mkdirSync(packDir, { recursive: true })
+    const packOut = execFileSync(
+      'npm',
+      ['pack', '--json', '--pack-destination', packDir],
+      { cwd: packageDir, encoding: 'utf8' }
+    )
+    const tgzName = JSON.parse(packOut)[0].filename
+    const artifact = readFileSync(join(packDir, tgzName))
 
     const headers = {
       authorization: `Bearer ${ctx.token}`,

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -309,6 +309,15 @@ export type PikkuCLIInput = {
     events?: PikkuScaffoldFeature
   }
 
+  /**
+   * Community-registry packages installed via `pikku fabric add`. The package
+   * source is copied into the project shadcn-style; each lands in
+   * `<addonDir>/<package-id>/`. `addonDir` defaults to `src/addons`.
+   */
+  addons?: {
+    addonDir?: string
+  }
+
   tests?: {
     outputDir?: string
   }

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -310,9 +310,12 @@ export type PikkuCLIInput = {
   }
 
   /**
-   * Community-registry packages installed via `pikku fabric add`. The package
+   * Community-registry addons installed via `pikku fabric addon add`. The
    * source is copied into the project shadcn-style; each lands in
-   * `<addonDir>/<package-id>/`. `addonDir` defaults to `src/addons`.
+   * `<addonDir>/<name>/` and the dir is registered as a yarn workspace so
+   * `wireAddon({ package })` resolves it by name. `addonDir` defaults to
+   * `addons` (top-level, outside the app's TS scan). Install provenance is
+   * tracked in pikku-addons.json.
    */
   addons?: {
     addonDir?: string

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -256,9 +256,16 @@ export const inspect = async (
   const rootDir = options.rootDir || findCommonAncestor(routeFiles)
 
   const startSourceFiles = performance.now()
+  // node_modules under rootDir (e.g. a locally-installed addon) is a
+  // dependency, not project source — scanning it double-counts the addon's
+  // own application types (CoreConfig/Services/SingletonServices).
   const sourceFiles = program
     .getSourceFiles()
-    .filter((sf) => sf.fileName.startsWith(rootDir))
+    .filter(
+      (sf) =>
+        sf.fileName.startsWith(rootDir) &&
+        !sf.fileName.includes('/node_modules/')
+    )
   logger.debug(
     `Got source files in ${(performance.now() - startSourceFiles).toFixed(2)}ms`
   )

--- a/verifiers/addon-registry/consumer/package.json
+++ b/verifiers/addon-registry/consumer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@pikku/verifier-registry-consumer",
+  "type": "module",
+  "private": true,
+  "imports": {
+    "#pikku": "./.pikku/pikku-types.gen.ts",
+    "#pikku/*": "./.pikku/*"
+  },
+  "dependencies": {
+    "@pikku/core": "*",
+    "@pikku/verifier-registry-addon": "*"
+  },
+  "devDependencies": {
+    "@pikku/cli": "*",
+    "@types/node": "^24",
+    "typescript": "^5.9",
+    "zod": "^4"
+  }
+}

--- a/verifiers/addon-registry/consumer/package.json
+++ b/verifiers/addon-registry/consumer/package.json
@@ -2,6 +2,7 @@
   "name": "@pikku/verifier-registry-consumer",
   "type": "module",
   "private": true,
+  "workspaces": ["addons/*"],
   "imports": {
     "#pikku": "./.pikku/pikku-types.gen.ts",
     "#pikku/*": "./.pikku/*"

--- a/verifiers/addon-registry/consumer/pikku.config.json
+++ b/verifiers/addon-registry/consumer/pikku.config.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/pikkujs/pikku/refs/heads/main/packages/cli/cli.schema.json",
+  "srcDirectories": ["./src", "./types"],
+  "outDir": "./.pikku",
+  "tsconfig": "./tsconfig.json",
+  "schema": {
+    "supportsImportAttributes": true
+  }
+}

--- a/verifiers/addon-registry/consumer/src/function/consume.functions.ts
+++ b/verifiers/addon-registry/consumer/src/function/consume.functions.ts
@@ -1,0 +1,23 @@
+/**
+ * Consumes the registry verifier addon — installed from the npm-pack artifact,
+ * not the workspace source — and calls its `hello` function over RPC.
+ */
+import { pikkuSessionlessFunc, wireAddon } from '#pikku'
+
+wireAddon({ name: 'ext', package: '@pikku/verifier-registry-addon' })
+
+export type ConsumeHelloInput = { name: string; greeting?: string }
+export type ConsumeHelloOutput = {
+  message: string
+  timestamp: number
+  noopCalls: number
+}
+
+export const consumeHello = pikkuSessionlessFunc<
+  ConsumeHelloInput,
+  ConsumeHelloOutput
+>({
+  func: async (_, data, { rpc }) => {
+    return await rpc.invoke('ext:hello', data)
+  },
+})

--- a/verifiers/addon-registry/consumer/src/function/consume.functions.ts
+++ b/verifiers/addon-registry/consumer/src/function/consume.functions.ts
@@ -1,8 +1,9 @@
 /**
  * Consumes the registry verifier addon — installed from the npm-pack artifact,
- * not the workspace source — and calls its `hello` function over RPC.
+ * not the workspace source — and calls its `hello` function over RPC through
+ * the `ext:` namespace that `wireAddon` sets up.
  */
-import { pikkuSessionlessFunc, wireAddon } from '#pikku'
+import { pikkuSessionlessFunc, wireAddon, wireHTTP } from '#pikku'
 
 wireAddon({ name: 'ext', package: '@pikku/verifier-registry-addon' })
 
@@ -20,4 +21,13 @@ export const consumeHello = pikkuSessionlessFunc<
   func: async (_, data, { rpc }) => {
     return await rpc.invoke('ext:hello', data)
   },
+})
+
+// Wire to HTTP so codegen registers the function (name + meta), which lets the
+// runtime verifier invoke it and exercise the real `ext:hello` namespace path.
+wireHTTP({
+  route: '/consume-hello',
+  method: 'post',
+  auth: false,
+  func: consumeHello,
 })

--- a/verifiers/addon-registry/consumer/src/services.ts
+++ b/verifiers/addon-registry/consumer/src/services.ts
@@ -1,0 +1,27 @@
+import { pikkuConfig, pikkuServices, pikkuWireServices } from '#pikku'
+import {
+  ConsoleLogger,
+  LocalVariablesService,
+  LocalSecretService,
+} from '@pikku/core/services'
+
+import '../.pikku/pikku-bootstrap.gen.js'
+
+export const createConfig = pikkuConfig(async () => {
+  return {}
+})
+
+export const createSingletonServices = pikkuServices(async (config) => {
+  const variables = new LocalVariablesService()
+
+  return {
+    config,
+    logger: new ConsoleLogger(),
+    variables,
+    secrets: new LocalSecretService(variables),
+  }
+})
+
+export const createWireServices = pikkuWireServices(async () => {
+  return {} as any
+})

--- a/verifiers/addon-registry/consumer/src/start.ts
+++ b/verifiers/addon-registry/consumer/src/start.ts
@@ -30,18 +30,18 @@ async function main(): Promise<void> {
   const baseSingletonServices = await createSingletonServices(config)
   const singletonServices = { ...baseSingletonServices, logger }
 
-  // Invoke the addon installed from the npm-pack artifact. `packageName`
-  // targets the addon's namespaced registry — the same resolution that
-  // `rpc.invoke('ext:hello')` performs for a wired addon.
+  // Invoke the consumer's own `consumeHello`, whose body calls
+  // `rpc.invoke('ext:hello')`. This exercises the full chain: the `ext:`
+  // namespace mapping that `wireAddon` registers → the addon installed from
+  // the npm-pack artifact → its NoopService and host-logger usage.
   const result = await runPikkuFunc<
     { name: string; greeting?: string },
     { message: string; timestamp: number; noopCalls: number }
-  >('rpc', 'hello', 'hello', {
+  >('rpc', 'consumeHello', 'consumeHello', {
     singletonServices,
     createWireServices,
     data: () => ({ name: 'Test', greeting: 'Hello' }),
     wire: {},
-    packageName: '@pikku/verifier-registry-addon',
   })
 
   let passed = true

--- a/verifiers/addon-registry/consumer/src/start.ts
+++ b/verifiers/addon-registry/consumer/src/start.ts
@@ -1,0 +1,77 @@
+import { runPikkuFunc } from '@pikku/core'
+import { createConfig, createSingletonServices, createWireServices } from './services.js'
+
+interface LogEntry {
+  level: string
+  message: string | object
+}
+
+/** Logger that captures entries so we can assert the addon logged. */
+class CapturingLogger {
+  public logs: LogEntry[] = []
+  info(message: string | object) {
+    this.logs.push({ level: 'info', message })
+  }
+  warn(message: string | object) {
+    this.logs.push({ level: 'warn', message })
+  }
+  error(message: string | object) {
+    this.logs.push({ level: 'error', message })
+  }
+  debug(message: string | object) {
+    this.logs.push({ level: 'debug', message })
+  }
+  setLevel() {}
+}
+
+async function main(): Promise<void> {
+  const config = await createConfig()
+  const logger = new CapturingLogger()
+  const baseSingletonServices = await createSingletonServices(config)
+  const singletonServices = { ...baseSingletonServices, logger }
+
+  // Invoke the addon installed from the npm-pack artifact. `packageName`
+  // targets the addon's namespaced registry — the same resolution that
+  // `rpc.invoke('ext:hello')` performs for a wired addon.
+  const result = await runPikkuFunc<
+    { name: string; greeting?: string },
+    { message: string; timestamp: number; noopCalls: number }
+  >('rpc', 'hello', 'hello', {
+    singletonServices,
+    createWireServices,
+    data: () => ({ name: 'Test', greeting: 'Hello' }),
+    wire: {},
+    packageName: '@pikku/verifier-registry-addon',
+  })
+
+  let passed = true
+  if (result.noopCalls === 1) {
+    console.log('✓ addon NoopService created + executed (noopCalls: 1)')
+  } else {
+    console.log(`✗ expected noopCalls: 1, got: ${result.noopCalls}`)
+    passed = false
+  }
+  if (result.message === 'Hello, Test!') {
+    console.log('✓ addon function returned the expected message')
+  } else {
+    console.log(`✗ expected "Hello, Test!", got: "${result.message}"`)
+    passed = false
+  }
+  const addonLog = logger.logs.find(
+    (l) => typeof l.message === 'string' && l.message.includes('Addon:')
+  )
+  if (addonLog) {
+    console.log('✓ addon invoked the host logger')
+  } else {
+    console.log('✗ addon did not invoke the host logger')
+    passed = false
+  }
+
+  if (!passed) process.exit(1)
+}
+
+main().catch((e) => {
+  console.error('✗ runtime invoke failed:', e?.message ?? e)
+  console.error(e?.stack)
+  process.exit(1)
+})

--- a/verifiers/addon-registry/consumer/tsconfig.json
+++ b/verifiers/addon-registry/consumer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": false,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "types/**/*", ".pikku/**/*"]
+}

--- a/verifiers/addon-registry/consumer/types/application-types.d.ts
+++ b/verifiers/addon-registry/consumer/types/application-types.d.ts
@@ -1,0 +1,14 @@
+import type {
+  CoreConfig,
+  CoreServices,
+  CoreSingletonServices,
+  CoreUserSession,
+} from '@pikku/core'
+
+export interface Config extends CoreConfig {}
+
+export interface UserSession extends CoreUserSession {}
+
+export interface SingletonServices extends CoreSingletonServices<Config> {}
+
+export interface Services extends CoreServices<SingletonServices> {}

--- a/verifiers/addon-registry/package.json
+++ b/verifiers/addon-registry/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@pikku/verifiers-addon-registry",
+  "type": "module",
+  "private": true,
+  "description": "Round-trips an addon through `npm pack` and installs it into a separate consumer to prove the registry publish/install artifact works",
+  "scripts": {
+    "test": "node run.mjs"
+  }
+}

--- a/verifiers/addon-registry/run.mjs
+++ b/verifiers/addon-registry/run.mjs
@@ -1,0 +1,72 @@
+/**
+ * Registry pack/install round-trip verifier.
+ *
+ * Proves the artifact produced by `npm pack` (the same shape the registry
+ * publish flow ships) installs into a *separate* consumer project and runs:
+ *   1. `pikku all` + build the source addon
+ *   2. `npm pack` the addon → tgz
+ *   3. extract the tgz into consumer/node_modules/<addon> (simulates install)
+ *   4. `pikku all` + `tsc --noEmit` in the consumer
+ *   5. invoke the addon's function over RPC and assert the result
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, rmSync, readdirSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(here, '../..')
+const sourceDir = join(here, 'source')
+const consumerDir = join(here, 'consumer')
+
+const PIKKU = join(repoRoot, 'packages/cli/dist/bin/pikku.js')
+const TSC = join(repoRoot, 'node_modules/.bin/tsc')
+const TSX = join(repoRoot, 'node_modules/.bin/tsx')
+const ADDON_PKG = '@pikku/verifier-registry-addon'
+
+function run(label, file, args, cwd) {
+  console.log(`\n▶ ${label}`)
+  console.log(`  ${file} ${args.join(' ')}  (cwd: ${cwd.replace(repoRoot, '.')})`)
+  execFileSync(file, args, { cwd, stdio: 'inherit' })
+}
+
+function capture(file, args, cwd) {
+  return execFileSync(file, args, { cwd, encoding: 'utf8' })
+}
+
+// 1. Build the source addon
+run('source: pikku all', 'node', [PIKKU, 'all'], sourceDir)
+
+// 2. Pack the addon — npm pack respects the `files` field (src + .pikku)
+console.log('\n▶ source: npm pack')
+const packOut = capture('npm', ['pack', '--json'], sourceDir)
+const tgzName = JSON.parse(packOut)[0].filename
+const tgzPath = join(sourceDir, tgzName)
+if (!existsSync(tgzPath)) {
+  throw new Error(`npm pack did not produce ${tgzPath}`)
+}
+console.log(`  packed → ${tgzName}`)
+
+// 3. Install: extract tgz into consumer/node_modules/<addon>
+const installDir = join(consumerDir, 'node_modules', ADDON_PKG)
+rmSync(installDir, { recursive: true, force: true })
+mkdirSync(installDir, { recursive: true })
+run(
+  'consumer: extract artifact into node_modules',
+  'tar',
+  ['-xzf', tgzPath, '-C', installDir, '--strip-components=1'],
+  consumerDir
+)
+console.log(`  installed files: ${readdirSync(installDir).join(', ')}`)
+
+// 4. Build + type-check the consumer against the installed artifact
+run('consumer: pikku all', 'node', [PIKKU, 'all'], consumerDir)
+run('consumer: tsc --noEmit', TSC, ['--noEmit', '-p', 'tsconfig.json'], consumerDir)
+
+// 5. Runtime invoke — prove the installed addon actually runs over RPC
+run('consumer: runtime invoke', TSX, ['src/start.ts'], consumerDir)
+
+// Cleanup the artifact (keep node_modules install for debugging)
+rmSync(tgzPath, { force: true })
+
+console.log('\n✓ registry pack/install round-trip passed')

--- a/verifiers/addon-registry/run.mjs
+++ b/verifiers/addon-registry/run.mjs
@@ -1,13 +1,15 @@
 /**
  * Registry pack/install round-trip verifier.
  *
- * Proves the artifact produced by `npm pack` (the same shape the registry
- * publish flow ships) installs into a *separate* consumer project and runs:
- *   1. `pikku all` + build the source addon
- *   2. `npm pack` the addon → tgz
- *   3. extract the tgz into consumer/node_modules/<addon> (simulates install)
+ * Mirrors the real registry flow without the network: `pikku fabric publish`
+ * packs with `npm pack`, and `pikku fabric add` extracts into
+ * `node_modules/<name>` with `--strip-components=1` (the location
+ * `wireAddon({ package })` resolves). This harness does the same locally:
+ *   1. `pikku all` on the source addon
+ *   2. `npm pack` the addon → tgz                          (publish artifact)
+ *   3. extract into consumer/node_modules/<name>, strip 1  (add install)
  *   4. `pikku all` + `tsc --noEmit` in the consumer
- *   5. invoke the addon's function over RPC and assert the result
+ *   5. invoke consumeHello → rpc.invoke('ext:hello') and assert the result
  */
 import { execFileSync } from 'node:child_process'
 import { existsSync, mkdirSync, rmSync, readdirSync } from 'node:fs'

--- a/verifiers/addon-registry/run.mjs
+++ b/verifiers/addon-registry/run.mjs
@@ -1,19 +1,32 @@
 /**
- * Registry pack/install round-trip verifier.
+ * Registry pack/install round-trip verifier (shadcn / yarn-workspace model).
  *
- * Mirrors the real registry flow without the network: `pikku fabric publish`
- * packs with `npm pack`, and `pikku fabric add` extracts into
- * `node_modules/<name>` with `--strip-components=1` (the location
- * `wireAddon({ package })` resolves). This harness does the same locally:
- *   1. `pikku all` on the source addon
- *   2. `npm pack` the addon → tgz                          (publish artifact)
- *   3. extract into consumer/node_modules/<name>, strip 1  (add install)
- *   4. `pikku all` + `tsc --noEmit` in the consumer
+ * Mirrors `pikku fabric addon publish` (npm pack) and `pikku fabric addon add`
+ * (copy source into addons/<name>, register a yarn workspace, record
+ * provenance). The addon lands in the consumer's own tree — editable,
+ * shadcn-style — and a node_modules symlink (exactly what `yarn install` makes
+ * for a workspace member) lets `wireAddon({ package })` resolve it by name.
+ * addons/ sits outside the consumer's tsconfig/pikku scan, so it never collides
+ * with the app's own CoreConfig.
+ *   1. pikku all on the source addon
+ *   2. npm pack the addon → tgz                           (publish artifact)
+ *   3. copy into consumer/addons/<name> (strip 1)         (add: shadcn copy)
+ *   3b. symlink node_modules/<pkg> → addons/<name>        (yarn workspace link)
+ *       + write pikku-addons.json                         (add: provenance)
+ *   4. pikku all + tsc --noEmit in the consumer
  *   5. invoke consumeHello → rpc.invoke('ext:hello') and assert the result
  */
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, rmSync, readdirSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import {
+  existsSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+} from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
@@ -25,6 +38,7 @@ const PIKKU = join(repoRoot, 'packages/cli/dist/bin/pikku.js')
 const TSC = join(repoRoot, 'node_modules/.bin/tsc')
 const TSX = join(repoRoot, 'node_modules/.bin/tsx')
 const ADDON_PKG = '@pikku/verifier-registry-addon'
+const ADDON_FOLDER = ADDON_PKG.split('/').pop()
 
 function run(label, file, args, cwd) {
   console.log(`\n▶ ${label}`)
@@ -39,7 +53,7 @@ function capture(file, args, cwd) {
 // 1. Build the source addon
 run('source: pikku all', 'node', [PIKKU, 'all'], sourceDir)
 
-// 2. Pack the addon — npm pack respects the `files` field (src + .pikku)
+// 2. Pack the addon — npm pack respects the `files` field (src + types + .pikku)
 console.log('\n▶ source: npm pack')
 const packOut = capture('npm', ['pack', '--json'], sourceDir)
 const tgzName = JSON.parse(packOut)[0].filename
@@ -49,26 +63,45 @@ if (!existsSync(tgzPath)) {
 }
 console.log(`  packed → ${tgzName}`)
 
-// 3. Install: extract tgz into consumer/node_modules/<addon>
-const installDir = join(consumerDir, 'node_modules', ADDON_PKG)
+// 3. add (shadcn copy): extract the artifact into consumer/addons/<name>
+const installDir = join(consumerDir, 'addons', ADDON_FOLDER)
 rmSync(installDir, { recursive: true, force: true })
 mkdirSync(installDir, { recursive: true })
 run(
-  'consumer: extract artifact into node_modules',
+  'consumer: copy addon into addons/',
   'tar',
   ['-xzf', tgzPath, '-C', installDir, '--strip-components=1'],
   consumerDir
 )
-console.log(`  installed files: ${readdirSync(installDir).join(', ')}`)
+console.log(`  addon files: ${readdirSync(installDir).join(', ')}`)
 
-// 4. Build + type-check the consumer against the installed artifact
+// 3b. yarn-workspace link: symlink node_modules/<pkg> → addons/<name> (the exact
+//     symlink `yarn install` creates for a workspace member), and record install
+//     provenance the way `pikku fabric addon add` does. Must happen before
+//     `pikku all` so the inspector resolves the addon's functions meta.
+const linkPath = join(consumerDir, 'node_modules', ...ADDON_PKG.split('/'))
+rmSync(linkPath, { recursive: true, force: true })
+mkdirSync(dirname(linkPath), { recursive: true })
+symlinkSync(relative(dirname(linkPath), installDir), linkPath, 'dir')
+console.log(`  linked node_modules/${ADDON_PKG} → addons/${ADDON_FOLDER}`)
+
+const version = JSON.parse(
+  readFileSync(join(installDir, 'package.json'), 'utf8')
+).version
+writeFileSync(
+  join(consumerDir, 'pikku-addons.json'),
+  JSON.stringify({ [ADDON_PKG]: { id: ADDON_PKG, version } }, null, 2) + '\n'
+)
+console.log(`  recorded pikku-addons.json (${ADDON_PKG}@${version})`)
+
+// 4. Build + type-check the consumer against the linked addon
 run('consumer: pikku all', 'node', [PIKKU, 'all'], consumerDir)
 run('consumer: tsc --noEmit', TSC, ['--noEmit', '-p', 'tsconfig.json'], consumerDir)
 
 // 5. Runtime invoke — prove the installed addon actually runs over RPC
 run('consumer: runtime invoke', TSX, ['src/start.ts'], consumerDir)
 
-// Cleanup the artifact (keep node_modules install for debugging)
+// Cleanup the artifact (keep addons/ install + symlink for debugging)
 rmSync(tgzPath, { force: true })
 
-console.log('\n✓ registry pack/install round-trip passed')
+console.log('\n✓ registry pack/install round-trip passed (shadcn/workspace model)')

--- a/verifiers/addon-registry/source/package.json
+++ b/verifiers/addon-registry/source/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@pikku/verifier-registry-addon",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "imports": {
+    "#pikku": "./.pikku/pikku-types.gen.ts",
+    "#pikku/*": "./.pikku/*"
+  },
+  "exports": {
+    "./.pikku/*": "./.pikku/*",
+    "./.pikku/pikku-metadata.gen.json": "./.pikku/pikku-metadata.gen.json",
+    "./.pikku/rpc/pikku-rpc-wirings-map.internal.gen.js": {
+      "types": "./.pikku/rpc/pikku-rpc-wirings-map.internal.gen.d.ts"
+    }
+  },
+  "files": [
+    "src",
+    "types",
+    ".pikku"
+  ],
+  "scripts": {
+    "prebuild": "pikku all",
+    "pikku": "pikku all"
+  },
+  "peerDependencies": {
+    "@pikku/core": "*",
+    "zod": "^4"
+  },
+  "devDependencies": {
+    "@pikku/cli": "*",
+    "@pikku/core": "*",
+    "typescript": "^5.9",
+    "zod": "^4"
+  }
+}

--- a/verifiers/addon-registry/source/pikku.config.json
+++ b/verifiers/addon-registry/source/pikku.config.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/pikkujs/pikku/refs/heads/main/packages/cli/cli.schema.json",
+  "tsconfig": "./tsconfig.json",
+  "srcDirectories": ["src", "types"],
+  "outDir": "./.pikku",
+  "addon": true,
+  "node": {
+    "displayName": "Registry Verifier Addon",
+    "description": "Hermetic addon used to verify the registry pack/install round-trip",
+    "categories": ["Utility"]
+  }
+}

--- a/verifiers/addon-registry/source/src/functions/hello.functions.ts
+++ b/verifiers/addon-registry/source/src/functions/hello.functions.ts
@@ -1,0 +1,28 @@
+import { pikkuSessionlessFunc } from '../../.pikku/pikku-types.gen.js'
+
+export const hello = pikkuSessionlessFunc<
+  { name: string; greeting?: string },
+  { message: string; timestamp: number; noopCalls: number }
+>({
+  description: 'Sends a friendly greeting message',
+  func: async ({ logger, noop }, data) => {
+    const greeting = data.greeting || 'Hello'
+    const message = `${greeting}, ${data.name}!`
+
+    logger.info(`Addon: ${message}`)
+
+    const noopResult = noop.execute()
+
+    return {
+      message,
+      timestamp: Date.now(),
+      noopCalls: noopResult.callCount,
+    }
+  },
+  tags: ['addon'],
+  node: {
+    displayName: 'Say Hello',
+    category: 'Utility',
+    type: 'action',
+  },
+})

--- a/verifiers/addon-registry/source/src/services.ts
+++ b/verifiers/addon-registry/source/src/services.ts
@@ -1,0 +1,10 @@
+import { pikkuAddonServices } from '#pikku'
+import { NoopService } from './services/noop-service.js'
+
+export const createSingletonServices = pikkuAddonServices(
+  async (_config, _services) => {
+    return {
+      noop: new NoopService(),
+    }
+  }
+)

--- a/verifiers/addon-registry/source/src/services/noop-service.ts
+++ b/verifiers/addon-registry/source/src/services/noop-service.ts
@@ -1,0 +1,9 @@
+/** Minimal addon-owned service: counts how many times it was called. */
+export class NoopService {
+  private callCount = 0
+
+  execute(): { callCount: number } {
+    this.callCount += 1
+    return { callCount: this.callCount }
+  }
+}

--- a/verifiers/addon-registry/source/tsconfig.json
+++ b/verifiers/addon-registry/source/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "types/**/*", ".pikku/**/*"]
+}

--- a/verifiers/addon-registry/source/types/application-types.d.ts
+++ b/verifiers/addon-registry/source/types/application-types.d.ts
@@ -1,0 +1,23 @@
+import type {
+  CoreConfig,
+  CoreServices,
+  CoreSingletonServices,
+  CoreUserSession,
+} from '@pikku/core'
+import type { NoopService } from '../src/services/noop-service.js'
+
+export interface Config extends CoreConfig {}
+
+export interface UserSession extends CoreUserSession {}
+
+export interface SingletonServices extends CoreSingletonServices<Config> {
+  noop: NoopService
+}
+
+export interface Services extends CoreServices<SingletonServices> {}
+
+export interface CreateSingletonServices {
+  noop: NoopService
+}
+
+export interface CreateWireServices {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6786,6 +6786,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@pikku/verifiers-addon-registry@workspace:verifiers/addon-registry":
+  version: 0.0.0-use.local
+  resolution: "@pikku/verifiers-addon-registry@workspace:verifiers/addon-registry"
+  languageName: unknown
+  linkType: soft
+
 "@pikku/verifiers-addon@workspace:verifiers/addon":
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-addon@workspace:verifiers/addon"


### PR DESCRIPTION
Adds the community-addon registry round-trip to the `pikku fabric` CLI, namespaced under `pikku fabric addon`.

## Commands
- **`pikku fabric addon publish [dir]`** — packs the addon in the directory with `npm pack` (honours `files`), uploads to R2 via a presigned URL, finalizes so the catalogue indexes it.
- **`pikku fabric addon add <id>`** — installs an addon **shadcn-style**: copies the source into `<addonDir>/<name>/` (default top-level `addons/`), registers it as a yarn workspace, and records registry id+version in `pikku-addons.json`.

## Why shadcn + yarn workspace
- **Ownership:** the source lands in the user's tree, editable. Re-running `add` overwrites it (merge conflicts if they forked — the accepted tradeoff).
- **Resolution for free:** the `workspaces` glob means `yarn install` symlinks the addon into `node_modules/<package>`, so `wireAddon({ package })` resolves it by name **unchanged** (`require.resolve('<package>/.pikku/...')`).
- **No CoreConfig collision:** `addons/` is top-level, outside the app's TS `include`/pikku `srcDirectories`, so the consumer's `pikku all` never scans the addon's own `application-types.d.ts` → no "More than one CoreConfig".
- **Provenance:** `pikku-addons.json` is CLI-owned and survives a fork, so we can still tell which registry package+version a folder came from.

## Verification
`verifiers/addon-registry` proves the full path hermetically: `pikku all` on the source addon → `npm pack` → copy into `consumer/addons/<name>` → symlink `node_modules/<pkg> → addons/<name>` (what `yarn install` makes) → `pikku all` + `tsc --noEmit` (addons/ unscanned) → runtime `rpc.invoke('ext:hello')`. Three assertions green: NoopService executed, message correct, host logger invoked. `yarn build:packages` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)