### PR TITLE
feat(queue): in-memory queue retries failed jobs + workflow load benchmark

### DIFF
--- a/.changeset/dedupe-dsl-step-execution.md
+++ b/.changeset/dedupe-dsl-step-execution.md
@@ -1,0 +1,5 @@
+---
+'@pikku/core': patch
+---
+
+Dedupe DSL step execution: extract a shared `invokeStepRpc` (step RPC + provenance wire, used by both the queue and inline executors) and a shared `runInlineRetryLoop` (the in-process running→result→retry scaffolding, used by inline RPC steps and inline function steps). No behavior change — the inline path stays straight-through O(K); the queue path keeps its suspend/replay model.

--- a/.changeset/getrunhistory-provenance.md
+++ b/.changeset/getrunhistory-provenance.md
@@ -1,0 +1,6 @@
+---
+'@pikku/kysely': patch
+'@pikku/redis': patch
+---
+
+Fix `getRunHistory` dropping step provenance (`fromStepName`). The value was persisted on the step row and used by the graph planner, but `getRunHistory` built its rows from the per-attempt history and never carried `fromStepName` through — so run history (and any timeline reconstructed from it) reported no predecessors. Redis and Kysely `getRunHistory` now return `fromStepName`. Also adds the missing `from_step_name` column (+ backfill) to the Kysely workflow mirror's `workflow_step` schema and persists it on mirror inserts, so a mirror-side history has identical provenance.

--- a/.changeset/in-memory-queue-retry.md
+++ b/.changeset/in-memory-queue-retry.md
@@ -1,0 +1,12 @@
+---
+'@pikku/core': patch
+---
+
+fix(queue): `InMemoryQueueService` redelivers failed jobs up to `options.attempts` with backoff
+
+Previously the in-memory queue ran each job once and dropped it on failure, so a
+transiently-failing workflow step dispatched via `inline: false` would stall the
+run forever (the orchestrator was never resumed). It now honors the `attempts`
+and `backoff` already produced by the workflow step job options, redelivering on
+failure — matching pg-boss/bullmq semantics so local/dev runs recover from
+transient step failures exactly as production does.

--- a/.changeset/inline-graph-shared-planner.md
+++ b/.changeset/inline-graph-shared-planner.md
@@ -1,0 +1,12 @@
+---
+'@pikku/core': patch
+---
+
+fix(workflow): inline graph runs use the same transition planner as the queue
+
+`continueGraphInline` had its own, weaker graph traversal that couldn't revisit a
+node (no cycles) and never recorded `fromStepName`, so an inline-run graph stored
+different step state than the same graph run through a queue. It now uses the
+shared `planGraphTransitions` planner — inline graphs get joins, cycle revisits
+(`node`, `node#1`, …) and step provenance identical to the queued path, and the
+duplicate traversal logic is removed.

--- a/.changeset/workflow-planned-steps.md
+++ b/.changeset/workflow-planned-steps.md
@@ -1,0 +1,5 @@
+---
+'@pikku/inspector': patch
+---
+
+Populate `plannedSteps` and `deterministic` on serialized DSL workflow graphs. For a DSL workflow with no loops (fanout), the inspector now records every named step in source order, so a UI can render the run's step skeleton up front without executing it or hand-listing steps. `deterministic` is `true` only for a flat, loopless, branch-free workflow (exact sequence known ahead of time); a branchy-but-loopless workflow lists all possible steps with `deterministic: false`; any fanout makes the count runtime-dependent so neither field is emitted (just `deterministic: false`). Only `source: 'dsl'` workflows are planned — `complex` step trees omit inline branches and flatten loops, so their plans would misreport determinism. The runtime already threads these fields from workflow meta onto each run via `getRun`.

