### PR TITLE
feat(workflow): workflow-owned step retries + stable invocationId

### DIFF
--- a/.changeset/workflow-retry-invocation-id.md
+++ b/.changeset/workflow-retry-invocation-id.md
@@ -1,0 +1,28 @@
+---
+'@pikku/core': patch
+'@pikku/queue-pg-boss': patch
+'@pikku/queue-bullmq': patch
+---
+
+feat(workflow): workflow-owned step retries + stable invocationId
+
+The workflow — not the queue — now owns step retry policy, and each step
+invocation gets a stable idempotency key.
+
+- **Default `retries: 5` with exponential backoff.** A step with no `retries`
+  previously inherited the queue's bare default (e.g. pg-boss `retry_limit 2`,
+  no backoff) so retries fired instantly and couldn't outlast a transient
+  outage. Retries now default to 5 with backoff, resolved at the workflow layer.
+- **`retries: 0` is honored.** Dispatch previously passed `undefined` options
+  for `retries: 0`, letting the queue re-run a non-idempotent step up to its own
+  default. The resolved policy now always sets `attempts` (`retries: 0` →
+  `attempts: 1`), so the queue never second-guesses the workflow. The persisted
+  step retries and the dispatched `attempts` are resolved together so
+  "retries exhausted" and "no more redeliveries" are the same event.
+- **`workflowStep.invocationId`** — a deterministic, dependency-free
+  `uuidv5(runId:stepName)` handed to every step. Unlike `stepId` (minted per
+  attempt), it is identical across retries, so a step can dedupe on it
+  (`ON CONFLICT (invocationId)`, Stripe idempotency keys, etc.).
+- **queue-bullmq**: `mapPikkuJobToBull` now maps `backoff` (previously dropped,
+  so a step's backoff silently never applied on Redis), and `registerQueues`
+  throws a clear error when no logger is available (matching queue-pg-boss).

--- a/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
+++ b/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
@@ -295,13 +295,18 @@ export type WorkflowStepMeta =
 export interface WorkflowStepWire {
   /** The workflow run ID */
   runId: string
-  /** The unique step ID (minted fresh per attempt — NOT stable across retries) */
+  /**
+   * The step row ID. Whether it stays the same or is minted fresh per attempt is
+   * STORE-SPECIFIC (in-memory mints a new one each attempt; the SQL store reuses
+   * the row) — do NOT use it as a dedupe key. Use `invocationId`.
+   */
   stepId: string
   /**
    * Stable identity of this step invocation — the idempotency / dedupe key.
    * Identical across every retry of the same call (derived from runId + step
-   * name), so a step can `ON CONFLICT (invocationId)` or pass it as an external
-   * idempotency key and have retries collapse onto the first attempt.
+   * name) regardless of storage backend, so a step can `ON CONFLICT (invocationId)`
+   * or pass it as an external idempotency key and have retries collapse onto the
+   * first attempt.
    */
   invocationId: string
   /** Current attempt number (1-indexed, increments on retry) */

--- a/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
+++ b/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
@@ -295,8 +295,15 @@ export type WorkflowStepMeta =
 export interface WorkflowStepWire {
   /** The workflow run ID */
   runId: string
-  /** The unique step ID */
+  /** The unique step ID (minted fresh per attempt — NOT stable across retries) */
   stepId: string
+  /**
+   * Stable identity of this step invocation — the idempotency / dedupe key.
+   * Identical across every retry of the same call (derived from runId + step
+   * name), so a step can `ON CONFLICT (invocationId)` or pass it as an external
+   * idempotency key and have retries collapse onto the first attempt.
+   */
+  invocationId: string
   /** Current attempt number (1-indexed, increments on retry) */
   attemptCount: number
 }

--- a/packages/core/src/wirings/workflow/graph/graph-runner.test.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.test.ts
@@ -10,6 +10,7 @@ import {
 import type { WorkflowRuntimeMeta } from '../workflow.types.js'
 import { pikkuState } from '../../../pikku-state.js'
 import { RPCNotFoundError } from '../../rpc/rpc-runner.js'
+import { DEFAULT_STEP_RETRIES } from '../pikku-workflow-service.js'
 
 describe('graph-runner bugs', () => {
   test('continueGraph should NOT mark workflow completed while nodes are still running', async () => {
@@ -618,9 +619,14 @@ describe('graph-runner bugs', () => {
     const cJob = enqueued.find((e) => e.data?.stepName === 'c')
     assert.ok(cJob, 'node c should have been enqueued')
     assert.equal(
-      cJob!.options,
-      undefined,
-      'no retries → no queue options (preserves prior queue defaults)'
+      cJob!.options?.attempts,
+      DEFAULT_STEP_RETRIES + 1,
+      'no retries → workflow default (5) + 1 attempt; queue never decides retries'
+    )
+    assert.equal(
+      cJob!.options?.backoff,
+      'exponential',
+      'default retries get exponential backoff so they ride out transient outages'
     )
   })
 })

--- a/packages/core/src/wirings/workflow/graph/graph-runner.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.ts
@@ -2,6 +2,7 @@ import {
   type PikkuWorkflowService,
   WorkflowAsyncException,
   WorkflowSuspendedException,
+  DEFAULT_STEP_RETRIES,
 } from '../pikku-workflow-service.js'
 import type { GraphWireState, PikkuGraphWire } from './workflow-graph.types.js'
 import { pikkuState, getSingletonServices } from '../../../pikku-state.js'
@@ -327,8 +328,10 @@ async function queueGraphNode(
   input: any,
   nodeConfig?: { retries?: number; retryDelay?: string | number }
 ): Promise<void> {
+  // Default to the workflow-wide retry policy when the node sets none, so the
+  // persisted step retries match the queue `attempts` (see resolveStepJobOptions).
   const stepOptions = {
-    retries: nodeConfig?.retries ?? 0,
+    retries: nodeConfig?.retries ?? DEFAULT_STEP_RETRIES,
     retryDelay: nodeConfig?.retryDelay,
   }
   await workflowService.insertStepState(

--- a/packages/core/src/wirings/workflow/index.ts
+++ b/packages/core/src/wirings/workflow/index.ts
@@ -7,7 +7,9 @@ export {
   WorkflowSuspendedException,
   WorkflowNotFoundError,
   WorkflowRunNotFoundError,
+  DEFAULT_STEP_RETRIES,
 } from './pikku-workflow-service.js'
+export { deriveInvocationId, uuidv5 } from './workflow-invocation-id.js'
 
 // Internal registration functions (used by generated code)
 export { addWorkflow } from './dsl/workflow-runner.js'

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -69,6 +69,17 @@ import type { WorkflowService } from '../../services/workflow-service.js'
 import { PikkuError, addError } from '../../errors/error-handler.js'
 import { RPCNotFoundError } from '../rpc/rpc-runner.js'
 import { ChildWorkflowStartedException } from './graph/graph-runner.js'
+import { deriveInvocationId } from './workflow-invocation-id.js'
+import type { JobOptions } from '../queue/queue.types.js'
+
+/**
+ * Default number of retries for a workflow step when none is specified. The
+ * workflow — not the queue — owns retry policy; a step inherits this unless it
+ * sets its own `retries` (including `retries: 0` to opt out entirely). Picked >0
+ * so a transient failure (a DB blip, a downstream restart, a deploy) is ridden
+ * out by default; safe because every step gets a stable `invocationId` to dedupe on.
+ */
+export const DEFAULT_STEP_RETRIES = 5
 
 /**
  * Exception thrown when workflow needs to pause for async step
@@ -789,6 +800,31 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     })
   }
 
+  /**
+   * Resolve a step's retry policy into queue job options. The workflow is the
+   * sole source of truth for retries: an explicitly-set `retries` (including 0)
+   * is always honored, an unset one defaults to {@link DEFAULT_STEP_RETRIES},
+   * and we ALWAYS pass `attempts` so the queue can never fall back to its own
+   * default — which would re-run a step the workflow said not to retry. Backoff
+   * defaults to exponential whenever there's at least one retry, so retries ride
+   * out a transient outage instead of firing instantly.
+   */
+  protected resolveStepJobOptions(
+    stepOptions?: WorkflowStepOptions
+  ): JobOptions {
+    const retries = stepOptions?.retries ?? DEFAULT_STEP_RETRIES
+    const retryDelay = stepOptions?.retryDelay
+    const backoff =
+      typeof retryDelay === 'number'
+        ? { type: 'fixed', delay: retryDelay }
+        : retryDelay === 'exponential'
+          ? 'exponential'
+          : retries > 0
+            ? 'exponential'
+            : undefined
+    return { attempts: retries + 1, ...(backoff ? { backoff } : {}) }
+  }
+
   public async queueStepWorker(
     runId: string,
     stepName: string,
@@ -797,29 +833,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepOptions?: WorkflowStepOptions
   ): Promise<void> {
     const queueService = this.verifyQueueService()
-    const retries = stepOptions?.retries ?? 0
-    const retryDelay = stepOptions?.retryDelay
     await queueService.add(
       this.getStepWorkerQueueName(rpcName),
-      JSON.parse(
-        JSON.stringify({
-          runId,
-          stepName,
-          rpcName,
-          data,
-        })
-      ),
-      retries > 0 || retryDelay
-        ? {
-            attempts: retries + 1,
-            backoff:
-              typeof retryDelay === 'number'
-                ? { type: 'fixed', delay: retryDelay }
-                : retryDelay === 'exponential'
-                  ? 'exponential'
-                  : undefined,
-          }
-        : undefined
+      JSON.parse(JSON.stringify({ runId, stepName, rpcName, data })),
+      this.resolveStepJobOptions(stepOptions)
     )
   }
 
@@ -903,27 +920,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       )
       return false
     }
-    const retries = stepOptions?.retries ?? 0
-    const retryDelay = stepOptions?.retryDelay
     await getSingletonServices()!.queueService!.add(
       this.getStepWorkerQueueName(rpcName),
-      JSON.parse(
-        JSON.stringify({
-          runId,
-          stepName,
-          rpcName,
-          data,
-        })
-      ),
-      {
-        attempts: retries + 1,
-        backoff:
-          typeof retryDelay === 'number'
-            ? { type: 'fixed', delay: retryDelay }
-            : retryDelay === 'exponential'
-              ? 'exponential'
-              : undefined,
-      }
+      JSON.parse(JSON.stringify({ runId, stepName, rpcName, data })),
+      this.resolveStepJobOptions(stepOptions)
     )
     return true
   }
@@ -1393,6 +1393,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
               workflowStep: {
                 runId,
                 stepId: stepState.stepId,
+                invocationId: deriveInvocationId(runId, stepName),
                 attemptCount: stepState.attemptCount,
               },
             })
@@ -1424,7 +1425,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         // Store error and mark failed
         await this.setStepError(stepState.stepId, error)
 
-        const maxAttempts = (stepState.retries ?? 0) + 1
+        const maxAttempts = (stepState.retries ?? DEFAULT_STEP_RETRIES) + 1
         const retriesExhausted = stepState.attemptCount >= maxAttempts
 
         if (retriesExhausted) {
@@ -1486,6 +1487,14 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     rpcService: any,
     stepOptions?: WorkflowStepOptions
   ): Promise<any> {
+    // Resolve the retry policy ONCE here so the value persisted on the step
+    // (which drives `retriesExhausted`) is the same one the queue dispatch turns
+    // into `attempts`. Without this the queue could retry N times while the
+    // engine thinks retries are already exhausted (or vice-versa).
+    const resolvedStepOptions: WorkflowStepOptions = {
+      retries: stepOptions?.retries ?? DEFAULT_STEP_RETRIES,
+      retryDelay: stepOptions?.retryDelay,
+    }
     // Check if step already exists
     let stepState: StepState
     try {
@@ -1497,7 +1506,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         stepName,
         rpcName,
         data,
-        stepOptions
+        resolvedStepOptions
       )
     }
 
@@ -1534,7 +1543,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       stepName,
       rpcName,
       data,
-      stepOptions
+      resolvedStepOptions
     )
     if (dispatched) {
       throw new WorkflowAsyncException(runId, stepName)
@@ -1542,8 +1551,8 @@ export abstract class PikkuWorkflowService implements WorkflowService {
 
     {
       // Inline (no transport available) - execute locally with retry loop
-      const retries = stepOptions?.retries ?? 0
-      const retryDelay = stepOptions?.retryDelay
+      const retries = resolvedStepOptions.retries ?? this.getConfig().retries
+      const retryDelay = resolvedStepOptions.retryDelay
       let currentStepState = stepState
 
       while (true) {
@@ -1592,6 +1601,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
               workflowStep: {
                 runId,
                 stepId: currentStepState.stepId,
+                invocationId: deriveInvocationId(runId, stepName),
                 attemptCount: currentStepState.attemptCount,
               },
             })
@@ -1900,7 +1910,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     const singletonServices = getSingletonServices()
     const workflow = singletonServices.config?.workflow
     return {
-      retries: workflow?.retries ?? 0,
+      retries: workflow?.retries ?? DEFAULT_STEP_RETRIES,
       retryDelay: workflow?.retryDelay ?? 0,
       orchestratorQueueName:
         workflow?.orchestratorQueueName ?? 'pikku-workflow-orchestrator',

--- a/packages/core/src/wirings/workflow/workflow-invocation-id.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-invocation-id.test.ts
@@ -1,0 +1,53 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { uuidv5, deriveInvocationId } from './workflow-invocation-id.js'
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+describe('uuidv5', () => {
+  test('matches the canonical RFC 4122 v5 vector', () => {
+    // www.example.com in the DNS namespace → known fixed UUID. Proves the
+    // SHA-1 + version/variant bit-twiddling is a correct v5 implementation.
+    const DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'
+    assert.equal(
+      uuidv5('www.example.com', DNS),
+      '2ed6657d-e927-568b-95e1-2665a8aea6a2'
+    )
+  })
+
+  test('is deterministic and sets version 5 + RFC variant bits', () => {
+    const a = uuidv5('hello')
+    const b = uuidv5('hello')
+    assert.equal(a, b, 'same input → same UUID')
+    assert.match(a, UUID_RE, 'version nibble is 5 and variant is 8/9/a/b')
+  })
+
+  test('different names produce different UUIDs', () => {
+    assert.notEqual(uuidv5('a'), uuidv5('b'))
+  })
+})
+
+describe('deriveInvocationId', () => {
+  test('is stable across calls for the same run + step (the dedupe key)', () => {
+    const id1 = deriveInvocationId('run-1', 'updateUser')
+    const id2 = deriveInvocationId('run-1', 'updateUser')
+    assert.equal(id1, id2)
+    assert.match(id1, UUID_RE)
+  })
+
+  test('differs per step name within a run', () => {
+    assert.notEqual(
+      deriveInvocationId('run-1', 'updateUser'),
+      deriveInvocationId('run-1', 'chargeCard')
+    )
+  })
+
+  test('differs per run for the same step name', () => {
+    assert.notEqual(
+      deriveInvocationId('run-1', 'updateUser'),
+      deriveInvocationId('run-2', 'updateUser')
+    )
+  })
+})

--- a/packages/core/src/wirings/workflow/workflow-invocation-id.ts
+++ b/packages/core/src/wirings/workflow/workflow-invocation-id.ts
@@ -1,0 +1,48 @@
+import { createHash } from 'crypto'
+
+// Fixed namespace for pikku workflow step invocation IDs. Frozen — changing it
+// would alter every derived invocationId and break dedupe across a deploy.
+const PIKKU_WORKFLOW_NAMESPACE = '70696b6b-7500-5770-9f6c-6f77000a0001'
+
+const parseUuid = (uuid: string): Buffer =>
+  Buffer.from(uuid.replace(/-/g, ''), 'hex')
+
+const formatUuid = (bytes: Buffer): string => {
+  const hex = bytes.toString('hex')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`
+}
+
+/**
+ * RFC 4122 v5 (SHA-1, name-based) UUID. Deterministic: the same name +
+ * namespace always yields the same UUID — no `uuid` dependency needed.
+ */
+export const uuidv5 = (
+  name: string,
+  namespace: string = PIKKU_WORKFLOW_NAMESPACE
+): string => {
+  const hash = createHash('sha1')
+    .update(parseUuid(namespace))
+    .update(name, 'utf8')
+    .digest()
+  const bytes = hash.subarray(0, 16)
+  bytes[6] = (bytes[6]! & 0x0f) | 0x50 // version 5
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80 // RFC 4122 variant
+  return formatUuid(bytes)
+}
+
+/**
+ * The stable identity of one step *invocation* within a run — the idempotency /
+ * dedupe key handed to a step. Unlike `stepId` (minted fresh per attempt), this
+ * stays identical across every retry of the same call, because it is derived
+ * purely from `runId` + `stepName`, both of which are stable across replays.
+ *
+ * Same inputs → same UUID, so a step can safely
+ * `INSERT … ON CONFLICT (invocation_id)` / pass it as a Stripe idempotency key,
+ * and a retry of a half-applied side effect is collapsed onto the first attempt.
+ *
+ * NOTE: calling the *same* `stepName` more than once in a run is not yet
+ * disambiguated here (the store still keys steps by `runId:stepName`); when
+ * per-invocation ordinals land, the ordinal becomes the third hash component.
+ */
+export const deriveInvocationId = (runId: string, stepName: string): string =>
+  uuidv5(`${runId}:${stepName}`)

--- a/packages/core/src/wirings/workflow/workflow-retry-policy.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-retry-policy.test.ts
@@ -1,0 +1,111 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState } from '../../pikku-state.js'
+import { DEFAULT_STEP_RETRIES } from './pikku-workflow-service.js'
+import type { PikkuWorkflowService } from './pikku-workflow-service.js'
+import { deriveInvocationId } from './workflow-invocation-id.js'
+import type { WorkflowStepOptions } from './workflow.types.js'
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+// Expose the protected retry-policy resolver for direct assertion.
+class TestWorkflowService extends InMemoryWorkflowService {
+  public resolve(options?: WorkflowStepOptions) {
+    return (this as PikkuWorkflowService as any).resolveStepJobOptions(options)
+  }
+}
+
+describe('resolveStepJobOptions — workflow owns retry policy', () => {
+  const ws = new TestWorkflowService()
+
+  test('unset retries → default + exponential backoff (rides out outages)', () => {
+    assert.deepEqual(ws.resolve(undefined), {
+      attempts: DEFAULT_STEP_RETRIES + 1,
+      backoff: 'exponential',
+    })
+  })
+
+  test('retries: 0 → attempts: 1 and NO backoff (the non-idempotent opt-out)', () => {
+    // The whole point: an explicit 0 must never inherit the queue default and
+    // re-run a step the workflow said to run exactly once.
+    assert.deepEqual(ws.resolve({ retries: 0 }), { attempts: 1 })
+  })
+
+  test('explicit retries always honored', () => {
+    assert.deepEqual(ws.resolve({ retries: 3 }), {
+      attempts: 4,
+      backoff: 'exponential',
+    })
+  })
+
+  test('numeric retryDelay → fixed backoff', () => {
+    assert.deepEqual(ws.resolve({ retries: 3, retryDelay: 250 }), {
+      attempts: 4,
+      backoff: { type: 'fixed', delay: 250 },
+    })
+  })
+
+  test("retryDelay: 'exponential' → exponential backoff", () => {
+    assert.deepEqual(ws.resolve({ retries: 2, retryDelay: 'exponential' }), {
+      attempts: 3,
+      backoff: 'exponential',
+    })
+  })
+})
+
+describe('executeWorkflowStep surfaces a stable invocationId', () => {
+  test('invocationId is stable across a retry; stepId is per-attempt', async () => {
+    const ws = new InMemoryWorkflowService()
+    pikkuState(null, 'package', 'singletonServices', {
+      queueService: { add: async () => {} },
+      logger: { error() {}, info() {}, warn() {}, debug() {} },
+    } as any)
+
+    const captured: Array<{
+      invocationId: string
+      stepId: string
+      attemptCount: number
+    }> = []
+    const rpc = {
+      rpcWithWire: async (_n: string, _d: any, opts: any) => {
+        captured.push(opts.workflowStep)
+        if (captured.length === 1) throw new Error('transient boom')
+        return { ok: true }
+      },
+    }
+
+    const runId = await ws.createRun('invflow', {}, false, 'hash', {
+      type: 'test',
+    })
+    await ws.insertStepState(runId, 'updateUser', 'doUpdateUser', {})
+
+    // First attempt fails (default retries not exhausted → throws, not failed-run).
+    await assert.rejects(
+      ws.executeWorkflowStep(runId, 'updateUser', 'doUpdateUser', {}, rpc)
+    )
+    // Retry attempt succeeds.
+    await ws.executeWorkflowStep(runId, 'updateUser', 'doUpdateUser', {}, rpc)
+
+    assert.equal(captured.length, 2, 'step ran twice')
+    assert.equal(
+      captured[0]!.invocationId,
+      captured[1]!.invocationId,
+      'invocationId is identical across retries — the dedupe key'
+    )
+    assert.equal(
+      captured[0]!.invocationId,
+      deriveInvocationId(runId, 'updateUser')
+    )
+    assert.match(captured[0]!.invocationId, UUID_RE)
+    assert.equal(captured[0]!.attemptCount, 1)
+    assert.equal(captured[1]!.attemptCount, 2)
+    assert.notEqual(
+      captured[0]!.stepId,
+      captured[1]!.stepId,
+      'stepId is minted per attempt — must NOT be used as the dedupe key'
+    )
+  })
+})

--- a/packages/services/queue-bullmq/package.json
+++ b/packages/services/queue-bullmq/package.json
@@ -8,6 +8,7 @@
   "type": "module",
   "scripts": {
     "tsc": "tsc",
+    "test": "bash run-tests.sh",
     "ncu": "npx npm-check-updates",
     "build": "tsc -b",
     "release": "npm run build && npm test",

--- a/packages/services/queue-bullmq/run-tests.sh
+++ b/packages/services/queue-bullmq/run-tests.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 cd "$(dirname "$0")"
-exec node --test --experimental-test-coverage --loader=tsx/esm dist/**/*.test.js
+files=($(find src -type f -name "*.test.ts"))
+if [ ${#files[@]} -eq 0 ]; then echo "No test files found"; exit 0; fi
+node --import tsx --test "$@" "${files[@]}"

--- a/packages/services/queue-bullmq/src/bull-queue-service.test.ts
+++ b/packages/services/queue-bullmq/src/bull-queue-service.test.ts
@@ -1,0 +1,36 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { mapPikkuJobToBull } from './bull-queue-service.js'
+
+// Same contract as the pg-boss adapter: the workflow's resolved retry policy
+// (attempts + backoff) must reach BullMQ. backoff mapping in particular was
+// previously dropped, so a step's backoff silently never applied on Redis.
+describe('mapPikkuJobToBull — retry mapping', () => {
+  test('attempts passes through unchanged (BullMQ uses attempts directly)', () => {
+    assert.equal(mapPikkuJobToBull({ attempts: 6 }).attempts, 6)
+    assert.equal(mapPikkuJobToBull({ attempts: 1 }).attempts, 1)
+  })
+
+  test("string backoff 'exponential' → { type: 'exponential' }", () => {
+    assert.deepEqual(mapPikkuJobToBull({ attempts: 6, backoff: 'exponential' }).backoff, {
+      type: 'exponential',
+    })
+  })
+
+  test('object backoff → { type, delay } (delay stays in ms)', () => {
+    assert.deepEqual(
+      mapPikkuJobToBull({ attempts: 4, backoff: { type: 'fixed', delay: 250 } })
+        .backoff,
+      { type: 'fixed', delay: 250 }
+    )
+  })
+
+  test('no backoff → backoff left unset', () => {
+    assert.equal(mapPikkuJobToBull({ attempts: 6 }).backoff, undefined)
+  })
+
+  test('no options → empty job options', () => {
+    assert.deepEqual(mapPikkuJobToBull(undefined), {})
+  })
+})

--- a/packages/services/queue-bullmq/src/bull-queue-service.ts
+++ b/packages/services/queue-bullmq/src/bull-queue-service.ts
@@ -19,6 +19,15 @@ export const mapPikkuJobToBull = (options?: JobOptions): JobsOptions => {
     bullOptions.attempts = options.attempts
   }
 
+  // Map retry backoff. BullMQ accepts `{ type, delay }`; our `delay` is in ms,
+  // which is what BullMQ expects too (unlike pg-boss, which uses seconds).
+  if (options?.backoff !== undefined) {
+    bullOptions.backoff =
+      typeof options.backoff === 'string'
+        ? { type: options.backoff }
+        : { type: options.backoff.type, delay: options.backoff.delay }
+  }
+
   if (options?.removeOnComplete !== undefined) {
     bullOptions.removeOnComplete = options.removeOnComplete
   }

--- a/packages/services/queue-bullmq/src/bull-queue-worker.test.ts
+++ b/packages/services/queue-bullmq/src/bull-queue-worker.test.ts
@@ -4,12 +4,12 @@ import assert from 'node:assert/strict'
 import { BullQueueWorkers } from './bull-queue-worker.js'
 
 describe('BullQueueWorkers', () => {
-  test('requires setJobRunner before registerQueues', async () => {
+  test('requires a logger (explicit or from singleton services)', async () => {
     const workers = new BullQueueWorkers({})
 
     await assert.rejects(() => workers.registerQueues(), {
       message:
-        'BullQueueWorkers requires setJobRunner() before registerQueues()',
+        'Logger is required for registerQueues — pass it explicitly or ensure singleton services are initialized first',
     })
   })
 })

--- a/packages/services/queue-bullmq/src/bull-queue-worker.ts
+++ b/packages/services/queue-bullmq/src/bull-queue-worker.ts
@@ -141,7 +141,12 @@ export class BullQueueWorkers implements QueueWorkers {
    * Scan state and register all compatible processors
    */
   async registerQueues(): Promise<Record<string, ConfigValidationResult[]>> {
-    const logger = pikkuState(null, 'package', 'singletonServices')!.logger
+    const logger = pikkuState(null, 'package', 'singletonServices')?.logger
+    if (!logger) {
+      throw new Error(
+        'Logger is required for registerQueues — pass it explicitly or ensure singleton services are initialized first'
+      )
+    }
 
     return await registerQueueWorkers(
       this.configMappings,

--- a/packages/services/queue-pg-boss/package.json
+++ b/packages/services/queue-pg-boss/package.json
@@ -8,6 +8,7 @@
   "type": "module",
   "scripts": {
     "tsc": "tsc",
+    "test": "bash run-tests.sh",
     "ncu": "npx npm-check-updates",
     "build": "tsc -b",
     "release": "npm run build && npm test",

--- a/packages/services/queue-pg-boss/run-tests.sh
+++ b/packages/services/queue-pg-boss/run-tests.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 cd "$(dirname "$0")"
-node --loader tsx --test --experimental-test-coverage src/**/*.test.ts "$@"
+files=($(find src -type f -name "*.test.ts"))
+if [ ${#files[@]} -eq 0 ]; then echo "No test files found"; exit 0; fi
+node --import tsx --test "$@" "${files[@]}"

--- a/packages/services/queue-pg-boss/src/pg-boss-queue-service.test.ts
+++ b/packages/services/queue-pg-boss/src/pg-boss-queue-service.test.ts
@@ -1,0 +1,51 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { mapPikkuJobToPgBoss } from './pg-boss-queue-service.js'
+
+// These guard the contract the workflow engine relies on: a step's resolved
+// retry policy (attempts + backoff) must survive translation into pg-boss
+// terms, so "workflow owns retries" actually reaches the queue.
+describe('mapPikkuJobToPgBoss — retry mapping', () => {
+  test('attempts → retryLimit (attempts - 1)', () => {
+    // Default policy: 5 retries → 6 attempts → retryLimit 5.
+    assert.equal(mapPikkuJobToPgBoss({ attempts: 6 }).retryLimit, 5)
+  })
+
+  test('attempts: 1 (retries: 0) → retryLimit 0 (pg-boss never re-runs it)', () => {
+    assert.equal(mapPikkuJobToPgBoss({ attempts: 1 }).retryLimit, 0)
+  })
+
+  test("backoff 'exponential' → retryBackoff true", () => {
+    assert.equal(
+      mapPikkuJobToPgBoss({ attempts: 6, backoff: 'exponential' })
+        .retryBackoff,
+      true
+    )
+  })
+
+  test('fixed backoff → retryBackoff false + retryDelay in seconds', () => {
+    const opts = mapPikkuJobToPgBoss({
+      attempts: 4,
+      backoff: { type: 'fixed', delay: 5000 },
+    })
+    assert.equal(opts.retryBackoff, false)
+    // pg-boss takes seconds; our delay is milliseconds.
+    assert.equal(opts.retryDelay, 5)
+  })
+
+  test('exponential object backoff → retryBackoff true + retryDelay in seconds', () => {
+    const opts = mapPikkuJobToPgBoss({
+      attempts: 4,
+      backoff: { type: 'exponential', delay: 2000 },
+    })
+    assert.equal(opts.retryBackoff, true)
+    assert.equal(opts.retryDelay, 2)
+  })
+
+  test('no options → no retry fields set', () => {
+    const opts = mapPikkuJobToPgBoss(undefined)
+    assert.equal(opts.retryLimit, undefined)
+    assert.equal(opts.retryBackoff, undefined)
+  })
+})

--- a/packages/services/queue-pg-boss/src/pg-boss-queue-worker.test.ts
+++ b/packages/services/queue-pg-boss/src/pg-boss-queue-worker.test.ts
@@ -4,12 +4,12 @@ import assert from 'node:assert/strict'
 import { PgBossQueueWorkers } from './pg-boss-queue-worker.js'
 
 describe('PgBossQueueWorkers', () => {
-  test('requires setJobRunner before registerQueues', async () => {
+  test('requires a logger (explicit or from singleton services)', async () => {
     const workers = new PgBossQueueWorkers({} as any)
 
     await assert.rejects(() => workers.registerQueues(), {
       message:
-        'PgBossQueueWorkers requires setJobRunner() before registerQueues()',
+        'Logger is required for registerQueues — pass it explicitly or ensure singleton services are initialized first',
     })
   })
 })

--- a/verifiers/workflows/package.json
+++ b/verifiers/workflows/package.json
@@ -34,6 +34,8 @@
     "test:function-versioning": "npx tsx src/runners/function-versioning.runner.ts",
     "test:version-mismatch": "npx tsx src/runners/version-mismatch.runner.ts",
     "test:version-mismatch:pg": "npx tsx src/runners/version-mismatch.runner.ts --pg",
-    "test:version-mismatch:redis": "npx tsx src/runners/version-mismatch.runner.ts --redis"
+    "test:version-mismatch:redis": "npx tsx src/runners/version-mismatch.runner.ts --redis",
+    "test:retry-idempotency:pg": "npx tsx src/runners/retry-idempotency.runner.ts --pg",
+    "test:retry-idempotency:redis": "npx tsx src/runners/retry-idempotency.runner.ts --redis"
   }
 }

--- a/verifiers/workflows/src/runners/retry-idempotency-tracker.ts
+++ b/verifiers/workflows/src/runners/retry-idempotency-tracker.ts
@@ -1,0 +1,63 @@
+/**
+ * In-process tracker for the retry/idempotency verifiers.
+ *
+ * Step functions run in the same process as the runner (the queue workers are
+ * registered in-process), so a module-level map is the simplest way to observe
+ * exactly how many times a step executed, with which `invocationId`/`stepId`/
+ * `attemptCount`, and whether an invocationId-keyed side effect was applied more
+ * than once. The runner asserts against these observations.
+ */
+
+export interface StepExecution {
+  invocationId: string
+  stepId: string
+  attemptCount: number
+}
+
+const executions = new Map<string, StepExecution[]>()
+const applied = new Map<string, Set<string>>() // key -> invocationIds that ran the side effect
+const sideEffects = new Map<string, number>() // key -> times the side effect actually ran
+
+export const tracker = {
+  reset(key: string): void {
+    executions.set(key, [])
+    applied.set(key, new Set())
+    sideEffects.set(key, 0)
+  },
+
+  record(key: string, execution: StepExecution): void {
+    const list = executions.get(key) ?? []
+    list.push(execution)
+    executions.set(key, list)
+  },
+
+  /**
+   * Apply a side effect exactly once per invocationId. Returns true if applied
+   * now, false if this invocationId already applied it (a retry). This is the
+   * idempotency pattern the stable invocationId enables: a side effect that
+   * crashed mid-flight is NOT re-run on retry.
+   */
+  applyOnce(key: string, invocationId: string): boolean {
+    const seen = applied.get(key) ?? new Set()
+    if (seen.has(invocationId)) {
+      applied.set(key, seen)
+      return false
+    }
+    seen.add(invocationId)
+    applied.set(key, seen)
+    sideEffects.set(key, (sideEffects.get(key) ?? 0) + 1)
+    return true
+  },
+
+  executions(key: string): StepExecution[] {
+    return executions.get(key) ?? []
+  },
+
+  count(key: string): number {
+    return this.executions(key).length
+  },
+
+  sideEffectCount(key: string): number {
+    return sideEffects.get(key) ?? 0
+  },
+}

--- a/verifiers/workflows/src/runners/retry-idempotency.runner.ts
+++ b/verifiers/workflows/src/runners/retry-idempotency.runner.ts
@@ -1,0 +1,293 @@
+/**
+ * Retry + Idempotency UNHAPPY-PATH Runner
+ *
+ * Drives purpose-built failing workflows through a REAL queue (pg-boss or
+ * bullmq) and real workflow storage, then asserts the retry/idempotency
+ * invariants the engine promises — actively trying to break them:
+ *
+ *   1. idempotent dedupe  — step crashes twice then succeeds; the invocationId
+ *      is identical across all 3 attempts (stepId is not), and an
+ *      invocationId-keyed side effect runs exactly ONCE.
+ *   2. retries: 0         — an always-failing step runs EXACTLY once (the queue
+ *      must never sneak in its own default retries) and the workflow fails.
+ *   3. default exhaust    — a step with NO retries option runs exactly
+ *      DEFAULT_STEP_RETRIES + 1 times then the workflow fails (proves the
+ *      default is honored and engine + queue agree on the count).
+ *   4. default recover    — a step with NO retries option recovers within the
+ *      default budget and the workflow completes.
+ *
+ * Usage:
+ *   yarn test:retry-idempotency:pg      # pg-boss + Postgres (KyselyWorkflowService)
+ *   yarn test:retry-idempotency:redis   # bullmq + Redis (RedisWorkflowService)
+ */
+
+import { DEFAULT_STEP_RETRIES } from '@pikku/core/workflow'
+import type { PikkuWorkflowService } from '@pikku/core/workflow'
+
+import { createConfig, createSingletonServices } from '../services.js'
+import { tracker, type StepExecution } from './retry-idempotency-tracker.js'
+
+import '../../.pikku/pikku-bootstrap.gen.js'
+
+type Backend = 'pg' | 'redis'
+
+const TIMEOUT_MS = 60_000
+const POLL_INTERVAL_MS = 100
+
+function parseBackend(): Backend {
+  if (process.argv.includes('--redis')) return 'redis'
+  if (process.argv.includes('--pg')) return 'pg'
+  throw new Error('Specify a backend: --pg or --redis')
+}
+
+async function setup(backend: Backend): Promise<{
+  workflowService: PikkuWorkflowService
+  registerQueues: () => Promise<unknown>
+  cleanup: () => Promise<void>
+}> {
+  const config = await createConfig()
+
+  if (backend === 'pg') {
+    const { KyselyWorkflowService } = await import('@pikku/kysely')
+    const { PgBossServiceFactory } = await import('@pikku/queue-pg-boss')
+    const { Kysely, CamelCasePlugin } = await import('kysely')
+    const { PostgresJSDialect } = await import('kysely-postgres-js')
+    const postgres = (await import('postgres')).default
+    const connectionString =
+      process.env.DATABASE_URL ||
+      'postgres://postgres:password@localhost:5432/pikku_queue'
+
+    const pgBossFactory = new PgBossServiceFactory(connectionString)
+    await pgBossFactory.init()
+    const sql = postgres(connectionString)
+    // KyselyWorkflowService creates snake_case tables but queries in camelCase —
+    // it requires the CamelCasePlugin to bridge the two.
+    const db = new Kysely<any>({
+      dialect: new PostgresJSDialect({ postgres: sql }),
+      plugins: [new CamelCasePlugin()],
+    })
+    const workflowService = new KyselyWorkflowService(db)
+    await workflowService.init()
+
+    await createSingletonServices(config, {
+      queueService: pgBossFactory.getQueueService(),
+      schedulerService: pgBossFactory.getSchedulerService(),
+      workflowService,
+    })
+
+    return {
+      workflowService,
+      registerQueues: () => pgBossFactory.getQueueWorkers().registerQueues(),
+      cleanup: async () => {
+        await workflowService.close()
+        await pgBossFactory.close()
+        await sql.end()
+      },
+    }
+  }
+
+  const { RedisWorkflowService } = await import('@pikku/redis')
+  const { BullServiceFactory } = await import('@pikku/queue-bullmq')
+
+  const bullFactory = new BullServiceFactory()
+  await bullFactory.init()
+  const workflowService = new RedisWorkflowService(undefined)
+  await workflowService.init()
+
+  await createSingletonServices(config, {
+    queueService: bullFactory.getQueueService(),
+    schedulerService: bullFactory.getSchedulerService(),
+    workflowService,
+  })
+
+  const queueWorkers = bullFactory.getQueueWorkers()
+  return {
+    workflowService,
+    registerQueues: () => queueWorkers.registerQueues(),
+    cleanup: async () => {
+      await queueWorkers.close()
+      await workflowService.close()
+      await bullFactory.close()
+    },
+  }
+}
+
+class AssertionFailed extends Error {}
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new AssertionFailed(message)
+}
+
+const attemptCounts = (execs: StepExecution[]) =>
+  execs.map((e) => e.attemptCount)
+const allSameInvocationId = (execs: StepExecution[]) =>
+  execs.length > 0 && execs.every((e) => e.invocationId === execs[0]!.invocationId)
+
+async function main(): Promise<void> {
+  const backend = parseBackend()
+  console.log(`=== Retry + Idempotency Unhappy-Path Runner (${backend}) ===\n`)
+
+  const { workflowService, registerQueues, cleanup } = await setup(backend)
+  await registerQueues()
+
+  const results: Array<{ name: string; ok: boolean; error?: string }> = []
+
+  async function runToTerminal(
+    name: string,
+    input: unknown
+  ): Promise<'completed' | 'failed' | 'cancelled'> {
+    const { runId } = await workflowService.startWorkflow(
+      name,
+      input,
+      { type: 'test' },
+      null as any
+    )
+    const deadline = Date.now() + TIMEOUT_MS
+    while (true) {
+      const run = await workflowService.getRun(runId)
+      if (
+        run &&
+        (run.status === 'completed' ||
+          run.status === 'failed' ||
+          run.status === 'cancelled')
+      ) {
+        return run.status
+      }
+      if (Date.now() > deadline) {
+        throw new AssertionFailed(
+          `${name} timed out after ${TIMEOUT_MS}ms (status: ${run?.status})`
+        )
+      }
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+    }
+  }
+
+  async function test(name: string, fn: () => Promise<void>): Promise<void> {
+    const start = Date.now()
+    try {
+      await fn()
+      results.push({ name, ok: true })
+      console.log(`PASS: ${name} (${Date.now() - start}ms)`)
+    } catch (error: any) {
+      results.push({ name, ok: false, error: error.message })
+      console.log(`FAIL: ${name} — ${error.message} (${Date.now() - start}ms)`)
+    }
+  }
+
+  // 1) Idempotent dedupe across retries
+  await test(
+    'idempotent dedupe: same invocationId across retries, side effect once',
+    async () => {
+      const key = 'dedupe'
+      tracker.reset(key)
+      const status = await runToTerminal('idempotentDedupeWorkflow', {
+        trackerKey: key,
+        failTimes: 2,
+      })
+      const execs = tracker.executions(key)
+      assert(status === 'completed', `expected completed, got ${status}`)
+      assert(execs.length === 3, `expected 3 executions, got ${execs.length}`)
+      assert(
+        allSameInvocationId(execs),
+        `invocationId must be stable across retries, got ${JSON.stringify(execs.map((e) => e.invocationId))}`
+      )
+      assert(
+        JSON.stringify(attemptCounts(execs)) === JSON.stringify([1, 2, 3]),
+        `expected attemptCounts [1,2,3], got ${JSON.stringify(attemptCounts(execs))}`
+      )
+      // The payoff: a side effect keyed on the stable invocationId runs exactly
+      // once even though the step body executed 3 times. (stepId is deliberately
+      // NOT asserted here — whether it changes per attempt is store-specific;
+      // invocationId is the cross-store dedupe key, which is the whole point.)
+      assert(
+        tracker.sideEffectCount(key) === 1,
+        `idempotent side effect must run once, ran ${tracker.sideEffectCount(key)} times`
+      )
+    }
+  )
+
+  // 2) retries: 0 is honored — exactly one execution, workflow fails
+  await test(
+    'retries:0 honored: step runs exactly once and workflow fails',
+    async () => {
+      const key = 'noretry'
+      tracker.reset(key)
+      const status = await runToTerminal('noRetryWorkflow', { trackerKey: key })
+      const execs = tracker.executions(key)
+      assert(status === 'failed', `expected failed, got ${status}`)
+      assert(
+        execs.length === 1,
+        `retries:0 must run exactly once, ran ${execs.length} times`
+      )
+      assert(
+        execs[0]!.attemptCount === 1,
+        `expected attemptCount 1, got ${execs[0]?.attemptCount}`
+      )
+    }
+  )
+
+  // 3) Default retries exhausted — exactly DEFAULT_STEP_RETRIES + 1 executions
+  await test(
+    `default retries: exhausts at DEFAULT_STEP_RETRIES+1 (${DEFAULT_STEP_RETRIES + 1}) then fails`,
+    async () => {
+      const key = 'exhaust'
+      tracker.reset(key)
+      const status = await runToTerminal('defaultRetryExhaustWorkflow', {
+        trackerKey: key,
+      })
+      const execs = tracker.executions(key)
+      assert(status === 'failed', `expected failed, got ${status}`)
+      assert(
+        execs.length === DEFAULT_STEP_RETRIES + 1,
+        `expected ${DEFAULT_STEP_RETRIES + 1} executions, got ${execs.length}`
+      )
+      assert(
+        allSameInvocationId(execs),
+        `invocationId must be stable across all attempts`
+      )
+      const expected = Array.from(
+        { length: DEFAULT_STEP_RETRIES + 1 },
+        (_, i) => i + 1
+      )
+      assert(
+        JSON.stringify(attemptCounts(execs)) === JSON.stringify(expected),
+        `expected attemptCounts ${JSON.stringify(expected)}, got ${JSON.stringify(attemptCounts(execs))}`
+      )
+    }
+  )
+
+  // 4) Default retries recover — completes within the default budget
+  await test(
+    'default retries: recovers within the default budget and completes',
+    async () => {
+      const key = 'recover'
+      tracker.reset(key)
+      const status = await runToTerminal('defaultRetryRecoverWorkflow', {
+        trackerKey: key,
+        failTimes: 2,
+      })
+      const execs = tracker.executions(key)
+      assert(status === 'completed', `expected completed, got ${status}`)
+      assert(execs.length === 3, `expected 3 executions, got ${execs.length}`)
+      assert(allSameInvocationId(execs), `invocationId must be stable`)
+    }
+  )
+
+  console.log('\n=== Summary ===')
+  const passed = results.filter((r) => r.ok).length
+  const failed = results.filter((r) => !r.ok).length
+  console.log(`Passed: ${passed}/${results.length}`)
+  if (failed > 0) {
+    console.log('\nFailures:')
+    for (const r of results.filter((r) => !r.ok)) {
+      console.log(`  ${r.name}: ${r.error}`)
+    }
+  }
+
+  await cleanup()
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+main().catch((error) => {
+  console.error('Runner failed:', error)
+  process.exit(1)
+})

--- a/verifiers/workflows/src/workflows/retry-idempotency.functions.ts
+++ b/verifiers/workflows/src/workflows/retry-idempotency.functions.ts
@@ -1,0 +1,138 @@
+/**
+ * UNHAPPY-PATH workflows for retry + idempotency.
+ *
+ * Steps are `inline: false` so they dispatch through the real queue (pg-boss /
+ * bullmq) and are retried by queue redelivery — the durability path. Each step
+ * records its `invocationId` / `stepId` / `attemptCount` into the shared tracker
+ * so the runner can assert exactly what happened under failure.
+ */
+import { pikkuWorkflowFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
+import { pikkuSessionlessFunc } from '#pikku'
+import { tracker } from '../runners/retry-idempotency-tracker.js'
+
+/**
+ * Fails its first `failTimes` executions, then succeeds. No dedupe — used to
+ * count executions (retries:0, default-exhaust, default-recover).
+ */
+export const flakyStep = pikkuSessionlessFunc<
+  { trackerKey: string; failTimes: number },
+  { ok: boolean }
+>({
+  inline: false,
+  func: async ({ logger }, data, { workflowStep }) => {
+    tracker.record(data.trackerKey, {
+      invocationId: workflowStep!.invocationId,
+      stepId: workflowStep!.stepId,
+      attemptCount: workflowStep!.attemptCount,
+    })
+    const soFar = tracker.count(data.trackerKey)
+    if (soFar <= data.failTimes) {
+      logger.info(
+        `[flakyStep] ${data.trackerKey} execution ${soFar} (attempt ${workflowStep!.attemptCount}) → fail`
+      )
+      throw new Error(`flakyStep ${data.trackerKey} failing execution ${soFar}`)
+    }
+    return { ok: true }
+  },
+})
+
+/**
+ * Applies a side effect exactly once per `invocationId` BEFORE crashing, so a
+ * retry must NOT re-apply it. Demonstrates invocationId-keyed idempotency: after
+ * N crashing executions the side effect ran exactly once.
+ */
+export const idempotentStep = pikkuSessionlessFunc<
+  { trackerKey: string; failTimes: number },
+  { ok: boolean }
+>({
+  inline: false,
+  func: async ({ logger }, data, { workflowStep }) => {
+    const invocationId = workflowStep!.invocationId
+    tracker.record(data.trackerKey, {
+      invocationId,
+      stepId: workflowStep!.stepId,
+      attemptCount: workflowStep!.attemptCount,
+    })
+    const firstTime = tracker.applyOnce(data.trackerKey, invocationId)
+    logger.info(
+      `[idempotentStep] ${data.trackerKey} invocation ${invocationId} sideEffect=${firstTime ? 'applied' : 'deduped'}`
+    )
+    const soFar = tracker.count(data.trackerKey)
+    if (soFar <= data.failTimes) {
+      // Crash AFTER the side effect — the retry sees the same invocationId and
+      // skips re-applying it.
+      throw new Error(`idempotentStep crash after side effect ${soFar}`)
+    }
+    return { ok: true }
+  },
+})
+
+// ── Workflows ────────────────────────────────────────────────────────────────
+
+/** Step crashes `failTimes` times then succeeds; explicit retries cover it. */
+export const idempotentDedupeWorkflow = pikkuWorkflowFunc<
+  { trackerKey: string; failTimes: number },
+  { ok: boolean }
+>({
+  func: async (_services, data, { workflow }) => {
+    await workflow.do('idempotent step', 'idempotentStep', data, {
+      retries: 5,
+      retryDelay: 0,
+    })
+    return { ok: true }
+  },
+  tags: ['test', 'retry', 'idempotency'],
+})
+
+/** retries:0 — must run EXACTLY once and fail the workflow (no sneaky retries). */
+export const noRetryWorkflow = pikkuWorkflowFunc<
+  { trackerKey: string },
+  { ok: boolean }
+>({
+  func: async (_services, data, { workflow }) => {
+    await workflow.do(
+      'no retry step',
+      'flakyStep',
+      { trackerKey: data.trackerKey, failTimes: 999 },
+      { retries: 0 }
+    )
+    return { ok: true }
+  },
+  tags: ['test', 'retry'],
+})
+
+/** No retries option → default policy; always fails → exhausts the default. */
+export const defaultRetryExhaustWorkflow = pikkuWorkflowFunc<
+  { trackerKey: string },
+  { ok: boolean }
+>({
+  func: async (_services, data, { workflow }) => {
+    await workflow.do(
+      'default exhaust step',
+      'flakyStep',
+      { trackerKey: data.trackerKey, failTimes: 999 },
+      // retryDelay only (0) — leaves `retries` to the workflow default so we can
+      // assert what that default actually is, while keeping the test fast.
+      { retryDelay: 0 }
+    )
+    return { ok: true }
+  },
+  tags: ['test', 'retry'],
+})
+
+/** No retries option → default policy; recovers before the default is exhausted. */
+export const defaultRetryRecoverWorkflow = pikkuWorkflowFunc<
+  { trackerKey: string; failTimes: number },
+  { ok: boolean }
+>({
+  func: async (_services, data, { workflow }) => {
+    await workflow.do(
+      'default recover step',
+      'flakyStep',
+      data,
+      { retryDelay: 0 }
+    )
+    return { ok: true }
+  },
+  tags: ['test', 'retry'],
+})


### PR DESCRIPTION
The workflow — not the queue — now owns step retry policy, and each step invocation gets a stable idempotency key. Closes the pg-boss-downtime / lost-jobs gap: bare queue defaults (e.g. pg-boss \`retry_limit 2\`, no backoff) fired retries instantly and couldn't outlast a transient outage.

## Changes

**@pikku/core**
- **Default \`retries: 5\` + exponential backoff**, resolved at the workflow layer (\`resolveStepJobOptions\`). A step with no \`retries\` no longer inherits the queue's bare default.
- **\`retries: 0\` honored.** Dispatch previously passed \`undefined\` options for \`retries: 0\`, letting the queue re-run a non-idempotent step up to its own default. The resolved policy now always sets \`attempts\` (\`retries: 0\` → \`attempts: 1\`). Persisted step retries and dispatched \`attempts\` are resolved together (in \`rpcStep\` and \`queueGraphNode\`) so "retries exhausted" (engine) and "no more redeliveries" (queue) coincide — a side effect runs exactly \`retries + 1\` times.
- **\`workflowStep.invocationId\`** — deterministic, dependency-free \`uuidv5(runId:stepName)\`, handed to every step. Unlike \`stepId\` (minted per attempt) it is identical across retries, so a step can dedupe on it (\`ON CONFLICT (invocationId)\`, Stripe idempotency keys, create-or-get).

**@pikku/queue-bullmq**
- \`mapPikkuJobToBull\` now maps \`backoff\` (previously dropped → a step's backoff silently never applied on Redis).
- \`registerQueues\` throws a clear "logger required" error instead of a raw \`TypeError\` (matches queue-pg-boss).

## Tests
- core: canonical RFC 4122 v5 vector for \`uuidv5\`, \`deriveInvocationId\` determinism, \`resolveStepJobOptions\` matrix, and \`invocationId\` stable across a real retry (with per-attempt \`stepId\` changing).
- queue-pg-boss / queue-bullmq: option-mapping unit tests, and wired \`test\` scripts into both package.json (their tests were never run in CI).

All green: core 1012 pass / 0 fail, pg-boss 7/7, bullmq 6/6.

## Follow-up (not in this PR)
Per-invocation **ordinals** so the *same* \`stepName\` can be called multiple times in one run without the \`runId:stepName\` map-key clobber (would extend \`invocationId\` to \`uuidv5(runId:stepName:ordinal)\` and needs store changes). Design notes in fabric \`docs/workflow-retry-idempotency.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Paraglide enum lookup generation, including a CLI and Vite integration.
  * Improved workflow retries with stable invocation IDs for repeatable step execution.
* **Bug Fixes**
  * Fixed infinite queries so pagination continues correctly instead of refetching the first page.
  * Better-auth session errors now surface properly instead of being hidden.
  * Auth handlers are no longer misidentified by the linter.
  * Default Fabric API URL now points to the hosted service.
* **Documentation**
  * Updated skill guidance and Fabric validation checks for scaffolding and ignored generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->