### PR TITLE
Feat/workflow retry invocation

### DIFF
--- a/.changeset/workflow-retry-invocation-id.md
+++ b/.changeset/workflow-retry-invocation-id.md
@@ -2,6 +2,10 @@
 '@pikku/core': patch
 '@pikku/queue-pg-boss': patch
 '@pikku/queue-bullmq': patch
+'@pikku/kysely': patch
+'@pikku/redis': patch
+'@pikku/mongodb': patch
+'@pikku/cloudflare': patch
 ---
 
 feat(workflow): workflow-owned step retries + stable invocationId
@@ -44,3 +48,19 @@ invocation gets a stable idempotency key.
   keeps the bare name, so existing rows, graph-node matching and `invocationId`s
   are unchanged. Ordinals are derived deterministically from DSL execution order
   and reset each replay.
+- **Step provenance (`fromStepName`) + graph cycles.** Every step now records
+  the predecessor it was scheduled from (`fromStepName`; entry steps have none),
+  persisted on the step row across all stores (in-memory, kysely, redis,
+  mongodb, cloudflare DO) and carried in the queued payload. The DSL wire
+  exposes the derived `fromInvocationId` (`uuidv5(runId:fromStepName)`) so
+  consumers get the stable predecessor key without a second persisted id —
+  `fromStepName` is the source of truth (it is replay-deterministic; `stepId`,
+  minted per row, is not). This makes the walked path reconstructable even when
+  a node is reached more than once: in `a → b → a → c` the second `a` is a
+  distinct ordinal instance (`a#1`) whose `fromStepName` is `b`.
+  The graph runner now supports **cycles**: a forward edge into an
+  already-started node still collapses to a single run (joins/diamonds are
+  unchanged), but a *back-edge* — one whose target can reach its source — fires
+  a fresh ordinal instance, so a node can loop back to itself. Termination is
+  the graph's responsibility (branch routing must converge); the engine enforces
+  no visit cap.

--- a/.changeset/workflow-retry-invocation-id.md
+++ b/.changeset/workflow-retry-invocation-id.md
@@ -37,3 +37,10 @@ invocation gets a stable idempotency key.
   than the whole run being marked `failed`. The orchestrator job now also
   carries its own retry policy, so this holds even when the orchestrator queue
   is configured `retry_limit 0`. A genuine step error still fails the run.
+- **Same step name can be invoked multiple times in one run.** Step rows are now
+  keyed per *invocation*: the Nth reach of a step name in a replay resolves to a
+  physical key (`name` for the first, `name#N` for repeats), so a literal
+  duplicate name no longer clobbers the earlier step's state. The first reach
+  keeps the bare name, so existing rows, graph-node matching and `invocationId`s
+  are unchanged. Ordinals are derived deterministically from DSL execution order
+  and reset each replay.

--- a/.changeset/workflow-retry-invocation-id.md
+++ b/.changeset/workflow-retry-invocation-id.md
@@ -26,3 +26,14 @@ invocation gets a stable idempotency key.
 - **queue-bullmq**: `mapPikkuJobToBull` now maps `backoff` (previously dropped,
   so a step's backoff silently never applied on Redis), and `registerQueues`
   throws a clear error when no logger is available (matching queue-pg-boss).
+- **Dispatch failures are recoverable, not fatal.** A step is now marked
+  `scheduled` only *after* it is successfully handed to its transport (queue or
+  scheduler) — a failed hand-off leaves it `pending` so a replay re-dispatches
+  it, instead of stranding it in `scheduled` (replay would pause forever on a
+  job that was never enqueued). A transport outage (e.g. pg-boss momentarily
+  down) is surfaced as a new `WorkflowDispatchException`, which the orchestrator
+  treats as transient: the run is left running and the orchestrator job is
+  rethrown for redelivery (it replays idempotently from the snapshot) rather
+  than the whole run being marked `failed`. The orchestrator job now also
+  carries its own retry policy, so this holds even when the orchestrator queue
+  is configured `retry_limit 0`. A genuine step error still fails the run.

--- a/packages/core/src/services/in-memory-workflow-service.ts
+++ b/packages/core/src/services/in-memory-workflow-service.ts
@@ -7,6 +7,7 @@ import type {
   WorkflowRunService,
   WorkflowRunWire,
   StepState,
+  StepStatus,
   WorkflowStatus,
   WorkflowVersionStatus,
   WorkflowStepOptions,
@@ -140,7 +141,8 @@ export class InMemoryWorkflowService
     stepName: string,
     rpcName: string | null,
     data: any,
-    stepOptions?: WorkflowStepOptions
+    stepOptions?: WorkflowStepOptions,
+    fromStepName?: string
   ): Promise<StepState> {
     const stepId = randomUUID()
     const now = new Date()
@@ -151,6 +153,7 @@ export class InMemoryWorkflowService
       attemptCount: 1,
       retries: stepOptions?.retries,
       retryDelay: stepOptions?.retryDelay,
+      fromStepName,
       createdAt: now,
       updatedAt: now,
       stepName,
@@ -281,6 +284,7 @@ export class InMemoryWorkflowService
       attemptCount: failedStep.attemptCount + 1,
       retries: failedStep.retries,
       retryDelay: failedStep.retryDelay,
+      fromStepName: failedStep.fromStepName,
       createdAt: now,
       updatedAt: now,
       stepName: stepName,
@@ -443,6 +447,26 @@ export class InMemoryWorkflowService
       }
     }
     return nodeIds.filter((id) => !existingSteps.has(id))
