### PR TITLE
fix(cli): log message only for expected failures, keep stack for uncaught errors

### DIFF
--- a/.changeset/expected-error-no-stack.md
+++ b/.changeset/expected-error-no-stack.md
@@ -1,0 +1,22 @@
+---
+'@pikku/core': patch
+'@pikku/cli': patch
+---
+
+fix(cli): log just the message for expected failures, keep the stack for uncaught errors
+
+A deliberate, expected failure — e.g. `pikku all` aborting because a build gate
+(blocking diagnostics) tripped — was dumping a full workflow stack trace, burying
+the one line that matters. Errors are now classified: a `PikkuError` (or any error
+carrying an `expected` marker) prints its message alone, while a genuinely uncaught
+error still prints the full stack so it can be debugged.
+
+- New `isExpectedError(error)` helper (exported from `@pikku/core`): true for a
+  `PikkuError` or an error flagged `expected`.
+- The `expected` flag is threaded through `SerializedError` and the in-memory
+  workflow step store so it survives the step-boundary rehydration that strips the
+  error's class.
+- The CLI runner's top-level catch, the `CLILogger`, and the workflow runner's
+  failure log all honour it.
+- The blocking-diagnostics abort now throws a `PikkuError` subclass so it is
+  treated as expected.

--- a/packages/cli/src/functions/commands/pikku-command-summary.ts
+++ b/packages/cli/src/functions/commands/pikku-command-summary.ts
@@ -1,5 +1,10 @@
 import { pikkuSessionlessFunc } from '#pikku'
+import { PikkuError } from '@pikku/core'
 import { CommandSummary } from '../../utils/command-summary.js'
