### PR TITLE
feat(workflow): per-step attempts in getRunStatus + stamp step transition timestamps

### DIFF
--- a/.changeset/workflow-step-timing-attempts.md
+++ b/.changeset/workflow-step-timing-attempts.md
@@ -1,5 +1,6 @@
 ---
 '@pikku/kysely': patch
+'@pikku/mongodb': patch
 '@pikku/core': patch
 ---
 
@@ -7,9 +8,10 @@ feat(workflow): expose per-step attempt count + record running/succeeded/failed 
 
 `getRunStatus` now returns `attempts` (the latest attempt count) per step, so
 consumers can show retry counts without a second history query. It already
-computed `duration` from `runningAt`/`succeededAt`, but the kysely workflow
-store only stamped those timestamps on the *insert* path — the `running` /
-`succeeded` / `failed` status transitions updated the history row's status
-without setting `runningAt` / `succeededAt` / `failedAt`, so `duration` was
-always undefined. The transitions now stamp the matching timestamp, so step
-duration is populated for kysely-backed runs.
+computed `duration` from `runningAt`/`succeededAt`, but the kysely and mongodb
+workflow stores only stamped those timestamps on the *insert* path — the
+`running` / `succeeded` / `failed` status transitions updated the history row's
+status without setting `runningAt` / `succeededAt` / `failedAt`, so `duration`
+was always undefined. The transitions now stamp the matching timestamp, so step
+duration is populated for kysely- and mongodb-backed runs. (Redis already
+stamped on transition.) A shared service-suite test guards both behaviours.

--- a/.changeset/workflow-step-timing-attempts.md
+++ b/.changeset/workflow-step-timing-attempts.md
@@ -1,0 +1,15 @@
+---
+'@pikku/kysely': patch
+'@pikku/core': patch
+---
+
+feat(workflow): expose per-step attempt count + record running/succeeded/failed timestamps
+
+`getRunStatus` now returns `attempts` (the latest attempt count) per step, so
+consumers can show retry counts without a second history query. It already
+computed `duration` from `runningAt`/`succeededAt`, but the kysely workflow
+store only stamped those timestamps on the *insert* path — the `running` /
+`succeeded` / `failed` status transitions updated the history row's status
+without setting `runningAt` / `succeededAt` / `failedAt`, so `duration` was
+always undefined. The transitions now stamp the matching timestamp, so step
+duration is populated for kysely-backed runs.

--- a/packages/core/src/testing/service-tests.ts
+++ b/packages/core/src/testing/service-tests.ts
@@ -320,6 +320,71 @@ export function defineServiceTests(config: ServiceTestConfig): void {
         assert.equal(retried.result, undefined)
       })
 
+      test('getRunStatus reports per-step duration and attempts', async () => {
+        const runId = await service.createRun(
+          'status-timing-workflow',
+          {},
+          false,
+          'hash-timing',
+          wire
+        )
+        const step = await service.insertStepState(
+          runId,
+          'timed-step',
+          'myRpc',
+          {}
+        )
+        await service.setStepRunning(step.stepId)
+        await service.setStepResult(step.stepId, { ok: true })
+
+        const status = await service.getRunStatus(runId)
+        assert.ok(status)
+        const timed = status.steps.find((s) => s.name === 'timed-step')
+        assert.ok(timed, 'step appears in run status')
+        // running→succeeded must stamp runningAt/succeededAt so a duration is
+        // computable. Regression guard: the kysely store previously updated
+        // only the status on transitions, leaving the timestamps null and
+        // duration permanently undefined.
+        assert.ok(
+          timed.duration !== undefined,
+          'duration is computed from stamped transition timestamps'
+        )
+        assert.ok(timed.duration >= 0, 'duration is non-negative')
+        assert.equal(timed.attempts, 1, 'single attempt')
+      })
+
+      test('getRunStatus surfaces retried attempt count', async () => {
+        const runId = await service.createRun(
+          'status-retry-workflow',
+          {},
+          false,
+          'hash-retry-status',
+          wire
+        )
+        const step = await service.insertStepState(
+          runId,
+          'flaky-step',
+          'myRpc',
+          {},
+          { retries: 2 }
+        )
+        await service.setStepRunning(step.stepId)
+        await service.setStepError(step.stepId, new Error('first try'))
+        // Guarantee the retry's history row sorts after the failed attempt so
+        // getRunStatus picks the latest attempt (it tie-breaks on timestamps).
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        const retry = await service.createRetryAttempt(step.stepId, 'pending')
+        await service.setStepRunning(retry.stepId)
+        await service.setStepResult(retry.stepId, { ok: true })
+
+        const status = await service.getRunStatus(runId)
+        assert.ok(status)
+        const flaky = status.steps.find((s) => s.name === 'flaky-step')
+        assert.ok(flaky, 'retried step collapses to a single status entry')
+        assert.equal(flaky.status, 'succeeded', 'latest attempt wins')
+        assert.equal(flaky.attempts, 2, 'attempt count surfaces in status')
+      })
+
       test('getNodesWithoutSteps', async () => {
         const runId = await service.createRun(
           'graph-workflow',

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -426,7 +426,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     // Build step summaries from history (latest attempt per step)
     const stepMap = new Map<
       string,
-      { status: StepStatus; startedAt?: Date; completedAt?: Date }
+      { status: StepStatus; startedAt?: Date; completedAt?: Date; attempts: number }
     >()
     for (const step of history) {
       const existing = stepMap.get(step.stepName)
@@ -435,6 +435,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
           status: step.status,
           startedAt: step.runningAt ?? step.createdAt,
           completedAt: step.succeededAt ?? step.failedAt,
+          attempts: step.attemptCount,
         })
       }
     }
