### PR TITLE
feat(cli): gate remote internal RPC scaffold behind scaffold.remoteRpc

### DIFF
--- a/.changeset/scaffold-remote-rpc-opt-in.md
+++ b/.changeset/scaffold-remote-rpc-opt-in.md
@@ -1,5 +1,5 @@
 ---
-'@pikku/cli': minor
+'@pikku/cli': patch
 ---
 
 feat(cli): gate the remote internal RPC scaffold behind `scaffold.remoteRpc`

--- a/.changeset/scaffold-remote-rpc-opt-in.md
+++ b/.changeset/scaffold-remote-rpc-opt-in.md
@@ -1,0 +1,33 @@
+---
+'@pikku/cli': minor
+---
+
+feat(cli): gate the remote internal RPC scaffold behind `scaffold.remoteRpc`
+
+The remote internal RPC handler (`rpc-remote.gen.ts` — a `pikku-remote-internal-rpc`
+queue worker plus a `/remote/rpc/:rpcName` HTTP endpoint) was generated for
+**every** project unconditionally, because `remoteRpcWorkersFile` defaulted to
+`<scaffoldDir>/rpc-remote.gen.ts` with no guard. Projects that never invoke RPCs
+across a deployable boundary (the call resolves inline, or service-to-service
+goes through a generated `PikkuRPC`/`PikkuFetch` HTTP client) ended up
+registering an idle queue worker they never dispatch to.
+
+Remote RPC is now an opt-in scaffold feature, consistent with `rpc`, `agent`,
+`workflow`, `console`, and `events`:
+
+```jsonc
+// pikku.config.json
+"scaffold": { "remoteRpc": "no-auth" }
+```
+
+or via the CLI: `pikku enable remote-rpc`.
+
+When `scaffold.remoteRpc` is unset, `remoteRpcWorkersFile` is left undefined and
+`pikkuRemoteRPC` skips generation (same guard the other scaffolds already use) —
+no `pikku-remote-internal-rpc` queue worker, no `/remote/rpc/:rpcName` endpoint.
+
+**Migration:** projects that rely on pikku's cross-deployable remote RPC
+transport must add `"scaffold": { "remoteRpc": "no-auth" }` (or run
+`pikku enable remote-rpc`) to keep the handler. The `remote-rpc-pg` /
+`remote-rpc-redis` templates (via the shared `functions` template) are updated
+accordingly.

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -48,6 +48,7 @@ import {
   enableAgent,
   enableWorkflow,
   enableEvents,
+  enableRemoteRpc,
 } from './functions/commands/enable.js'
 import { pikkuRealtime } from './functions/wirings/realtime/pikku-command-realtime.js'
 import { binary } from './functions/commands/binary.js'