--- a/.changeset/workflow-run-timeline.md
+++ b/.changeset/workflow-run-timeline.md
@@ -1,0 +1,5 @@
+---
+'@pikku/core': minor
+---
+
+Add workflow run time-travel. A run's durable history (`getRunHistory`) is one row per step attempt with lifecycle timestamps; `buildRunTimeline(history)` explodes those into a flat, chronologically-ordered event stream and `reconstructStateAt(timeline, at)` folds it up to any point — a seq index or a `Date` — to recover what the run "knew" then: per-step status, the accumulated step-result cache, the walked path (via `fromStepName`), and a derived phase. These are pure, transport-independent functions (same fold for Redis/Kysely/in-memory), exported from `@pikku/core/workflow` alongside `reconstructFinalState`. `PikkuWorkflowService` gains `getRunTimeline(id)` and `reconstructRunStateAt(id, at?)` that wrap them over a run's history, inherited by every backend. Correctly handles retries (a retry's created event reopens the step and clears the prior outcome) and graph cycles (revisit ordinals are distinct path entries).

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -122,6 +122,41 @@ jobs:
       - uses: ./.github/actions/setup
       - run: cd verifiers/${{ matrix.verifier }} && ${{ matrix.package-manager == 'bun' && 'bun run' || 'yarn' }} test
 
+  # The workflow verifier's pg/redis runners need real queue + storage backends,
+  # so they can't run in the plain `verifiers` job. This job gives them Postgres
+  # (KyselyWorkflowService + pg-boss) and Redis (RedisWorkflowService + bullmq)
+  # and asserts every node's state — provenance + cycles — on both transports.
+  verifiers-workflows-db:
+    name: Verifiers (workflows, db-backed)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: pikku_queue
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: cd verifiers/workflows && yarn test:db
+    env:
+      DATABASE_URL: postgres://postgres:password@localhost:5432/pikku_queue
+      REDIS_URL: redis://localhost:6379
+
   verifier-coverage:
     name: Verifier Coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,41 @@ jobs:
           bun-version: latest
       - run: cd verifiers/${{ matrix.verifier }} && ${{ matrix.package-manager == 'bun' && 'bun run' || 'yarn' }} test
 
+  # The workflow verifier's pg/redis runners need real queue + storage backends,
+  # so they can't run in the plain `verifiers` job. This job gives them Postgres
+  # (KyselyWorkflowService + pg-boss) and Redis (RedisWorkflowService + bullmq)
+  # and asserts every node's state — provenance + cycles — on both transports.
+  verifiers-workflows-db:
+    name: Verifiers (workflows, db-backed)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: pikku_queue
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: cd verifiers/workflows && yarn test:db
+    env:
+      DATABASE_URL: postgres://postgres:password@localhost:5432/pikku_queue
+      REDIS_URL: redis://localhost:6379
+
   templates:
     name: Templates (${{ matrix.version }}, ${{ matrix.template }}, ${{ matrix.package-manager }})
     runs-on: ubuntu-latest
@@ -248,6 +283,7 @@ jobs:
       [
         validate-deps,
         verifiers,
+        verifiers-workflows-db,
         templates,
         templates-no-services,
         template-runtime-targets,

--- a/benchmarks/bench-workflow.ts
+++ b/benchmarks/bench-workflow.ts
@@ -1,24 +1,35 @@
 /**
  * Workflow load benchmark.
  *
- * Runs hundreds of DSL workflows concurrently, each with many RPC steps, where
- * a deterministic ~2/3 of steps fail transiently on their first one or two
+ * Runs hundreds of DSL workflows concurrently, each with many steps, where a
+ * deterministic ~2/3 of steps fail transiently on their first one or two
  * attempts (mimicking flaky real-world work). The point is correctness under
  * load: EVERY run must reach `completed` and every step must produce its result
  * once retries ride out the transient failures — nothing dropped, nothing stuck.
  *
- * Drives the engine directly via pikkuState wiring (no codegen), the same way
- * the HTTP benchmarks register functions, so it runs with a plain `tsx`:
+ * Three transports, same workload, same assertions — proving the dispatch path
+ * is transport-independent (switching a step inline↔queued changes only timing):
  *
- *   yarn workspace @pikku/workspace tsx benchmarks/bench-workflow.ts
- *   tsx benchmarks/bench-workflow.ts --runs 500 --steps 30
+ *   (default)  every step inline (in-process retry loop, no queue service)
+ *   --mixed    alternate steps marked `inline: false` → dispatched through an
+ *              in-process InMemoryQueueService (retry via queue redelivery)
+ *   --queue    run orchestrated entirely through the queue (run-level inline:false)
+ *
+ * Drives the engine directly via pikkuState wiring (no codegen), the same way the
+ * HTTP benchmarks register functions, so it runs with a plain `tsx`:
+ *
+ *   tsx benchmarks/bench-workflow.ts --runs 300 --steps 20
+ *   tsx benchmarks/bench-workflow.ts --mixed --runs 200 --steps 16
+ *   tsx benchmarks/bench-workflow.ts --queue --runs 200 --steps 16
  */
 
 import { addFunction } from '@pikku/core'
 import { pikkuState, resetPikkuState } from '@pikku/core/internal'
-import { InMemoryWorkflowService } from '@pikku/core/services'
+import { InMemoryWorkflowService, InMemoryQueueService } from '@pikku/core/services'
 import { addWorkflow } from '@pikku/core/workflow'
 import { rpcService } from '@pikku/core/rpc'
+
+type Mode = 'inline' | 'mixed' | 'queue'
 
 const arg = (flag: string, fallback: number): number => {
   const i = process.argv.indexOf(flag)
@@ -27,11 +38,17 @@ const arg = (flag: string, fallback: number): number => {
   return Number.isFinite(v) ? v : fallback
 }
 
-const RUNS = arg('--runs', 300)
-const STEPS = arg('--steps', 20)
+const MODE: Mode = process.argv.includes('--queue')
+  ? 'queue'
+  : process.argv.includes('--mixed')
+    ? 'mixed'
+    : 'inline'
+const RUNS = arg('--runs', MODE === 'inline' ? 300 : 200)
+const STEPS = arg('--steps', MODE === 'inline' ? 20 : 16)
 
 const WORKFLOW_NAME = 'benchWorkflow'
-const STEP_RPC = 'benchStep'
+const STEP_RPC = 'benchStep' // default → runs inline
+const STEP_QUEUED_RPC = 'benchStepQueued' // inline: false → dispatched to the queue
 
 // Per-step attempt counter, keyed by the run-stable `${wfId}:${stepIdx}`. The
 // step throws while its count is within its assigned `failTimes`, then succeeds
@@ -41,7 +58,7 @@ let totalAttempts = 0
 
 // Cheap deterministic string hash → assign each step 0, 1 or 2 transient
 // failures. Deterministic so the DSL body (which computes failTimes) replays
-// identically and the benchmark is reproducible.
+// identically and the benchmark is reproducible across runs and transports.
 const failTimesFor = (wfId: string, stepIdx: number): number => {
   let h = 2166136261
   const s = `${wfId}:${stepIdx}`
@@ -60,88 +77,136 @@ const randomPayload = (seed: number) => ({
   values: Array.from({ length: 8 }, (_, i) => (seed * 7 + i) % 1000),
 })
 
-function registerEngine() {
-  resetPikkuState()
+const flakyStep = async (
+  _services: any,
+  data: { wfId: string; stepIdx: number; failTimes: number }
+) => {
+  const key = `${data.wfId}:${data.stepIdx}`
+  const count = (attempts.get(key) ?? 0) + 1
+  attempts.set(key, count)
+  totalAttempts++
+  if (count <= data.failTimes) {
+    throw new Error(`transient failure ${count}/${data.failTimes} on ${key}`)
+  }
+  return randomPayload(data.stepIdx + count)
+}
 
-  pikkuState(null, 'package', 'singletonServices', {
-    logger: { error() {}, info() {}, warn() {}, debug() {} },
-  } as any)
-  pikkuState(null, 'package', 'factories', {
-    createWireServices: async () => ({}),
-  } as any)
-
-  // Flaky step RPC: fails its first `failTimes` attempts, then returns a result.
-  pikkuState(null, 'rpc', 'meta')[STEP_RPC] = STEP_RPC as any
-  pikkuState(null, 'function', 'meta')[STEP_RPC] = {
-    pikkuFuncId: STEP_RPC,
+const mkStepMeta = (funcId: string, inline?: boolean) =>
+  ({
+    pikkuFuncId: funcId,
     sessionless: true,
     permissions: [],
     inputSchemaName: null,
     outputSchemaName: null,
-  } as any
-  addFunction(STEP_RPC, {
-    func: async (
-      _services: any,
-      data: { wfId: string; stepIdx: number; failTimes: number }
-    ) => {
-      const key = `${data.wfId}:${data.stepIdx}`
-      const count = (attempts.get(key) ?? 0) + 1
-      attempts.set(key, count)
-      totalAttempts++
-      if (count <= data.failTimes) {
-        throw new Error(
-          `transient failure ${count}/${data.failTimes} on ${key}`
-        )
-      }
-      return randomPayload(data.stepIdx + count)
-    },
+    ...(inline === undefined ? {} : { inline }),
+  }) as any
+
+function registerEngine(mode: Mode) {
+  resetPikkuState()
+
+  const singletonServices: any = {
+    logger: { error() {}, info() {}, warn() {}, debug() {} },
+  }
+  // mixed/queue route dispatch through an in-process queue with retry redelivery.
+  if (mode !== 'inline') {
+    singletonServices.queueService = new InMemoryQueueService()
+  }
+  pikkuState(null, 'package', 'singletonServices', singletonServices)
+  pikkuState(null, 'package', 'factories', {
+    createWireServices: async () => ({}),
   } as any)
 
-  // DSL workflow: run STEPS sequential RPC steps, each with deterministic flakiness.
+  // Default (inline) flaky step.
+  pikkuState(null, 'rpc', 'meta')[STEP_RPC] = STEP_RPC as any
+  pikkuState(null, 'function', 'meta')[STEP_RPC] = mkStepMeta(STEP_RPC)
+  addFunction(STEP_RPC, { func: flakyStep } as any)
+
+  // Same logic, but `inline: false` so it dispatches to the queue (mixed mode).
+  pikkuState(null, 'rpc', 'meta')[STEP_QUEUED_RPC] = STEP_QUEUED_RPC as any
+  pikkuState(null, 'function', 'meta')[STEP_QUEUED_RPC] = mkStepMeta(
+    STEP_QUEUED_RPC,
+    false
+  )
+  addFunction(STEP_QUEUED_RPC, { func: flakyStep } as any)
+
+  // DSL workflow: run STEPS sequential steps; in mixed mode alternate steps use
+  // the queued RPC so half the work crosses the queue transport.
   pikkuState(null, 'workflows', 'meta')[WORKFLOW_NAME] = {
     name: WORKFLOW_NAME,
     pikkuFuncId: WORKFLOW_NAME,
     source: 'dsl',
     graphHash: 'bench-workflow-hash',
   } as any
-  pikkuState(null, 'function', 'meta')[WORKFLOW_NAME] = {
-    name: WORKFLOW_NAME,
-    sessionless: true,
-    permissions: [],
-    inputSchemaName: null,
-    outputSchemaName: null,
-  } as any
+  pikkuState(null, 'function', 'meta')[WORKFLOW_NAME] = mkStepMeta(WORKFLOW_NAME)
   addWorkflow(WORKFLOW_NAME, {
-    func: async (_services: any, data: { wfId: string; steps: number }, { workflow }: any) => {
-      const results: number[] = []
+    func: async (
+      _services: any,
+      data: { wfId: string; steps: number; mixed: boolean },
+      { workflow }: any
+    ) => {
+      let completed = 0
       for (let i = 0; i < data.steps; i++) {
-        const out = await workflow.do(`s${i}`, STEP_RPC, {
+        const rpc = data.mixed && i % 2 === 1 ? STEP_QUEUED_RPC : STEP_RPC
+        const out = await workflow.do(`s${i}`, rpc, {
           wfId: data.wfId,
           stepIdx: i,
           failTimes: failTimesFor(data.wfId, i),
         })
-        results.push(out.id)
+        if (out?.id !== undefined) completed++
       }
-      return { wfId: data.wfId, completed: results.length }
+      return { wfId: data.wfId, completed }
     },
   } as any)
 }
 
+async function pollToCompletion(
+  ws: InMemoryWorkflowService,
+  runId: string,
+  wfId: string,
+  timeoutMs: number
+): Promise<void> {
+  const deadline = performance.now() + timeoutMs
+  while (true) {
+    const run = await ws.getRun(runId)
+    if (run?.status === 'completed') {
+      if ((run.output as any)?.completed !== STEPS) {
+        throw new Error(
+          `run ${wfId} completed ${(run.output as any)?.completed}/${STEPS} steps`
+        )
+      }
+      return
+    }
+    if (run?.status === 'failed' || run?.status === 'cancelled') {
+      throw new Error(
+        `run ${wfId} ended '${run.status}': ${run.error?.message ?? 'unknown'}`
+      )
+    }
+    if (performance.now() > deadline) {
+      throw new Error(`run ${wfId} timed out in '${run?.status}'`)
+    }
+    await new Promise((r) => setTimeout(r, 20))
+  }
+}
+
 async function main() {
-  registerEngine()
+  registerEngine(MODE)
 
   const ws = new InMemoryWorkflowService()
-  // No queueService configured → runs execute inline (in-process), exercising
-  // the inline step retry loop under concurrent load.
+  // The queue workers (orchestrator/step-worker) resolve the workflow service
+  // off the singleton services, so it must be present for queued dispatch.
+  ;(pikkuState(null, 'package', 'singletonServices') as any).workflowService = ws
   const rpc = rpcService.getContextRPCService(
-    getSingletonServicesRef(),
+    pikkuState(null, 'package', 'singletonServices') as any,
     {} as any,
     false
   )
 
+  const totalSteps = RUNS * STEPS
   console.log(
-    `=== Workflow load benchmark ===\n` +
-      `runs=${RUNS} steps/run=${STEPS} total steps=${RUNS * STEPS}\n`
+    `=== Workflow load benchmark (${MODE}) ===\n` +
+      `runs=${RUNS} steps/run=${STEPS} total steps=${totalSteps}` +
+      (MODE === 'mixed' ? ` (half dispatched through the queue)` : '') +
+      '\n'
   )
 
   const start = performance.now()
@@ -150,22 +215,28 @@ async function main() {
       const wfId = `wf-${i}`
       const { runId } = await ws.startWorkflow(
         WORKFLOW_NAME,
-        { wfId, steps: STEPS },
+        { wfId, steps: STEPS, mixed: MODE === 'mixed' },
         { type: 'bench' } as any,
         rpc,
-        { inline: true }
+        // queue mode orchestrates the whole run through the queue; inline/mixed
+        // start the run in-process (queued steps still suspend to the queue).
+        { inline: MODE !== 'queue' }
       )
-      const run = await ws.getRun(runId)
-      if (run?.status !== 'completed') {
-        throw new Error(
-          `run ${wfId} ended '${run?.status}': ${run?.error?.message ?? 'unknown'}`
-        )
+      if (MODE === 'inline') {
+        const run = await ws.getRun(runId)
+        if (run?.status !== 'completed') {
+          throw new Error(
+            `run ${wfId} ended '${run?.status}': ${run?.error?.message ?? 'unknown'}`
+          )
+        }
+        if ((run.output as any)?.completed !== STEPS) {
+          throw new Error(
+            `run ${wfId} completed ${(run.output as any)?.completed}/${STEPS} steps`
+          )
+        }
+        return wfId
       }
-      if ((run.output as any)?.completed !== STEPS) {
-        throw new Error(
-          `run ${wfId} completed ${(run.output as any)?.completed}/${STEPS} steps`
-        )
-      }
+      await pollToCompletion(ws, runId, wfId, 60_000)
       return wfId
     })
   )
@@ -173,7 +244,6 @@ async function main() {
 
   const failed = settled.filter((s) => s.status === 'rejected')
   const ok = settled.length - failed.length
-  const totalSteps = RUNS * STEPS
 
   console.log('=== Results ===')
   console.log(`completed runs : ${ok}/${RUNS}`)
@@ -182,7 +252,9 @@ async function main() {
     `total attempts : ${totalAttempts} (${(totalAttempts / totalSteps).toFixed(2)}x — retries from transient failures)`
   )
   console.log(`wall time      : ${elapsedMs.toFixed(0)}ms`)
-  console.log(`throughput     : ${((RUNS / elapsedMs) * 1000).toFixed(0)} runs/s, ${((totalSteps / elapsedMs) * 1000).toFixed(0)} steps/s`)
+  console.log(
+    `throughput     : ${((RUNS / elapsedMs) * 1000).toFixed(0)} runs/s, ${((totalSteps / elapsedMs) * 1000).toFixed(0)} steps/s`
+  )
 
   if (failed.length > 0) {
     console.log(`\n=== ${failed.length} FAILED ===`)
@@ -191,14 +263,8 @@ async function main() {
     }
     process.exit(1)
   }
-  console.log('\nPASS: every workflow completed under load.')
+  console.log(`\nPASS: every workflow completed under load (${MODE}).`)
   process.exit(0)
-}
-
-// getSingletonServices is internal; reach it through pikkuState the same way the
-// engine does, so the rpc service and workflow service share one services object.
-function getSingletonServicesRef(): any {
-  return pikkuState(null, 'package', 'singletonServices')
 }
 
 main().catch((error) => {

--- a/benchmarks/bench-workflow.ts
+++ b/benchmarks/bench-workflow.ts
@@ -35,7 +35,10 @@ const arg = (flag: string, fallback: number): number => {
   const i = process.argv.indexOf(flag)
   if (i === -1 || i + 1 >= process.argv.length) return fallback
   const v = Number(process.argv[i + 1])
-  return Number.isFinite(v) ? v : fallback
+  if (!Number.isInteger(v) || v <= 0) {
+    throw new Error(`${flag} must be a positive integer`)
+  }
+  return v
 }
 
 const MODE: Mode = process.argv.includes('--queue')

--- a/benchmarks/bench-workflow.ts
+++ b/benchmarks/bench-workflow.ts
@@ -1,0 +1,207 @@
+/**
+ * Workflow load benchmark.
+ *
+ * Runs hundreds of DSL workflows concurrently, each with many RPC steps, where
+ * a deterministic ~2/3 of steps fail transiently on their first one or two
+ * attempts (mimicking flaky real-world work). The point is correctness under
+ * load: EVERY run must reach `completed` and every step must produce its result
+ * once retries ride out the transient failures — nothing dropped, nothing stuck.
+ *
+ * Drives the engine directly via pikkuState wiring (no codegen), the same way
+ * the HTTP benchmarks register functions, so it runs with a plain `tsx`:
+ *
+ *   yarn workspace @pikku/workspace tsx benchmarks/bench-workflow.ts
+ *   tsx benchmarks/bench-workflow.ts --runs 500 --steps 30
+ */
+
+import { addFunction } from '@pikku/core'
+import { pikkuState, resetPikkuState } from '@pikku/core/internal'
+import { InMemoryWorkflowService } from '@pikku/core/services'
+import { addWorkflow } from '@pikku/core/workflow'
+import { rpcService } from '@pikku/core/rpc'
+
+const arg = (flag: string, fallback: number): number => {
+  const i = process.argv.indexOf(flag)
+  if (i === -1 || i + 1 >= process.argv.length) return fallback
+  const v = Number(process.argv[i + 1])
+  return Number.isFinite(v) ? v : fallback
+}
+
+const RUNS = arg('--runs', 300)
+const STEPS = arg('--steps', 20)
+
+const WORKFLOW_NAME = 'benchWorkflow'
+const STEP_RPC = 'benchStep'
+
+// Per-step attempt counter, keyed by the run-stable `${wfId}:${stepIdx}`. The
+// step throws while its count is within its assigned `failTimes`, then succeeds
+// — so a fresh process sees the same flaky-then-recovering behavior every run.
+const attempts = new Map<string, number>()
+let totalAttempts = 0
+
+// Cheap deterministic string hash → assign each step 0, 1 or 2 transient
+// failures. Deterministic so the DSL body (which computes failTimes) replays
+// identically and the benchmark is reproducible.
+const failTimesFor = (wfId: string, stepIdx: number): number => {
+  let h = 2166136261
+  const s = `${wfId}:${stepIdx}`
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return (h >>> 0) % 3
+}
+
+// Random-ish payload to mimic real step output size without being a fixed blob.
+const randomPayload = (seed: number) => ({
+  id: seed,
+  ts: seed * 31,
+  tag: `payload-${seed % 97}`,
+  values: Array.from({ length: 8 }, (_, i) => (seed * 7 + i) % 1000),
+})
+
+function registerEngine() {
+  resetPikkuState()
+
+  pikkuState(null, 'package', 'singletonServices', {
+    logger: { error() {}, info() {}, warn() {}, debug() {} },
+  } as any)
+  pikkuState(null, 'package', 'factories', {
+    createWireServices: async () => ({}),
+  } as any)
+
+  // Flaky step RPC: fails its first `failTimes` attempts, then returns a result.
+  pikkuState(null, 'rpc', 'meta')[STEP_RPC] = STEP_RPC as any
+  pikkuState(null, 'function', 'meta')[STEP_RPC] = {
+    pikkuFuncId: STEP_RPC,
+    sessionless: true,
+    permissions: [],
+    inputSchemaName: null,
+    outputSchemaName: null,
+  } as any
+  addFunction(STEP_RPC, {
+    func: async (
+      _services: any,
+      data: { wfId: string; stepIdx: number; failTimes: number }
+    ) => {
+      const key = `${data.wfId}:${data.stepIdx}`
+      const count = (attempts.get(key) ?? 0) + 1
+      attempts.set(key, count)
+      totalAttempts++
+      if (count <= data.failTimes) {
+        throw new Error(
+          `transient failure ${count}/${data.failTimes} on ${key}`
+        )
+      }
+      return randomPayload(data.stepIdx + count)
+    },
+  } as any)
+
+  // DSL workflow: run STEPS sequential RPC steps, each with deterministic flakiness.
+  pikkuState(null, 'workflows', 'meta')[WORKFLOW_NAME] = {
+    name: WORKFLOW_NAME,
+    pikkuFuncId: WORKFLOW_NAME,
+    source: 'dsl',
+    graphHash: 'bench-workflow-hash',
+  } as any
+  pikkuState(null, 'function', 'meta')[WORKFLOW_NAME] = {
+    name: WORKFLOW_NAME,
+    sessionless: true,
+    permissions: [],
+    inputSchemaName: null,
+    outputSchemaName: null,
+  } as any
+  addWorkflow(WORKFLOW_NAME, {
+    func: async (_services: any, data: { wfId: string; steps: number }, { workflow }: any) => {
+      const results: number[] = []
+      for (let i = 0; i < data.steps; i++) {
+        const out = await workflow.do(`s${i}`, STEP_RPC, {
+          wfId: data.wfId,
+          stepIdx: i,
+          failTimes: failTimesFor(data.wfId, i),
+        })
+        results.push(out.id)
+      }
+      return { wfId: data.wfId, completed: results.length }
+    },
+  } as any)
+}
+
+async function main() {
+  registerEngine()
+
+  const ws = new InMemoryWorkflowService()
+  // No queueService configured → runs execute inline (in-process), exercising
+  // the inline step retry loop under concurrent load.
+  const rpc = rpcService.getContextRPCService(
+    getSingletonServicesRef(),
+    {} as any,
+    false
+  )
+
+  console.log(
+    `=== Workflow load benchmark ===\n` +
+      `runs=${RUNS} steps/run=${STEPS} total steps=${RUNS * STEPS}\n`
+  )
+
+  const start = performance.now()
+  const settled = await Promise.allSettled(
+    Array.from({ length: RUNS }, async (_, i) => {
+      const wfId = `wf-${i}`
+      const { runId } = await ws.startWorkflow(
+        WORKFLOW_NAME,
+        { wfId, steps: STEPS },
+        { type: 'bench' } as any,
+        rpc,
+        { inline: true }
+      )
+      const run = await ws.getRun(runId)
+      if (run?.status !== 'completed') {
+        throw new Error(
+          `run ${wfId} ended '${run?.status}': ${run?.error?.message ?? 'unknown'}`
+        )
+      }
+      if ((run.output as any)?.completed !== STEPS) {
+        throw new Error(
+          `run ${wfId} completed ${(run.output as any)?.completed}/${STEPS} steps`
+        )
+      }
+      return wfId
+    })
+  )
+  const elapsedMs = performance.now() - start
+
+  const failed = settled.filter((s) => s.status === 'rejected')
+  const ok = settled.length - failed.length
+  const totalSteps = RUNS * STEPS
+
+  console.log('=== Results ===')
+  console.log(`completed runs : ${ok}/${RUNS}`)
+  console.log(`total steps    : ${totalSteps}`)
+  console.log(
+    `total attempts : ${totalAttempts} (${(totalAttempts / totalSteps).toFixed(2)}x — retries from transient failures)`
+  )
+  console.log(`wall time      : ${elapsedMs.toFixed(0)}ms`)
+  console.log(`throughput     : ${((RUNS / elapsedMs) * 1000).toFixed(0)} runs/s, ${((totalSteps / elapsedMs) * 1000).toFixed(0)} steps/s`)
+
+  if (failed.length > 0) {
+    console.log(`\n=== ${failed.length} FAILED ===`)
+    for (const f of failed.slice(0, 10)) {
+      console.log(`  ${(f as PromiseRejectedResult).reason?.message}`)
+    }
+    process.exit(1)
+  }
+  console.log('\nPASS: every workflow completed under load.')
+  process.exit(0)
+}
+
+// getSingletonServices is internal; reach it through pikkuState the same way the
+// engine does, so the rpc service and workflow service share one services object.
+function getSingletonServicesRef(): any {
+  return pikkuState(null, 'package', 'singletonServices')
+}
+
+main().catch((error) => {
+  console.error('Benchmark crashed:', error)
+  process.exit(1)
+})

--- a/e2e/tests/features/workflow-ui.feature
+++ b/e2e/tests/features/workflow-ui.feature
@@ -35,3 +35,17 @@ Feature: Workflow Console UI
     Then the workflow should be cancelled
     When I open the workflow "dslCancellationWorkflow" in the console
     Then the run status should show "Cancelled"
+
+  Scenario: Timeline scrubbing time-travels the canvas
+    When I run the "dslSequentialWorkflow" workflow with:
+      | value | name         |
+      | 5     | UITimeTravel |
+    Then the workflow should complete successfully
+    When I open the workflow "dslSequentialWorkflow" in the console
+    Then the timeline drawer should be visible
+    And the canvas node "sendNotification" should be "green"
+    When I scrub the timeline to step "Double value"
+    Then the canvas node "doubleValue" should be "green"
+    And the canvas node "sendNotification" should not be "green"
+    When I follow the live timeline
+    Then the canvas node "sendNotification" should be "green"

--- a/e2e/tests/steps/workflow-ui.steps.ts
+++ b/e2e/tests/steps/workflow-ui.steps.ts
@@ -51,50 +51,108 @@ Then(
   }
 )
 
+// Reads the first child with an inline background colour and returns its
+// computed rgb — '' when nothing is coloured (an unreached/pending node).
+async function readCanvasNodeColor(
+  world: AgentWorld,
+  nodeLabel: string
+): Promise<string> {
+  const node = world.page
+    .locator('.react-flow__node')
+    .filter({ hasText: nodeLabel })
+    .first()
+  await expect(node).toBeVisible({ timeout: 5_000 })
+  return node.evaluate((el) => {
+    const allEls = el.querySelectorAll('*')
+    for (const child of allEls) {
+      const bg = (child as HTMLElement).style.backgroundColor
+      if (bg && bg !== 'transparent' && !bg.includes('0, 0, 0, 0')) {
+        return window.getComputedStyle(child as HTMLElement).backgroundColor
+      }
+    }
+    return ''
+  })
+}
+
+function classifyColor(
+  bgColor: string
+): { green: boolean; red: boolean; gray: boolean } | null {
+  const match = bgColor.match(
+    /^rgba?\(\s*(\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+\s*)?\)$/
+  )
+  if (!match) return null
+  const [, rs, gs, bs] = match
+  const r = Number(rs),
+    g = Number(gs),
+    b = Number(bs)
+  return {
+    green: g > r && g > b,
+    red: r > g && r > b,
+    gray: Math.abs(r - g) < 30 && Math.abs(g - b) < 30,
+  }
+}
+
 Then(
   'the canvas node {string} should be {string}',
   async function (this: AgentWorld, nodeLabel: string, expectedColor: string) {
-    const node = this.page
-      .locator('.react-flow__node')
-      .filter({ hasText: nodeLabel })
-      .first()
-    await expect(node).toBeVisible({ timeout: 5_000 })
-
-    const bgColor = await node.evaluate((el) => {
-      const allEls = el.querySelectorAll('*')
-      for (const child of allEls) {
-        const bg = (child as HTMLElement).style.backgroundColor
-        if (bg && bg !== 'transparent' && !bg.includes('0, 0, 0, 0')) {
-          return window.getComputedStyle(child as HTMLElement).backgroundColor
-        }
-      }
-      return ''
-    })
-
-    const match = bgColor.match(
-      /^rgba?\(\s*(\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+\s*)?\)$/
-    )
-    if (!match) {
+    const bgColor = await readCanvasNodeColor(this, nodeLabel)
+    const c = classifyColor(bgColor)
+    if (!c) {
       throw new Error(
         `Canvas node "${nodeLabel}" has no rgb background: "${bgColor}"`
       )
     }
-    const [, rs, gs, bs] = match
-    const r = Number(rs),
-      g = Number(gs),
-      b = Number(bs)
-
     if (expectedColor === 'green') {
-      expect(g > r && g > b, `Expected green but got ${bgColor}`).toBeTruthy()
+      expect(c.green, `Expected green but got ${bgColor}`).toBeTruthy()
     } else if (expectedColor === 'red') {
-      expect(r > g && r > b, `Expected red but got ${bgColor}`).toBeTruthy()
+      expect(c.red, `Expected red but got ${bgColor}`).toBeTruthy()
     } else if (expectedColor === 'gray') {
-      expect(
-        Math.abs(r - g) < 30 && Math.abs(g - b) < 30,
-        `Expected gray but got ${bgColor}`
-      ).toBeTruthy()
+      expect(c.gray, `Expected gray but got ${bgColor}`).toBeTruthy()
     } else {
       throw new Error(`Unknown expected color: "${expectedColor}"`)
     }
   }
 )
+
+Then(
+  'the canvas node {string} should not be {string}',
+  async function (this: AgentWorld, nodeLabel: string, color: string) {
+    const bgColor = await readCanvasNodeColor(this, nodeLabel)
+    const c = classifyColor(bgColor)
+    // No coloured background → the node is unreached at this point in time,
+    // which trivially satisfies "is not <color>".
+    if (!c) return
+    if (color === 'green') {
+      expect(c.green, `Expected NOT green but got ${bgColor}`).toBeFalsy()
+    } else if (color === 'red') {
+      expect(c.red, `Expected NOT red but got ${bgColor}`).toBeFalsy()
+    } else {
+      throw new Error(`Unknown color: "${color}"`)
+    }
+  }
+)
+
+Then(
+  'the timeline drawer should be visible',
+  async function (this: AgentWorld) {
+    await expect(
+      this.page.getByTestId('workflow-timeline')
+    ).toBeVisible({ timeout: 10_000 })
+  }
+)
+
+When(
+  'I scrub the timeline to step {string}',
+  async function (this: AgentWorld, stepName: string) {
+    const timeline = this.page.getByTestId('workflow-timeline')
+    await timeline.locator(`[data-step="${stepName}"]`).first().click()
+    // Let the context reconstruct + the canvas re-colour.
+    await this.page.waitForTimeout(800)
+  }
+)
+
+When('I follow the live timeline', async function (this: AgentWorld) {
+  const timeline = this.page.getByTestId('workflow-timeline')
+  await timeline.getByRole('button', { name: 'Follow live' }).click()
+  await this.page.waitForTimeout(800)
+})

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "benchmark:baseline:express": "tsx benchmarks/bench-baseline-express.ts",
     "benchmark:baseline:fastify": "tsx benchmarks/bench-baseline-fastify.ts",
     "benchmark:baseline:uws": "tsx benchmarks/bench-baseline-uws.ts",
-    "benchmark:flame": "npx 0x -- npx tsx benchmarks/bench-express.ts --flame"
+    "benchmark:flame": "npx 0x -- npx tsx benchmarks/bench-express.ts --flame",
+    "benchmark:workflow": "tsx benchmarks/bench-workflow.ts"
   },
   "packageManager": "yarn@4.10.3",
   "devDependencies": {

--- a/packages/console/src/components/project/WorkflowCanvas.tsx
+++ b/packages/console/src/components/project/WorkflowCanvas.tsx
@@ -21,7 +21,13 @@ import {
   Stack,
 } from '@pikku/mantine/core'
 import { asI18n } from '@pikku/react'
-import { AlertTriangle, History, ChevronDown, Search, Check } from 'lucide-react'
+import {
+  AlertTriangle,
+  History,
+  ChevronDown,
+  Search,
+  Check,
+} from 'lucide-react'
 import {
   CanvasDrawerProvider,
   useCanvasDrawerContext,
@@ -37,6 +43,7 @@ import {
 import { usePanelContext } from '../../context/PanelContext'
 import { usePikkuRPC } from '../../context/PikkuRpcProvider'
 import { createCanvasDrawerContent } from '../canvas-drawer/CanvasDrawerFactory'
+import { WorkflowTimelineDrawer } from './WorkflowTimelineDrawer'
 import { useWorkflowRuns } from '../../hooks/useWorkflowRuns'
 import { RunsPanel, type RunItem } from '../layout/RunsPanel'
 import { WiringNode } from './nodes/WiringNode'
@@ -234,7 +241,9 @@ const WorkflowRunsPanel: React.FC<{
     if (!search) return items
     const q = search.toLowerCase()
     return items.filter(
-      (i) => i.name.toLowerCase().includes(q) || i.description?.toLowerCase().includes(q)
+      (i) =>
+        i.name.toLowerCase().includes(q) ||
+        i.description?.toLowerCase().includes(q)
     )
   }, [items, search])
 
@@ -288,7 +297,16 @@ const WorkflowRunsPanel: React.FC<{
           }}
           onClick={() => setSelectorOpen((o) => !o)}
         >
-          <Text size="sm" fw={600} style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          <Text
+            size="sm"
+            fw={600}
+            style={{
+              flex: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
             {asI18n(workflowName)}
           </Text>
           <ChevronDown size={14} style={{ flexShrink: 0 }} />
@@ -445,7 +463,14 @@ const WorkflowCanvasContent: React.FC<WorkflowCanvasProps> = ({
         emptyPanelMessage={asI18n('Select a node to view its details')}
         runsPanel={runsPanel}
       >
-        <Box style={{ height: '100%', position: 'relative', display: 'flex', flexDirection: 'column' }}>
+        <Box
+          style={{
+            height: '100%',
+            position: 'relative',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
           {isComplex && (
             <Alert
               icon={<AlertTriangle size={16} />}
@@ -455,7 +480,9 @@ const WorkflowCanvasContent: React.FC<WorkflowCanvasProps> = ({
               style={{ flexShrink: 0 }}
             >
               <Text size="sm">
-                {asI18n('This is a complex workflow. The visual representation may not be accurate.')}
+                {asI18n(
+                  'This is a complex workflow. The visual representation may not be accurate.'
+                )}
               </Text>
             </Alert>
           )}
@@ -468,7 +495,9 @@ const WorkflowCanvasContent: React.FC<WorkflowCanvasProps> = ({
               style={{ flexShrink: 0 }}
             >
               <Text size="sm">
-                {asI18n('Viewing historical version — workflow definition has changed since this run')}
+                {asI18n(
+                  'Viewing historical version — workflow definition has changed since this run'
+                )}
               </Text>
             </Alert>
           )}
@@ -478,6 +507,7 @@ const WorkflowCanvasContent: React.FC<WorkflowCanvasProps> = ({
               onPaneClick={handlePaneClick}
             />
           </Box>
+          <WorkflowTimelineDrawer />
         </Box>
       </ThreePaneLayout>
       {canvasDrawer && (

--- a/packages/console/src/components/project/WorkflowTimelineDrawer.tsx
+++ b/packages/console/src/components/project/WorkflowTimelineDrawer.tsx
@@ -1,0 +1,239 @@
+import React, { useMemo } from 'react'
+import {
+  Box,
+  Group,
+  Stack,
+  Text,
+  Tooltip,
+  Collapse,
+  ScrollArea,
+  Slider,
+  ActionIcon,
+  UnstyledButton,
+} from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import {
+  reconstructStateAt,
+  reconstructFinalState,
+  type StepStatus,
+} from '@pikku/core/workflow'
+import {
+  Clock,
+  ChevronDown,
+  ChevronUp,
+  Radio,
+  SkipBack,
+  SkipForward,
+} from 'lucide-react'
+import { useWorkflowRunContextSafe } from '../../context/WorkflowRunContext'
+
+// Mirror of the canvas node status palette so a step's pill matches its node.
+const statusColor: Record<string, string> = {
+  succeeded: 'var(--pikku-status-succeeded, var(--mantine-color-green-5))',
+  failed: 'var(--pikku-status-failed, var(--mantine-color-red-5))',
+  running: 'var(--pikku-status-running, var(--mantine-color-blue-5))',
+  scheduled: 'var(--pikku-status-scheduled, var(--mantine-color-orange-5))',
+  pending: 'var(--pikku-status-pending, var(--mantine-color-gray-4))',
+  suspended: 'var(--pikku-status-suspended, var(--mantine-color-yellow-5))',
+}
+
+const colorFor = (status?: StepStatus): string =>
+  (status && statusColor[status]) || 'var(--mantine-color-gray-3)'
+
+/**
+ * Bottom drawer that turns a run's durable history into a linear, scrubbable
+ * timeline. Dragging the scrubber (or clicking a step) time-travels: the
+ * WorkflowRunContext reconstructs the run's state at that point and the canvas
+ * above re-colors to match. Following the live tail clears the override.
+ */
+export const WorkflowTimelineDrawer: React.FC = () => {
+  const ctx = useWorkflowRunContextSafe()
+  const [open, setOpen] = React.useState(true)
+
+  const timeline = ctx?.timeline ?? []
+  const hasTimeline = timeline.length > 0
+
+  // Stable step order (the full walked path) for the linear pill strip, and the
+  // last event seq per step so clicking a pill jumps to where it settled.
+  const { path, lastSeqByStep } = useMemo(() => {
+    if (!hasTimeline)
+      return { path: [] as string[], lastSeqByStep: new Map<string, number>() }
+    const lastSeqByStep = new Map<string, number>()
+    for (const e of timeline) lastSeqByStep.set(e.stepName, e.seq)
+    return { path: reconstructFinalState(timeline).path, lastSeqByStep }
+  }, [timeline, hasTimeline])
+
+  if (!ctx || !ctx.selectedRunId || !hasTimeline) return null
+
+  const maxSeq = timeline.length - 1
+  const isLive = ctx.timelineSeq === null
+  const cursor = ctx.timelineSeq ?? maxSeq
+  // State at the cursor — drives pill colours and the read-out.
+  const current = reconstructStateAt(timeline, cursor)
+  const statusByStep = new Map(current.steps.map((s) => [s.stepName, s]))
+  const cursorEvent = timeline[cursor]
+  const activeStep = cursorEvent?.stepName
+
+  const marks = path.map((name) => ({ value: lastSeqByStep.get(name) ?? 0 }))
+
+  const jumpTo = (seq: number) => ctx.setTimelineSeq(seq)
+  const goLive = () => ctx.setTimelineSeq(null)
+
+  return (
+    <Box
+      data-testid="workflow-timeline"
+      style={{
+        flexShrink: 0,
+        borderTop: '1px solid var(--mantine-color-default-border)',
+        background: 'var(--mantine-color-body)',
+      }}
+    >
+      <Group justify="space-between" px="md" py={6} wrap="nowrap">
+        <Group gap="xs" wrap="nowrap">
+          <Clock size={16} />
+          <Text size="sm" fw={600}>
+            {asI18n('Timeline')}
+          </Text>
+          <Text size="xs" c="dimmed">
+            {isLive
+              ? asI18n('Live')
+              : asI18n(`Step ${cursor + 1} of ${timeline.length}`)}
+          </Text>
+        </Group>
+        <Group gap={4} wrap="nowrap">
+          {!isLive && (
+            <Tooltip label={asI18n('Follow live')} withinPortal>
+              <ActionIcon
+                size="sm"
+                variant="subtle"
+                color="blue"
+                onClick={goLive}
+                aria-label={asI18n('Follow live')}
+              >
+                <Radio size={15} />
+              </ActionIcon>
+            </Tooltip>
+          )}
+          <ActionIcon
+            size="sm"
+            variant="subtle"
+            onClick={() => setOpen((o) => !o)}
+            aria-label={asI18n('Toggle timeline')}
+          >
+            {open ? <ChevronDown size={15} /> : <ChevronUp size={15} />}
+          </ActionIcon>
+        </Group>
+      </Group>
+
+      <Collapse in={open}>
+        <Stack gap="xs" px="md" pb="sm">
+          <ScrollArea type="hover" scrollbarSize={6}>
+            <Group gap={6} wrap="nowrap" py={2}>
+              {path.map((name) => {
+                const step = statusByStep.get(name)
+                const reached = step !== undefined
+                const seq = lastSeqByStep.get(name) ?? 0
+                return (
+                  <UnstyledButton
+                    key={name}
+                    data-step={name}
+                    onClick={() => jumpTo(seq)}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      padding: '2px 8px',
+                      borderRadius: 6,
+                      whiteSpace: 'nowrap',
+                      opacity: reached ? 1 : 0.45,
+                      border:
+                        name === activeStep
+                          ? '1px solid var(--mantine-color-blue-5)'
+                          : '1px solid transparent',
+                      background:
+                        name === activeStep
+                          ? 'var(--mantine-color-blue-light)'
+                          : 'var(--mantine-color-default-hover)',
+                    }}
+                  >
+                    <Box
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: '50%',
+                        background: colorFor(step?.status),
+                        flexShrink: 0,
+                      }}
+                    />
+                    <Text size="xs">{asI18n(name)}</Text>
+                  </UnstyledButton>
+                )
+              })}
+            </Group>
+          </ScrollArea>
+
+          <Group gap="sm" wrap="nowrap" align="center">
+            <ActionIcon
+              size="sm"
+              variant="default"
+              disabled={cursor <= 0}
+              onClick={() => jumpTo(cursor - 1)}
+              aria-label={asI18n('Previous event')}
+            >
+              <SkipBack size={14} />
+            </ActionIcon>
+            <Box style={{ flex: 1 }}>
+              <Slider
+                min={0}
+                max={maxSeq}
+                value={cursor}
+                marks={marks}
+                label={(v) => timeline[v]?.stepName ?? ''}
+                onChange={jumpTo}
+                size="sm"
+              />
+            </Box>
+            <ActionIcon
+              size="sm"
+              variant="default"
+              disabled={cursor >= maxSeq}
+              onClick={() => jumpTo(cursor + 1)}
+              aria-label={asI18n('Next event')}
+            >
+              <SkipForward size={14} />
+            </ActionIcon>
+          </Group>
+
+          {cursorEvent && (
+            <Group gap="xs" wrap="nowrap" align="baseline">
+              <Box
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  background: colorFor(
+                    activeStep
+                      ? statusByStep.get(activeStep)?.status
+                      : undefined
+                  ),
+                  flexShrink: 0,
+                }}
+              />
+              <Text size="sm" fw={500}>
+                {asI18n(cursorEvent.stepName)}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {asI18n(cursorEvent.type)}
+              </Text>
+              {cursorEvent.fromStepName && (
+                <Text size="xs" c="dimmed">
+                  {asI18n(`← ${cursorEvent.fromStepName}`)}
+                </Text>
+              )}
+            </Group>
+          )}
+        </Stack>
+      </Collapse>
+    </Box>
+  )
+}

--- a/packages/console/src/context/WorkflowRunContext.tsx
+++ b/packages/console/src/context/WorkflowRunContext.tsx
@@ -10,8 +10,15 @@ import { useSearchParams } from '../router'
 import {
   useWorkflowRun,
   useWorkflowRunSteps,
+  useWorkflowRunHistory,
   useWorkflowVersion,
 } from '../hooks/useWorkflowRuns'
+import {
+  buildRunTimeline,
+  reconstructStateAt,
+  type RunTimeline,
+  type ReconstructedRunState,
+} from '@pikku/core/workflow'
 
 interface WorkflowRunContextType {
   selectedRunId: string | null
@@ -25,6 +32,13 @@ interface WorkflowRunContextType {
   historicalLoading: boolean
   isCreatingRun: boolean
   setIsCreatingRun: (creating: boolean) => void
+  /** Ordered event stream for the selected run (empty until history loads). */
+  timeline: RunTimeline
+  /** Time-travel cursor: a timeline seq, or null when following the live tail. */
+  timelineSeq: number | null
+  setTimelineSeq: (seq: number | null) => void
+  /** Run state reconstructed at `timelineSeq`; null while live. */
+  reconstructed: ReconstructedRunState | null
 }
 
 const WorkflowRunContext = createContext<WorkflowRunContextType | undefined>(
@@ -89,9 +103,14 @@ export const WorkflowRunProvider: React.FC<WorkflowRunProviderProps> = ({
     useWorkflowRun(selectedRunId)
   const { data: querySteps, isLoading: stepsLoading } =
     useWorkflowRunSteps(selectedRunId)
+  const { data: queryHistory } = useWorkflowRunHistory(selectedRunId)
 
   const runData = queryRunData
   const steps = querySteps
+
+  // Time-travel cursor — null follows the live tail; a number pins the canvas
+  // to the run's reconstructed state at that timeline event.
+  const [timelineSeq, setTimelineSeqState] = useState<number | null>(null)
 
   const setSelectedRunId = useCallback(
     (id: string | null) => {
@@ -127,21 +146,81 @@ export const WorkflowRunProvider: React.FC<WorkflowRunProviderProps> = ({
     [workflowNodes]
   )
 
-  const stepStates = useMemo(() => {
+  const resolveNodeId = useCallback(
+    (stepName: string): string =>
+      stepNameToNodeId.get(stepName) ??
+      (stepNameToNodeId as any).__templatePatterns?.find(
+        ([_, regex]: [string, RegExp]) => regex.test(stepName)
+      )?.[0] ??
+      stepName,
+    [stepNameToNodeId]
+  )
+
+  // RPC serializes the step lifecycle Dates as ISO strings; the timeline fold
+  // sorts on `.getTime()`, so rehydrate them before building.
+  const timeline = useMemo<RunTimeline>(() => {
+    if (!queryHistory || !Array.isArray(queryHistory)) return []
+    const toDate = (v: unknown) => (v ? new Date(v as string) : undefined)
+    const rehydrated = queryHistory.map((h: any) => ({
+      ...h,
+      createdAt: new Date(h.createdAt),
+      updatedAt: new Date(h.updatedAt ?? h.createdAt),
+      scheduledAt: toDate(h.scheduledAt),
+      runningAt: toDate(h.runningAt),
+      succeededAt: toDate(h.succeededAt),
+      failedAt: toDate(h.failedAt),
+    }))
+    return buildRunTimeline(rehydrated as any)
+  }, [queryHistory])
+
+  // Reset the cursor to live whenever the selected run changes.
+  useEffect(() => {
+    setTimelineSeqState(null)
+  }, [selectedRunId])
+
+  const setTimelineSeq = useCallback(
+    (seq: number | null) => {
+      if (seq === null) {
+        setTimelineSeqState(null)
+        return
+      }
+      const max = timeline.length - 1
+      setTimelineSeqState(Math.max(0, Math.min(seq, max)))
+    },
+    [timeline.length]
+  )
+
+  const reconstructed = useMemo<ReconstructedRunState | null>(
+    () =>
+      timelineSeq === null || timeline.length === 0
+        ? null
+        : reconstructStateAt(timeline, timelineSeq),
+    [timeline, timelineSeq]
+  )
+
+  // Live step states (from the polled steps query) drive the canvas by default.
+  const liveStepStates = useMemo(() => {
     const map = new Map<string, any>()
     if (steps && Array.isArray(steps)) {
       for (const step of steps) {
-        const nodeId =
-          stepNameToNodeId.get(step.stepName) ??
-          (stepNameToNodeId as any).__templatePatterns?.find(
-            ([_, regex]: [string, RegExp]) => regex.test(step.stepName)
-          )?.[0] ??
-          step.stepName
-        map.set(nodeId, step)
+        map.set(resolveNodeId(step.stepName), step)
       }
     }
     return map
-  }, [steps, stepNameToNodeId])
+  }, [steps, resolveNodeId])
+
+  // While scrubbing, the reconstructed state overrides live so the canvas
+  // re-colors to the chosen point in time.
+  const reconstructedStepStates = useMemo(() => {
+    if (!reconstructed) return null
+    const map = new Map<string, any>()
+    for (const step of reconstructed.steps) {
+      map.set(resolveNodeId(step.stepName), step)
+    }
+    return map
+  }, [reconstructed, resolveNodeId])
+
+  const stepStates = reconstructedStepStates ?? liveStepStates
 
   const isRunActive = runData?.status === 'running'
   const isLoading = runLoading || stepsLoading
@@ -176,6 +255,10 @@ export const WorkflowRunProvider: React.FC<WorkflowRunProviderProps> = ({
         historicalLoading,
         isCreatingRun,
         setIsCreatingRun,
+        timeline,
+        timelineSeq,
+        setTimelineSeq,
+        reconstructed,
       }}
     >
       {children}

--- a/packages/core/src/services/in-memory-queue-service.test.ts
+++ b/packages/core/src/services/in-memory-queue-service.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryQueueService } from './in-memory-queue-service.js'
+import { wireQueueWorker } from '../wirings/queue/queue-runner.js'
+import { resetPikkuState, pikkuState } from '../pikku-state.js'
+
+beforeEach(() => {
+  resetPikkuState()
+  pikkuState(null, 'package', 'singletonServices', {
+    logger: { error() {}, info() {}, warn() {}, debug() {} },
+  } as any)
+  pikkuState(null, 'package', 'factories', {
+    createWireServices: async () => ({}),
+  } as any)
+})
+
+// Register a queue worker whose handler runs `behavior` (which may throw) and
+// counts invocations. Returns the live call counter.
+const registerWorker = (
+  queueName: string,
+  behavior: (count: number) => void
+) => {
+  const calls = { count: 0 }
+  const funcId = `queue_${queueName}`
+  pikkuState(null, 'queue', 'meta')[queueName] = { pikkuFuncId: funcId, name: queueName }
+  pikkuState(null, 'function', 'meta')[funcId] = {
+    pikkuFuncId: funcId,
+    inputSchemaName: null,
+    outputSchemaName: null,
+    sessionless: true,
+  } as any
+  wireQueueWorker({
+    name: queueName,
+    func: {
+      auth: false,
+      func: async () => {
+        calls.count++
+        behavior(calls.count)
+      },
+    },
+  } as any)
+  return calls
+}
+
+const waitUntil = async (
+  predicate: () => boolean,
+  timeoutMs = 2000
+): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await new Promise((r) => setTimeout(r, 10))
+  }
+  return predicate()
+}
+
+describe('InMemoryQueueService retry', () => {
+  test('redelivers a transiently-failing job until it succeeds', async () => {
+    const calls = registerWorker('flaky', (count) => {
+      if (count <= 2) throw new Error(`transient ${count}`)
+    })
+    const queue = new InMemoryQueueService()
+
+    await queue.add('flaky', {}, { attempts: 5, delay: 0 })
+
+    // Succeeds on the 3rd attempt; must not exceed the configured attempts.
+    assert.equal(await waitUntil(() => calls.count >= 3), true)
+    await new Promise((r) => setTimeout(r, 150))
+    assert.equal(calls.count, 3, 'should stop retrying once the job succeeds')
+  })
+
+  test('stops after `attempts` when a job always fails', async () => {
+    const calls = registerWorker('always-fails', () => {
+      throw new Error('boom')
+    })
+    const queue = new InMemoryQueueService()
+
+    await queue.add('always-fails', {}, { attempts: 3, delay: 0 })
+
+    assert.equal(await waitUntil(() => calls.count >= 3), true)
+    await new Promise((r) => setTimeout(r, 150))
+    assert.equal(calls.count, 3, 'must not redeliver beyond `attempts`')
+  })
+
+  test('runs once and does not retry when no attempts are configured', async () => {
+    const calls = registerWorker('no-retry', () => {
+      throw new Error('boom')
+    })
+    const queue = new InMemoryQueueService()
+
+    await queue.add('no-retry', {}, { delay: 0 })
+
+    await new Promise((r) => setTimeout(r, 150))
+    assert.equal(calls.count, 1, 'a job without attempts runs exactly once')
+  })
+})

--- a/packages/core/src/services/in-memory-queue-service.ts
+++ b/packages/core/src/services/in-memory-queue-service.ts
@@ -5,6 +5,13 @@ import type {
 } from '../wirings/queue/queue.types.js'
 import { runQueueJob } from '../wirings/queue/queue-runner.js'
 
+/**
+ * In-process queue for local/dev runs. Schedules jobs on the macrotask queue
+ * (setTimeout) so dispatch is genuinely asynchronous — the same timing shape as
+ * a real queue — and redelivers a failed job up to `options.attempts` times with
+ * backoff, so a transiently-failing workflow step recovers exactly as it would
+ * on pg-boss/bullmq instead of being silently dropped on its first error.
+ */
 export class InMemoryQueueService implements QueueService {
   readonly supportsResults = false
   private jobCounter = 0
@@ -15,29 +22,52 @@ export class InMemoryQueueService implements QueueService {
     options?: JobOptions
   ): Promise<string> {
     const jobId = `inmem-${++this.jobCounter}`
+    const maxAttempts = Math.max(1, options?.attempts ?? 1)
+    let attemptsMade = 0
 
-    const job: QueueJob<T> = {
-      id: jobId,
-      queueName,
-      data,
-      status: () => 'active',
-      pikkuUserId: options?.pikkuUserId,
-    }
-
-    const delay = options?.delay ?? 100 + Math.floor(Math.random() * 201)
-
-    setTimeout(async () => {
+    const runAttempt = async () => {
+      attemptsMade++
+      const job: QueueJob<T> = {
+        id: jobId,
+        queueName,
+        data,
+        status: () => 'active',
+        metadata: () => ({ attemptsMade, maxAttempts, createdAt: new Date() }),
+        pikkuUserId: options?.pikkuUserId,
+      }
       try {
         await runQueueJob({ job })
       } catch (e: any) {
-        console.error(
-          `[InMemoryQueue] Job ${jobId} on ${queueName} failed:`,
-          e.message
-        )
+        if (attemptsMade < maxAttempts) {
+          // Transient failure — redeliver with backoff, mirroring a real queue.
+          setTimeout(runAttempt, this.backoffDelay(options?.backoff, attemptsMade))
+        } else {
+          console.error(
+            `[InMemoryQueue] Job ${jobId} on ${queueName} failed after ${attemptsMade} attempt(s):`,
+            e.message
+          )
+        }
       }
-    }, delay)
+    }
+
+    const delay = options?.delay ?? 100 + Math.floor(Math.random() * 201)
+    setTimeout(runAttempt, delay)
 
     return jobId
+  }
+
+  /** Delay before the next redelivery, honoring the job's backoff policy. */
+  private backoffDelay(
+    backoff: JobOptions['backoff'],
+    attemptsMade: number
+  ): number {
+    if (backoff === 'exponential' || (backoff as any)?.type === 'exponential') {
+      return Math.min(2 ** (attemptsMade - 1) * 50, 2000)
+    }
+    if (typeof backoff === 'object' && backoff?.type === 'fixed') {
+      return backoff.delay ?? 50
+    }
+    return 50
   }
 
   async getJob(): Promise<null> {

--- a/packages/core/src/services/in-memory-queue-service.ts
+++ b/packages/core/src/services/in-memory-queue-service.ts
@@ -24,6 +24,7 @@ export class InMemoryQueueService implements QueueService {
     const jobId = `inmem-${++this.jobCounter}`
     const maxAttempts = Math.max(1, options?.attempts ?? 1)
     let attemptsMade = 0
+    const createdAt = new Date()
 
     const runAttempt = async () => {
       attemptsMade++
@@ -32,7 +33,7 @@ export class InMemoryQueueService implements QueueService {
         queueName,
         data,
         status: () => 'active',
-        metadata: () => ({ attemptsMade, maxAttempts, createdAt: new Date() }),
+        metadata: () => ({ attemptsMade, maxAttempts, createdAt }),
         pikkuUserId: options?.pikkuUserId,
       }
       try {
@@ -61,8 +62,12 @@ export class InMemoryQueueService implements QueueService {
     backoff: JobOptions['backoff'],
     attemptsMade: number
   ): number {
-    if (backoff === 'exponential' || (backoff as any)?.type === 'exponential') {
-      return Math.min(2 ** (attemptsMade - 1) * 50, 2000)
+    const baseDelay = typeof backoff === 'object' ? (backoff.delay ?? 50) : 50
+    if (
+      backoff === 'exponential' ||
+      (typeof backoff === 'object' && backoff?.type === 'exponential')
+    ) {
+      return Math.min(2 ** (attemptsMade - 1) * baseDelay, 2000)
     }
     if (typeof backoff === 'object' && backoff?.type === 'fixed') {
       return backoff.delay ?? 50

--- a/packages/core/src/services/workflow-service.ts
+++ b/packages/core/src/services/workflow-service.ts
@@ -8,6 +8,10 @@ import type {
   WorkflowStatus,
   WorkflowVersionStatus,
 } from '../wirings/workflow/workflow.types.js'
+import type {
+  RunTimeline,
+  ReconstructedRunState,
+} from '../wirings/workflow/run-timeline.js'
 
 /**
  * Interface for workflow orchestration
@@ -29,6 +33,11 @@ export interface WorkflowService {
   getRun(id: string): Promise<WorkflowRun | null>
   getRunStatus(id: string): Promise<WorkflowRunStatus | null>
   getRunHistory(runId: string): Promise<Array<StepState & { stepName: string }>>
+  getRunTimeline(id: string): Promise<RunTimeline | null>
+  reconstructRunStateAt(
+    id: string,
+    at?: number | Date
+  ): Promise<ReconstructedRunState | null>
   updateRunStatus(
     id: string,
     status: WorkflowStatus,

--- a/packages/core/src/wirings/workflow/graph/graph-runner.test.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.test.ts
@@ -416,6 +416,78 @@ describe('graph-runner bugs', () => {
     delete metaState['testInlineFailure']
   })
 
+  test('inline graph revisits a cyclic node and records the walked path via fromStepName', async () => {
+    const ws = new InMemoryWorkflowService()
+
+    // attempt loops back to itself via `again` until it converges to `done`.
+    const mockRpcService = {
+      rpcWithWire: async (rpcName: string, _data: any, wire: any) => {
+        if (rpcName === 'cyclicBegin') return { attempts: 3 }
+        if (rpcName === 'cyclicAttempt') {
+          const state = await wire.graph.getState()
+          const count = ((state.count as number) ?? 0) + 1
+          await wire.graph.setState('count', count)
+          wire.graph.branch(count >= 3 ? 'done' : 'again')
+          return { count }
+        }
+        if (rpcName === 'cyclicFinish') return { ok: true }
+        return {}
+      },
+    }
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    metaState['testInlineCyclic'] = {
+      name: 'testInlineCyclic',
+      pikkuFuncId: 'testInlineCyclic',
+      source: 'graph',
+      entryNodeIds: ['begin'],
+      graphHash: 'inline-cyclic-hash',
+      nodes: {
+        begin: { nodeId: 'begin', rpcName: 'cyclicBegin', next: 'attempt' },
+        attempt: {
+          nodeId: 'attempt',
+          rpcName: 'cyclicAttempt',
+          next: { again: 'attempt', done: 'finish' },
+        },
+        finish: { nodeId: 'finish', rpcName: 'cyclicFinish' },
+      },
+    }
+
+    const { runId } = await runWorkflowGraph(
+      ws,
+      'testInlineCyclic',
+      {},
+      mockRpcService,
+      true
+    )
+
+    const run = await ws.getRun(runId)
+    assert.equal(run?.status, 'completed')
+
+    // The self-cycle produced three ordinal instances of `attempt`.
+    const instances = await ws.getStepInstances(runId)
+    const names = instances.map((i) => i.stepName).sort()
+    assert.ok(
+      names.includes('attempt') &&
+        names.includes('attempt#1') &&
+        names.includes('attempt#2'),
+      `expected attempt/attempt#1/attempt#2, got ${JSON.stringify(names)}`
+    )
+
+    // Walk the fromStepName chain back from the terminal node — inline now
+    // records provenance identical to the queued path.
+    const from = new Map(instances.map((i) => [i.stepName, i.fromStepName]))
+    const path: string[] = []
+    let cursor: string | undefined = 'finish'
+    while (cursor) {
+      path.unshift(cursor)
+      cursor = from.get(cursor) ?? undefined
+    }
+    assert.deepEqual(path, ['begin', 'attempt', 'attempt#1', 'attempt#2', 'finish'])
+
+    delete metaState['testInlineCyclic']
+  })
+
   test('executeGraphStep should throw after queueing onError nodes', async () => {
     const ws = new InMemoryWorkflowService()
 

--- a/packages/core/src/wirings/workflow/graph/graph-runner.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.ts
@@ -705,20 +705,26 @@ async function executeGraphNodeInline(
   runId: string,
   graphName: string,
   nodeId: string,
+  instanceKey: string,
   input: any,
-  nodes: Record<string, any>
+  nodes: Record<string, any>,
+  fromStepName?: string
 ): Promise<void> {
   const node = nodes[nodeId]
   if (!node) return
 
   const rpcName = node.rpcName
 
+  // Persist under the physical instance key (node, node#1 … for revisits) and
+  // record the predecessor — same as the queued path (queueGraphNode), so an
+  // inline graph run stores identical step rows + provenance.
   const stepState = await workflowService.insertStepState(
     runId,
-    nodeId,
+    instanceKey,
     rpcName,
     input,
-    { retries: node.retries ?? 0, retryDelay: node.retryDelay }
+    { retries: node.retries ?? 0, retryDelay: node.retryDelay },
+    fromStepName
   )
 
   await workflowService.setStepRunning(stepState.stepId)
@@ -811,8 +817,10 @@ async function executeGraphNodeInline(
             runId,
             graphName,
             errorNodeId,
+            errorNodeId,
             { error: { message: (error as Error).message } },
-            nodes
+            nodes,
+            nodeId
           )
         )
       )
@@ -831,20 +839,22 @@ async function continueGraphInline(
   triggerInput: any,
   entryNodeIds: string[]
 ): Promise<void> {
+  // Drive the run to completion in-process using the SAME planner as the queued
+  // path (continueGraph): each loop plans the next wave of transitions, executes
+  // them inline (vs queueGraphNode dispatch), then re-plans. Sharing the planner
+  // gives the inline path joins, cycle revisits and fromStepName provenance
+  // identical to the queue — instead of a second, weaker traversal.
   while (true) {
     const {
-      completedNodeIds: rawCompleted,
       failedNodeIds: rawFailed,
-      branchKeys: rawBranch,
+      branchKeys: branchByStep,
+      completedNodeIds: rawCompleted,
     } = await workflowService.getCompletedGraphState(runId)
-    const completedNodeIds = remapStepNamesToNodeIds(
-      rawCompleted,
-      nodes,
-      graphName
-    )
-    const completedNodeIdSet = new Set(completedNodeIds)
+    // Validate step/branch names map to unambiguous nodes (planning keys
+    // physically; these calls only surface ambiguous template configs).
+    remapStepNamesToNodeIds(rawCompleted, nodes, graphName)
+    remapBranchKeys(branchByStep, nodes, graphName)
     const failedNodeIds = remapStepNamesToNodeIds(rawFailed, nodes, graphName)
-    const branchKeys = remapBranchKeys(rawBranch, nodes, graphName)
 
     if (failedNodeIds.length > 0) {
       const failedNode = failedNodeIds[0]!
@@ -856,46 +866,31 @@ async function continueGraphInline(
       return
     }
 
-    const candidateNodes = new Set<string>()
-
-    for (const nodeId of completedNodeIds) {
-      const node = nodes[nodeId]
-      if (!node?.next) continue
-
-      const nextNodes = resolveNextFromConfig(node.next, branchKeys[nodeId])
-      for (const nextNode of nextNodes) {
-        candidateNodes.add(nextNode)
-      }
-    }
-
-    for (const entryId of entryNodeIds) {
-      candidateNodes.add(entryId)
-    }
-
-    if (candidateNodes.size === 0 && completedNodeIds.length > 0) {
-      await workflowService.updateRunStatus(runId, 'completed')
+    const run = await workflowService.getRun(runId)
+    if (run?.status === 'suspended') {
       return
     }
 
-    const unstartedNodes = await workflowService.getNodesWithoutSteps(runId, [
-      ...candidateNodes,
-    ])
+    const instances = await workflowService.getStepInstances(runId)
+    const plan = planGraphTransitions(
+      nodes,
+      instances,
+      branchByStep,
+      entryNodeIds,
+      graphName
+    )
 
-    const nodesToExecute = unstartedNodes.filter((nodeId) => {
-      const node = nodes[nodeId]
-      return node && areDependenciesSatisfied(node, completedNodeIdSet)
-    })
-
-    if (nodesToExecute.length === 0) {
-      if (completedNodeIds.length > 0 && unstartedNodes.length === 0) {
+    if (plan.toFire.length === 0) {
+      if (!plan.hasInFlight && !plan.blockedWaiting) {
         await workflowService.updateRunStatus(runId, 'completed')
       }
       return
     }
 
+    let executed = 0
     await Promise.all(
-      nodesToExecute.map(async (nodeId) => {
-        const node = nodes[nodeId]
+      plan.toFire.map(async (fire) => {
+        const node = nodes[fire.logical]
         if (!node?.rpcName) return
 
         const referencedNodeIds = extractReferencedNodeIds(node.input).filter(
@@ -905,21 +900,25 @@ async function continueGraphInline(
           runId,
           referencedNodeIds
         )
-
         const nodeResults = { trigger: triggerInput, ...fetchedResults }
         const resolvedInput = resolveSerializedInput(node.input, nodeResults)
 
+        executed++
         await executeGraphNodeInline(
           workflowService,
           rpcService,
           runId,
           graphName,
-          nodeId,
+          fire.logical,
+          fire.instanceKey,
           resolvedInput,
-          nodes
+          nodes,
+          fire.fromStepName
         )
       })
     )
+    // Nothing executable fired (e.g. nodes without an rpcName) → can't progress.
+    if (executed === 0) return
   }
 }
 
@@ -1001,6 +1000,7 @@ export async function runWorkflowGraph(
               rpcService,
               runId,
               graphName,
+              nodeId,
               nodeId,
               resolvedInput,
               nodes

--- a/packages/core/src/wirings/workflow/graph/graph-runner.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.ts
@@ -565,14 +565,21 @@ export async function continueGraph(
   }
 }
 
-export async function executeGraphStep(
+/**
+ * Invoke a graph node's RPC with the graph + workflow wires, capturing any
+ * branch the node selects and persisting it. Shared by the queued
+ * (executeGraphStep) and inline (executeGraphNodeInline) executors so both build
+ * the wire and record the branch identically — only their child-workflow and
+ * onError handling differs around this call.
+ */
+async function invokeGraphNodeRpc(
   workflowService: PikkuWorkflowService,
   rpcService: any,
   runId: string,
   stepId: string,
   nodeId: string,
   rpcName: string,
-  data: any,
+  input: any,
   graphName: string
 ): Promise<any> {
   const wireState: GraphWireState = {}
@@ -588,6 +595,28 @@ export async function executeGraphStep(
     getState: () => workflowService.getRunState(runId),
   }
 
+  const result = await rpcService.rpcWithWire(rpcName, input, {
+    graph: graphWire,
+    workflow: workflowService.createWorkflowWire(graphName, runId, rpcService),
+  })
+
+  if (wireState.branchKey) {
+    await workflowService.setBranchTaken(stepId, wireState.branchKey)
+  }
+
+  return result
+}
+
+export async function executeGraphStep(
+  workflowService: PikkuWorkflowService,
+  rpcService: any,
+  runId: string,
+  stepId: string,
+  nodeId: string,
+  rpcName: string,
+  data: any,
+  graphName: string
+): Promise<any> {
   try {
     let result: any
 
@@ -622,18 +651,16 @@ export async function executeGraphStep(
         throw new ChildWorkflowStartedException(runId, stepId, childRunId)
       }
     } else {
-      result = await rpcService.rpcWithWire(rpcName, data, {
-        graph: graphWire,
-        workflow: workflowService.createWorkflowWire(
-          graphName,
-          runId,
-          rpcService
-        ),
-      })
-    }
-
-    if (wireState.branchKey) {
-      await workflowService.setBranchTaken(stepId, wireState.branchKey)
+      result = await invokeGraphNodeRpc(
+        workflowService,
+        rpcService,
+        runId,
+        stepId,
+        nodeId,
+        rpcName,
+        data,
+        graphName
+      )
     }
 
     return result
@@ -729,19 +756,6 @@ async function executeGraphNodeInline(
 
   await workflowService.setStepRunning(stepState.stepId)
 
-  const wireState: GraphWireState = {}
-  const graphWire: PikkuGraphWire = {
-    runId,
-    graphName,
-    nodeId,
-    branch: (key: string) => {
-      wireState.branchKey = key
-    },
-    setState: (name: string, value: unknown) =>
-      workflowService.updateRunState(runId, name, value),
-    getState: () => workflowService.getRunState(runId),
-  }
-
   try {
     let result: any
 
@@ -770,20 +784,15 @@ async function executeGraphNodeInline(
       }
       result = childRun?.output
     } else {
-      result = await rpcService.rpcWithWire(rpcName, input, {
-        graph: graphWire,
-        workflow: workflowService.createWorkflowWire(
-          graphName,
-          runId,
-          rpcService
-        ),
-      })
-    }
-
-    if (wireState.branchKey) {
-      await workflowService.setBranchTaken(
+      result = await invokeGraphNodeRpc(
+        workflowService,
+        rpcService,
+        runId,
         stepState.stepId,
-        wireState.branchKey
+        nodeId,
+        rpcName,
+        input,
+        graphName
       )
     }
 

--- a/packages/core/src/wirings/workflow/index.ts
+++ b/packages/core/src/wirings/workflow/index.ts
@@ -12,6 +12,20 @@ export {
 } from './pikku-workflow-service.js'
 export { deriveInvocationId, uuidv5 } from './workflow-invocation-id.js'
 
+// Time-travel: reconstruct run state at any point from durable history
+export {
+  buildRunTimeline,
+  reconstructStateAt,
+  reconstructFinalState,
+} from './run-timeline.js'
+export type {
+  RunTimeline,
+  RunTimelineEvent,
+  ReconstructedRunState,
+  ReconstructedStep,
+  RunPhase,
+} from './run-timeline.js'
+
 // Internal registration functions (used by generated code)
 export { addWorkflow } from './dsl/workflow-runner.js'
 

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -1509,17 +1509,14 @@ export abstract class PikkuWorkflowService implements WorkflowService {
               )
             }
           } else {
-            result = await rpcService.rpcWithWire(rpcName, data, {
-              workflowStep: {
-                runId,
-                stepId: stepState.stepId,
-                invocationId: deriveInvocationId(runId, stepName),
-                attemptCount: stepState.attemptCount,
-                fromInvocationId: stepState.fromStepName
-                  ? deriveInvocationId(runId, stepState.fromStepName)
-                  : undefined,
-              },
-            })
+            result = await this.invokeStepRpc(
+              runId,
+              stepName,
+              stepState,
+              rpcName,
+              data,
+              rpcService
+            )
           }
         }
 
@@ -1613,6 +1610,82 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     return getSingletonServices()!.queueService!
   }
 
+  /**
+   * Invoke a step's RPC with the workflow-step wire (step identity + provenance).
+   * Identical for the queue executor and the inline executor — the only thing
+   * that differs between transports is who calls it, not the call itself.
+   */
+  private async invokeStepRpc(
+    runId: string,
+    stepName: string,
+    stepState: StepState,
+    rpcName: string,
+    data: any,
+    rpcService: any
+  ): Promise<any> {
+    return rpcService.rpcWithWire(rpcName, data, {
+      workflowStep: {
+        runId,
+        stepId: stepState.stepId,
+        invocationId: deriveInvocationId(runId, stepName),
+        attemptCount: stepState.attemptCount,
+        fromInvocationId: stepState.fromStepName
+          ? deriveInvocationId(runId, stepState.fromStepName)
+          : undefined,
+      },
+    })
+  }
+
+  /**
+   * Inline (straight-through) step execution with an in-process retry loop —
+   * shared by inline RPC steps and inline function steps. Same scaffolding
+   * (running → result, or fail → retry-attempt → backoff → retry) wrapped
+   * around a step-specific `doWork` body. Stays O(K): no suspend/replay.
+   *
+   * `onError` is an optional hook for terminal errors that must NOT retry
+   * (e.g. RPC-not-found → suspend the run for redeploy). If it throws, the
+   * loop exits immediately without recording a step error or retrying.
+   */
+  private async runInlineRetryLoop(
+    stepState: StepState,
+    retries: number,
+    retryDelay: WorkflowStepOptions['retryDelay'],
+    doWork: (currentStepState: StepState) => Promise<any>,
+    onError?: (error: any) => Promise<void>
+  ): Promise<any> {
+    let currentStepState = stepState
+    while (true) {
+      try {
+        await this.setStepRunning(currentStepState.stepId)
+        const result = await doWork(currentStepState)
+        await this.setStepResult(currentStepState.stepId, result)
+        return result
+      } catch (error: any) {
+        if (onError) await onError(error)
+
+        // Record the error (marks step as failed)
+        await this.setStepError(currentStepState.stepId, error)
+
+        if (currentStepState.attemptCount < retries) {
+          // Create a new pending retry attempt, then back off if configured.
+          currentStepState = await this.createRetryAttempt(
+            currentStepState.stepId,
+            'pending'
+          )
+          if (retryDelay) {
+            await new Promise((resolve) =>
+              setTimeout(resolve, getDurationInMilliseconds(retryDelay))
+            )
+          }
+          // Continue loop to retry
+        } else {
+          // No more retries, fail the workflow
+          throw error
+        }
+      }
+    }
+  }
+
   private async rpcStep(
     runId: string,
     logicalStepName: string,
@@ -1691,102 +1764,70 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       throw new WorkflowAsyncException(runId, stepName)
     }
 
-    {
-      // Inline (no transport available) - execute locally with retry loop
-      const retries = resolvedStepOptions.retries ?? this.getConfig().retries
-      const retryDelay = resolvedStepOptions.retryDelay
-      let currentStepState = stepState
+    // Inline (no transport available) - execute locally with the shared retry
+    // loop. The body resolves to a sub-workflow result or a plain RPC result.
+    const retries = resolvedStepOptions.retries ?? this.getConfig().retries
+    const retryDelay = resolvedStepOptions.retryDelay
 
-      while (true) {
-        try {
-          await this.setStepRunning(currentStepState.stepId)
-          // Check if the name refers to a workflow
-          const workflowMeta = pikkuState(null, 'workflows', 'meta')[rpcName]
-          let result: any
-          if (workflowMeta) {
-            const childWire = {
-              type: 'workflow',
-              id: rpcName,
-              parentRunId: runId,
-              pikkuUserId: rpcService.wire?.pikkuUserId,
-            }
-            const { runId: childRunId } = await this.startWorkflow(
-              rpcName,
-              data,
-              childWire,
-              rpcService,
-              { inline: true }
-            )
-            await this.setStepChildRunId(currentStepState.stepId, childRunId)
-            // Poll until child workflow completes
-            while (true) {
-              const childRun = await this.getRun(childRunId)
-              if (!childRun) {
-                throw new WorkflowRunNotFoundError(childRunId)
-              }
-              if (WORKFLOW_END_STATES.has(childRun.status)) {
-                if (childRun.status === 'failed') {
-                  throw new Error(
-                    childRun.error?.message || 'Sub-workflow failed'
-                  )
-                }
-                if (childRun.status === 'cancelled') {
-                  throw new Error('Sub-workflow was cancelled')
-                }
-                result = childRun.output
-                break
-              }
-              await new Promise((resolve) => setTimeout(resolve, 500))
-            }
-          } else {
-            result = await rpcService.rpcWithWire(rpcName, data, {
-              workflowStep: {
-                runId,
-                stepId: currentStepState.stepId,
-                invocationId: deriveInvocationId(runId, stepName),
-                attemptCount: currentStepState.attemptCount,
-                fromInvocationId: currentStepState.fromStepName
-                  ? deriveInvocationId(runId, currentStepState.fromStepName)
-                  : undefined,
-              },
-            })
+    return this.runInlineRetryLoop(
+      stepState,
+      retries,
+      retryDelay,
+      async (currentStepState) => {
+        // Check if the name refers to a workflow
+        const workflowMeta = pikkuState(null, 'workflows', 'meta')[rpcName]
+        if (workflowMeta) {
+          const childWire = {
+            type: 'workflow',
+            id: rpcName,
+            parentRunId: runId,
+            pikkuUserId: rpcService.wire?.pikkuUserId,
           }
-          await this.setStepResult(currentStepState.stepId, result)
-          return result
-        } catch (error: any) {
-          if (error instanceof RPCNotFoundError) {
-            await this.updateRunStatus(runId, 'suspended', undefined, {
-              message: `RPC '${rpcName}' not found. Deploy the missing function and resume.`,
-              code: 'RPC_NOT_FOUND',
-            })
-            throw error
-          }
-
-          // Record the error (marks step as failed)
-          await this.setStepError(currentStepState.stepId, error)
-
-          // Check if we should retry
-          if (currentStepState.attemptCount < retries) {
-            // Create a new pending retry attempt
-            currentStepState = await this.createRetryAttempt(
-              currentStepState.stepId,
-              'pending'
-            )
-
-            // Wait for retry delay if specified
-            if (retryDelay) {
-              await new Promise((resolve) =>
-                setTimeout(resolve, getDurationInMilliseconds(retryDelay))
-              )
+          const { runId: childRunId } = await this.startWorkflow(
+            rpcName,
+            data,
+            childWire,
+            rpcService,
+            { inline: true }
+          )
+          await this.setStepChildRunId(currentStepState.stepId, childRunId)
+          // Poll until child workflow completes
+          while (true) {
+            const childRun = await this.getRun(childRunId)
+            if (!childRun) {
+              throw new WorkflowRunNotFoundError(childRunId)
             }
-            // Continue loop to retry
-          } else {
-            // No more retries, fail the workflow
-            throw error
+            if (WORKFLOW_END_STATES.has(childRun.status)) {
+              if (childRun.status === 'failed') {
+                throw new Error(childRun.error?.message || 'Sub-workflow failed')
+              }
+              if (childRun.status === 'cancelled') {
+                throw new Error('Sub-workflow was cancelled')
+              }
+              return childRun.output
+            }
+            await new Promise((resolve) => setTimeout(resolve, 500))
           }
         }
+        return this.invokeStepRpc(
+          runId,
+          stepName,
+          currentStepState,
+          rpcName,
+          data,
+          rpcService
+        )
+      },
+      async (error) => {
+        if (error instanceof RPCNotFoundError) {
+          await this.updateRunStatus(runId, 'suspended', undefined, {
+            message: `RPC '${rpcName}' not found. Deploy the missing function and resume.`,
+            code: 'RPC_NOT_FOUND',
+          })
+          throw error
+        }
       }
-    }
+    )
   }
 
   private async inlineStep(
@@ -1821,44 +1862,14 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     // Execute inline function
     const retries = stepOptions?.retries ?? this.getConfig().retries
     const retryDelay = stepOptions?.retryDelay ?? this.getConfig().retryDelay
-    let currentStepState = stepState
 
     // Check if we're running inline (in-memory) or remote (queue-based)
     if (this.isInline(runId)) {
-      // Inline mode - execute with retry loop
-      while (true) {
-        try {
-          await this.setStepRunning(currentStepState.stepId)
-          const result = await fn()
-          await this.setStepResult(currentStepState.stepId, result)
-          return result
-        } catch (error: any) {
-          // Record the error (marks step as failed)
-          await this.setStepError(currentStepState.stepId, error)
-
-          // Check if we should retry
-          if (currentStepState.attemptCount < retries) {
-            // Create a new pending retry attempt
-            currentStepState = await this.createRetryAttempt(
-              currentStepState.stepId,
-              'pending'
-            )
-
-            // Wait for retry delay if specified
-            if (retryDelay) {
-              await new Promise((resolve) =>
-                setTimeout(resolve, getDurationInMilliseconds(retryDelay))
-              )
-            }
-            // Continue loop to retry
-          } else {
-            // No more retries, fail the workflow
-            throw error
-          }
-        }
-      }
+      // Inline mode - execute with the shared in-process retry loop.
+      return this.runInlineRetryLoop(stepState, retries, retryDelay, () => fn())
     } else {
-      // Remote mode - use queue-based retry
+      // Remote mode - single attempt, then suspend for orchestrator-driven retry.
+      let currentStepState = stepState
       try {
         await this.setStepRunning(currentStepState.stepId)
         const result = await fn()

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -70,6 +70,12 @@ import { PikkuError, addError } from '../../errors/error-handler.js'
 import { RPCNotFoundError } from '../rpc/rpc-runner.js'
 import { ChildWorkflowStartedException } from './graph/graph-runner.js'
 import { deriveInvocationId } from './workflow-invocation-id.js'
+import {
+  buildRunTimeline,
+  reconstructStateAt,
+  type RunTimeline,
+  type ReconstructedRunState,
+} from './run-timeline.js'
 import type { JobOptions } from '../queue/queue.types.js'
 
 /**
@@ -451,6 +457,33 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         ? { message: run.error.message ?? 'Unknown error' }
         : undefined,
     }
+  }
+
+  /**
+   * Build the run's time-travel event stream from durable history.
+   * @param id - Run ID
+   * @returns Ordered timeline, or null if the run doesn't exist
+   */
+  public async getRunTimeline(id: string): Promise<RunTimeline | null> {
+    const run = await this.getRun(id)
+    if (!run) return null
+    return buildRunTimeline(await this.getRunHistory(id))
+  }
+
+  /**
+   * Reconstruct the run's state at a point in its timeline.
+   * @param id - Run ID
+   * @param at - A seq index (inclusive) or a Date (inclusive); omit for the
+   *             final state.
+   * @returns Reconstructed state, or null if the run doesn't exist
+   */
+  public async reconstructRunStateAt(
+    id: string,
+    at?: number | Date
+  ): Promise<ReconstructedRunState | null> {
+    const timeline = await this.getRunTimeline(id)
+    if (!timeline) return null
+    return reconstructStateAt(timeline, at ?? timeline.length - 1)
   }
 
   /**

--- a/packages/core/src/wirings/workflow/run-timeline.test.ts
+++ b/packages/core/src/wirings/workflow/run-timeline.test.ts
@@ -91,6 +91,29 @@ describe('buildRunTimeline', () => {
       undefined
     )
   })
+
+  test('terminal event is driven by status, not lifecycle timestamps', () => {
+    // Kysely leaves succeededAt/runningAt null but the row's status + result
+    // are authoritative — the terminal event must still fire (off updatedAt).
+    const noStamps = {
+      stepId: 's-1',
+      stepName: 'begin',
+      status: 'succeeded',
+      attemptCount: 1,
+      result: { ok: 1 },
+      createdAt: T(0),
+      updatedAt: T(5),
+    } as HistoryEntry
+    const tl = buildRunTimeline([noStamps])
+    assert.deepEqual(
+      tl.map((e) => e.type),
+      ['pending', 'succeeded']
+    )
+    const succeeded = tl.find((e) => e.type === 'succeeded')!
+    assert.equal(succeeded.at.getTime(), T(5).getTime(), 'falls back to updatedAt')
+    assert.deepEqual(succeeded.result, { ok: 1 })
+    assert.deepEqual(reconstructFinalState(tl).results, { begin: { ok: 1 } })
+  })
 })
 
 describe('reconstructStateAt', () => {

--- a/packages/core/src/wirings/workflow/run-timeline.test.ts
+++ b/packages/core/src/wirings/workflow/run-timeline.test.ts
@@ -1,0 +1,185 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildRunTimeline,
+  reconstructStateAt,
+  reconstructFinalState,
+} from './run-timeline.js'
+import type { StepState } from './workflow.types.js'
+
+type HistoryEntry = StepState & { stepName: string }
+
+const T = (ms: number) => new Date(1_700_000_000_000 + ms)
+
+/** A succeeded step attempt with the standard lifecycle timestamps. */
+const ok = (
+  stepName: string,
+  base: number,
+  opts: { from?: string; result?: unknown; attempt?: number } = {}
+): HistoryEntry =>
+  ({
+    stepId: `${stepName}-${opts.attempt ?? 1}`,
+    stepName,
+    status: 'succeeded',
+    attemptCount: opts.attempt ?? 1,
+    fromStepName: opts.from,
+    result: opts.result,
+    createdAt: T(base),
+    runningAt: T(base + 1),
+    succeededAt: T(base + 2),
+    updatedAt: T(base + 2),
+  }) as HistoryEntry
+
+const failed = (
+  stepName: string,
+  base: number,
+  opts: { from?: string; attempt?: number; message?: string } = {}
+): HistoryEntry =>
+  ({
+    stepId: `${stepName}-${opts.attempt ?? 1}`,
+    stepName,
+    status: 'failed',
+    attemptCount: opts.attempt ?? 1,
+    fromStepName: opts.from,
+    error: { message: opts.message ?? 'boom' },
+    createdAt: T(base),
+    runningAt: T(base + 1),
+    failedAt: T(base + 2),
+    updatedAt: T(base + 2),
+  }) as HistoryEntry
+
+describe('buildRunTimeline', () => {
+  test('explodes each attempt into ordered lifecycle events', () => {
+    const tl = buildRunTimeline([ok('begin', 0, { result: { n: 1 } })])
+    assert.deepEqual(
+      tl.map((e) => e.type),
+      ['pending', 'running', 'succeeded']
+    )
+    // seq is monotonic from 0
+    assert.deepEqual(
+      tl.map((e) => e.seq),
+      [0, 1, 2]
+    )
+    // result rides only on the succeeded event
+    assert.deepEqual(tl[2]!.result, { n: 1 })
+    assert.equal(tl[0]!.result, undefined)
+  })
+
+  test('orders across steps by timestamp, lifecycle, then history index', () => {
+    // two steps; b created at the same instant begin succeeds
+    const tl = buildRunTimeline([
+      ok('begin', 0, { result: 1 }),
+      ok('next', 2, { from: 'begin', result: 2 }),
+    ])
+    // begin.pending(0) begin.running(1) begin.succeeded(2)==next.pending(2)
+    // → succeeded sorts before pending at the same instant (lifecycle 3 vs 0)?
+    // No: pending=0 < succeeded=3, so next.pending precedes begin.succeeded.
+    const at2 = tl.filter((e) => e.at.getTime() === T(2).getTime())
+    assert.deepEqual(
+      at2.map((e) => `${e.stepName}:${e.type}`),
+      ['next:pending', 'begin:succeeded']
+    )
+  })
+
+  test('carries provenance on the created event only', () => {
+    const tl = buildRunTimeline([ok('next', 5, { from: 'begin' })])
+    const created = tl.find((e) => e.type === 'pending')!
+    assert.equal(created.fromStepName, 'begin')
+    assert.equal(tl.find((e) => e.type === 'succeeded')!.fromStepName, undefined)
+  })
+})
+
+describe('reconstructStateAt', () => {
+  // begin → next → finish, each succeeding in order
+  const history: HistoryEntry[] = [
+    ok('begin', 0, { result: { step: 'begin' } }),
+    ok('next', 10, { from: 'begin', result: { step: 'next' } }),
+    ok('finish', 20, { from: 'next', result: { step: 'finish' } }),
+  ]
+  const tl = buildRunTimeline(history)
+
+  test('a point before the first event is the empty initial state', () => {
+    const s = reconstructStateAt(tl, -1)
+    assert.equal(s.seq, -1)
+    assert.deepEqual(s.steps, [])
+    assert.deepEqual(s.results, {})
+    assert.equal(s.phase, 'pending')
+  })
+
+  test('mid-run by seq: only steps up to that event exist', () => {
+    // fold through begin.succeeded (seq 2)
+    const s = reconstructStateAt(tl, 2)
+    assert.deepEqual(s.path, ['begin'])
+    assert.equal(s.steps[0]!.status, 'succeeded')
+    assert.deepEqual(s.results, { begin: { step: 'begin' } })
+    // next hasn't been created yet at this point
+    assert.equal(s.phase, 'idle')
+  })
+
+  test('mid-run captures an in-flight step as running', () => {
+    // begin done (0,1,2), next created+running (3,4) but not yet succeeded
+    const s = reconstructStateAt(tl, 4)
+    assert.deepEqual(s.path, ['begin', 'next'])
+    assert.equal(s.steps[1]!.stepName, 'next')
+    assert.equal(s.steps[1]!.status, 'running')
+    assert.equal(s.steps[1]!.fromStepName, 'begin')
+    assert.equal(s.phase, 'running')
+    // next's result not yet available in the replay cache
+    assert.deepEqual(s.results, { begin: { step: 'begin' } })
+  })
+
+  test('time-travel by Date folds every event at or before the instant', () => {
+    const s = reconstructStateAt(tl, T(12))
+    // begin fully done (<=2), next created(10)+running(11) but succeeded at 12
+    assert.deepEqual(s.path, ['begin', 'next'])
+    assert.equal(s.steps[1]!.status, 'succeeded')
+    assert.deepEqual(s.results, {
+      begin: { step: 'begin' },
+      next: { step: 'next' },
+    })
+  })
+
+  test('final state has the full walked path and all results', () => {
+    const s = reconstructFinalState(tl)
+    assert.deepEqual(s.path, ['begin', 'next', 'finish'])
+    assert.deepEqual(s.results, {
+      begin: { step: 'begin' },
+      next: { step: 'next' },
+      finish: { step: 'finish' },
+    })
+    assert.equal(s.phase, 'idle')
+  })
+})
+
+describe('reconstructStateAt — retries', () => {
+  // attempt 1 fails, attempt 2 (created later) succeeds
+  const history: HistoryEntry[] = [
+    failed('flaky', 0, { message: 'first try' }),
+    ok('flaky', 10, { result: { ok: true }, attempt: 2 }),
+  ]
+  const tl = buildRunTimeline(history)
+
+  test('between attempts the step is failed', () => {
+    const s = reconstructStateAt(tl, T(2)) // through failedAt of attempt 1
+    assert.equal(s.steps[0]!.status, 'failed')
+    assert.equal(s.steps[0]!.error?.message, 'first try')
+    assert.equal(s.phase, 'failed')
+    assert.deepEqual(s.results, {})
+  })
+
+  test("the retry's created event reopens the step and clears the error", () => {
+    const s = reconstructStateAt(tl, T(10)) // attempt-2 pending
+    assert.equal(s.steps[0]!.status, 'pending')
+    assert.equal(s.steps[0]!.error, undefined)
+    assert.equal(s.steps[0]!.attemptCount, 2)
+    assert.equal(s.phase, 'running')
+  })
+
+  test('after the retry succeeds the result is available', () => {
+    const s = reconstructFinalState(tl)
+    assert.equal(s.steps[0]!.status, 'succeeded')
+    assert.deepEqual(s.results, { flaky: { ok: true } })
+    assert.equal(s.path.length, 1, 'a retried step is still one path entry')
+  })
+})

--- a/packages/core/src/wirings/workflow/run-timeline.test.ts
+++ b/packages/core/src/wirings/workflow/run-timeline.test.ts
@@ -86,7 +86,10 @@ describe('buildRunTimeline', () => {
     const tl = buildRunTimeline([ok('next', 5, { from: 'begin' })])
     const created = tl.find((e) => e.type === 'pending')!
     assert.equal(created.fromStepName, 'begin')
-    assert.equal(tl.find((e) => e.type === 'succeeded')!.fromStepName, undefined)
+    assert.equal(
+      tl.find((e) => e.type === 'succeeded')!.fromStepName,
+      undefined
+    )
   })
 })
 

--- a/packages/core/src/wirings/workflow/run-timeline.ts
+++ b/packages/core/src/wirings/workflow/run-timeline.ts
@@ -74,24 +74,28 @@ export function buildRunTimeline(history: HistoryEntry[]): RunTimeline {
       type: 'pending',
       fromStepName: entry.fromStepName,
     })
+    // Intermediate events are optional enrichment — emit only if the backend
+    // recorded their timestamp.
     if (entry.scheduledAt) {
       raw.push({ ...base, at: entry.scheduledAt, type: 'scheduled' })
     }
     if (entry.runningAt) {
       raw.push({ ...base, at: entry.runningAt, type: 'running' })
     }
-    if (entry.succeededAt) {
+    // The terminal event is driven by the row's authoritative status (the
+    // lifecycle timestamps aren't populated by every backend — Kysely leaves
+    // them null), falling back to updatedAt when the specific stamp is absent.
+    if (entry.status === 'succeeded') {
       raw.push({
         ...base,
-        at: entry.succeededAt,
+        at: entry.succeededAt ?? entry.updatedAt,
         type: 'succeeded',
         result: entry.result,
       })
-    }
-    if (entry.failedAt) {
+    } else if (entry.status === 'failed') {
       raw.push({
         ...base,
-        at: entry.failedAt,
+        at: entry.failedAt ?? entry.updatedAt,
         type: 'failed',
         error: entry.error,
       })

--- a/packages/core/src/wirings/workflow/run-timeline.ts
+++ b/packages/core/src/wirings/workflow/run-timeline.ts
@@ -1,0 +1,237 @@
+import type { SerializedError } from '../../types/core.types.js'
+import type { StepState, StepStatus } from './workflow.types.js'
+
+/**
+ * Time-travel over a workflow run.
+ *
+ * A run's durable history (`getRunHistory`) is one row per step *attempt*, each
+ * carrying lifecycle timestamps (created/scheduled/running/succeeded/failed).
+ * `buildRunTimeline` explodes those rows into a flat, chronologically-ordered
+ * event stream, and `reconstructStateAt` folds the stream up to any point to
+ * recover what the run "knew" then — the same step cache a replay would hold:
+ * per-step status, accumulated results, and the walked path.
+ *
+ * These are pure functions over history — no IO — so they're trivially testable
+ * and transport-independent (the same fold works for Redis/Kysely/in-memory).
+ */
+
+/** A single observable transition of one step attempt. */
+export interface RunTimelineEvent {
+  /** Monotonic 0-based position in the timeline. */
+  seq: number
+  /** When it happened. */
+  at: Date
+  /** The step's new status at this event (matches StepStatus lifecycle). */
+  type: Extract<
+    StepStatus,
+    'pending' | 'scheduled' | 'running' | 'succeeded' | 'failed'
+  >
+  /** Physical step name (includes revisit ordinal, e.g. `attempt#2`). */
+  stepName: string
+  /** Which attempt this event belongs to (1-based). */
+  attemptCount: number
+  /** Predecessor that scheduled this step — only on the `pending` (created)
+   *  event; undefined for entry steps. Reconstructs the walked edge. */
+  fromStepName?: string
+  /** Result snapshot — only on `succeeded`. */
+  result?: unknown
+  /** Error snapshot — only on `failed`. */
+  error?: SerializedError
+}
+
+export type RunTimeline = RunTimelineEvent[]
+
+type HistoryEntry = StepState & { stepName: string }
+
+/** Lifecycle tiebreak for events that share a timestamp. */
+const LIFECYCLE_ORDER: Record<RunTimelineEvent['type'], number> = {
+  pending: 0,
+  scheduled: 1,
+  running: 2,
+  succeeded: 3,
+  failed: 3,
+}
+
+/**
+ * Build the ordered event stream for a run from its raw history.
+ *
+ * History is expected oldest-first but is sorted defensively by (timestamp,
+ * lifecycle, original index) so simultaneous timestamps stay deterministic.
+ */
+export function buildRunTimeline(history: HistoryEntry[]): RunTimeline {
+  const raw: Array<Omit<RunTimelineEvent, 'seq'> & { order: number }> = []
+
+  history.forEach((entry, order) => {
+    const base = {
+      stepName: entry.stepName,
+      attemptCount: entry.attemptCount,
+      order,
+    }
+    // The created event always exists; it carries provenance.
+    raw.push({
+      ...base,
+      at: entry.createdAt,
+      type: 'pending',
+      fromStepName: entry.fromStepName,
+    })
+    if (entry.scheduledAt) {
+      raw.push({ ...base, at: entry.scheduledAt, type: 'scheduled' })
+    }
+    if (entry.runningAt) {
+      raw.push({ ...base, at: entry.runningAt, type: 'running' })
+    }
+    if (entry.succeededAt) {
+      raw.push({
+        ...base,
+        at: entry.succeededAt,
+        type: 'succeeded',
+        result: entry.result,
+      })
+    }
+    if (entry.failedAt) {
+      raw.push({
+        ...base,
+        at: entry.failedAt,
+        type: 'failed',
+        error: entry.error,
+      })
+    }
+  })
+
+  raw.sort((a, b) => {
+    const ta = a.at.getTime()
+    const tb = b.at.getTime()
+    if (ta !== tb) return ta - tb
+    const la = LIFECYCLE_ORDER[a.type]
+    const lb = LIFECYCLE_ORDER[b.type]
+    if (la !== lb) return la - lb
+    return a.order - b.order
+  })
+
+  return raw.map(({ order: _order, ...event }, seq) => ({ ...event, seq }))
+}
+
+/** A step's reconstructed state at a point in the timeline. */
+export interface ReconstructedStep {
+  stepName: string
+  status: StepStatus
+  attemptCount: number
+  fromStepName?: string
+  result?: unknown
+  error?: SerializedError
+}
+
+/** Coarse run phase derived purely from step states (not the run's output). */
+export type RunPhase = 'pending' | 'running' | 'failed' | 'idle'
+
+/** The whole run's reconstructed state at a point in the timeline. */
+export interface ReconstructedRunState {
+  /** seq of the last applied event, or -1 if the point precedes all events. */
+  seq: number
+  /** Wall-clock time of the last applied event. */
+  at?: Date
+  /** Per-step latest state, in first-seen (walked) order. */
+  steps: ReconstructedStep[]
+  /** Outputs available to downstream steps — the replay step cache at this
+   *  point (succeeded steps only). */
+  results: Record<string, unknown>
+  /** Step names in the order they were first created — the walked path. */
+  path: string[]
+  /** Derived phase: `running` if any step is in-flight, else `failed` if a step
+   *  is failed with no in-flight work, else `idle` (between transitions). */
+  phase: RunPhase
+}
+
+const IN_FLIGHT: ReadonlySet<StepStatus> = new Set([
+  'pending',
+  'scheduled',
+  'running',
+])
+
+/**
+ * Fold the timeline up to `at` and return the run's state at that point.
+ *
+ * `at` is either a seq index (inclusive — apply events `0..at`) or a `Date`
+ * (inclusive — apply every event at or before that instant). A point before the
+ * first event yields the empty initial state.
+ */
+export function reconstructStateAt(
+  timeline: RunTimeline,
+  at: number | Date
+): ReconstructedRunState {
+  const cutoff = (event: RunTimelineEvent): boolean =>
+    typeof at === 'number'
+      ? event.seq <= at
+      : event.at.getTime() <= at.getTime()
+
+  const steps = new Map<string, ReconstructedStep>()
+  const path: string[] = []
+  let lastSeq = -1
+  let lastAt: Date | undefined
+
+  for (const event of timeline) {
+    if (!cutoff(event)) break
+    lastSeq = event.seq
+    lastAt = event.at
+
+    let step = steps.get(event.stepName)
+    if (!step) {
+      step = {
+        stepName: event.stepName,
+        status: event.type,
+        attemptCount: event.attemptCount,
+        fromStepName: event.fromStepName,
+      }
+      steps.set(event.stepName, step)
+      path.push(event.stepName)
+    }
+    step.status = event.type
+    step.attemptCount = event.attemptCount
+    if (event.fromStepName !== undefined) {
+      step.fromStepName = event.fromStepName
+    }
+    // A retry's created event reopens the step — drop the prior outcome.
+    if (event.type === 'pending') {
+      delete step.result
+      delete step.error
+    }
+    if (event.type === 'succeeded') {
+      step.result = event.result
+      step.error = undefined
+    }
+    if (event.type === 'failed') {
+      step.error = event.error
+    }
+  }
+
+  const orderedSteps = path.map((name) => steps.get(name)!)
+  const results: Record<string, unknown> = {}
+  for (const step of orderedSteps) {
+    if (step.status === 'succeeded') {
+      results[step.stepName] = step.result
+    }
+  }
+
+  return {
+    seq: lastSeq,
+    at: lastAt,
+    steps: orderedSteps,
+    results,
+    path,
+    phase: derivePhase(orderedSteps),
+  }
+}
+
+/** Reconstruct the final state (fold the whole timeline). */
+export function reconstructFinalState(
+  timeline: RunTimeline
+): ReconstructedRunState {
+  return reconstructStateAt(timeline, timeline.length - 1)
+}
+
+function derivePhase(steps: ReconstructedStep[]): RunPhase {
+  if (steps.length === 0) return 'pending'
+  if (steps.some((s) => IN_FLIGHT.has(s.status))) return 'running'
+  if (steps.some((s) => s.status === 'failed')) return 'failed'
+  return 'idle'
+}

--- a/packages/inspector/src/utils/workflow/derive-workflow-plan.test.ts
+++ b/packages/inspector/src/utils/workflow/derive-workflow-plan.test.ts
@@ -1,0 +1,122 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import type { WorkflowStepMeta } from '@pikku/core/workflow'
+import { deriveWorkflowPlan } from './derive-workflow-plan.js'
+
+const rpc = (stepName: string, rpcName = 'rpc.fn'): WorkflowStepMeta =>
+  ({ type: 'rpc', stepName, rpcName }) as WorkflowStepMeta
+const sleep = (stepName: string): WorkflowStepMeta =>
+  ({ type: 'sleep', stepName }) as WorkflowStepMeta
+const inline = (stepName: string): WorkflowStepMeta =>
+  ({ type: 'inline', stepName }) as WorkflowStepMeta
+
+describe('deriveWorkflowPlan', () => {
+  test('linear workflow is deterministic with every step listed in order', () => {
+    const plan = deriveWorkflowPlan([rpc('a'), sleep('b'), inline('c')])
+    assert.equal(plan.deterministic, true)
+    assert.deepEqual(plan.plannedSteps, [
+      { stepName: 'a' },
+      { stepName: 'b' },
+      { stepName: 'c' },
+    ])
+  })
+
+  test('parallel group lists each child step', () => {
+    const plan = deriveWorkflowPlan([
+      rpc('a'),
+      {
+        type: 'parallel',
+        children: [rpc('p1'), rpc('p2')],
+      } as WorkflowStepMeta,
+    ])
+    assert.equal(plan.deterministic, true)
+    assert.deepEqual(plan.plannedSteps, [
+      { stepName: 'a' },
+      { stepName: 'p1' },
+      { stepName: 'p2' },
+    ])
+  })
+
+  test('branch is loopless: plannedSteps cover every arm but not deterministic', () => {
+    const plan = deriveWorkflowPlan([
+      rpc('start'),
+      {
+        type: 'branch',
+        branches: [{ condition: 'x', steps: [rpc('left')] }],
+        elseSteps: [rpc('right')],
+      } as WorkflowStepMeta,
+      rpc('end'),
+    ])
+    assert.equal(plan.deterministic, false, 'a branch picks a path at runtime')
+    assert.deepEqual(plan.plannedSteps, [
+      { stepName: 'start' },
+      { stepName: 'left' },
+      { stepName: 'right' },
+      { stepName: 'end' },
+    ])
+  })
+
+  test('switch is loopless: cases + default contribute steps, not deterministic', () => {
+    const plan = deriveWorkflowPlan([
+      {
+        type: 'switch',
+        expression: 'kind',
+        cases: [{ steps: [rpc('caseA')] }, { steps: [rpc('caseB')] }],
+        defaultSteps: [rpc('fallback')],
+      } as WorkflowStepMeta,
+    ])
+    assert.equal(plan.deterministic, false)
+    assert.deepEqual(plan.plannedSteps, [
+      { stepName: 'caseA' },
+      { stepName: 'caseB' },
+      { stepName: 'fallback' },
+    ])
+  })
+
+  test('fanout (loop) yields no plannedSteps and is not deterministic', () => {
+    const plan = deriveWorkflowPlan([
+      rpc('before'),
+      {
+        type: 'fanout',
+        stepName: 'each',
+        child: rpc('child'),
+        mode: 'parallel',
+      } as WorkflowStepMeta,
+    ])
+    assert.equal(plan.deterministic, false)
+    assert.equal(plan.plannedSteps, undefined, 'loop count is runtime-dependent')
+  })
+
+  test('a fanout nested inside a branch still suppresses the plan', () => {
+    const plan = deriveWorkflowPlan([
+      {
+        type: 'branch',
+        branches: [
+          {
+            condition: 'x',
+            steps: [
+              {
+                type: 'fanout',
+                stepName: 'each',
+                child: rpc('child'),
+                mode: 'serial',
+              } as WorkflowStepMeta,
+            ],
+          },
+        ],
+      } as WorkflowStepMeta,
+    ])
+    assert.equal(plan.deterministic, false)
+    assert.equal(plan.plannedSteps, undefined)
+  })
+
+  test('non-named steps (set/return/cancel) are skipped', () => {
+    const plan = deriveWorkflowPlan([
+      { type: 'set' } as WorkflowStepMeta,
+      rpc('a'),
+      { type: 'return' } as WorkflowStepMeta,
+    ])
+    assert.equal(plan.deterministic, true)
+    assert.deepEqual(plan.plannedSteps, [{ stepName: 'a' }])
+  })
+})

--- a/packages/inspector/src/utils/workflow/derive-workflow-plan.ts
+++ b/packages/inspector/src/utils/workflow/derive-workflow-plan.ts
@@ -1,0 +1,90 @@
+import type {
+  WorkflowStepMeta,
+  WorkflowPlannedStep,
+} from '@pikku/core/workflow'
+
+/**
+ * Derive the static UI plan for a DSL workflow from its extracted step tree.
+ *
+ * `plannedSteps` is the ordered list of every named step the workflow can run,
+ * so a frontend can render the step skeleton up front without executing the
+ * workflow or hand-listing steps. It is populated whenever the workflow has NO
+ * loops (fanout) — loops make the step COUNT runtime-dependent, so a workflow
+ * containing any fanout gets neither field.
+ *
+ * `deterministic` is true only when the exact executed sequence is known up
+ * front: a flat list of named steps with no branches/switches (which pick a
+ * path at runtime) and no loops. A branchy-but-loopless workflow is therefore
+ * `deterministic: false` but still gets `plannedSteps` (the full set of
+ * possible steps, in source order).
+ */
+export function deriveWorkflowPlan(steps: WorkflowStepMeta[]): {
+  deterministic: boolean
+  plannedSteps?: WorkflowPlannedStep[]
+} {
+  if (containsLoop(steps)) {
+    return { deterministic: false }
+  }
+  return {
+    deterministic: !containsConditional(steps),
+    plannedSteps: collectNamedSteps(steps),
+  }
+}
+
+/** Any fanout (loop) anywhere in the tree — including inside branches/switches. */
+function containsLoop(steps: WorkflowStepMeta[]): boolean {
+  return steps.some((step) => {
+    switch (step.type) {
+      case 'fanout':
+        return true
+      case 'branch':
+        return (
+          step.branches.some((b) => containsLoop(b.steps)) ||
+          (step.elseSteps ? containsLoop(step.elseSteps) : false)
+        )
+      case 'switch':
+        return (
+          step.cases.some((c) => containsLoop(c.steps)) ||
+          (step.defaultSteps ? containsLoop(step.defaultSteps) : false)
+        )
+      default:
+        return false
+    }
+  })
+}
+
+/** Any branch/switch — the run takes a runtime-decided path. */
+function containsConditional(steps: WorkflowStepMeta[]): boolean {
+  return steps.some((step) => step.type === 'branch' || step.type === 'switch')
+}
+
+/** Flatten named steps (rpc/inline/sleep/parallel children) in source order. */
+function collectNamedSteps(steps: WorkflowStepMeta[]): WorkflowPlannedStep[] {
+  const planned: WorkflowPlannedStep[] = []
+  for (const step of steps) {
+    switch (step.type) {
+      case 'rpc':
+      case 'inline':
+      case 'sleep':
+        planned.push({ stepName: step.stepName })
+        break
+      case 'parallel':
+        for (const child of step.children) {
+          planned.push({ stepName: child.stepName })
+        }
+        break
+      case 'branch':
+        for (const b of step.branches) planned.push(...collectNamedSteps(b.steps))
+        if (step.elseSteps) planned.push(...collectNamedSteps(step.elseSteps))
+        break
+      case 'switch':
+        for (const c of step.cases) planned.push(...collectNamedSteps(c.steps))
+        if (step.defaultSteps) {
+          planned.push(...collectNamedSteps(step.defaultSteps))
+        }
+        break
+      // set / return / cancel / filter / arrayPredicate produce no named step
+    }
+  }
+  return planned
+}

--- a/packages/inspector/src/utils/workflow/graph/finalize-workflows.ts
+++ b/packages/inspector/src/utils/workflow/graph/finalize-workflows.ts
@@ -3,6 +3,7 @@ import { isVersionedId, formatVersionedId, parseVersionedId } from '@pikku/core'
 import type { SerializedWorkflowGraph } from './workflow-graph.types.js'
 import { canonicalJSON, hashString } from '../../hash.js'
 import { convertDslToGraph } from './convert-dsl-to-graph.js'
+import { deriveWorkflowPlan } from '../derive-workflow-plan.js'
 import type { InspectorState } from '../../../types.js'
 
 export function finalizeWorkflows(state: InspectorState): void {
@@ -14,6 +15,20 @@ export function finalizeWorkflows(state: InspectorState): void {
     stampVersionsOnGraph(graph, functionsMeta)
     computeStepHashes(graph, functionsMeta)
     graph.graphHash = computeGraphHash(graph)
+    // Predictable (loopless) DSL workflows carry their full step list so a UI
+    // can render the skeleton up front without executing the run. Only DSL is
+    // gated: a complex workflow's step tree is incomplete (inline JS branches
+    // aren't captured) and flattens loops into plain steps, so its plan would
+    // lie about determinism.
+    if (graph.source === 'dsl') {
+      const { deterministic, plannedSteps } = deriveWorkflowPlan(meta.steps)
+      graph.deterministic = deterministic
+      // Omit an empty list — a deterministic workflow with no plannedSteps is
+      // simply one with no named steps (e.g. a bare return).
+      if (plannedSteps?.length) {
+        graph.plannedSteps = plannedSteps
+      }
+    }
     workflows.graphMeta[name] = graph
   }
 

--- a/packages/inspector/src/utils/workflow/graph/workflow-graph.types.ts
+++ b/packages/inspector/src/utils/workflow/graph/workflow-graph.types.ts
@@ -108,7 +108,11 @@ export type FlowType =
   | 'set'
 
 // Import and re-export context types from core
-import type { ContextVariable, WorkflowContext } from '@pikku/core/workflow'
+import type {
+  ContextVariable,
+  WorkflowContext,
+  WorkflowPlannedStep,
+} from '@pikku/core/workflow'
 
 export type { ContextVariable, WorkflowContext }
 
@@ -202,6 +206,19 @@ export interface SerializedWorkflowGraph {
   entryNodeIds: string[]
   /** Hash of graph topology (nodes, edges, input mappings) */
   graphHash?: string
+  /**
+   * True when the exact executed step sequence is known up front: a loopless
+   * DSL workflow with no branches/switches. Lets a UI render the run as a fixed
+   * pipeline. Loops (fanout) → omitted; branchy-but-loopless → false.
+   */
+  deterministic?: boolean
+  /**
+   * Every named step the workflow can run, in source order — so a frontend can
+   * render the step skeleton before the run starts. Populated for any loopless
+   * DSL workflow (a branchy one lists all possible steps); omitted when the step
+   * count is runtime-dependent (any fanout).
+   */
+  plannedSteps?: WorkflowPlannedStep[]
   /** Wire entry points (HTTP, channel, queue, etc.) that trigger this workflow */
   wires?: WorkflowWires
 }

--- a/packages/runtimes/cloudflare/src/workflow-do/pikku-workflow-do-client.ts
+++ b/packages/runtimes/cloudflare/src/workflow-do/pikku-workflow-do-client.ts
@@ -1,7 +1,10 @@
 import type { DurableObjectNamespace } from '@cloudflare/workers-types'
 import type { SerializedError } from '@pikku/core'
 import type { WorkflowService } from '@pikku/core'
+import { buildRunTimeline, reconstructStateAt } from '@pikku/core/workflow'
 import type {
+  RunTimeline,
+  ReconstructedRunState,
   StepState,
   WorkflowPlannedStep,
   WorkflowRun,
@@ -88,6 +91,21 @@ export class PikkuWorkflowDoClient implements WorkflowService {
     runId: string
   ): Promise<Array<StepState & { stepName: string }>> {
     return this.getStub(runId).getRunHistory()
+  }
+
+  async getRunTimeline(id: string): Promise<RunTimeline | null> {
+    const run = await this.getRun(id)
+    if (!run) return null
+    return buildRunTimeline(await this.getRunHistory(id))
+  }
+
+  async reconstructRunStateAt(
+    id: string,
+    at?: number | Date
+  ): Promise<ReconstructedRunState | null> {
+    const timeline = await this.getRunTimeline(id)
+    if (!timeline) return null
+    return reconstructStateAt(timeline, at ?? timeline.length - 1)
   }
 
   async updateRunStatus(

--- a/packages/services/kysely/src/kysely-workflow-mirror.test.ts
+++ b/packages/services/kysely/src/kysely-workflow-mirror.test.ts
@@ -103,6 +103,29 @@ describe('KyselyWorkflowMirror — step lifecycle', () => {
     assert.equal(history[0]!.status, 'pending')
   })
 
+  test('getRunHistory surfaces step provenance (fromStepName)', async () => {
+    // The mirror persists fromStepName and getRunHistory reads it back, so the
+    // run history reconstructs the walked path (entry has none, the next step
+    // records its predecessor).
+    await seedStep(STEP_ID, 'begin')
+    await mirror.insertStepState(RUN_ID, {
+      stepId: `${STEP_ID}-2`,
+      stepName: 'next',
+      rpcName: 'rpc.fn',
+      data: { x: 2 },
+      status: 'pending',
+      attemptCount: 1,
+      fromStepName: 'begin',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any)
+
+    const history = await runService.getRunHistory(RUN_ID)
+    const from = new Map(history.map((h) => [h.stepName, h.fromStepName]))
+    assert.equal(from.get('begin'), undefined, 'entry step has no predecessor')
+    assert.equal(from.get('next'), 'begin', 'next records its predecessor')
+  })
+
   test('running → succeeded updates the in-place history row', async () => {
     await seedStep()
     await mirror.setStepRunning(STEP_ID)

--- a/packages/services/kysely/src/kysely-workflow-mirror.ts
+++ b/packages/services/kysely/src/kysely-workflow-mirror.ts
@@ -79,6 +79,7 @@ export class KyselyWorkflowMirror implements WorkflowRunMirror {
       .addColumn('branch_taken', 'text')
       .addColumn('retries', 'integer')
       .addColumn('retry_delay', 'text')
+      .addColumn('from_step_name', 'text')
       .addColumn('created_at', 'timestamp', (col) =>
         col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull()
       )
@@ -90,6 +91,15 @@ export class KyselyWorkflowMirror implements WorkflowRunMirror {
         'step_name',
       ])
       .execute()
+
+    // Additive: backfill the column on mirror tables created before from_step_name.
+    await this.db.schema
+      .alterTable('workflow_step')
+      .addColumn('from_step_name', 'text')
+      .execute()
+      .catch(() => {
+        // Column already exists (fresh tables include it above) — nothing to do.
+      })
 
     await this.db.schema
       .createTable('workflow_step_history')
@@ -202,6 +212,7 @@ export class KyselyWorkflowMirror implements WorkflowRunMirror {
         status: step.status,
         retries: step.retries ?? null,
         retryDelay: step.retryDelay?.toString() ?? null,
+        fromStepName: step.fromStepName ?? null,
         createdAt: now,
         updatedAt: now,
       })

--- a/packages/services/kysely/src/kysely-workflow-run-service.ts
+++ b/packages/services/kysely/src/kysely-workflow-run-service.ts
@@ -192,6 +192,7 @@ export class KyselyWorkflowRunService implements WorkflowRunService {
       .select([
         's.workflowStepId',
         's.stepName',
+        's.fromStepName',
         's.retries',
         's.retryDelay',
         'h.status',
@@ -215,6 +216,7 @@ export class KyselyWorkflowRunService implements WorkflowRunService {
       return {
         stepId,
         stepName: row.stepName,
+        fromStepName: row.fromStepName ?? undefined,
         status: row.status as StepState['status'],
         result: parseJson(row.result),
         error: parseJson(row.error),

--- a/packages/services/redis/src/redis-workflow-service.ts
+++ b/packages/services/redis/src/redis-workflow-service.ts
@@ -429,6 +429,8 @@ export class RedisWorkflowService extends PikkuWorkflowService {
         allHistoryEntries.push({
           stepId: entry.stepId,
           stepName: entry.stepName,
+          // Provenance lives on the step row, not the per-attempt history entry.
+          fromStepName: stepData.fromStepName || undefined,
           status: entry.status,
           result: entry.result ? JSON.parse(entry.result) : undefined,
           error: entry.error ? JSON.parse(entry.error) : undefined,

--- a/verifiers/workflows/package.json
+++ b/verifiers/workflows/package.json
@@ -28,7 +28,7 @@
     "pikku": "pikku",
     "serialize-dsl": "npx tsx src/tests/serialize-dsl.test.ts",
     "serialize-graph": "npx tsx src/tests/serialize-graph.test.ts",
-    "test": "pikku && npx tsx --test src/tests/complex-inline.assert.ts && npx tsx --test src/tests/dsl-validation.assert.ts && npx tsx src/tests/serialize-dsl.test.ts",
+    "test": "pikku && npx tsx --test src/tests/complex-inline.assert.ts && npx tsx --test src/tests/dsl-validation.assert.ts && npx tsx --test src/tests/planned-steps.assert.ts && npx tsx src/tests/serialize-dsl.test.ts",
     "test:bullmq": "npx tsx src/runners/bullmq.runner.ts",
     "test:pgboss": "npx tsx src/runners/pgboss.runner.ts",
     "test:function-versioning": "npx tsx src/runners/function-versioning.runner.ts",

--- a/verifiers/workflows/package.json
+++ b/verifiers/workflows/package.json
@@ -38,6 +38,7 @@
     "test:retry-idempotency:pg": "npx tsx src/runners/retry-idempotency.runner.ts --pg",
     "test:retry-idempotency:redis": "npx tsx src/runners/retry-idempotency.runner.ts --redis",
     "test:cyclic-graph:pg": "npx tsx src/runners/cyclic-graph.runner.ts --pg",
-    "test:cyclic-graph:redis": "npx tsx src/runners/cyclic-graph.runner.ts --redis"
+    "test:cyclic-graph:redis": "npx tsx src/runners/cyclic-graph.runner.ts --redis",
+    "test:db": "pikku && npx tsx src/runners/cyclic-graph.runner.ts --redis && npx tsx src/runners/cyclic-graph.runner.ts --pg && npx tsx src/runners/retry-idempotency.runner.ts --redis && npx tsx src/runners/retry-idempotency.runner.ts --pg"
   }
 }

--- a/verifiers/workflows/src/runners/cyclic-graph.runner.ts
+++ b/verifiers/workflows/src/runners/cyclic-graph.runner.ts
@@ -18,6 +18,7 @@
  */
 
 import type { PikkuWorkflowService } from '@pikku/core/workflow'
+import { rpcService } from '@pikku/core/rpc'
 
 import { createConfig, createSingletonServices } from '../services.js'
 
@@ -36,6 +37,7 @@ function parseBackend(): Backend {
 
 async function setup(backend: Backend): Promise<{
   workflowService: PikkuWorkflowService
+  singletonServices: any
   registerQueues: () => Promise<unknown>
   cleanup: () => Promise<void>
 }> {
@@ -61,7 +63,7 @@ async function setup(backend: Backend): Promise<{
     const workflowService = new KyselyWorkflowService(db)
     await workflowService.init()
 
-    await createSingletonServices(config, {
+    const singletonServices = await createSingletonServices(config, {
       queueService: pgBossFactory.getQueueService(),
       schedulerService: pgBossFactory.getSchedulerService(),
       workflowService,
@@ -69,6 +71,7 @@ async function setup(backend: Backend): Promise<{
 
     return {
       workflowService,
+      singletonServices,
       registerQueues: () => pgBossFactory.getQueueWorkers().registerQueues(),
       cleanup: async () => {
         await workflowService.close()
@@ -86,7 +89,7 @@ async function setup(backend: Backend): Promise<{
   const workflowService = new RedisWorkflowService(undefined)
   await workflowService.init()
 
-  await createSingletonServices(config, {
+  const singletonServices = await createSingletonServices(config, {
     queueService: bullFactory.getQueueService(),
     schedulerService: bullFactory.getSchedulerService(),
     workflowService,
@@ -95,6 +98,7 @@ async function setup(backend: Backend): Promise<{
   const queueWorkers = bullFactory.getQueueWorkers()
   return {
     workflowService,
+    singletonServices,
     registerQueues: () => queueWorkers.registerQueues(),
     cleanup: async () => {
       await queueWorkers.close()
@@ -109,16 +113,104 @@ function assert(condition: boolean, message: string): void {
   if (!condition) throw new AssertionFailed(message)
 }
 
+type HistoryStep = {
+  stepName: string
+  status: string
+  result?: any
+  attemptCount: number
+  fromStepName?: string
+}
+
+// The full, transport-independent node state a `graphCyclicRetry { attempts: 3 }`
+// run must produce: every node present, succeeded, with the exact result and the
+// exact predecessor it was reached from. Inline and queued runs must match this
+// to the letter — that is the whole point of the equivalence test below.
+const EXPECTED_NODES: Record<
+  string,
+  { from: string | undefined; result: any }
+> = {
+  begin: { from: undefined, result: { attempts: 3 } },
+  attempt: { from: 'begin', result: { count: 1, target: 3 } },
+  'attempt#1': { from: 'attempt', result: { count: 2, target: 3 } },
+  'attempt#2': { from: 'attempt#1', result: { count: 3, target: 3 } },
+  finish: { from: 'attempt#2', result: { ok: true, loops: 3 } },
+}
+
+// Normalize a run's history into a sorted, comparable shape (drops per-run noise
+// like stepId/runId/timestamps, keeps the node-correctness fields).
+function normalizeNodes(steps: HistoryStep[]) {
+  return steps
+    .map((s) => ({
+      stepName: s.stepName,
+      status: s.status,
+      from: s.fromStepName ?? undefined,
+      result: s.result,
+    }))
+    .sort((a, b) => a.stepName.localeCompare(b.stepName))
+}
+
+// Assert EVERY node is correct — not just the path: presence, no extras, status,
+// single attempt (no retries in this graph), result payload, and provenance.
+function assertAllNodesCorrect(steps: HistoryStep[]): void {
+  const byName = new Map(steps.map((s) => [s.stepName, s]))
+  const expectedNames = Object.keys(EXPECTED_NODES).sort()
+  const actualNames = steps.map((s) => s.stepName).sort()
+  assert(
+    JSON.stringify(actualNames) === JSON.stringify(expectedNames),
+    `node set mismatch — expected ${JSON.stringify(expectedNames)}, got ${JSON.stringify(actualNames)}`
+  )
+
+  for (const [name, expected] of Object.entries(EXPECTED_NODES)) {
+    const node = byName.get(name)!
+    assert(
+      node.status === 'succeeded',
+      `node '${name}' status — expected succeeded, got ${node.status}`
+    )
+    assert(
+      node.attemptCount === 1,
+      `node '${name}' attemptCount — expected 1, got ${node.attemptCount}`
+    )
+    assert(
+      (node.fromStepName ?? undefined) === expected.from,
+      `node '${name}' fromStepName — expected ${expected.from}, got ${node.fromStepName}`
+    )
+    assert(
+      JSON.stringify(node.result) === JSON.stringify(expected.result),
+      `node '${name}' result — expected ${JSON.stringify(expected.result)}, got ${JSON.stringify(node.result)}`
+    )
+  }
+
+  // The provenance chain reconstructs the exact walked path, cycle included.
+  const from = new Map(steps.map((s) => [s.stepName, s.fromStepName ?? undefined]))
+  const path: string[] = []
+  let cursor: string | undefined = 'finish'
+  while (cursor) {
+    path.unshift(cursor)
+    cursor = from.get(cursor)
+  }
+  assert(
+    JSON.stringify(path) ===
+      JSON.stringify(['begin', 'attempt', 'attempt#1', 'attempt#2', 'finish']),
+    `reconstructed path mismatch, got ${JSON.stringify(path)}`
+  )
+}
+
 async function main(): Promise<void> {
   const backend = parseBackend()
   console.log(`=== Cyclic Graph Runner (${backend}) ===\n`)
 
-  const { workflowService, registerQueues, cleanup } = await setup(backend)
+  const { workflowService, singletonServices, registerQueues, cleanup } =
+    await setup(backend)
   await registerQueues()
+
+  // Inline graph execution runs the nodes in-process, so it needs a real RPC
+  // service (the queued path rebuilds one inside each worker).
+  const rpc = rpcService.getContextRPCService(singletonServices, {})
 
   const results: Array<{ name: string; ok: boolean; error?: string }> = []
 
-  async function runToTerminal(
+  // Start QUEUED (default): step execution happens in the queue workers; poll.
+  async function runQueued(
     name: string,
     input: unknown
   ): Promise<{ status: string; runId: string }> {
@@ -148,6 +240,23 @@ async function main(): Promise<void> {
     }
   }
 
+  // Start INLINE: the whole graph runs straight-through in-process (no queue),
+  // so startWorkflow returns only once the run has reached a terminal state.
+  async function runInline(
+    name: string,
+    input: unknown
+  ): Promise<{ status: string; runId: string }> {
+    const { runId } = await workflowService.startWorkflow(
+      name,
+      input,
+      { type: 'test' },
+      rpc,
+      { inline: true }
+    )
+    const run = await workflowService.getRun(runId)
+    return { status: run?.status ?? 'unknown', runId }
+  }
+
   async function test(name: string, fn: () => Promise<void>): Promise<void> {
     const start = Date.now()
     try {
@@ -160,51 +269,46 @@ async function main(): Promise<void> {
     }
   }
 
+  let queuedNodes: ReturnType<typeof normalizeNodes> | null = null
+
   await test(
-    'cyclic node revisits as ordinal instances and the fromStepName chain reconstructs the path',
+    'QUEUED cyclic graph: every node is correct (status, result, provenance)',
     async () => {
-      const { status, runId } = await runToTerminal('graphCyclicRetry', {
+      const { status, runId } = await runQueued('graphCyclicRetry', {
         attempts: 3,
       })
       assert(status === 'completed', `expected completed, got ${status}`)
+      const steps = (await workflowService.getRunHistory(runId)) as HistoryStep[]
+      assertAllNodesCorrect(steps)
+      queuedNodes = normalizeNodes(steps)
+    }
+  )
 
-      const steps = await workflowService.getRunHistory(runId)
-      const from = new Map(
-        steps.map((s: any) => [s.stepName, s.fromStepName ?? undefined])
-      )
+  await test(
+    'INLINE cyclic graph: every node is correct (proves inline supports cycles)',
+    async () => {
+      const { status, runId } = await runInline('graphCyclicRetry', {
+        attempts: 3,
+      })
+      assert(status === 'completed', `expected completed, got ${status}`)
+      const steps = (await workflowService.getRunHistory(runId)) as HistoryStep[]
+      assertAllNodesCorrect(steps)
+    }
+  )
 
-      // The self-cycle produced three ordinal instances of `attempt`.
-      const stepNames = steps.map((s: any) => s.stepName).sort()
+  await test(
+    'INLINE and QUEUED produce byte-identical node state (transport independence)',
+    async () => {
+      assert(queuedNodes !== null, 'queued run did not record node state')
+      const { status, runId } = await runInline('graphCyclicRetry', {
+        attempts: 3,
+      })
+      assert(status === 'completed', `expected completed, got ${status}`)
+      const steps = (await workflowService.getRunHistory(runId)) as HistoryStep[]
+      const inlineNodes = normalizeNodes(steps)
       assert(
-        stepNames.includes('attempt') &&
-          stepNames.includes('attempt#1') &&
-          stepNames.includes('attempt#2'),
-        `expected attempt/attempt#1/attempt#2, got ${JSON.stringify(stepNames)}`
-      )
-
-      // Each step records its predecessor; the entry has none.
-      assert(
-        from.get('begin') === undefined,
-        `entry step must have no predecessor, got ${from.get('begin')}`
-      )
-
-      // Walk back from the terminal node — the cycle is fully reconstructable.
-      const path: string[] = []
-      let cursor: string | undefined = 'finish'
-      while (cursor) {
-        path.unshift(cursor)
-        cursor = from.get(cursor)
-      }
-      assert(
-        JSON.stringify(path) ===
-          JSON.stringify([
-            'begin',
-            'attempt',
-            'attempt#1',
-            'attempt#2',
-            'finish',
-          ]),
-        `reconstructed path mismatch, got ${JSON.stringify(path)}`
+        JSON.stringify(inlineNodes) === JSON.stringify(queuedNodes),
+        `inline vs queued node state diverged\n  inline: ${JSON.stringify(inlineNodes)}\n  queued: ${JSON.stringify(queuedNodes)}`
       )
     }
   )

--- a/verifiers/workflows/src/runners/cyclic-graph.runner.ts
+++ b/verifiers/workflows/src/runners/cyclic-graph.runner.ts
@@ -313,6 +313,66 @@ async function main(): Promise<void> {
     }
   )
 
+  await test(
+    'TIMELINE time-travel reconstructs run state at any point (cycle included)',
+    async () => {
+      const { status, runId } = await runInline('graphCyclicRetry', {
+        attempts: 3,
+      })
+      assert(status === 'completed', `expected completed, got ${status}`)
+
+      // Final state: the reconstructed path + results must match EXPECTED_NODES
+      // exactly — same durable history the provenance test reads, now folded.
+      const final = await workflowService.reconstructRunStateAt(runId)
+      assert(final !== null, 'reconstructRunStateAt returned null for a real run')
+      assert(
+        JSON.stringify(final!.path) ===
+          JSON.stringify(['begin', 'attempt', 'attempt#1', 'attempt#2', 'finish']),
+        `final path mismatch, got ${JSON.stringify(final!.path)}`
+      )
+      for (const [name, expected] of Object.entries(EXPECTED_NODES)) {
+        assert(
+          JSON.stringify(final!.results[name]) === JSON.stringify(expected.result),
+          `final result for '${name}' mismatch — expected ${JSON.stringify(expected.result)}, got ${JSON.stringify(final!.results[name])}`
+        )
+      }
+
+      // Time-travel: rewind to the instant the 2nd cycle pass (attempt#1) is
+      // created. begin + attempt have succeeded; attempt#1 is freshly pending;
+      // attempt#2 and finish do not exist yet.
+      const timeline = await workflowService.getRunTimeline(runId)
+      assert(timeline !== null, 'getRunTimeline returned null for a real run')
+      const created = timeline!.find(
+        (e) => e.type === 'pending' && e.stepName === 'attempt#1'
+      )
+      assert(created !== undefined, 'no created event for attempt#1')
+      const mid = await workflowService.reconstructRunStateAt(runId, created!.seq)
+      assert(
+        JSON.stringify(mid!.path) ===
+          JSON.stringify(['begin', 'attempt', 'attempt#1']),
+        `mid-run path mismatch, got ${JSON.stringify(mid!.path)}`
+      )
+      const attempt1 = mid!.steps.find((s) => s.stepName === 'attempt#1')!
+      assert(
+        attempt1.status === 'pending',
+        `attempt#1 should be pending mid-run, got ${attempt1.status}`
+      )
+      assert(
+        mid!.phase === 'running',
+        `mid-run phase should be running, got ${mid!.phase}`
+      )
+      assert(
+        mid!.results.begin !== undefined && mid!.results.attempt !== undefined,
+        'begin + attempt results must be in the replay cache mid-run'
+      )
+      assert(
+        mid!.results['attempt#1'] === undefined &&
+          mid!.results.finish === undefined,
+        'future steps must NOT be in the replay cache mid-run'
+      )
+    }
+  )
+
   console.log('\n=== Summary ===')
   const passed = results.filter((r) => r.ok).length
   const failed = results.filter((r) => !r.ok).length

--- a/verifiers/workflows/src/tests/planned-steps.assert.ts
+++ b/verifiers/workflows/src/tests/planned-steps.assert.ts
@@ -1,0 +1,112 @@
+/**
+ * Verifies the static UI plan the inspector bakes into workflow meta.
+ *
+ * A predictable (loopless) DSL workflow ships `plannedSteps` (every named step
+ * in source order) + `deterministic`, so a frontend can render the run skeleton
+ * before execution. This asserts the gating invariants across the whole
+ * generated corpus plus a few named anchors. Run after `pikku` codegen.
+ */
+
+import { readdir, readFile } from 'fs/promises'
+import { join } from 'path'
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import type { SerializedWorkflowGraph } from '@pikku/inspector'
+
+const META_DIR = join(import.meta.dirname!, '../../.pikku/workflow/meta')
+
+async function loadCorpus(): Promise<SerializedWorkflowGraph[]> {
+  const files = (await readdir(META_DIR)).filter((f) => f.endsWith('.gen.json'))
+  return Promise.all(
+    files.map(async (f) =>
+      JSON.parse(await readFile(join(META_DIR, f), 'utf-8'))
+    )
+  )
+}
+
+function byName(
+  corpus: SerializedWorkflowGraph[],
+  name: string
+): SerializedWorkflowGraph {
+  const wf = corpus.find((w) => w.name === name)
+  assert.ok(wf, `expected generated meta for workflow "${name}"`)
+  return wf
+}
+
+describe('workflow meta — static plannedSteps plan', async () => {
+  const corpus = await loadCorpus()
+
+  test('only DSL workflows carry a plan (never complex/graph)', () => {
+    for (const wf of corpus) {
+      if (wf.source !== 'dsl') {
+        assert.equal(
+          wf.plannedSteps,
+          undefined,
+          `${wf.name} (${wf.source}) must not have plannedSteps`
+        )
+        assert.equal(
+          wf.deterministic,
+          undefined,
+          `${wf.name} (${wf.source}) must not have deterministic`
+        )
+      }
+    }
+  })
+
+  test('every DSL workflow has a deterministic flag', () => {
+    for (const wf of corpus) {
+      if (wf.source === 'dsl') {
+        assert.equal(
+          typeof wf.deterministic,
+          'boolean',
+          `${wf.name} missing deterministic`
+        )
+      }
+    }
+  })
+
+  test('plannedSteps, when present, are named and non-empty', () => {
+    // An empty array is never emitted: a deterministic workflow with no named
+    // steps (e.g. a bare return) simply omits plannedSteps.
+    for (const wf of corpus) {
+      if (wf.plannedSteps !== undefined) {
+        assert.ok(
+          wf.plannedSteps.length > 0,
+          `${wf.name} has an empty plannedSteps array (should be omitted)`
+        )
+        for (const step of wf.plannedSteps) {
+          assert.ok(
+            typeof step.stepName === 'string' && step.stepName.length > 0,
+            `${wf.name} has an unnamed planned step`
+          )
+        }
+      }
+    }
+  })
+
+  test('a loopless linear workflow is deterministic with steps in order', () => {
+    const wf = byName(corpus, 'taskCrudWorkflow')
+    assert.equal(wf.source, 'dsl')
+    assert.equal(wf.deterministic, true)
+    assert.deepEqual(
+      wf.plannedSteps?.map((s) => s.stepName),
+      [
+        'Create task',
+        'Get task',
+        'Update task status',
+        'Mark task completed',
+        'Delete task',
+      ]
+    )
+  })
+
+  test('a branchy loopless workflow lists all arms but is not deterministic', () => {
+    const wf = byName(corpus, 'autoRestockWorkflow')
+    assert.equal(wf.source, 'dsl')
+    assert.equal(wf.deterministic, false)
+    assert.ok(
+      wf.plannedSteps && wf.plannedSteps.length > 0,
+      'branchy workflow still lists its possible steps'
+    )
+  })
+})


### PR DESCRIPTION
## What

Two related changes to the workflow queue path, plus a load benchmark that proves transport-independence:

1. **`InMemoryQueueService` now retries failed jobs** (`@pikku/core`, patch). It previously ran each job once and dropped it on failure. So a transiently-failing workflow step dispatched via `inline: false` would **stall the run forever** — the step worker threw, the job was discarded, and the orchestrator was never resumed. It now honors the `attempts` + `backoff` already produced by `resolveStepJobOptions`, redelivering on failure with backoff — matching pg-boss/bullmq semantics. This is the queue used by `pikku dev` and the standalone deploy runtime, so local/dev workflows now recover from transient step failures exactly as production does.

2. **Workflow load benchmark** (`benchmarks/bench-workflow.ts`). Runs hundreds of DSL workflows concurrently, each with many steps where a deterministic ~2/3 of steps fail transiently on their first 1–2 attempts. Asserts **every** run reaches `completed` under load (nothing dropped, nothing stuck). Three transports, same workload, same assertions:

   | mode | what it exercises | result |
   |------|-------------------|--------|
   | (default) | every step inline (in-process retry loop) | 300×20 = 6000 steps → 300/300 ✅ |
   | `--mixed` | alternate steps `inline: false` → dispatched through the in-process queue | 200×16 = 3200 steps → 200/200 ✅ |
   | `--queue` | run-level queue orchestration | 50/50 ✅ |

   ```
   tsx benchmarks/bench-workflow.ts --runs 300 --steps 20
   tsx benchmarks/bench-workflow.ts --mixed --runs 200 --steps 16
   tsx benchmarks/bench-workflow.ts --queue --runs 200 --steps 16
   ```

## Why this matters

Flipping a step between `inline: true` and `inline: false` should change only *where* it runs, never *whether the workflow completes*. Before change (1), `--mixed` hangs every run; after, all three transports complete the identical flaky workload. The benchmark is the regression guard for this invariant (and for the follow-up that collapses the duplicated inline/queue execution paths into one).

## Tests

- New `in-memory-queue-service.test.ts`: retries a transient job until success, stops exactly at `attempts` for an always-failing job, and runs once when no `attempts` are set (backward-compat).
- Full `@pikku/core` suite green: **1019 pass, 0 fail**.

## Notes for reviewers

- Retry count alignment: the queue's `maxAttempts` (`retries + 1` from `resolveStepJobOptions`) matches `executeWorkflowStep`'s own `retriesExhausted` accounting, so there's no double-counting — the queue redelivery *is* the step retry, and the orchestrator is only resumed on success or final exhaustion (never between retries, so no re-dispatch race).
- The dedicated `InlineQueueService` refactor (collapsing `rpcStep`/`inlineStep`'s bespoke inline-execute loops into one "always dispatch through a queue service" path) is intentionally **not** in this PR — it's a deeper engine change best done as a focused follow-up with this benchmark guarding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new workflow benchmark to compare inline, mixed, and queued execution.
  * Added workflow “time-travel” APIs and UI timeline scrubbing in the workflow console.
  * Inspector now emits `plannedSteps` and `deterministic` metadata for eligible DSL graphs.
* **Bug Fixes**
  * Local in-memory queue now retries failed jobs using attempt limits and backoff, preventing stalled runs.
  * Step provenance (`fromStepName`) is preserved consistently across history reconstruction and graph cycles/revisits.
* **Tests**
  * Added retry, run timeline, cyclic provenance, and planned-steps assertions, plus DB-backed verifier coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->