### PR TITLE
fix(inspector): register functions before wiring resolution (fixes PKU559 + green CI)

### DIFF
--- a/.changeset/deterministic-codegen-prepass.md
+++ b/.changeset/deterministic-codegen-prepass.md
@@ -1,0 +1,20 @@
+---
+'@pikku/inspector': patch
+'@pikku/cli': patch
+---
+
+fix(inspector): register functions in a dedicated pass before wiring resolution
+
+The deterministic-codegen change sorted `program.getSourceFiles()` so generated
+output is byte-identical across runs. But function registration (`addFunctions`)
+ran in the same sweep as wiring resolution (`visitRoutes`), so once traversal
+became alphabetical, a wiring file could be visited before the file that defines
+the function it references — e.g. an addon contract (`hello.contracts.ts`)
+before `hello.functions.ts` — producing a spurious `PKU559` ("No function
+metadata found for channel handler").
+
+Function registration now runs in its own pass (`visitFunctions`) over the
+sorted files, completing before any transport/wiring resolution, so resolution
+no longer depends on source-file order. Also sort the `register.gen.ts` schema
+imports (driven by a `Set`) so that file is stable too, and opt the PII-check
+tests into the now-opt-in classification scan.

--- a/benchmarks/bench-codegen-perf.ts
+++ b/benchmarks/bench-codegen-perf.ts
@@ -229,7 +229,20 @@ function schedulerWiringFile(count: number): string {
 
 // ── runner ────────────────────────────────────────────────────────────────────
 
+// pikku persists generated TS schemas under node_modules/.cache/pikku across
+// runs. This benchmark measures *cold* codegen (the worst case the threshold
+// and structural gate are about), so clear that cache before every run —
+// otherwise a warm run skips schema generation, shrinking the initial pass and
+// inflating the re-inspect ratio.
+function clearSchemaCache(): void {
+  rmSync(resolve(PROJECT_DIR, 'node_modules', '.cache', 'pikku'), {
+    recursive: true,
+    force: true,
+  })
+}
+
 function runAll(timing = false): { ms: number; stdout: string } {
+  clearSchemaCache()
   const start = performance.now()
   const result = spawnSync(PIKKU_BIN, ['all'], {
     cwd: PROJECT_DIR,

--- a/packages/cli/src/utils/serialize-schemas.ts
+++ b/packages/cli/src/utils/serialize-schemas.ts
@@ -43,9 +43,11 @@ export async function saveSchemas(
     })
   )
 
-  const availableSchemas = Array.from(requiredSchemas).filter(
-    (schema) => schemas[schema]
-  )
+  // Sort so register.gen.ts is byte-identical across runs — requiredSchemas is
+  // a Set in (nondeterministic) traversal-insertion order.
+  const availableSchemas = Array.from(requiredSchemas)
+    .filter((schema) => schemas[schema])
+    .sort()
 
   const packageNameArg = packageName ? `, '${packageName}'` : ''
 

--- a/packages/inspector/src/add/pii-check.test.ts
+++ b/packages/inspector/src/add/pii-check.test.ts
@@ -48,7 +48,9 @@ async function runInspect(sourceCode: string) {
   await writeFile(file, sourceCode)
   const { logger, criticals } = makeLogger()
   try {
-    await inspect(logger, [file], { rootDir: tmpDir })
+    // The data-classification leak scan is opt-in (off by default to keep it
+    // off the `pikku all` hot path); these tests exercise it, so enable it.
+    await inspect(logger, [file], { rootDir: tmpDir, classificationCheck: true })
   } finally {
     await rm(tmpDir, { recursive: true, force: true })
   }

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript'
 import { performance } from 'perf_hooks'
 import { resolve } from 'path'
-import { visitSetup, visitRoutes } from './visit.js'
+import { visitSetup, visitFunctions, visitRoutes } from './visit.js'
 import { TypesMap } from './types-map.js'
 import type {
   InspectorState,
@@ -269,6 +269,12 @@ export const inspect = async (
   // node_modules under rootDir (e.g. a locally-installed addon) is a
   // dependency, not project source — scanning it double-counts the addon's
   // own application types (CoreConfig/Services/SingletonServices).
+  // Sort by file name so the sweeps populate state in a stable order. The
+  // program's own file order depends on glob + import-graph resolution, which
+  // varies run to run — leaving generated meta keys (and anything serialized
+  // in insertion order) non-reproducible across identical `pikku all` runs.
+  // Safe because function registration is a dedicated pass (visitFunctions)
+  // that completes before any order-sensitive wiring resolution in visitRoutes.
   const sourceFiles = program
     .getSourceFiles()
     .filter(
@@ -276,10 +282,6 @@ export const inspect = async (
         sf.fileName.startsWith(rootDir) &&
         !sf.fileName.includes('/node_modules/')
     )
-    // Sort by file name so the sweeps populate state in a stable order. The
-    // program's own file order depends on glob + import-graph resolution, which
-    // varies run to run — leaving generated meta keys (and anything serialized
-    // in insertion order) non-reproducible across identical `pikku all` runs.
     .sort((a, b) =>
       a.fileName < b.fileName ? -1 : a.fileName > b.fileName ? 1 : 0
     )
@@ -305,7 +307,20 @@ export const inspect = async (
   await loadAddonFunctionsMeta(logger, state)
 
   if (!options.setupOnly) {
-    // Second sweep: add all transports
+    // Function sweep: register every function before transports/wirings resolve
+    // them, so resolution doesn't depend on source-file order.
+    const startFunctions = performance.now()
+    for (const sourceFile of sourceFiles) {
+      const sourceOptions = { ...options, sourceFile }
+      ts.forEachChild(sourceFile, (child) =>
+        visitFunctions(logger, checker, child, state, sourceOptions)
+      )
+    }
+    logger.debug(
+      `Visit functions phase completed in ${(performance.now() - startFunctions).toFixed(0)}ms`
+    )
+
+    // Transport sweep: add all transports/wirings
     const startRoutes = performance.now()
     for (const sourceFile of sourceFiles) {
       const sourceOptions = { ...options, sourceFile }

--- a/packages/inspector/src/visit.ts
+++ b/packages/inspector/src/visit.ts
@@ -100,6 +100,28 @@ export const visitSetup = (
   )
 }
 
+// Register every pikku function before transports/wirings are resolved, so that
+// resolution (e.g. a channel handler referencing a function defined in another
+// file) is independent of source-file traversal order. Runs between visitSetup
+// and visitRoutes.
+export const visitFunctions = (
+  logger: InspectorLogger,
+  checker: ts.TypeChecker,
+  node: ts.Node,
+  state: InspectorState,
+  options: InspectorOptions
+) => {
+  const nextOptions = ts.isSourceFile(node)
+    ? { ...options, sourceFile: node }
+    : options
+
+  addFunctions(logger, node, checker, state, nextOptions)
+
+  ts.forEachChild(node, (child) =>
+    visitFunctions(logger, checker, child, state, nextOptions)
+  )
+}
+
 export const visitRoutes = (
   logger: InspectorLogger,
   checker: ts.TypeChecker,
@@ -113,7 +135,9 @@ export const visitRoutes = (
 
   checkAddonBans(logger, node, checker, state, nextOptions)
 
-  addFunctions(logger, node, checker, state, nextOptions)
+  // NOTE: addFunctions runs in its own earlier pass (visitFunctions) so that
+  // every function is registered before any wiring (channels, CLI, etc.)
+  // resolves it — wiring resolution must not depend on source-file order.
   addAuth(logger, node, checker, state, nextOptions)
   addSecret(logger, node, checker, state, nextOptions)
   addCredential(logger, node, checker, state, nextOptions)

--- a/verifiers/classification/src/tests/pii-gate.assert.ts
+++ b/verifiers/classification/src/tests/pii-gate.assert.ts
@@ -2,10 +2,13 @@
  * Verifies the diagnostic-severity build gate end-to-end through the real CLI.
  *
  * PKU910 (a sessionless function exposing a Private-classified field) is emitted
- * at `error` severity. By default the gate only fails on `critical`, so
- * `pikku all` must still exit 0 (the dev server keeps starting) while printing
- * the finding. Passing `--fail-on-error` (e.g. at deploy) must turn the same
- * finding into a non-zero exit so leaks become blocking-with-a-recommendation.
+ * at `error` severity. The data-classification scan is opt-in (it forces
+ * expensive return-type inference on every function), so every run here passes
+ * `--security` to enable it. With the scan on, the gate still only fails on
+ * `critical`, so `pikku all --security` must exit 0 (the dev server keeps
+ * starting) while printing the finding. Adding `--fail-on-error` (e.g. at
+ * deploy) must turn the same finding into a non-zero exit so leaks become
+ * blocking-with-a-recommendation.
  *
  * The temp project is created *inside the repo tree* so `@pikku/core` resolves
  * via upward node_modules traversal — a bare /tmp project cannot resolve the
@@ -31,7 +34,8 @@ function runPikkuAll(
   dir: string,
   extraArgs: string[] = []
 ): { exitCode: number; output: string } {
-  const res = spawnSync('node', [PIKKU_BIN, 'all', ...extraArgs], {
+  // The classification scan is opt-in; --security turns it on for every run.
+  const res = spawnSync('node', [PIKKU_BIN, 'all', '--security', ...extraArgs], {
     cwd: dir,
     timeout: 60_000,
     encoding: 'utf8',


### PR DESCRIPTION
## What

Forward-fix for the two CI failures introduced by the recent deterministic-codegen + schema-cache work on `main`:

1. **`PKU559` during codegen** — sorting `program.getSourceFiles()` (for byte-identical output) made traversal alphabetical, but `addFunctions` ran in the *same* sweep as wiring resolution (`visitRoutes`). So a wiring file could be visited before the file defining the function it references — e.g. the addon contract `hello.contracts.ts` before `hello.functions.ts` — yielding a spurious *"No function metadata found for channel handler"*. Fixed by moving function registration into its own pass (`visitFunctions`) over the sorted files, completing before any transport/wiring resolution. Resolution no longer depends on source-file order.

2. **`@pikku/inspector` unit tests red** — the data-classification scan became opt-in (`classificationCheck`), but `pii-check.test.ts` still asserted it ran by default. The tests now opt in.

Also sorts the `register.gen.ts` schema imports (driven by a `Set`, previously insertion-ordered) so that file is stable too.

## Verification

- `@pikku/inspector` tests: **257/257 pass**
- `templates/function-addon` codegen: **succeeds, no PKU559**
- Full generated `.pikku` tree of a 331-function project: **byte-identical across 4 consecutive `pikku all` runs**
- Schema disk-cache cold→warm output: **byte-identical**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made code generation and schema import ordering deterministic, reducing flaky output and preventing unexpected inspector errors during scans.
  * Improved inspection stability by ensuring function registration happens before later resolution steps.

* **Tests**
  * Updated PII-check coverage to run with classification scanning enabled, aligning test behavior with the new detection mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->