@@ -446,6 +447,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         s.startedAt && s.completedAt
           ? s.completedAt.getTime() - s.startedAt.getTime()
           : undefined,
+      attempts: s.attempts,
     }))
 
     return {

--- a/packages/core/src/wirings/workflow/workflow.types.ts
+++ b/packages/core/src/wirings/workflow/workflow.types.ts
@@ -164,6 +164,8 @@ export interface WorkflowRunStatus {
     name: string
     status: StepStatus
     duration?: number
+    /** Number of attempts for this step (1 = first try; > 1 means it retried). */
+    attempts?: number
   }>
   output?: unknown
   error?: { message: string }

--- a/packages/services/kysely/src/kysely-workflow-service.ts
+++ b/packages/services/kysely/src/kysely-workflow-service.ts
@@ -319,7 +319,7 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
     if (latestHistory) {
       await this.db
         .updateTable('workflowStepHistory')
-        .set({ status: 'running' })
+        .set({ status: 'running', runningAt: new Date() })
         .where('historyId', '=', latestHistory.historyId)
         .execute()
     }
@@ -417,7 +417,7 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
     if (latestHistory) {
       await this.db
         .updateTable('workflowStepHistory')
-        .set({ status: 'succeeded', result: resultJson })
+        .set({ status: 'succeeded', result: resultJson, succeededAt: new Date() })
         .where('historyId', '=', latestHistory.historyId)
         .execute()
     }
@@ -456,7 +456,7 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
     if (latestHistory) {
       await this.db
         .updateTable('workflowStepHistory')
-        .set({ status: 'failed', error: errorJson })
+        .set({ status: 'failed', error: errorJson, failedAt: new Date() })
         .where('historyId', '=', latestHistory.historyId)
         .execute()
     }

--- a/packages/services/mongodb/src/mongodb-workflow-service.ts
+++ b/packages/services/mongodb/src/mongodb-workflow-service.ts
@@ -264,7 +264,7 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
     if (latestHistory.length > 0) {
       await this.stepHistory.updateOne(
         { _id: latestHistory[0]!._id },
-        { $set: { status: 'running' } }
+        { $set: { status: 'running', runningAt: new Date() } }
       )
     }
   }
@@ -359,7 +359,7 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
     if (latestHistory.length > 0) {
       await this.stepHistory.updateOne(
         { _id: latestHistory[0]!._id },
-        { $set: { status: 'succeeded', result } }
+        { $set: { status: 'succeeded', result, succeededAt: new Date() } }
       )
     }
   }
@@ -395,7 +395,7 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
     if (latestHistory.length > 0) {
       await this.stepHistory.updateOne(
         { _id: latestHistory[0]!._id },
-        { $set: { status: 'failed', error: serializedError } }
+        { $set: { status: 'failed', error: serializedError, failedAt: new Date() } }
       )
     }
   }


### PR DESCRIPTION
## What

Two small additions to the workflow run status so UIs can render a real provisioning timeline:

1. **`getRunStatus` returns `attempts` per step** (latest `attemptCount`). Consumers can show retry counts without a second history query.
2. **The kysely workflow store now stamps `runningAt`/`succeededAt`/`failedAt` on the running/succeeded/failed status transitions.** Previously these were only set on the *insert* path — `setStepRunningImpl`/`setStepResultImpl`/`setStepErrorImpl` updated the history row's `status` without the matching timestamp. Since `getRunStatus` computes `duration` as `succeededAt − runningAt`, step duration was **always `undefined`** for kysely-backed runs.

## Why

Pikku Fabric's console renders sandbox-boot / project-creation / deploy progress straight from `GET /workflow/:name/status/:runId`. It needs per-step duration and attempt count to show a `#<attempts> | <duration>` timeline. `duration` was silently null because the transitions never wrote the timestamps; `attempts` wasn't surfaced at all.

## Changes

- `@pikku/core` — `getRunStatus` adds `attempts` to each step summary; `WorkflowRunStatus.steps[]` gains `attempts?: number`.
- `@pikku/kysely` — the three step-transition history updates now set `runningAt`/`succeededAt`/`failedAt`.

Changeset included (both `patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)