### PR TITLE
test(e2e): console user-impersonation end-to-end suite

### DIFF
--- a/e2e/bin/start.ts
+++ b/e2e/bin/start.ts
@@ -2,6 +2,7 @@ import { PikkuUWSServer } from '@pikku/uws'
 
 import { createConfig } from '../src/config.js'
 import { createSingletonServices } from '../src/services.js'
+import { seedAuthUsers } from '../src/seed-auth.js'
 import { startMockOAuthServer } from '../tests/support/mock-oauth-server.js'
 
 import '../src/middleware.js'
@@ -18,6 +19,9 @@ async function main(): Promise<void> {
     appServer.enableExitOnSigInt()
     await appServer.init({ exposeErrors: true })
     await appServer.start()
+
+    const apiBase = process.env.API_URL ?? `http://localhost:${config.port}`
+    await seedAuthUsers(singletonServices, apiBase)
   } catch (e: any) {
     console.error(e.toString())
     process.exit(1)

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -29,6 +29,7 @@
     "test:changes-console": "cucumber-js --config tests/cucumber.mjs --tags @changes-console",
     "test:auth": "cucumber-js --config tests/cucumber.mjs --tags @auth",
     "test:emails-console": "cucumber-js --config tests/cucumber.mjs --tags @emails-console",
+    "test:impersonation": "cucumber-js --config tests/cucumber.mjs --tags @impersonation",
     "tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/e2e/packages/functions/src/auth.ts
+++ b/e2e/packages/functions/src/auth.ts
@@ -1,6 +1,6 @@
 import { betterAuth } from 'better-auth'
 import { getMigrations } from 'better-auth/db/migration'
-import { bearer } from 'better-auth/plugins'
+import { admin, bearer } from 'better-auth/plugins'
 import { pikkuBetterAuth } from '#pikku/pikku-types.gen.js'
 
 /**
@@ -21,9 +21,14 @@ import { pikkuBetterAuth } from '#pikku/pikku-types.gen.js'
 let migrated: Promise<void> | undefined
 
 export const auth = pikkuBetterAuth(async ({ secrets, variables, kysely }) => {
+  const baseURL = (await variables.get('API_URL')) ?? 'http://localhost:4077'
+  const consoleURL =
+    (await variables.get('CONSOLE_URL')) ?? 'http://localhost:7071'
   const instance = betterAuth({
     secret: await secrets.getSecret('BETTER_AUTH_SECRET'),
-    baseURL: (await variables.get('API_URL')) ?? 'http://localhost:4077',
+    baseURL,
+    // Console signs in cross-origin; without this better-auth rejects the POST.
+    trustedOrigins: [baseURL, consoleURL],
     database: { db: kysely, type: 'sqlite' },
     emailAndPassword: {
       enabled: true,
@@ -34,7 +39,8 @@ export const auth = pikkuBetterAuth(async ({ secrets, variables, kysely }) => {
     socialProviders: {
       github: await secrets.getSecret('GITHUB_OAUTH'),
     },
-    plugins: [bearer()],
+    // admin: role/banned session fields + listUsers/impersonation endpoints.
+    plugins: [bearer(), admin()],
   })
 
   migrated ??= getMigrations(instance.options).then(({ runMigrations }) =>

--- a/e2e/src/auth-fixtures.ts
+++ b/e2e/src/auth-fixtures.ts
@@ -1,0 +1,18 @@
+// Seeded console users, shared by src/seed-auth.ts and the @console tests.
+export interface SeedUser {
+  name: string
+  email: string
+  password: string
+}
+
+export const ADMIN_USER: SeedUser = {
+  name: 'E2E Admin',
+  email: 'admin@e2e.test',
+  password: 'admin-password',
+}
+
+export const GUEST_USER: SeedUser = {
+  name: 'E2E Guest',
+  email: 'guest@e2e.test',
+  password: 'guest-password',
+}

--- a/e2e/src/middleware.ts
+++ b/e2e/src/middleware.ts
@@ -1,6 +1,7 @@
 import { cors } from '@pikku/core/middleware'
 import { addHTTPMiddleware } from '@pikku/core/http'
 import type { CoreSingletonServices, CorePikkuMiddleware } from '@pikku/core'
+import { betterAuthSession } from '@pikku/better-auth'
 
 const setSessionFromHeader: CorePikkuMiddleware = async (
   _services,
@@ -35,10 +36,22 @@ const loadCredentials: CorePikkuMiddleware = async (services, wire, next) => {
   await next()
 }
 
-// The Better Auth session-bridge middleware (betterAuthSession) is registered
-// globally by the generated auth.gen.ts, so it is not added here.
+// Registered before the generated betterAuthSession (import order) so the
+// impersonation overlay wins; the generated one then skips (session already set).
+const impersonationSession = betterAuthSession({
+  impersonation: {
+    loadUser: (userId, services) =>
+      (services as CoreSingletonServices & { kysely: any }).kysely
+        .selectFrom('user')
+        .where('id', '=', userId)
+        .select(['id'])
+        .executeTakeFirst(),
+  },
+})
+
 addHTTPMiddleware('*', [
   cors({ origin: true, credentials: true }),
+  impersonationSession,
   setSessionFromHeader,
   loadCredentials,
 ])

--- a/e2e/src/seed-auth.ts
+++ b/e2e/src/seed-auth.ts
@@ -1,0 +1,29 @@
+import type { CoreSingletonServices } from '@pikku/core'
+import { ADMIN_USER, GUEST_USER, type SeedUser } from './auth-fixtures.js'
+
+type SeedServices = CoreSingletonServices & { kysely?: any }
+
+const signUp = async (baseUrl: string, user: SeedUser) => {
+  const res = await fetch(`${baseUrl}/api/auth/sign-up/email`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: baseUrl },
+    body: JSON.stringify(user),
+  })
+  if (!res.ok && res.status !== 422) {
+    throw new Error(`seed sign-up failed for ${user.email}: ${res.status}`)
+  }
+}
+
+export const seedAuthUsers = async (
+  services: SeedServices,
+  baseUrl: string
+) => {
+  await signUp(baseUrl, ADMIN_USER)
+  await signUp(baseUrl, GUEST_USER)
+  await (services.kysely as any)
+    .updateTable('user')
+    .set({ role: 'admin' })
+    .where('email', '=', ADMIN_USER.email)
+    .execute()
+  services.logger.info(`seeded console users: ${ADMIN_USER.email} (admin), ${GUEST_USER.email}`)
+}

--- a/e2e/tests/features/impersonation-console.feature
+++ b/e2e/tests/features/impersonation-console.feature
@@ -1,0 +1,21 @@
+@impersonation @console
+Feature: Scoped user impersonation in the console
+
+  Impersonating a user overlays only execution surfaces (workflows/agents/apis).
+  The console chrome keeps running as the signed-in admin.
+
+  Background:
+    Given the API is available
+
+  Scenario: Impersonation scopes to execution, not the console chrome
+    When I open the users page in the console
+    Then I should see the user "guest@e2e.test" in the users list
+    When I impersonate the user "guest@e2e.test"
+    Then the impersonation banner should show "guest@e2e.test"
+    When I search the users list for "admin@e2e.test"
+    Then I should see the user "admin@e2e.test" in the users list
+    And no console chrome request should carry the impersonation header
+    When I start a "dslSequentialWorkflow" run from the console
+    Then the workflow start request should carry the impersonation header
+    When I stop impersonating
+    Then the impersonation banner should not be shown

--- a/e2e/tests/steps/impersonation-console.steps.ts
+++ b/e2e/tests/steps/impersonation-console.steps.ts
@@ -1,0 +1,100 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import type { AgentWorld } from '../support/world.js'
+
+When('I open the users page in the console', async function (this: AgentWorld) {
+  await this.page.getByRole('link', { name: 'Users', exact: true }).click()
+  await expect(this.page.getByRole('table')).toBeVisible()
+})
+
+Then(
+  'I should see the user {string} in the users list',
+  async function (this: AgentWorld, email: string) {
+    await expect(this.page.getByText(email, { exact: true })).toBeVisible()
+  }
+)
+
+When(
+  'I impersonate the user {string}',
+  async function (this: AgentWorld, email: string) {
+    const row = this.page.getByRole('row').filter({ hasText: email })
+    await row.getByRole('button', { name: 'Impersonate' }).click()
+  }
+)
+
+Then(
+  'the impersonation banner should show {string}',
+  async function (this: AgentWorld, email: string) {
+    await expect(
+      this.page.getByText(`Impersonating ${email}`)
+    ).toBeVisible()
+  }
+)
+
+When(
+  'I search the users list for {string}',
+  async function (this: AgentWorld, query: string) {
+    await this.page
+      .getByPlaceholder('Search users by email')
+      .fill(query)
+  }
+)
+
+Then(
+  'no console chrome request should carry the impersonation header',
+  function (this: AgentWorld) {
+    const leaked = this.recorded.filter(
+      (r) => r.url.includes('/api/auth/') && r.impersonate !== null
+    )
+    expect(leaked, JSON.stringify(leaked)).toHaveLength(0)
+  }
+)
+
+When(
+  'I start a {string} run from the console',
+  async function (this: AgentWorld, workflowName: string) {
+    await this.page
+      .getByRole('link', { name: 'Workflows', exact: true })
+      .click()
+    // Pick the workflow from the selector popover.
+    const search = this.page.getByPlaceholder('Search workflows...')
+    if (!(await search.isVisible().catch(() => false))) {
+      await this.page.locator('button:has(svg.lucide-chevron-down)').first().click()
+    }
+    await search.fill(workflowName)
+    await this.page
+      .getByText(workflowName, { exact: true })
+      .last()
+      .click()
+    // Open the new-run form and submit it. The outgoing startWorkflow request
+    // carries the impersonation header regardless of the server's response.
+    await this.page.getByRole('button', { name: 'New workflow run' }).click()
+    const value = this.page.locator('input[type="number"]')
+    if (await value.count()) {
+      await value.first().fill('5')
+    }
+    await this.page.getByRole('button', { name: 'Run', exact: true }).click()
+  }
+)
+
+Then(
+  'the workflow start request should carry the impersonation header',
+  async function (this: AgentWorld) {
+    await expect
+      .poll(() => this.recorded.some((r) => r.impersonate !== null), {
+        timeout: 15_000,
+      })
+      .toBe(true)
+  }
+)
+
+When('I stop impersonating', async function (this: AgentWorld) {
+  await this.page.getByRole('button', { name: 'Stop impersonating' }).click()
+})
+
+Then(
+  'the impersonation banner should not be shown',
+  async function (this: AgentWorld) {
+    await expect(this.page.getByText(/^Impersonating /)).toHaveCount(0)
+  }
+)

--- a/e2e/tests/support/hooks.ts
+++ b/e2e/tests/support/hooks.ts
@@ -132,6 +132,8 @@ Before('@console', async function (this: AgentWorld) {
     }),
   ])
   await this.openBrowser()
+  await this.login()
+  this.recordRequests()
 })
 
 After(

--- a/e2e/tests/support/world.ts
+++ b/e2e/tests/support/world.ts
@@ -7,6 +7,9 @@ import {
 } from '@playwright/test'
 import { randomUUID } from 'crypto'
 import { config } from './types.js'
+import { ADMIN_USER, type SeedUser } from '../../src/auth-fixtures.js'
+
+const IMPERSONATE_HEADER = 'x-pikku-impersonate-user-id'
 
 export class AgentWorld extends World {
   browser!: Browser
@@ -15,6 +18,9 @@ export class AgentWorld extends World {
 
   /** Unique thread per scenario */
   threadId: string = randomUUID()
+
+  /** Requests seen since recordRequests() was called, with their impersonate header. */
+  recorded: { url: string; impersonate: string | null }[] = []
 
   async openBrowser() {
     const headed = process.env.HEADED === '1' || process.env.HEADED === 'true'
@@ -34,6 +40,31 @@ export class AgentWorld extends World {
   async closeBrowser() {
     await this.context?.close()
     await this.browser?.close()
+  }
+
+  // Sign in through the LoginScreen UI so the AuthGate lets the console render.
+  async login(user: SeedUser = ADMIN_USER) {
+    await this.page.goto(config.consoleUrl)
+    const instance = this.page.locator('input').first()
+    await instance.waitFor({ state: 'visible' })
+    await instance.fill(config.apiUrl)
+    await this.page.locator('input[type="email"]').fill(user.email)
+    await this.page.locator('input[type="password"]').fill(user.password)
+    await this.page.locator('button[type="submit"]').click()
+    await this.page
+      .locator('input[type="password"]')
+      .waitFor({ state: 'detached' })
+  }
+
+  // Start recording outgoing requests + their impersonation header.
+  recordRequests() {
+    this.recorded = []
+    this.page.on('request', (req) => {
+      this.recorded.push({
+        url: req.url(),
+        impersonate: req.headers()[IMPERSONATE_HEADER] ?? null,
+      })
+    })
   }
 
   /**


### PR DESCRIPTION
Adds an end-to-end suite covering admin **user impersonation** through the console.

An admin acts as another user; requests are scoped end-to-end via the `x-pikku-impersonate-user-id` header — the `betterAuthSession({ impersonation })` / `resolveImpersonatedSession` support that shipped in #778 and the console UI in #780.

### What's here (e2e only, clean on `main`)
- `e2e/tests/features/impersonation-console.feature` + `steps/impersonation-console.steps.ts`
- `e2e/src/auth-fixtures.ts`, `seed-auth.ts`, `middleware.ts` wiring
- `e2e/tests/support/{world,hooks}.ts`, `e2e/packages/functions/src/auth.ts` seed roles

### Notes
Rebased onto latest `main`; all package-source changes from the original branch were dropped as already-merged (#774 setHeader, #778 impersonation) — this PR is purely the e2e coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for user impersonation in the console, including a visible impersonation banner and a new end-to-end test path.
  * Added a dedicated end-to-end test command for impersonation scenarios.

* **Bug Fixes**
  * Improved authentication setup so console sign-in works more reliably across local and configured API endpoints.
  * Ensured impersonation is applied only where needed, while normal console requests stay unaffected.
  * Streamlined test setup by seeding required test users before E2E runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->