@@ -460,6 +461,17 @@ wireCLI({
           func: enableEvents,
           description:
             'Enable the realtime events channel + SSE stream (scaffolds events.gen.ts)',
+          options: {
+            noAuth: {
+              description: 'Disable auth requirement',
+              default: false,
+            },
+          },
+        }),
+        'remote-rpc': pikkuCLICommand({
+          func: enableRemoteRpc,
+          description:
+            'Enable the remote internal RPC queue worker + HTTP endpoint (scaffolds rpc-remote.gen.ts)',
           options: {
             noAuth: {
               description: 'Disable auth requirement',

--- a/packages/cli/src/fabric/functions/validate.function.ts
+++ b/packages/cli/src/fabric/functions/validate.function.ts
@@ -244,6 +244,7 @@ export async function runValidate(
       agent?: unknown
       workflow?: unknown
       events?: unknown
+      remoteRpc?: unknown
     }
     db?: {
       engine?: 'sqlite' | 'postgres'

--- a/packages/cli/src/functions/commands/enable.ts
+++ b/packages/cli/src/functions/commands/enable.ts
@@ -3,7 +3,13 @@ import { join } from 'path'
 import { pikkuVoidFunc } from '#pikku'
 import type { PikkuScaffoldFeature } from '../../../types/config.js'
 
-type Feature = 'rpc' | 'console' | 'agent' | 'workflow' | 'events'
+type Feature =
+  | 'rpc'
+  | 'console'
+  | 'agent'
+  | 'workflow'
+  | 'events'
+  | 'remoteRpc'
 
 const FEATURE_DEFAULTS: Record<Feature, 'auth' | 'no-auth'> = {
   rpc: 'auth',
@@ -11,6 +17,7 @@ const FEATURE_DEFAULTS: Record<Feature, 'auth' | 'no-auth'> = {
   console: 'no-auth',
   workflow: 'auth',
   events: 'auth',
+  remoteRpc: 'no-auth',
 }
 
 async function enableFeature(
@@ -64,4 +71,9 @@ export const enableWorkflow = pikkuVoidFunc({
 export const enableEvents = pikkuVoidFunc({
   func: async ({ logger, config }, data: any) =>
     enableFeature('events', logger, config, data),
+})
+
+export const enableRemoteRpc = pikkuVoidFunc({
+  func: async ({ logger, config }, data: any) =>
+    enableFeature('remoteRpc', logger, config, data),
 })

--- a/packages/cli/src/utils/pikku-cli-config.ts
+++ b/packages/cli/src/utils/pikku-cli-config.ts
@@ -302,7 +302,7 @@ const _getPikkuCLIConfig = async (
       ? scaffoldDir
       : join(result.rootDir, scaffoldDir)
 
-    if (!result.remoteRpcWorkersFile) {
+    if (result.scaffold?.remoteRpc && !result.remoteRpcWorkersFile) {
       result.remoteRpcWorkersFile = join(
         resolvedScaffoldDir,
         'rpc-remote.gen.ts'

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -49,8 +49,9 @@ export interface PikkuCLICoreOutputFiles {
   // RPC Exposed
   rpcMapDeclarationFile: string
 
-  // Remote RPC workers (auto-derived)
-  remoteRpcWorkersFile: string
+  // Remote RPC workers (derived from scaffold.pikkuDir when scaffold.remoteRpc is enabled).
+  // Optional: left undefined when scaffold.remoteRpc is not enabled, so consumers must guard.
+  remoteRpcWorkersFile?: string
 
   // Feature-generated files (derived from scaffold.pikkuDir when enabled)
   publicRpcFile: string
@@ -315,6 +316,7 @@ export type PikkuCLIInput = {
     agent?: PikkuScaffoldFeature
     workflow?: PikkuScaffoldFeature
     events?: PikkuScaffoldFeature
+    remoteRpc?: PikkuScaffoldFeature
   }
 
   /**

--- a/templates/functions/pikku.config.json
+++ b/templates/functions/pikku.config.json
@@ -29,6 +29,7 @@
     "workflow": "no-auth",
     "console": "no-auth",
     "events": "no-auth",
+    "remoteRpc": "no-auth",
     "pikkuDir": "pikku"
   },
   "cli": {


### PR DESCRIPTION
## What

The remote internal RPC handler — `rpc-remote.gen.ts`, which wires a `pikku-remote-internal-rpc` **queue worker** *and* a `/remote/rpc/:rpcName` **HTTP endpoint** to a generic `remoteRPCHandler` — was generated for **every** project, unconditionally.

The cause: `remoteRpcWorkersFile` defaulted to `<scaffoldDir>/rpc-remote.gen.ts` with **no guard**, unlike `publicRpcFile`/`publicAgentFile`/etc. which are all gated behind their `scaffold.*` flag:

```ts
// before — always set
if (!result.remoteRpcWorkersFile) { result.remoteRpcWorkersFile = join(scaffoldDir, 'rpc-remote.gen.ts') }
// the others — gated
if (result.scaffold?.rpc && !result.publicRpcFile) { ... }
```

So any project that never invokes an RPC across a deployable boundary (the call resolves **inline**, or service-to-service goes through a generated `PikkuRPC`/`PikkuFetch` HTTP client) still registered an idle `pikku-remote-internal-rpc` queue worker it never dispatches to.

## Change

Remote RPC becomes an opt-in scaffold feature, consistent with `rpc`, `agent`, `workflow`, `console`, `events`:

```jsonc
// pikku.config.json
"scaffold": { "remoteRpc": "no-auth" }
```

or `pikku enable remote-rpc`.

- `scaffold.remoteRpc` now gates the `remoteRpcWorkersFile` default (mirrors `publicRpcFile`). When unset, `pikkuRemoteRPC` skips generation via its existing `if (config.remoteRpcWorkersFile)` guard — no queue worker, no HTTP endpoint.
- Added `pikku enable remote-rpc` subcommand + `enableRemoteRpc`, `remoteRpc` added to the scaffold type (`config.d.ts`) and the fabric-validate scaffold shape.
- Enabled `scaffold.remoteRpc` in the shared `functions` template — the `remote-rpc-pg` / `remote-rpc-redis` templates bootstrap from it and genuinely need the handler.

## Migration

Projects that rely on pikku's cross-deployable remote RPC transport must add `"scaffold": { "remoteRpc": "no-auth" }` (or run `pikku enable remote-rpc`) to keep the handler generated. Everyone else sheds an unused queue worker.

Changeset: `@pikku/cli` patch. `tsc` green; no tests reference the old always-on default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in remote RPC scaffolding via `scaffold.remoteRpc`, including a new CLI command to enable it (`enable remote-rpc`) with an optional `--noAuth` flag.
  * Updated default templates to include the new `scaffold.remoteRpc` setting.
* **Bug Fixes**
  * Remote RPC workers and the `/remote/rpc/:rpcName` endpoint are no longer generated unless remote RPC scaffolding is explicitly enabled.
* **Documentation**
  * Included migration guidance for projects that depend on remote RPC transport.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
