### PR TITLE
fix(changeset): correct package name in sse-unexpected-close-onerror

### DIFF
--- a/.changeset/sse-unexpected-close-onerror.md
+++ b/.changeset/sse-unexpected-close-onerror.md
@@ -1,5 +1,5 @@
 ---
-"@pikku/client-fetch": patch
+"@pikku/fetch": patch
 ---
 
 `subscribeToSSE`: call `onError` when the stream closes cleanly without the caller having called `close()`. Previously a server-side connection drop (or any clean EOF before the terminal event) exited the read loop silently, leaving the caller's `runPhase` stuck at `'running'` indefinitely with no way to recover.


### PR DESCRIPTION
## Summary

- The changeset `sse-unexpected-close-onerror` referenced `@pikku/client-fetch`, which does not exist in the workspace
- The correct package name is `@pikku/fetch` (lives at `packages/client-fetch/`)
- This caused the Release CI job to fail: _"Found changeset sse-unexpected-close-onerror for package @pikku/client-fetch which is not in the workspace"_

## Test plan

- [ ] Release CI job passes after merge (changeset version step no longer errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Server-Sent Events handling to properly notify the application when a stream closes without an explicit close command. This prevents the system from remaining stuck in an incomplete state and ensures proper error handling and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->