### PR TITLE
feat(fetch): add CorePikkuFetch.setHeader for arbitrary request headers

### DIFF
--- a/.changeset/client-fetch-set-header.md
+++ b/.changeset/client-fetch-set-header.md
@@ -1,0 +1,5 @@
+---
+"@pikku/fetch": patch
+---
+
+Add `CorePikkuFetch.setHeader(name, value)` to set or clear an arbitrary request header (passing `null` removes it). Enables per-client headers such as admin impersonation (`x-pikku-impersonate-user-id`) without subclassing the fetch client.

--- a/packages/client-fetch/src/core-pikku-fetch.ts
+++ b/packages/client-fetch/src/core-pikku-fetch.ts
@@ -32,6 +32,7 @@ export type CorePikkuFetchOptions = {
  */
 export class CorePikkuFetch {
   private authHeaders: AuthHeaders = {}
+  private extraHeaders: Record<string, string> = {}
 
   /**
    * Constructs a new instance of the `CorePikkuFetch` class.
@@ -50,6 +51,7 @@ export class CorePikkuFetch {
   private getHeaders(): Record<string, string> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
+      ...this.extraHeaders,
     }
     if (this.authHeaders.jwt) {
       headers.Authorization = `Bearer ${this.authHeaders.jwt}`
@@ -57,6 +59,14 @@ export class CorePikkuFetch {
       headers['X-API-KEY'] = this.authHeaders.apiKey
     }
     return headers
+  }
+
+  public setHeader(name: string, value: string | null): void {
+    if (value === null) {
+      delete this.extraHeaders[name]
+    } else {
+      this.extraHeaders[name] = value
+    }
   }
 
   /**

--- a/packages/client-fetch/src/index.test.ts
+++ b/packages/client-fetch/src/index.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { describe, test } from 'node:test'
+import { describe, test, afterEach } from 'node:test'
 
 import { CorePikkuFetch, corePikkuFetch } from './index.js'
 
@@ -7,5 +7,48 @@ describe('@pikku/fetch', () => {
   test('exports the public fetch client API', () => {
     assert.equal(typeof CorePikkuFetch, 'function')
     assert.equal(typeof corePikkuFetch, 'function')
+  })
+})
+
+describe('CorePikkuFetch.setHeader', () => {
+  const realFetch = globalThis.fetch
+  afterEach(() => {
+    globalThis.fetch = realFetch
+  })
+
+  const capture = () => {
+    const seen: { headers?: Record<string, string> } = {}
+    globalThis.fetch = (async (_input: any, init?: any) => {
+      seen.headers = (init?.headers ?? {}) as Record<string, string>
+      return new Response('{}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+    return seen
+  }
+
+  test('sends a set header on every request', async () => {
+    const seen = capture()
+    const client = new CorePikkuFetch({ serverUrl: 'https://api.test' })
+    client.setHeader('x-pikku-impersonate-user-id', 'u_guest')
+    await client.fetch('/anything', 'GET', undefined)
+    assert.equal(seen.headers?.['x-pikku-impersonate-user-id'], 'u_guest')
+  })
+
+  test('removes the header when set to null', async () => {
+    const seen = capture()
+    const client = new CorePikkuFetch({ serverUrl: 'https://api.test' })
+    client.setHeader('x-pikku-impersonate-user-id', 'u_guest')
+    client.setHeader('x-pikku-impersonate-user-id', null)
+    await client.fetch('/anything', 'GET', undefined)
+    assert.equal(seen.headers?.['x-pikku-impersonate-user-id'], undefined)
+  })
+
+  test('no header is sent by default (inherits the session)', async () => {
+    const seen = capture()
+    const client = new CorePikkuFetch({ serverUrl: 'https://api.test' })
+    await client.fetch('/anything', 'GET', undefined)
+    assert.equal(seen.headers?.['x-pikku-impersonate-user-id'], undefined)
   })
 })


### PR DESCRIPTION
## What

Adds `CorePikkuFetch.setHeader(name, value)` to `@pikku/fetch`:
- sets a header that is sent on **every** request from that client
- passing `null` removes it
- merged into `getHeaders()` alongside `Content-Type` / auth headers

## Why

Lets a consumer attach a per-client header without subclassing the fetch client. The motivating case is **admin impersonation** in a console: a scoped `PikkuFetch` instance carries `x-pikku-impersonate-user-id` so only opted-in surfaces act as the impersonated user, while the main client stays the admin.

## Tests

Unit tests in `packages/client-fetch/src/index.test.ts` (run via `node --test`): header is sent when set, removed when set to `null`, and absent by default. All 4 suite tests pass.

## Changeset

Patch bump for `@pikku/fetch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting custom headers on fetch clients.
  * Headers can now be added or removed per client instance, including clearing a header by passing a null value.

* **Tests**
  * Expanded coverage to verify headers are sent, removed, and omitted as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->