### PR TITLE
fix(cli): make pikku dev + db seed work under the Bun runtime

### DIFF
--- a/.changeset/bun-dev-ipv4-bind-and-seed.md
+++ b/.changeset/bun-dev-ipv4-bind-and-seed.md
@@ -1,0 +1,15 @@
+---
+'@pikku/cli': patch
+---
+
+Fix two `pikku dev`/`pikku db seed` failures under the Bun runtime.
+
+- **IPv4 bind:** `pikku dev` passed `hostname: 'localhost'`, which `Bun.serve`
+  resolves to IPv6 `[::1]` only — unreachable from an IPv4 `127.0.0.1` reverse
+  proxy. Both the Bun and Node dev servers now bind explicit `127.0.0.1`
+  (works on both runtimes; Node previously relied on `--dns-result-order=ipv4first`).
+  The user-facing content URL still shows `localhost`.
+- **Seed tolerance:** the Bun sqlite runtime's `exec` threw
+  `no valid SQL statement` on comment-only/empty input (e.g. a placeholder
+  `seed.sql`), whereas `node:sqlite` silently no-ops. It now skips when nothing
+  executable remains after stripping comments; real SQL still runs verbatim.

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -49,6 +49,12 @@ export const dev = pikkuSessionlessFunc<
   ) => {
     const resolvedPort = parseInt(port || '3000', 10)
     const hostname = 'localhost'
+    // Bind on IPv4 loopback explicitly. Under Bun, hostname 'localhost' resolves
+    // to IPv6 [::1] only, so a 127.0.0.1 proxy (e.g. the sandbox Caddy) can't
+    // reach it. '127.0.0.1' binds IPv4 on both Node and Bun (Node otherwise
+    // relies on --dns-result-order=ipv4first for the same effect). `hostname`
+    // stays 'localhost' for the user-facing content URL below.
+    const bindHostname = '127.0.0.1'
     const enableWatch = watch !== false
     const enableHmr = hmr !== false
     const watchDirectories = [
@@ -307,7 +313,7 @@ export const dev = pikkuSessionlessFunc<
       pikkuServer = new bun.mod.PikkuBunServer(
         {
           ...userConfig,
-          hostname,
+          hostname: bindHostname,
           port: resolvedPort,
           content: localContentConfig,
         },
@@ -319,7 +325,7 @@ export const dev = pikkuSessionlessFunc<
       pikkuServer = new PikkuNodeHTTPServer(
         {
           ...userConfig,
-          hostname,
+          hostname: bindHostname,
           port: resolvedPort,
           content: localContentConfig,
         },

--- a/packages/cli/src/functions/db/sqlite/sqlite-runtime-bun.ts
+++ b/packages/cli/src/functions/db/sqlite/sqlite-runtime-bun.ts
@@ -45,6 +45,15 @@ class BunSqliteDatabase implements SyncSqliteDatabase {
   constructor(private readonly db: Database) {}
 
   exec(sql: string): void {
+    // bun:sqlite throws "no valid SQL statement" on comment-only/empty input
+    // (e.g. a placeholder seed.sql); node:sqlite silently no-ops. Match node's
+    // tolerance by skipping when nothing executable remains after stripping
+    // comments. The original `sql` is still exec'd verbatim when non-empty.
+    const executable = sql
+      .replace(/--[^\n]*/g, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .trim()
+    if (executable.length === 0) return
     this.db.exec(sql)
   }
 


### PR DESCRIPTION
- Bind the dev server on explicit 127.0.0.1 instead of 'localhost'. Bun resolves 'localhost' to IPv6 [::1] only, which a 127.0.0.1 reverse proxy (e.g. the sandbox Caddy) cannot reach. Binds IPv4 on both Node and Bun.
- Make the Bun sqlite runtime's exec tolerate comment-only/empty SQL (e.g. a placeholder seed.sql), matching node:sqlite's no-op behaviour instead of throwing "no valid SQL statement".