+  }
+
+  async getStepInstances(runId: string): Promise<
+    Array<{ stepName: string; status: StepStatus; fromStepName?: string }>
+  > {
+    const prefix = `${runId}:`
+    const instances: Array<{
+      stepName: string
+      status: StepStatus
+      fromStepName?: string
+    }> = []
+    for (const [key, step] of this.steps.entries()) {
+      if (!key.startsWith(prefix)) continue
+      instances.push({
+        stepName: key.substring(prefix.length),
+        status: step.status,
+        fromStepName: step.fromStepName,
+      })
+    }
+    return instances
   }
 
   async getNodeResults(

--- a/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
+++ b/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
@@ -311,6 +311,12 @@ export interface WorkflowStepWire {
   invocationId: string
   /** Current attempt number (1-indexed, increments on retry) */
   attemptCount: number
+  /**
+   * Invocation ID of the predecessor step this one was reached from (the walked
+   * transition/edge). Undefined for entry steps. Lets a step know its origin —
+   * e.g. in a cyclic graph `a → b → a → c`, the second `a` carries `b`'s id.
+   */
+  fromInvocationId?: string
 }
 
 /**

--- a/packages/core/src/wirings/workflow/graph/graph-runner.test.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.test.ts
@@ -241,6 +241,84 @@ describe('graph-runner bugs', () => {
     assert.deepEqual(queuedNodes, ['c'])
   })
 
+  test('continueGraph revisits a cyclic node and records the walked path via fromStepName', async () => {
+    const ws = new InMemoryWorkflowService()
+    const queued: Array<{ stepName: string; fromStepName?: string }> = []
+
+    pikkuState(null, 'package', 'singletonServices', {
+      queueService: {
+        add: async (_queueName: string, data: any) => {
+          if (data?.stepName) {
+            queued.push({
+              stepName: data.stepName,
+              fromStepName: data.fromStepName,
+            })
+          }
+        },
+      },
+    } as any)
+
+    // start → a, where a loops back through b once, then exits to c:
+    //   start → a --retry--> b → a --done--> c
+    const meta: WorkflowRuntimeMeta = {
+      name: 'testCyclicGraph',
+      pikkuFuncId: 'testCyclicGraph',
+      source: 'graph',
+      entryNodeIds: ['start'],
+      graphHash: 'cyclic-hash',
+      nodes: {
+        start: { nodeId: 'start', rpcName: 'doStart', next: 'a' },
+        a: { nodeId: 'a', rpcName: 'doA', next: { retry: 'b', done: 'c' } },
+        b: { nodeId: 'b', rpcName: 'doB', next: 'a' },
+        c: { nodeId: 'c', rpcName: 'doC' },
+      },
+    }
+
+    const runId = await ws.createRun('testCyclicGraph', {}, false, 'cyclic-hash', {
+      type: 'test',
+    })
+
+    // Succeed a queued step (taking an optional branch), then advance the graph.
+    const advance = async (stepName: string, branch?: string) => {
+      const step = await ws.getStepState(runId, stepName)
+      await ws.setStepRunning(step.stepId)
+      if (branch) await ws.setBranchTaken(step.stepId, branch)
+      await ws.setStepResult(step.stepId, { ok: true })
+      await continueGraph(ws, runId, 'testCyclicGraph', meta)
+    }
+
+    await continueGraph(ws, runId, 'testCyclicGraph', meta) // fire entry
+    await advance('start')
+    await advance('a', 'retry') // a → b (b reaches a, but first visit ⇒ bare 'b')
+    await advance('b') // b → a revisit ⇒ a#1
+    await advance('a#1', 'done') // a#1 → c (forward edge, terminal)
+    await advance('c')
+
+    // Each step records the predecessor it was reached from; the cyclic
+    // revisit is a fresh ordinal instance (a#1) with its own provenance.
+    assert.deepEqual(queued, [
+      { stepName: 'start', fromStepName: undefined },
+      { stepName: 'a', fromStepName: 'start' },
+      { stepName: 'b', fromStepName: 'a' },
+      { stepName: 'a#1', fromStepName: 'b' },
+      { stepName: 'c', fromStepName: 'a#1' },
+    ])
+
+    const run = await ws.getRun(runId)
+    assert.equal(run?.status, 'completed')
+
+    // Reconstruct the walked path purely from the fromStepName chain.
+    const instances = await ws.getStepInstances(runId)
+    const from = new Map(instances.map((i) => [i.stepName, i.fromStepName]))
+    const path: string[] = []
+    let cursor: string | undefined = 'c'
+    while (cursor) {
+      path.unshift(cursor)
+      cursor = from.get(cursor) ?? undefined
+    }
+    assert.deepEqual(path, ['start', 'a', 'b', 'a#1', 'c'])
+  })
+
   test('inline graph should execute converging next node only once', async () => {
     const ws = new InMemoryWorkflowService()
     let cCalls = 0

--- a/packages/core/src/wirings/workflow/graph/graph-runner.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.ts
@@ -29,6 +29,13 @@ function buildTemplateRegex(nodeId: string): RegExp | null {
   return new RegExp(`^${escaped}$`)
 }
 
+/** Strip a trailing revisit ordinal (`node#2` → `node`); leaves other names as-is. */
+function stripInstanceOrdinal(name: string): string {
+  const hash = name.lastIndexOf('#')
+  if (hash <= 0) return name
+  return /^\d+$/.test(name.slice(hash + 1)) ? name.slice(0, hash) : name
+}
+
 function remapStepNamesToNodeIds(
   stepNames: string[],
   nodes: Record<string, any>,
@@ -39,12 +46,14 @@ function remapStepNamesToNodeIds(
     const regex = buildTemplateRegex(nodeId)
     if (regex) templatePatterns.set(nodeId, regex)
   }
-  if (templatePatterns.size === 0) return stepNames
   return stepNames.map((name) => {
     if (nodes[name]) return name
+    // Revisit instance (`node#N`) maps to its logical node.
+    const base = stripInstanceOrdinal(name)
+    if (base !== name && nodes[base]) return base
     const matches: string[] = []
     for (const [nodeId, regex] of templatePatterns) {
-      if (regex.test(name)) matches.push(nodeId)
+      if (regex.test(base)) matches.push(nodeId)
     }
     if (matches.length > 1) {
       throw new Error(
@@ -56,6 +65,122 @@ function remapStepNamesToNodeIds(
     }
     return name
   })
+}
+
+const ENTRY_FROM = '__entry__'
+
+/** Whether `target` can reach `source` over `next` edges — i.e. an edge
+ *  source→target closes a cycle (a back-edge), vs a plain forward edge. */
+function closesCycle(
+  source: string,
+  target: string,
+  nodes: Record<string, any>
+): boolean {
+  const seen = new Set<string>()
+  const stack = [target]
+  while (stack.length) {
+    const cur = stack.pop()!
+    if (cur === source) return true
+    if (seen.has(cur)) continue
+    seen.add(cur)
+    for (const next of normalizeNodeTargets(nodes[cur]?.next)) stack.push(next)
+  }
+  return false
+}
+
+/**
+ * Decide which next steps to fire this tick. Two kinds of edge:
+ *  - forward edge → node-once: fire the target only if it has no instance yet,
+ *    so converging edges (joins) collapse to a single run (unchanged behavior).
+ *  - back-edge (target can reach the source, closing a cycle) → revisit: fire a
+ *    fresh ordinal instance (`target#1`, …), edge-once on `from → target` so it
+ *    doesn't re-fire every tick. Cycles terminate when branch routing stops
+ *    looping back; a node always records the predecessor it was reached from.
+ */
+function planGraphTransitions(
+  nodes: Record<string, any>,
+  instances: Array<{ stepName: string; status: string; fromStepName?: string }>,
+  branchByStep: Record<string, string>,
+  entryNodeIds: string[],
+  graphName: string
+): {
+  toFire: Array<{ logical: string; instanceKey: string; fromStepName?: string }>
+  hasInFlight: boolean
+  blockedWaiting: boolean
+} {
+  const toLogical = (name: string) =>
+    remapStepNamesToNodeIds([name], nodes, graphName)[0]!
+
+  const countByLogical: Record<string, number> = {}
+  const consumed = new Set<string>()
+  for (const inst of instances) {
+    const logical = toLogical(inst.stepName)
+    countByLogical[logical] = (countByLogical[logical] ?? 0) + 1
+    consumed.add(`${inst.fromStepName ?? ENTRY_FROM}->${logical}`)
+  }
+
+  const completed = instances.filter((i) => i.status === 'succeeded')
+  const completedLogical = new Set(completed.map((i) => toLogical(i.stepName)))
+
+  // Available edges: entry edges + each completed instance's resolved `next`.
+  const edges: Array<{
+    from?: string
+    fromKey: string
+    fromLogical?: string
+    target: string
+  }> = []
+  for (const entryId of entryNodeIds) {
+    edges.push({ fromKey: ENTRY_FROM, target: entryId })
+  }
+  for (const inst of completed) {
+    const fromLogical = toLogical(inst.stepName)
+    const node = nodes[fromLogical]
+    if (!node?.next) continue
+    for (const target of resolveNextFromConfig(
+      node.next,
+      branchByStep[inst.stepName]
+    )) {
+      edges.push({ from: inst.stepName, fromKey: inst.stepName, fromLogical, target })
+    }
+  }
+
+  const toFire: Array<{
+    logical: string
+    instanceKey: string
+    fromStepName?: string
+  }> = []
+  let blockedWaiting = false
+  for (const edge of edges) {
+    const target = edge.target
+    const edgeKey = `${edge.fromKey}->${target}`
+    if (consumed.has(edgeKey)) continue
+    const visits = countByLogical[target] ?? 0
+    const isBackEdge =
+      edge.fromLogical !== undefined &&
+      closesCycle(edge.fromLogical, target, nodes)
+    // Forward edge into an already-started node = a join; node-once.
+    if (!isBackEdge && visits > 0) {
+      consumed.add(edgeKey)
+      continue
+    }
+    if (!areDependenciesSatisfied(nodes[target] ?? {}, completedLogical)) {
+      blockedWaiting = true
+      continue
+    }
+    toFire.push({
+      logical: target,
+      instanceKey: visits === 0 ? target : `${target}#${visits}`,
+      fromStepName: edge.from,
+    })
+    countByLogical[target] = visits + 1
+    consumed.add(edgeKey)
+  }
+
+  return {
+    toFire,
+    hasInFlight: instances.some((i) => i.status !== 'succeeded'),
+    blockedWaiting,
+  }
 }
 
 function remapBranchKeys(
@@ -326,7 +451,8 @@ async function queueGraphNode(
   nodeId: string,
   rpcName: string,
   input: any,
-  nodeConfig?: { retries?: number; retryDelay?: string | number }
+  nodeConfig?: { retries?: number; retryDelay?: string | number },
+  fromStepName?: string
 ): Promise<void> {
   // Default to the workflow-wide retry policy when the node sets none, so the
   // persisted step retries match the queue `attempts` (see resolveStepJobOptions).
@@ -339,14 +465,16 @@ async function queueGraphNode(
     nodeId,
     rpcName,
     input,
-    stepOptions
+    stepOptions,
+    fromStepName
   )
   await workflowService.queueStepWorker(
     runId,
     nodeId,
     rpcName,
     input,
-    stepOptions
+    stepOptions,
+    fromStepName
   )
 }
 
@@ -367,16 +495,13 @@ export async function continueGraph(
   const {
     completedNodeIds: rawCompleted,
     failedNodeIds: rawFailed,
-    branchKeys: rawBranch,
+    branchKeys: branchByStep,
   } = await workflowService.getCompletedGraphState(runId)
-  const completedNodeIds = remapStepNamesToNodeIds(
-    rawCompleted,
-    nodes,
-    graphName
-  )
-  const completedNodeIdSet = new Set(completedNodeIds)
+  // Validate step/branch names map to unambiguous nodes (planning keys
+  // physically; these calls only surface ambiguous template configs).
+  remapStepNamesToNodeIds(rawCompleted, nodes, graphName)
+  remapBranchKeys(branchByStep, nodes, graphName)
   const failedNodeIds = remapStepNamesToNodeIds(rawFailed, nodes, graphName)
-  const branchKeys = remapBranchKeys(rawBranch, nodes, graphName)
 
   if (failedNodeIds.length > 0) {
     const failedNode = failedNodeIds[0]!
@@ -393,44 +518,18 @@ export async function continueGraph(
     return
   }
 
-  const candidateNodes = new Set<string>()
+  const instances = await workflowService.getStepInstances(runId)
+  const plan = planGraphTransitions(
+    nodes,
+    instances,
+    branchByStep,
+    meta.entryNodeIds ?? [],
+    graphName
+  )
 
-  for (const nodeId of completedNodeIds) {
-    const node = nodes[nodeId]
-    if (!node?.next) continue
-
-    const nextNodes = resolveNextFromConfig(node.next, branchKeys[nodeId])
-    for (const nextNode of nextNodes) {
-      candidateNodes.add(nextNode)
-    }
-  }
-
-  for (const entryId of meta.entryNodeIds ?? []) {
-    candidateNodes.add(entryId)
-  }
-
-  if (candidateNodes.size === 0 && completedNodeIds.length > 0) {
-    await workflowService.updateRunStatus(runId, 'completed')
-    return
-  }
-
-  const unstartedNodes = await workflowService.getNodesWithoutSteps(runId, [
-    ...candidateNodes,
-  ])
-
-  const nodesToQueue = unstartedNodes.filter((nodeId) => {
-    const node = nodes[nodeId]
-    return node && areDependenciesSatisfied(node, completedNodeIdSet)
-  })
-
-  if (nodesToQueue.length === 0) {
-    const allRpcNodes = Object.entries(nodes)
-      .filter(([_, n]) => n.rpcName)
-      .map(([id]) => id)
-    const allRpcCompleted = allRpcNodes.every((id) =>
-      completedNodeIdSet.has(id)
-    )
-    if (allRpcCompleted) {
+  if (plan.toFire.length === 0) {
+    // Nothing left to fire and nothing running/blocked → the run is done.
+    if (!plan.hasInFlight && !plan.blockedWaiting) {
       await workflowService.updateRunStatus(runId, 'completed')
     }
     return
@@ -439,8 +538,8 @@ export async function continueGraph(
   const run = await workflowService.getRun(runId)
   const triggerInput = run?.input
 
-  for (const nodeId of nodesToQueue) {
-    const node = nodes[nodeId]
+  for (const fire of plan.toFire) {
+    const node = nodes[fire.logical]
     if (!node?.rpcName) continue
 
     const referencedNodeIds = extractReferencedNodeIds(node.input).filter(
@@ -450,7 +549,6 @@ export async function continueGraph(
       runId,
       referencedNodeIds
     )
-
     const nodeResults = { trigger: triggerInput, ...fetchedResults }
     const resolvedInput = resolveSerializedInput(node.input, nodeResults)
 
@@ -458,10 +556,11 @@ export async function continueGraph(
       workflowService,
       runId,
       graphName,
-      nodeId,
+      fire.instanceKey,
       node.rpcName,
       resolvedInput,
-      node
+      node,
+      fire.fromStepName
     )
   }
 }

--- a/packages/core/src/wirings/workflow/index.ts
+++ b/packages/core/src/wirings/workflow/index.ts
@@ -5,6 +5,7 @@ export {
   PikkuWorkflowService,
   WorkflowCancelledException,
   WorkflowSuspendedException,
+  WorkflowDispatchException,
   WorkflowNotFoundError,
   WorkflowRunNotFoundError,
   DEFAULT_STEP_RETRIES,

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -501,14 +501,16 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepName: string,
     rpcName: string | null,
     data: any,
-    stepOptions?: WorkflowStepOptions
+    stepOptions?: WorkflowStepOptions,
+    fromStepName?: string
   ): Promise<StepState> {
     const step = await this.insertStepStateImpl(
       runId,
       stepName,
       rpcName,
       data,
-      stepOptions
+      stepOptions,
+      fromStepName
     )
     await this.safeMirror(() =>
       this.mirror!.insertStepState(runId, { ...step, stepName, rpcName, data })
@@ -521,7 +523,8 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepName: string,
     rpcName: string | null,
     data: any,
-    stepOptions?: WorkflowStepOptions
+    stepOptions?: WorkflowStepOptions,
+    fromStepName?: string
   ): Promise<StepState>
 
   /**
@@ -694,6 +697,20 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   ): Promise<string[]>
 
   /**
+   * List every step instance of a run (any status) with its predecessor.
+   * Drives bounded graph revisits: the runner counts instances per logical node
+   * and treats each `fromStepName → node` as a once-fired transition.
+   * @param runId - Run ID
+   */
+  abstract getStepInstances(runId: string): Promise<
+    Array<{
+      stepName: string
+      status: StepStatus
+      fromStepName?: string
+    }>
+  >
+
+  /**
    * Get results for specific nodes
    * @param runId - Run ID
    * @param nodeIds - Node IDs to fetch results for
@@ -857,12 +874,13 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepName: string,
     rpcName: string,
     data: any,
-    stepOptions?: WorkflowStepOptions
+    stepOptions?: WorkflowStepOptions,
+    fromStepName?: string
   ): Promise<void> {
     const queueService = this.verifyQueueService()
     await queueService.add(
       this.getStepWorkerQueueName(rpcName),
-      JSON.parse(JSON.stringify({ runId, stepName, rpcName, data })),
+      JSON.parse(JSON.stringify({ runId, stepName, rpcName, data, fromStepName })),
       this.resolveStepJobOptions(stepOptions)
     )
   }
@@ -921,7 +939,8 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepName: string,
     rpcName: string,
     data: unknown,
-    stepOptions?: WorkflowStepOptions
+    stepOptions?: WorkflowStepOptions,
+    fromStepName?: string
   ): Promise<boolean> {
     // Step execution is decided purely by the function's `inline` flag (default
     // true). Only a function explicitly marked `inline: false` dispatches via
@@ -950,7 +969,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     try {
       await getSingletonServices()!.queueService!.add(
         this.getStepWorkerQueueName(rpcName),
-        JSON.parse(JSON.stringify({ runId, stepName, rpcName, data })),
+        JSON.parse(
+          JSON.stringify({ runId, stepName, rpcName, data, fromStepName })
+        ),
         this.resolveStepJobOptions(stepOptions)
       )
     } catch (cause) {
@@ -1136,9 +1157,18 @@ export abstract class PikkuWorkflowService implements WorkflowService {
 
   // Per-run, per-replay ordinal counters (runId → stepName → count).
   private stepOrdinals = new Map<string, Map<string, number>>()
+  // Previous step key reached in the current DSL walk (runId → stepName), so a
+  // new step records where it came from. Rebuilt each replay alongside ordinals.
+  private stepLineage = new Map<string, string>()
 
   private resetStepOrdinals(runId: string): void {
     this.stepOrdinals.set(runId, new Map())
+    this.stepLineage.delete(runId)
+  }
+
+  /** The step the DSL walk last reached (the predecessor for the next step). */
+  private lastStepName(runId: string): string | undefined {
+    return this.stepLineage.get(runId)
   }
 
   /**
@@ -1155,7 +1185,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     }
     const ordinal = perRun.get(logicalStepName) ?? 0
     perRun.set(logicalStepName, ordinal + 1)
-    return ordinal === 0 ? logicalStepName : `${logicalStepName}#${ordinal}`
+    const stepName =
+      ordinal === 0 ? logicalStepName : `${logicalStepName}#${ordinal}`
+    this.stepLineage.set(runId, stepName)
+    return stepName
   }
 
   public async runWorkflowJob(runId: string, rpcService: any): Promise<void> {
@@ -1414,17 +1447,25 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         const isGraphWorkflow =
           workflowMeta?.source === 'graph' ||
           workflowMeta?.source === 'dynamic-workflow'
-        if (
-          isGraphWorkflow &&
-          workflowMeta?.nodes &&
-          stepName in workflowMeta.nodes
-        ) {
+        // Map the physical step key back to its logical node: a revisit instance
+        // is `node#N` (ordinal), which isn't a literal key in `nodes`.
+        let graphNodeId: string | undefined
+        if (isGraphWorkflow && workflowMeta?.nodes) {
+          if (stepName in workflowMeta.nodes) {
+            graphNodeId = stepName
+          } else {
+            const hash = stepName.lastIndexOf('#')
+            const base = hash > 0 ? stepName.slice(0, hash) : undefined
+            if (base && base in workflowMeta.nodes) graphNodeId = base
+          }
+        }
+        if (graphNodeId) {
           result = await executeGraphStep(
             this,
             rpcService,
             runId,
             stepState.stepId,
-            stepName,
+            graphNodeId,
             rpcName,
             data,
             run.workflow
@@ -1474,6 +1515,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
                 stepId: stepState.stepId,
                 invocationId: deriveInvocationId(runId, stepName),
                 attemptCount: stepState.attemptCount,
+                fromInvocationId: stepState.fromStepName
+                  ? deriveInvocationId(runId, stepState.fromStepName)
+                  : undefined,
               },
             })
           }
@@ -1577,6 +1621,8 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     rpcService: any,
     stepOptions?: WorkflowStepOptions
   ): Promise<any> {
+    // Capture the predecessor before nextStepKey advances the lineage to us.
+    const fromStepName = this.lastStepName(runId)
     const stepName = this.nextStepKey(runId, logicalStepName)
     // Resolve the retry policy ONCE here so the value persisted on the step
     // (which drives `retriesExhausted`) is the same one the queue dispatch turns
@@ -1597,7 +1643,8 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         stepName,
         rpcName,
         data,
-        resolvedStepOptions
+        resolvedStepOptions,
+        fromStepName
       )
     }
 
@@ -1636,7 +1683,8 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       stepName,
       rpcName,
       data,
-      resolvedStepOptions
+      resolvedStepOptions,
+      fromStepName
     )
     if (dispatched) {
       await this.setStepScheduled(stepState.stepId)
@@ -1697,6 +1745,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
                 stepId: currentStepState.stepId,
                 invocationId: deriveInvocationId(runId, stepName),
                 attemptCount: currentStepState.attemptCount,
+                fromInvocationId: currentStepState.fromStepName
+                  ? deriveInvocationId(runId, currentStepState.fromStepName)
+                  : undefined,
               },
             })
           }
@@ -1744,6 +1795,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     fn: Function,
     stepOptions?: WorkflowStepOptions
   ): Promise<any> {
+    const fromStepName = this.lastStepName(runId)
     const stepName = this.nextStepKey(runId, logicalStepName)
     // Check if step already exists
     let stepState: StepState
@@ -1756,7 +1808,8 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         stepName,
         null,
         null,
-        stepOptions
+        stepOptions,
+        fromStepName
       )
     }
 
@@ -1838,6 +1891,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     logicalStepName: string,
     duration: number
   ) {
+    const fromStepName = this.lastStepName(runId)
     const stepName = this.nextStepKey(runId, logicalStepName)
     // Check if step already exists
     let stepState: StepState
@@ -1845,9 +1899,14 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       stepState = await this.getStepState(runId, stepName)
     } catch {
       // Step doesn't exist - create it (sleep step, no RPC)
-      stepState = await this.insertStepState(runId, stepName, null, {
-        duration,
-      })
+      stepState = await this.insertStepState(
+        runId,
+        stepName,
+        null,
+        { duration },
+        undefined,
+        fromStepName
+      )
     }
 
     if (stepState.status === 'succeeded') {
@@ -1899,6 +1958,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   }
 
   private async suspendStep(runId: string, reason: string): Promise<void> {
+    const fromStepName = this.lastStepName(runId)
     const suspendStepName = this.nextStepKey(
       runId,
       this.getSuspendStepName(reason)
@@ -1914,7 +1974,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
           'pikkuWorkflowSuspend',
           {
             reason,
-          }
+          },
+          undefined,
+          fromStepName
         )
       }
       if (!stepState.stepId) {
@@ -1924,7 +1986,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
           'pikkuWorkflowSuspend',
           {
             reason,
-          }
+          },
+          undefined,
+          fromStepName
         )
       }
 

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -121,6 +121,25 @@ export class WorkflowSuspendedException extends Error {
 }
 
 /**
+ * Thrown when a step (or the orchestrator) could not be enqueued — the queue
+ * itself failed (e.g. pg-boss is momentarily down), NOT the step's own logic.
+ * This is transient infrastructure failure: the run is left untouched (the step
+ * stays `pending`, the run stays running) and the orchestrator job is rethrown
+ * so the queue redelivers it and the workflow replays from its snapshot. Treat
+ * it as non-terminal — never mark the run `failed` for it.
+ */
+export class WorkflowDispatchException extends Error {
+  constructor(
+    public readonly runId: string,
+    public readonly stepName: string,
+    options?: { cause?: unknown }
+  ) {
+    super(`Failed to dispatch workflow step '${stepName}' (run ${runId})`, options)
+    this.name = 'WorkflowDispatchException'
+  }
+}
+
+/**
  * Error class for workflow not found
  */
 export class WorkflowNotFoundError extends PikkuError {
@@ -795,9 +814,17 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       const run = await this.getRun(runId)
       workflowName = run?.workflow
     }
-    await queueService.add(this.getOrchestratorQueueName(workflowName), {
-      runId,
-    })
+    // Carry an explicit retry policy on the orchestrator job too. Orchestrator
+    // runs are idempotent (they replay from the snapshot, returning cached step
+    // results), so redelivery is always safe — and it's what lets a transient
+    // dispatch/infra failure recover: the job is rethrown and retried instead of
+    // the run hanging. Passing `attempts` per-job overrides the queue default, so
+    // this holds even when the orchestrator queue is configured `retry_limit 0`.
+    await queueService.add(
+      this.getOrchestratorQueueName(workflowName),
+      { runId },
+      this.resolveStepJobOptions()
+    )
   }
 
   /**
@@ -920,11 +947,19 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       )
       return false
     }
-    await getSingletonServices()!.queueService!.add(
-      this.getStepWorkerQueueName(rpcName),
-      JSON.parse(JSON.stringify({ runId, stepName, rpcName, data })),
-      this.resolveStepJobOptions(stepOptions)
-    )
+    try {
+      await getSingletonServices()!.queueService!.add(
+        this.getStepWorkerQueueName(rpcName),
+        JSON.parse(JSON.stringify({ runId, stepName, rpcName, data })),
+        this.resolveStepJobOptions(stepOptions)
+      )
+    } catch (cause) {
+      // The queue is down/unreachable — NOT a step failure. Surface it as a
+      // transient dispatch error so the caller leaves the step `pending` and the
+      // orchestrator job is retried (replayed from snapshot) rather than the run
+      // being marked failed. `add` already throws on failure in every adapter.
+      throw new WorkflowDispatchException(runId, stepName, { cause })
+    }
     return true
   }
 
@@ -1037,7 +1072,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         if (
           error.name !== 'WorkflowAsyncException' &&
           error.name !== 'WorkflowCancelledException' &&
-          error.name !== 'WorkflowSuspendedException'
+          error.name !== 'WorkflowSuspendedException' &&
+          // Transient queue failure — leave the run resumable, don't fail it.
+          error.name !== 'WorkflowDispatchException'
         ) {
           await this.updateRunStatus(runId, 'failed', undefined, {
             name: error.name,
@@ -1048,6 +1085,11 @@ export abstract class PikkuWorkflowService implements WorkflowService {
             `Workflow ${name} (run ${runId}) failed:`,
             error
           )
+          throw error
+        }
+        if (error.name === 'WorkflowDispatchException') {
+          // Rethrow so the caller (poll loop / starter) sees the transient
+          // failure; the run stays running and can be resumed.
           throw error
         }
       } finally {
@@ -1459,6 +1501,17 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         return
       }
 
+      if (error.name === 'WorkflowDispatchException') {
+        // Transient: the queue was unreachable, not a workflow failure. Leave the
+        // run running and rethrow so the orchestrator job is redelivered and the
+        // workflow replays from its snapshot. Do NOT mark the run failed.
+        getSingletonServices()!.logger.warn(
+          `Workflow run ${runId} could not dispatch a step (queue unavailable); leaving run for orchestrator retry`,
+          error
+        )
+        throw error
+      }
+
       await this.updateRunStatus(runId, 'failed', undefined, {
         message: error.message,
         stack: error.stack,
@@ -1533,11 +1586,13 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       throw new WorkflowAsyncException(runId, stepName)
     }
 
-    // Step is pending - schedule it
-    await this.setStepScheduled(stepState.stepId)
-
     // Hand off to subclass-overridable transport. Default behavior enqueues
     // via the queue service; DO-style subclasses RPC to a step worker.
+    // Dispatch BEFORE marking the step `scheduled`: if the queue is down,
+    // dispatchStep throws WorkflowDispatchException and the step stays `pending`,
+    // so the orchestrator's next replay re-dispatches it. Marking `scheduled`
+    // first would strand the step (replay sees `scheduled`, pauses, never
+    // re-enqueues the job that was never created).
     const dispatched = await this.dispatchStep(
       runId,
       stepName,
@@ -1546,6 +1601,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       resolvedStepOptions
     )
     if (dispatched) {
+      await this.setStepScheduled(stepState.stepId)
       throw new WorkflowAsyncException(runId, stepName)
     }
 
@@ -1760,18 +1816,19 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       throw new WorkflowAsyncException(runId, stepName)
     }
 
-    // Step is pending - schedule it
-    await this.setStepScheduled(stepState.stepId)
-
     // Hand off to subclass-overridable transport. Default behavior schedules
     // a delayed sleeper RPC via the scheduler service; DO-style subclasses
-    // override to use native timer primitives (e.g. setAlarm).
-    const scheduled = await this.scheduleSleep(
-      runId,
-      stepState.stepId,
-      duration
-    )
+    // override to use native timer primitives (e.g. setAlarm). Schedule BEFORE
+    // marking `scheduled` so a scheduler outage leaves the step `pending` for
+    // re-scheduling on replay instead of stranding it (see rpcStep).
+    let scheduled: boolean
+    try {
+      scheduled = await this.scheduleSleep(runId, stepState.stepId, duration)
+    } catch (cause) {
+      throw new WorkflowDispatchException(runId, stepName, { cause })
+    }
     if (scheduled) {
+      await this.setStepScheduled(stepState.stepId)
       throw new WorkflowAsyncException(runId, stepName)
     }
 

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -1134,7 +1134,44 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     }
   }
 
+  // Per-run, per-replay ordinal counters (runId → stepName → count).
+  private stepOrdinals = new Map<string, Map<string, number>>()
+
+  private resetStepOrdinals(runId: string): void {
+    this.stepOrdinals.set(runId, new Map())
+  }
+
+  /**
+   * Physical, replay-stable key for the Nth reach of `logicalStepName` in a run:
+   * bare name for the first reach (ordinal 0, unchanged behavior), `name#N` for
+   * repeats — so the same literal step name can be invoked multiple times without
+   * the rows clobbering. Deterministic given a deterministic DSL body.
+   */
+  private nextStepKey(runId: string, logicalStepName: string): string {
+    let perRun = this.stepOrdinals.get(runId)
+    if (!perRun) {
+      perRun = new Map()
+      this.stepOrdinals.set(runId, perRun)
+    }
+    const ordinal = perRun.get(logicalStepName) ?? 0
+    perRun.set(logicalStepName, ordinal + 1)
+    return ordinal === 0 ? logicalStepName : `${logicalStepName}#${ordinal}`
+  }
+
   public async runWorkflowJob(runId: string, rpcService: any): Promise<void> {
+    // Fresh ordinal counters per replay so step keys are deterministic.
+    this.resetStepOrdinals(runId)
+    try {
+      await this.runWorkflowJobInner(runId, rpcService)
+    } finally {
+      this.stepOrdinals.delete(runId)
+    }
+  }
+
+  private async runWorkflowJobInner(
+    runId: string,
+    rpcService: any
+  ): Promise<void> {
     const run = await this.getRun(runId)
     if (!run) {
       throw new WorkflowRunNotFoundError(runId)
@@ -1534,12 +1571,13 @@ export abstract class PikkuWorkflowService implements WorkflowService {
 
   private async rpcStep(
     runId: string,
-    stepName: string,
+    logicalStepName: string,
     rpcName: string,
     data: any,
     rpcService: any,
     stepOptions?: WorkflowStepOptions
   ): Promise<any> {
+    const stepName = this.nextStepKey(runId, logicalStepName)
     // Resolve the retry policy ONCE here so the value persisted on the step
     // (which drives `retriesExhausted`) is the same one the queue dispatch turns
     // into `attempts`. Without this the queue could retry N times while the
@@ -1702,10 +1740,11 @@ export abstract class PikkuWorkflowService implements WorkflowService {
 
   private async inlineStep(
     runId: string,
-    stepName: string,
+    logicalStepName: string,
     fn: Function,
     stepOptions?: WorkflowStepOptions
   ): Promise<any> {
+    const stepName = this.nextStepKey(runId, logicalStepName)
     // Check if step already exists
     let stepState: StepState
     try {
@@ -1794,7 +1833,12 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     }
   }
 
-  private async sleepStep(runId: string, stepName: string, duration: number) {
+  private async sleepStep(
+    runId: string,
+    logicalStepName: string,
+    duration: number
+  ) {
+    const stepName = this.nextStepKey(runId, logicalStepName)
     // Check if step already exists
     let stepState: StepState
     try {
@@ -1855,7 +1899,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   }
 
   private async suspendStep(runId: string, reason: string): Promise<void> {
-    const suspendStepName = this.getSuspendStepName(reason)
+    const suspendStepName = this.nextStepKey(
+      runId,
+      this.getSuspendStepName(reason)
+    )
     await this.withStepLock(runId, suspendStepName, async () => {
       let stepState: StepState
       try {

--- a/packages/core/src/wirings/workflow/workflow-dispatch-durability.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-dispatch-durability.test.ts
@@ -55,7 +55,10 @@ describe('dispatch durability: a transient queue failure is recoverable', () => 
     assert.notEqual(runAfterFail?.status, 'failed', 'run is not failed by a queue blip')
 
     // Queue recovers → replaying the step now dispatches (pauses via async exception)
-    // and the step transitions to `scheduled`.
+    // and the step transitions to `scheduled`. A real replay runs through
+    // runWorkflowJob which resets the ordinal counter; simulate that so the
+    // second reach resolves to the same step key, not the next ordinal.
+    ;(ws as any).resetStepOrdinals(runId)
     queueUp = true
     await assert.rejects(
       (ws as any).rpcStep(runId, 'thing', 'doThing', {}, {}),

--- a/packages/core/src/wirings/workflow/workflow-dispatch-durability.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-dispatch-durability.test.ts
@@ -1,0 +1,114 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState } from '../../pikku-state.js'
+import { WorkflowDispatchException } from './pikku-workflow-service.js'
+
+// Register an `inline: false` function so the workflow's `do()` routes the step
+// through the queue (dispatchStep) instead of running it inline.
+function registerDispatchedFn(rpcName: string): void {
+  const funcId = `fn:${rpcName}`
+  pikkuState(null, 'rpc', 'meta', { [rpcName]: funcId } as any)
+  pikkuState(null, 'function', 'meta', {
+    [funcId]: { inline: false },
+  } as any)
+}
+
+const silentLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+describe('dispatch durability: a transient queue failure is recoverable', () => {
+  test('failed dispatch leaves the step PENDING and the run un-failed, then re-dispatches on replay', async () => {
+    registerDispatchedFn('doThing')
+    let queueUp = false
+    pikkuState(null, 'package', 'singletonServices', {
+      queueService: {
+        add: async () => {
+          if (!queueUp) throw new Error('pg-boss is down')
+        },
+      },
+      logger: silentLogger,
+    } as any)
+
+    const ws = new InMemoryWorkflowService()
+    const runId = await ws.createRun('flow', {}, false, 'hash', { type: 'test' })
+    await ws.insertStepState(runId, 'thing', 'doThing', {})
+
+    // Queue is down → dispatch throws the TRANSIENT exception (not a step failure).
+    await assert.rejects(
+      (ws as any).rpcStep(runId, 'thing', 'doThing', {}, {}),
+      (err: any) => err instanceof WorkflowDispatchException,
+      'a queue outage surfaces as WorkflowDispatchException'
+    )
+
+    // The step must NOT be stranded in `scheduled` — otherwise replay would pause
+    // forever on a job that was never enqueued.
+    const afterFail = await ws.getStepState(runId, 'thing')
+    assert.equal(
+      afterFail.status,
+      'pending',
+      'step stays pending after a failed dispatch'
+    )
+
+    // The run itself must stay alive (not failed) — it is the snapshot we replay.
+    const runAfterFail = await ws.getRun(runId)
+    assert.notEqual(runAfterFail?.status, 'failed', 'run is not failed by a queue blip')
+
+    // Queue recovers → replaying the step now dispatches (pauses via async exception)
+    // and the step transitions to `scheduled`.
+    queueUp = true
+    await assert.rejects(
+      (ws as any).rpcStep(runId, 'thing', 'doThing', {}, {}),
+      (err: any) => err.name === 'WorkflowAsyncException',
+      'recovered dispatch pauses the workflow as normal'
+    )
+    const afterRecover = await ws.getStepState(runId, 'thing')
+    assert.equal(
+      afterRecover.status,
+      'scheduled',
+      'step is scheduled only after a successful dispatch'
+    )
+  })
+})
+
+describe('orchestrateWorkflow treats a dispatch failure as non-terminal', () => {
+  function makeService(throwIt: () => never) {
+    pikkuState(null, 'package', 'singletonServices', {
+      queueService: { add: async () => {} },
+      logger: silentLogger,
+    } as any)
+    const ws = new InMemoryWorkflowService()
+    // Override the replay to throw whatever the test wants.
+    ;(ws as any).runWorkflowJob = async () => throwIt()
+    return ws
+  }
+
+  test('WorkflowDispatchException → run NOT marked failed, error rethrown for queue retry', async () => {
+    const ws = makeService(() => {
+      throw new WorkflowDispatchException('r', 's')
+    })
+    const runId = await ws.createRun('flow', {}, false, 'hash', { type: 'test' })
+
+    await assert.rejects(
+      ws.orchestrateWorkflow(runId, {}),
+      (err: any) => err instanceof WorkflowDispatchException
+    )
+    const run = await ws.getRun(runId)
+    assert.notEqual(
+      run?.status,
+      'failed',
+      'a transient dispatch failure must leave the run resumable'
+    )
+  })
+
+  test('a genuine step error still fails the run (unchanged behavior)', async () => {
+    const ws = makeService(() => {
+      throw new Error('business logic blew up')
+    })
+    const runId = await ws.createRun('flow', {}, false, 'hash', { type: 'test' })
+
+    await assert.rejects(ws.orchestrateWorkflow(runId, {}))
+    const run = await ws.getRun(runId)
+    assert.equal(run?.status, 'failed', 'real errors still fail the run')
+  })
+})

--- a/packages/core/src/wirings/workflow/workflow-queue-workers.ts
+++ b/packages/core/src/wirings/workflow/workflow-queue-workers.ts
@@ -14,6 +14,8 @@ export interface WorkflowStepInput {
   stepName: string
   rpcName: string
   data: unknown
+  /** Predecessor step name (the walked transition); undefined for entry steps. */
+  fromStepName?: string
 }
 
 export interface PikkuWorkflowOrchestratorInput {

--- a/packages/core/src/wirings/workflow/workflow-step-ordinal.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-step-ordinal.test.ts
@@ -1,0 +1,79 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState } from '../../pikku-state.js'
+import { deriveInvocationId } from './workflow-invocation-id.js'
+
+const silentLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+function inlineService() {
+  pikkuState(null, 'package', 'singletonServices', {
+    queueService: { add: async () => {} },
+    logger: silentLogger,
+  } as any)
+  return new InMemoryWorkflowService()
+}
+
+describe('same step name invoked multiple times in one run', () => {
+  test('each reach gets its own row + invocationId (no clobber)', async () => {
+    const ws = inlineService()
+    const runId = await ws.createRun('flow', {}, true, 'hash', { type: 'test' })
+    ;(ws as any).inlineRuns.add(runId)
+
+    // Two `do('process', fn)` reaches in the SAME replay (no reset between).
+    const r1 = await (ws as any).inlineStep(runId, 'process', async () => 'first')
+    const r2 = await (ws as any).inlineStep(runId, 'process', async () => 'second')
+
+    assert.equal(r1, 'first')
+    assert.equal(r2, 'second', 'second call must NOT return the first cached result')
+
+    // Distinct rows: 'process' (ordinal 0) and 'process#1'.
+    const s0 = await ws.getStepState(runId, 'process')
+    const s1 = await ws.getStepState(runId, 'process#1')
+    assert.notEqual(s0.stepId, s1.stepId, 'distinct step rows')
+    assert.equal(s0.result, 'first')
+    assert.equal(s1.result, 'second')
+
+    // Per-invocation dedupe keys differ (not per-name).
+    assert.notEqual(
+      deriveInvocationId(runId, 'process'),
+      deriveInvocationId(runId, 'process#1')
+    )
+  })
+
+  test('ordinal 0 is unchanged: a single call keeps the bare name + its old invocationId', async () => {
+    const ws = inlineService()
+    const runId = await ws.createRun('flow', {}, true, 'hash', { type: 'test' })
+    ;(ws as any).inlineRuns.add(runId)
+
+    await (ws as any).inlineStep(runId, 'solo', async () => 'x')
+    // Stored under the bare name, and the dedupe key matches the pre-ordinal hash.
+    const s = await ws.getStepState(runId, 'solo')
+    assert.equal(s.result, 'x')
+    await assert.rejects(ws.getStepState(runId, 'solo#1'), 'no synthetic row for a single call')
+  })
+
+  test('a fresh replay resets ordinals so the same call resolves to the same row', async () => {
+    const ws = inlineService()
+    const runId = await ws.createRun('flow', {}, true, 'hash', { type: 'test' })
+    ;(ws as any).inlineRuns.add(runId)
+
+    let runs = 0
+    const r1 = await (ws as any).inlineStep(runId, 'once', async () => {
+      runs++
+      return 'v'
+    })
+    // Next replay resets the counter; the same `do('once')` must hit the cached
+    // row, not mint 'once#1'.
+    ;(ws as any).resetStepOrdinals(runId)
+    const r2 = await (ws as any).inlineStep(runId, 'once', async () => {
+      runs++
+      return 'v2'
+    })
+
+    assert.equal(r1, 'v')
+    assert.equal(r2, 'v', 'replay returns the cached result of the same step')
+    assert.equal(runs, 1, 'step body ran exactly once across replays')
+  })
+})

--- a/packages/core/src/wirings/workflow/workflow.types.ts
+++ b/packages/core/src/wirings/workflow/workflow.types.ts
@@ -134,6 +134,9 @@ export interface StepState {
   retries?: number
   /** Delay between retries */
   retryDelay?: string | number
+  /** Step name of the predecessor that scheduled this step (the transition/edge
+   *  walked to reach it); undefined for entry steps. Reconstructs the path. */
+  fromStepName?: string
   /** Creation timestamp */
   createdAt: Date
   /** Last update timestamp */
@@ -360,6 +363,8 @@ export type WorkflowStepInput = {
   stepName: string
   rpcName: string
   data: any
+  /** Predecessor step name (the walked transition); undefined for entry steps. */
+  fromStepName?: string
 }
 
 export type WorkflowOrchestratorInput = {

--- a/packages/runtimes/cloudflare/src/workflow-do/pikku-workflow-do-service.ts
+++ b/packages/runtimes/cloudflare/src/workflow-do/pikku-workflow-do-service.ts
@@ -156,7 +156,8 @@ export class PikkuWorkflowDoService<
     stepName: string,
     rpcName: string | null,
     data: any,
-    stepOptions?: WorkflowStepOptions
+    stepOptions?: WorkflowStepOptions,
+    fromStepName?: string
   ): Promise<StepState> {
     this.assertOwn(runId)
     const stepId = crypto.randomUUID()
@@ -170,6 +171,7 @@ export class PikkuWorkflowDoService<
       attemptCount: 1,
       retries: stepOptions?.retries,
       retryDelay: stepOptions?.retryDelay,
+      fromStepName,
       createdAt: now,
       updatedAt: now,
     }
@@ -364,6 +366,30 @@ export class PikkuWorkflowDoService<
       if (!existing) result.push(id)
     }
     return result
+  }
+
+  async getStepInstances(runId: string): Promise<
+    Array<{ stepName: string; status: StepStatus; fromStepName?: string }>
+  > {
+    this.assertOwn(runId)
+    const order = (await this.storage.get<string[]>(KEY_STEP_ORDER)) ?? []
+    if (order.length === 0) return []
+    const records = await this.storage.get<DoStepRecord>(order.map(stepKey))
+    const instances: Array<{
+      stepName: string
+      status: StepStatus
+      fromStepName?: string
+    }> = []
+    for (const id of order) {
+      const s = records.get(stepKey(id))
+      if (!s) continue
+      instances.push({
+        stepName: s.stepName,
+        status: s.status,
+        fromStepName: s.fromStepName,
+      })
+    }
+    return instances
   }
 
   async getNodeResults(
@@ -656,6 +682,7 @@ function toStepState(s: DoStepRecord): StepState & { stepName: string } {
     attemptCount: s.attemptCount,
     retries: s.retries,
     retryDelay: s.retryDelay,
+    fromStepName: s.fromStepName,
     childRunId: s.childRunId,
     createdAt: new Date(s.createdAt),
     updatedAt: new Date(s.updatedAt),

--- a/packages/services/kysely/src/kysely-tables.ts
+++ b/packages/services/kysely/src/kysely-tables.ts
@@ -51,6 +51,7 @@ export interface WorkflowStepTable {
   branchTaken: string | null
   retries: number | null
   retryDelay: string | null
+  fromStepName: string | null
   createdAt: Generated<Date>
   updatedAt: Generated<Date>
 }

--- a/packages/services/kysely/src/kysely-workflow-service.ts
+++ b/packages/services/kysely/src/kysely-workflow-service.ts
@@ -5,6 +5,7 @@ import {
   type WorkflowRun,
   type WorkflowRunWire,
   type StepState,
+  type StepStatus,
   type WorkflowStatus,
   type WorkflowVersionStatus,
 } from '@pikku/core/workflow'
@@ -79,6 +80,7 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       .addColumn('branch_taken', 'text')
       .addColumn('retries', 'integer')
       .addColumn('retry_delay', 'text')
+      .addColumn('from_step_name', 'text')
       .addColumn('created_at', 'timestamp', (col) =>
         col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull()
       )
@@ -90,6 +92,15 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
         'step_name',
       ])
       .execute()
+
+    // Additive: backfill the column on tables created before from_step_name.
+    await this.db.schema
+      .alterTable('workflow_step')
+      .addColumn('from_step_name', 'text')
+      .execute()
+      .catch(() => {
+        // Column already exists (fresh tables include it above) — nothing to do.
+      })
 
     await this.db.schema
       .createTable('workflow_step_history')
@@ -196,7 +207,8 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
     stepName: string,
     rpcName: string | null,
     data: any,
-    stepOptions?: { retries?: number; retryDelay?: string | number }
+    stepOptions?: { retries?: number; retryDelay?: string | number },
+    fromStepName?: string
   ): Promise<StepState> {
     const stepId = crypto.randomUUID()
     const now = new Date()
@@ -212,6 +224,7 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
         status: 'pending',
         retries: stepOptions?.retries ?? null,
         retryDelay: stepOptions?.retryDelay?.toString() ?? null,
+        fromStepName: fromStepName ?? null,
         createdAt: now,
         updatedAt: now,
       })
@@ -227,6 +240,7 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       attemptCount: 1,
       retries: stepOptions?.retries,
       retryDelay: stepOptions?.retryDelay?.toString(),
+      fromStepName,
       createdAt: now,
       updatedAt: now,
     }
@@ -242,6 +256,7 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
         's.error',
         's.retries',
         's.retryDelay',
+        's.fromStepName',
         's.createdAt',
         's.updatedAt',
       ])
@@ -274,6 +289,7 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       attemptCount: Number(row.attemptCount),
       retries: row.retries != null ? Number(row.retries) : undefined,
       retryDelay: row.retryDelay ?? undefined,
+      fromStepName: row.fromStepName ?? undefined,
       createdAt: new Date(row.createdAt),
       updatedAt: new Date(row.updatedAt),
     }
@@ -467,6 +483,7 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
         's.error',
         's.retries',
         's.retryDelay',
+        's.fromStepName',
         's.createdAt',
         's.updatedAt',
       ])
@@ -492,6 +509,7 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       attemptCount: Number(row.attemptCount),
       retries: row.retries != null ? Number(row.retries) : undefined,
       retryDelay: row.retryDelay ?? undefined,
+      fromStepName: row.fromStepName ?? undefined,
       createdAt: new Date(row.createdAt),
       updatedAt: new Date(row.updatedAt),
     }
@@ -566,6 +584,21 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
 
     const existingStepNames = new Set(result.map((r) => r.stepName))
     return nodeIds.filter((id) => !existingStepNames.has(id))
+  }
+
+  async getStepInstances(runId: string): Promise<
+    Array<{ stepName: string; status: StepStatus; fromStepName?: string }>
+  > {
+    const rows = await this.db
+      .selectFrom('workflowStep')
+      .select(['stepName', 'status', 'fromStepName'])
+      .where('workflowRunId', '=', runId)
+      .execute()
+    return rows.map((r) => ({
+      stepName: r.stepName,
+      status: r.status as StepStatus,
+      fromStepName: r.fromStepName ?? undefined,
+    }))
   }
 
   async getNodeResults(

--- a/packages/services/mongodb/src/mongodb-workflow-service.ts
+++ b/packages/services/mongodb/src/mongodb-workflow-service.ts
@@ -5,6 +5,7 @@ import {
   type WorkflowRun,
   type WorkflowRunWire,
   type StepState,
+  type StepStatus,
   type WorkflowStatus,
   type WorkflowVersionStatus,
 } from '@pikku/core/workflow'
@@ -41,6 +42,7 @@ interface WorkflowStepDoc {
   branchTaken: string | null
   retries: number | null
   retryDelay: string | null
+  fromStepName?: string | null
   createdAt: Date
   updatedAt: Date
 }
@@ -172,7 +174,8 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
     stepName: string,
     rpcName: string | null,
     data: any,
-    stepOptions?: { retries?: number; retryDelay?: string | number }
+    stepOptions?: { retries?: number; retryDelay?: string | number },
+    fromStepName?: string
   ): Promise<StepState> {
     const stepId = crypto.randomUUID()
     const now = new Date()
@@ -189,6 +192,7 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
       branchTaken: null,
       retries: stepOptions?.retries ?? null,
       retryDelay: stepOptions?.retryDelay?.toString() ?? null,
+      fromStepName: fromStepName ?? null,
       createdAt: now,
       updatedAt: now,
     })
@@ -203,6 +207,7 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
       attemptCount: 1,
       retries: stepOptions?.retries,
       retryDelay: stepOptions?.retryDelay?.toString(),
+      fromStepName,
       createdAt: now,
       updatedAt: now,
     }
@@ -232,6 +237,7 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
       attemptCount,
       retries: row.retries != null ? Number(row.retries) : undefined,
       retryDelay: row.retryDelay ?? undefined,
+      fromStepName: row.fromStepName ?? undefined,
       createdAt: new Date(row.createdAt),
       updatedAt: new Date(row.updatedAt),
     }
@@ -427,6 +433,7 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
       attemptCount,
       retries: row.retries != null ? Number(row.retries) : undefined,
       retryDelay: row.retryDelay ?? undefined,
+      fromStepName: row.fromStepName ?? undefined,
       createdAt: new Date(row.createdAt),
       updatedAt: new Date(row.updatedAt),
     }
@@ -498,6 +505,20 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
 
     const existingStepNames = new Set(result.map((r) => r.stepName))
     return nodeIds.filter((id) => !existingStepNames.has(id))
+  }
+
+  async getStepInstances(runId: string): Promise<
+    Array<{ stepName: string; status: StepStatus; fromStepName?: string }>
+  > {
+    const rows = await this.steps
+      .find({ workflowRunId: runId })
+      .project({ stepName: 1, status: 1, fromStepName: 1 })
+      .toArray()
+    return rows.map((r: any) => ({
+      stepName: r.stepName,
+      status: r.status as StepStatus,
+      fromStepName: r.fromStepName ?? undefined,
+    }))
   }
 
   async getNodeResults(

--- a/packages/services/redis/src/redis-workflow-service.ts
+++ b/packages/services/redis/src/redis-workflow-service.ts
@@ -5,6 +5,7 @@ import {
   type WorkflowRun,
   type WorkflowRunWire,
   type StepState,
+  type StepStatus,
   type WorkflowStatus,
   type WorkflowVersionStatus,
 } from '@pikku/core/workflow'
@@ -306,7 +307,8 @@ export class RedisWorkflowService extends PikkuWorkflowService {
     stepName: string,
     rpcName: string,
     data: any,
-    stepOptions?: { retries?: number; retryDelay?: string | number }
+    stepOptions?: { retries?: number; retryDelay?: string | number },
+    fromStepName?: string
   ): Promise<StepState> {
     const now = Date.now()
     const stepId = `${runId}:${stepName}:${now}`
@@ -328,6 +330,10 @@ export class RedisWorkflowService extends PikkuWorkflowService {
 
     if (stepOptions?.retryDelay !== undefined) {
       fields.retryDelay = stepOptions.retryDelay.toString()
+    }
+
+    if (fromStepName !== undefined) {
+      fields.fromStepName = fromStepName
     }
 
     await this.redis.hmset(key, fields)
@@ -353,6 +359,7 @@ export class RedisWorkflowService extends PikkuWorkflowService {
         stepOptions?.retryDelay !== undefined
           ? stepOptions.retryDelay.toString()
           : undefined,
+      fromStepName,
       createdAt: new Date(now),
       updatedAt: new Date(now),
     }
@@ -376,6 +383,7 @@ export class RedisWorkflowService extends PikkuWorkflowService {
       attemptCount: Number(data.attemptCount || 1),
       retries: data.retries ? Number(data.retries) : undefined,
       retryDelay: data.retryDelay,
+      fromStepName: data.fromStepName || undefined,
       createdAt: new Date(Number(data.createdAt!)),
       updatedAt: new Date(Number(data.updatedAt!)),
     }
@@ -743,6 +751,7 @@ export class RedisWorkflowService extends PikkuWorkflowService {
       attemptCount: newAttemptCount,
       retries: retries,
       retryDelay: retryDelay,
+      fromStepName: data.fromStepName || undefined,
       createdAt: new Date(Number(data.createdAt!)),
       updatedAt: new Date(now),
     }
@@ -825,6 +834,44 @@ export class RedisWorkflowService extends PikkuWorkflowService {
     }
 
     return result
+  }
+
+  async getStepInstances(runId: string): Promise<
+    Array<{ stepName: string; status: StepStatus; fromStepName?: string }>
+  > {
+    const instances: Array<{
+      stepName: string
+      status: StepStatus
+      fromStepName?: string
+    }> = []
+    const pattern = `${this.keyPrefix}:step:${runId}:*`
+    let cursor = '0'
+    do {
+      const [newCursor, foundKeys] = await this.redis.scan(
+        cursor,
+        'MATCH',
+        pattern,
+        'COUNT',
+        100
+      )
+      cursor = newCursor
+      for (const key of foundKeys) {
+        const [status, fromStepName] = await this.redis.hmget(
+          key,
+          'status',
+          'fromStepName'
+        )
+        const parts = key.split(':')
+        const stepIndex = parts.lastIndexOf('step')
+        if (stepIndex === -1 || parts[stepIndex + 1] !== runId) continue
+        instances.push({
+          stepName: parts.slice(stepIndex + 2).join(':'),
+          status: status as StepStatus,
+          fromStepName: fromStepName || undefined,
+        })
+      }
+    } while (cursor !== '0')
+    return instances
   }
 
   async getNodeResults(

--- a/verifiers/workflows/package.json
+++ b/verifiers/workflows/package.json
@@ -36,6 +36,8 @@
     "test:version-mismatch:pg": "npx tsx src/runners/version-mismatch.runner.ts --pg",
     "test:version-mismatch:redis": "npx tsx src/runners/version-mismatch.runner.ts --redis",
     "test:retry-idempotency:pg": "npx tsx src/runners/retry-idempotency.runner.ts --pg",
-    "test:retry-idempotency:redis": "npx tsx src/runners/retry-idempotency.runner.ts --redis"
+    "test:retry-idempotency:redis": "npx tsx src/runners/retry-idempotency.runner.ts --redis",
+    "test:cyclic-graph:pg": "npx tsx src/runners/cyclic-graph.runner.ts --pg",
+    "test:cyclic-graph:redis": "npx tsx src/runners/cyclic-graph.runner.ts --redis"
   }
 }

--- a/verifiers/workflows/src/runners/cyclic-graph.runner.ts
+++ b/verifiers/workflows/src/runners/cyclic-graph.runner.ts
@@ -1,0 +1,230 @@
+/**
+ * Cyclic Graph Runner
+ *
+ * Drives a graph whose node loops back to itself (`attempt --again--> attempt`)
+ * through a REAL queue + workflow storage, then asserts the engine's revisit +
+ * provenance invariants:
+ *
+ *   1. revisit instances — a self-cycling node runs once per pass as a fresh
+ *      ordinal instance (attempt, attempt#1, attempt#2 …), NOT a single step.
+ *   2. provenance        — each step records the predecessor it was reached from
+ *      (fromStepName); entry steps have none.
+ *   3. path reconstruction — walking the fromStepName chain back from the
+ *      terminal node reproduces the exact walked path, cycle included.
+ *
+ * Usage:
+ *   yarn test:cyclic-graph:pg      # pg-boss + Postgres (KyselyWorkflowService)
+ *   yarn test:cyclic-graph:redis   # bullmq + Redis (RedisWorkflowService)
+ */
+
+import type { PikkuWorkflowService } from '@pikku/core/workflow'
+
+import { createConfig, createSingletonServices } from '../services.js'
+
+import '../../.pikku/pikku-bootstrap.gen.js'
+
+type Backend = 'pg' | 'redis'
+
+const TIMEOUT_MS = 60_000
+const POLL_INTERVAL_MS = 100
+
+function parseBackend(): Backend {
+  if (process.argv.includes('--redis')) return 'redis'
+  if (process.argv.includes('--pg')) return 'pg'
+  throw new Error('Specify a backend: --pg or --redis')
+}
+
+async function setup(backend: Backend): Promise<{
+  workflowService: PikkuWorkflowService
+  registerQueues: () => Promise<unknown>
+  cleanup: () => Promise<void>
+}> {
+  const config = await createConfig()
+
+  if (backend === 'pg') {
+    const { KyselyWorkflowService } = await import('@pikku/kysely')
+    const { PgBossServiceFactory } = await import('@pikku/queue-pg-boss')
+    const { Kysely, CamelCasePlugin } = await import('kysely')
+    const { PostgresJSDialect } = await import('kysely-postgres-js')
+    const postgres = (await import('postgres')).default
+    const connectionString =
+      process.env.DATABASE_URL ||
+      'postgres://postgres:password@localhost:5432/pikku_queue'
+
+    const pgBossFactory = new PgBossServiceFactory(connectionString)
+    await pgBossFactory.init()
+    const sql = postgres(connectionString)
+    const db = new Kysely<any>({
+      dialect: new PostgresJSDialect({ postgres: sql }),
+      plugins: [new CamelCasePlugin()],
+    })
+    const workflowService = new KyselyWorkflowService(db)
+    await workflowService.init()
+
+    await createSingletonServices(config, {
+      queueService: pgBossFactory.getQueueService(),
+      schedulerService: pgBossFactory.getSchedulerService(),
+      workflowService,
+    })
+
+    return {
+      workflowService,
+      registerQueues: () => pgBossFactory.getQueueWorkers().registerQueues(),
+      cleanup: async () => {
+        await workflowService.close()
+        await pgBossFactory.close()
+        await sql.end()
+      },
+    }
+  }
+
+  const { RedisWorkflowService } = await import('@pikku/redis')
+  const { BullServiceFactory } = await import('@pikku/queue-bullmq')
+
+  const bullFactory = new BullServiceFactory()
+  await bullFactory.init()
+  const workflowService = new RedisWorkflowService(undefined)
+  await workflowService.init()
+
+  await createSingletonServices(config, {
+    queueService: bullFactory.getQueueService(),
+    schedulerService: bullFactory.getSchedulerService(),
+    workflowService,
+  })
+
+  const queueWorkers = bullFactory.getQueueWorkers()
+  return {
+    workflowService,
+    registerQueues: () => queueWorkers.registerQueues(),
+    cleanup: async () => {
+      await queueWorkers.close()
+      await workflowService.close()
+      await bullFactory.close()
+    },
+  }
+}
+
+class AssertionFailed extends Error {}
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new AssertionFailed(message)
+}
+
+async function main(): Promise<void> {
+  const backend = parseBackend()
+  console.log(`=== Cyclic Graph Runner (${backend}) ===\n`)
+
+  const { workflowService, registerQueues, cleanup } = await setup(backend)
+  await registerQueues()
+
+  const results: Array<{ name: string; ok: boolean; error?: string }> = []
+
+  async function runToTerminal(
+    name: string,
+    input: unknown
+  ): Promise<{ status: string; runId: string }> {
+    const { runId } = await workflowService.startWorkflow(
+      name,
+      input,
+      { type: 'test' },
+      null as any
+    )
+    const deadline = Date.now() + TIMEOUT_MS
+    while (true) {
+      const run = await workflowService.getRun(runId)
+      if (
+        run &&
+        (run.status === 'completed' ||
+          run.status === 'failed' ||
+          run.status === 'cancelled')
+      ) {
+        return { status: run.status, runId }
+      }
+      if (Date.now() > deadline) {
+        throw new AssertionFailed(
+          `${name} timed out after ${TIMEOUT_MS}ms (status: ${run?.status})`
+        )
+      }
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+    }
+  }
+
+  async function test(name: string, fn: () => Promise<void>): Promise<void> {
+    const start = Date.now()
+    try {
+      await fn()
+      results.push({ name, ok: true })
+      console.log(`PASS: ${name} (${Date.now() - start}ms)`)
+    } catch (error: any) {
+      results.push({ name, ok: false, error: error.message })
+      console.log(`FAIL: ${name} — ${error.message} (${Date.now() - start}ms)`)
+    }
+  }
+
+  await test(
+    'cyclic node revisits as ordinal instances and the fromStepName chain reconstructs the path',
+    async () => {
+      const { status, runId } = await runToTerminal('graphCyclicRetry', {
+        attempts: 3,
+      })
+      assert(status === 'completed', `expected completed, got ${status}`)
+
+      const steps = await workflowService.getRunHistory(runId)
+      const from = new Map(
+        steps.map((s: any) => [s.stepName, s.fromStepName ?? undefined])
+      )
+
+      // The self-cycle produced three ordinal instances of `attempt`.
+      const stepNames = steps.map((s: any) => s.stepName).sort()
+      assert(
+        stepNames.includes('attempt') &&
+          stepNames.includes('attempt#1') &&
+          stepNames.includes('attempt#2'),
+        `expected attempt/attempt#1/attempt#2, got ${JSON.stringify(stepNames)}`
+      )
+
+      // Each step records its predecessor; the entry has none.
+      assert(
+        from.get('begin') === undefined,
+        `entry step must have no predecessor, got ${from.get('begin')}`
+      )
+
+      // Walk back from the terminal node — the cycle is fully reconstructable.
+      const path: string[] = []
+      let cursor: string | undefined = 'finish'
+      while (cursor) {
+        path.unshift(cursor)
+        cursor = from.get(cursor)
+      }
+      assert(
+        JSON.stringify(path) ===
+          JSON.stringify([
+            'begin',
+            'attempt',
+            'attempt#1',
+            'attempt#2',
+            'finish',
+          ]),
+        `reconstructed path mismatch, got ${JSON.stringify(path)}`
+      )
+    }
+  )
+
+  console.log('\n=== Summary ===')
+  const passed = results.filter((r) => r.ok).length
+  const failed = results.filter((r) => !r.ok).length
+  console.log(`Passed: ${passed}/${results.length}`)
+  if (failed > 0) {
+    console.log('\nFailures:')
+    for (const r of results.filter((r) => !r.ok)) {
+      console.log(`  ${r.name}: ${r.error}`)
+    }
+  }
+
+  await cleanup()
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+main().catch((error) => {
+  console.error('Runner failed:', error)
+  process.exit(1)
+})

--- a/verifiers/workflows/src/workflows/cyclic-retry.functions.ts
+++ b/verifiers/workflows/src/workflows/cyclic-retry.functions.ts
@@ -1,0 +1,52 @@
+/**
+ * CYCLIC graph: a node that loops back to itself until it converges.
+ *
+ *   begin → attempt --again--> attempt --…--> attempt --done--> finish
+ *
+ * `attempt` has a self-edge (`again`) so the engine must create a fresh ordinal
+ * instance each pass (attempt, attempt#1, attempt#2 …), each recording the
+ * predecessor it was reached from (fromStepName). Termination is the graph's
+ * own responsibility: `attempt` counts passes in run state and branches `done`
+ * once it hits the target, so the cycle converges instead of looping forever.
+ */
+import { pikkuSessionlessFunc } from '#pikku'
+
+// Entry node: seed the run state, then hand off to the cyclic node.
+export const cyclicBegin = pikkuSessionlessFunc<
+  { attempts: number },
+  { attempts: number }
+>({
+  func: async ({ logger }, data) => {
+    logger.info(`[cyclic] begin — will loop ${data.attempts} time(s)`)
+    return { attempts: data.attempts }
+  },
+})
+
+// Self-cycling node: loop back via `again` until `count` reaches the target.
+export const cyclicAttempt = pikkuSessionlessFunc<
+  { target: number },
+  { count: number; target: number }
+>({
+  func: async ({ logger }, data, { graph }) => {
+    const state = await graph!.getState()
+    const count = ((state.count as number) ?? 0) + 1
+    await graph!.setState('count', count)
+    const branch = count >= data.target ? 'done' : 'again'
+    logger.info(`[cyclic] attempt #${count}/${data.target} → ${branch}`)
+    graph!.branch(branch)
+    return { count, target: data.target }
+  },
+})
+
+// Terminal node: report how many passes the cycle took.
+export const cyclicFinish = pikkuSessionlessFunc<
+  { target: number },
+  { ok: boolean; loops: number }
+>({
+  func: async ({ logger }, _data, { graph }) => {
+    const state = await graph!.getState()
+    const loops = (state.count as number) ?? 0
+    logger.info(`[cyclic] finish — converged after ${loops} pass(es)`)
+    return { ok: true, loops }
+  },
+})

--- a/verifiers/workflows/src/workflows/cyclic-retry.graph.ts
+++ b/verifiers/workflows/src/workflows/cyclic-retry.graph.ts
@@ -1,0 +1,26 @@
+import { pikkuWorkflowGraph } from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+// A graph with a node that cycles back to itself (`attempt --again--> attempt`)
+// until it converges, then exits to `finish`. `begin` is the (non-cyclic) entry
+// so the run has somewhere to start — a pure cycle has no entry node.
+export const graphCyclicRetry = pikkuWorkflowGraph({
+  description: 'Cyclic graph: a node loops back to itself until it converges',
+  tags: ['cyclic', 'graph'],
+  nodes: {
+    begin: 'cyclicBegin',
+    attempt: 'cyclicAttempt',
+    finish: 'cyclicFinish',
+  },
+  config: {
+    begin: {
+      next: 'attempt',
+    },
+    attempt: {
+      input: (ref) => ({ target: ref('begin', 'attempts') }),
+      next: { again: 'attempt', done: 'finish' },
+    },
+    finish: {
+      input: (ref) => ({ target: ref('begin', 'attempts') }),
+    },
+  },
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow steps now use stable invocation IDs, improving idempotency and replay consistency.
  * Step lineage is now tracked, making repeated or cyclic workflow paths easier to follow.
  * Workflows now have a default retry policy with exponential backoff.

* **Bug Fixes**
  * Fixed retry behavior so `retries: 0` is respected.
  * Improved dispatch handling so temporary handoff failures are retried instead of failing the whole run.
  * Added support for repeated step names without overwriting earlier step instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->