+
+// A blocking-diagnostics failure is expected (the gate did its job) — throw a
+// PikkuError so the workflow runner logs the message alone, not a stack trace.
+class PikkuInspectionFailedError extends PikkuError {}
 
 export const pikkuSummary = pikkuSessionlessFunc<void, void>({
   func: async ({ logger, getInspectorState }) => {
@@ -73,7 +78,9 @@ export const pikkuSummary = pikkuSessionlessFunc<void, void>({
 
     if (logger.hasBlockingDiagnostics()) {
       const severities = logger.blockingSeverities().join(', ')
-      throw new Error(`Pikku inspection failed due to ${severities} diagnostics`)
+      throw new PikkuInspectionFailedError(
+        `Pikku inspection failed due to ${severities} diagnostics`
+      )
     }
   },
 })

--- a/packages/cli/src/services/cli-logger.service.ts
+++ b/packages/cli/src/services/cli-logger.service.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import type { Logger } from '@pikku/core/services'
 import { LogLevel } from '@pikku/core/services'
+import { isExpectedError } from '@pikku/core'
 import type {
   ErrorCode,
   DiagnosticSeverity,
@@ -165,7 +166,15 @@ export class CLILogger implements Logger {
   ) {
     if (this.level > LogLevel.error) return
     if (message instanceof Error) {
-      this.emit('error', message.stack ?? message.message)
+      // An expected failure (a deliberate PikkuError, e.g. a build gate
+      // tripping) — its message says everything, so don't dump the stack.
+      // Anything else is an uncaught error: show the full trace to debug it.
+      this.emit(
+        'error',
+        isExpectedError(message)
+          ? message.message
+          : (message.stack ?? message.message)
+      )
       return
     }
     const msg = typeof message === 'string' ? message : message.message

--- a/packages/core/src/errors/error-handler.ts
+++ b/packages/core/src/errors/error-handler.ts
@@ -17,6 +17,16 @@ export class PikkuError extends Error {
 }
 
 /**
+ * Whether an error is a deliberate, expected failure rather than an uncaught
+ * bug. A `PikkuError` always counts; so does any error carrying `expected:
+ * true` — used to keep the marker alive when an error is serialized across a
+ * workflow step boundary and rehydrated as a plain `Error`. Callers log the
+ * message alone for expected errors and the full stack for everything else.
+ */
+export const isExpectedError = (error: unknown): boolean =>
+  error instanceof PikkuError || (error as any)?.expected === true
+
+/**
  * Interface for error details.
  */
 export interface ErrorDetails {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,6 +93,7 @@ export type {
 export { runQueueJob } from './wirings/queue/queue-runner.js'
 export { runScheduledTask } from './wirings/scheduler/scheduler-runner.js'
 export { NotFoundError } from './errors/errors.js'
+export { PikkuError, isExpectedError } from './errors/error-handler.js'
 export type { EventHubService } from './wirings/channel/eventhub-service.js'
 export type { QueueService } from './wirings/queue/queue.types.js'
 export type { JWTService } from './services/jwt-service.js'

--- a/packages/core/src/services/in-memory-workflow-service.ts
+++ b/packages/core/src/services/in-memory-workflow-service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto'
 import { PikkuWorkflowService } from '../wirings/workflow/pikku-workflow-service.js'
+import { isExpectedError } from '../errors/error-handler.js'
 import type { SerializedError } from '../types/core.types.js'
 import type {
   WorkflowPlannedStep,
@@ -230,6 +231,7 @@ export class InMemoryWorkflowService
           name: error.name,
           message: error.message,
           stack: error.stack,
+          expected: isExpectedError(error),
         }
         step.failedAt = new Date()
         step.updatedAt = new Date()

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -558,5 +558,9 @@ export interface SerializedError {
   message: string
   stack?: string
   code?: string
+  // True when the original error was a deliberate, expected failure (a
+  // PikkuError). Survives the step-boundary rehydration so the workflow runner
+  // can log the message alone instead of a stack trace. See isExpectedError.
+  expected?: boolean
   [key: string]: any
 }

--- a/packages/core/src/wirings/cli/cli-runner.ts
+++ b/packages/core/src/wirings/cli/cli-runner.ts
@@ -545,9 +545,14 @@ export async function executeCLI({
     }
 
     // An expected failure (a deliberate PikkuError, e.g. a build gate
-    // tripping) — its message says everything, so print that alone. Anything
-    // else is an uncaught error: log the object so its stack shows.
-    console.error('Error:', isExpectedError(error) ? error.message : error)
+    // tripping) — its message says everything, so print that alone (no
+    // `Error:` prefix). Anything else is an uncaught error: log the object so
+    // its stack shows.
+    if (isExpectedError(error)) {
+      console.error(error.message)
+    } else {
+      console.error('Error:', error)
+    }
 
     // Show stack trace in verbose mode (even for expected errors).
     if (args.includes('--verbose') || args.includes('-v')) {

--- a/packages/core/src/wirings/cli/cli-runner.ts
+++ b/packages/core/src/wirings/cli/cli-runner.ts
@@ -1,4 +1,5 @@
 import { NotFoundError } from '../../errors/errors.js'
+import { isExpectedError } from '../../errors/error-handler.js'
 import { addFunction, runPikkuFunc } from '../../function/function-runner.js'
 import { pikkuState } from '../../pikku-state.js'
 import type {
@@ -543,10 +544,12 @@ export async function executeCLI({
       throw error
     }
 
-    // Wrap other errors in CLIError
-    console.error('Error:', error)
+    // An expected failure (a deliberate PikkuError, e.g. a build gate
+    // tripping) — its message says everything, so print that alone. Anything
+    // else is an uncaught error: log the object so its stack shows.
+    console.error('Error:', isExpectedError(error) ? error.message : error)
 
-    // Show stack trace in verbose mode
+    // Show stack trace in verbose mode (even for expected errors).
     if (args.includes('--verbose') || args.includes('-v')) {
       console.error('Stack trace:', error.stack)
     }

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -66,7 +66,11 @@ import {
   runFromMeta,
 } from './graph/graph-runner.js'
 import type { WorkflowService } from '../../services/workflow-service.js'
-import { PikkuError, addError } from '../../errors/error-handler.js'
+import {
+  PikkuError,
+  addError,
+  isExpectedError,
+} from '../../errors/error-handler.js'
 import { RPCNotFoundError } from '../rpc/rpc-runner.js'
 import { ChildWorkflowStartedException } from './graph/graph-runner.js'
 import { deriveInvocationId } from './workflow-invocation-id.js'
@@ -640,6 +644,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       message: error.message,
       stack: error.stack,
       code: (error as any).code,
+      expected: isExpectedError(error),
     }
     await this.safeMirror(() => this.mirror!.setStepError(stepId, serialized))
   }
@@ -1135,9 +1140,14 @@ export abstract class PikkuWorkflowService implements WorkflowService {
             message: error.message,
             stack: error.stack,
           })
+          // An expected failure (a PikkuError, e.g. a build gate tripping) —
+          // its message is the whole story, so don't dump the stack. The
+          // `expected` flag survives the step-boundary rehydration that strips
+          // the class. Anything else is an uncaught/unexpected error: log it in
+          // full so the trace is there to debug.
           getSingletonServices()!.logger.error(
             `Workflow ${name} (run ${runId}) failed:`,
-            error
+            isExpectedError(error) ? error.message : error
           )
           throw error
         }


### PR DESCRIPTION
## Problem

A deliberate, *expected* failure — e.g. `pikku all` aborting because a build gate (blocking diagnostics) tripped — was dumping a full workflow stack trace, burying the one line that actually matters:

```
Workflow allWorkflow (run …) failed:
Error: Error: Pikku inspection failed due to critical diagnostics
    at Object.func (…/pikku-command-summary.js:59:19)
    at async executeFunction (…/function-runner.js:285:20)
    … 8 more frames …
```

## Fix

Classify errors so the noise only appears when it's useful:
- **Expected** (a `PikkuError`, or an error flagged `expected`) → log the message alone.
- **Uncaught / unexpected** → still print the full stack so it can be debugged.

```
Workflow allWorkflow (run …) failed:
Error: Pikku inspection failed due to error diagnostics
```

(exit code unchanged — the build still fails; `--verbose` still shows the stack.)

### Changes
- New `isExpectedError(error)` helper, exported from `@pikku/core`.
- The `expected` flag is threaded through `SerializedError` and the in-memory workflow step store so it survives the step-boundary rehydration that strips the error's class.
- The CLI runner's top-level catch (the actual culprit — a raw `console.error('Error:', error)`), `CLILogger.error`, and the workflow runner's failure log all honour it.
- The blocking-diagnostics abort throws a `PikkuError` subclass so it's treated as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expected failures now show a concise error message instead of a full stack trace in the CLI and workflow logs.
  * Error details now preserve an “expected” marker across workflow steps, keeping handling consistent after rehydration.

* **Bug Fixes**
  * Blocking diagnostics and other deliberate failures are now logged more cleanly, while unexpected errors still include full stack information.
  * CLI command inspection failures now use a more specific error type for clearer reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->