### PR TITLE
feat(cli,inspector): add deploy.defaultTarget config option

### DIFF
--- a/.changeset/deploy-default-target.md
+++ b/.changeset/deploy-default-target.md
@@ -1,0 +1,6 @@
+---
+'@pikku/inspector': patch
+'@pikku/cli': patch
+---
+
+Add `deploy.defaultTarget` to `pikku.config.json` to override the default deploy target ('serverless') for functions without an explicit `deploy` flag.

--- a/packages/cli/src/deploy/analyzer/analyzer.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.ts
@@ -43,6 +43,12 @@ export interface AnalyzerOptions {
   /** Services that can't run serverless — functions using them get target: 'server' */
   serverlessIncompatible?: string[]
   /**
+   * Default deploy target for functions without an explicit `deploy` flag
+   * and no serverless-incompatible service. Sourced from `pikku.config.json`
+   * → `deploy.defaultTarget`. Defaults to 'serverless'.
+   */
+  defaultTarget?: 'serverless' | 'server'
+  /**
    * When `true` (default), the analyzer synthesizes a per-workflow
    * orchestrator queue + a per-step queue, plus the matching producer
    * bindings, so providers whose workflow runtime fans out via queues
@@ -64,6 +70,7 @@ export function analyzeDeployment(
   options: AnalyzerOptions
 ): DeploymentManifest {
   const serverlessIncompatible = new Set(options.serverlessIncompatible ?? [])
+  const defaultTarget = options.defaultTarget ?? 'serverless'
   const workflowQueues = options.workflowQueues ?? true
   const units: DeploymentUnit[] = []
   const queues: QueueDefinition[] = []
@@ -192,7 +199,12 @@ export function analyzeDeployment(
     units.push({
       name: toSafeKebab(funcId),
       role: 'function',
-      target: resolveDeployTarget(funcMeta, serverlessIncompatible, funcId),
+      target: resolveDeployTarget(
+        funcMeta,
+        serverlessIncompatible,
+        funcId,
+        defaultTarget
+      ),
       functionIds: [funcId],
       services: collectServicesForFunction(funcMeta),
       dependsOn: [],
@@ -376,7 +388,8 @@ export function analyzeDeployment(
             target: resolveDeployTarget(
               funcMeta,
               serverlessIncompatible,
-              funcId
+              funcId,
+              defaultTarget
             ),
             functionIds: [funcId],
             services: collectServicesForFunction(funcMeta),

--- a/packages/cli/src/deploy/build-pipeline.ts
+++ b/packages/cli/src/deploy/build-pipeline.ts
@@ -74,6 +74,7 @@ export async function runBuildPipeline(options: {
   provider: ProviderAdapter
   inspectorState: InspectorState
   serverlessIncompatible?: string[]
+  defaultTarget?: 'serverless' | 'server'
   getEntryContext: (
     unitDir: string,
     pikkuDir: string,
@@ -103,6 +104,7 @@ export async function runBuildPipeline(options: {
   const manifest = analyzeDeployment(inspectorState, {
     projectId,
     serverlessIncompatible: options.serverlessIncompatible,
+    defaultTarget: options.defaultTarget,
     workflowQueues,
   })
 

--- a/packages/cli/src/functions/commands/deploy-apply.ts
+++ b/packages/cli/src/functions/commands/deploy-apply.ts
@@ -311,6 +311,7 @@ export const deployApply = pikkuSessionlessFunc<
       provider,
       inspectorState,
       serverlessIncompatible: config.deploy?.serverlessIncompatible,
+      defaultTarget: config.deploy?.defaultTarget,
       getEntryContext,
       outDir: config.outDir,
       debugArtifacts: data?.debugArtifacts ?? false,

--- a/packages/cli/src/functions/commands/deploy-plan.ts
+++ b/packages/cli/src/functions/commands/deploy-plan.ts
@@ -74,6 +74,7 @@ export const deployPlan = pikkuSessionlessFunc<
       provider,
       inspectorState,
       serverlessIncompatible: config.deploy?.serverlessIncompatible,
+      defaultTarget: config.deploy?.defaultTarget,
       getEntryContext,
       outDir: config.outDir,
       debugArtifacts: data?.debugArtifacts ?? false,

--- a/packages/cli/src/services/filter-parsing.test.ts
+++ b/packages/cli/src/services/filter-parsing.test.ts
@@ -67,3 +67,20 @@ test('parseCLIFilters validates target and excludeTarget values', () => {
   assert.deepStrictEqual(filters.excludeTarget, ['server'])
   assert.deepStrictEqual(filters.serverlessIncompatible, ['db'])
 })
+
+test('parseCLIFilters threads deploy.defaultTarget when a target filter is set', () => {
+  const filters = parse(
+    { target: 'server' },
+    { deploy: { providers: {}, defaultTarget: 'server' } }
+  )
+  assert.deepStrictEqual(filters.target, ['server'])
+  assert.strictEqual(filters.defaultTarget, 'server')
+})
+
+test('parseCLIFilters omits defaultTarget when no target filter is set', () => {
+  const filters = parse(
+    { tags: 'api' },
+    { deploy: { providers: {}, defaultTarget: 'server' } }
+  )
+  assert.strictEqual(filters.defaultTarget, undefined)
+})

--- a/packages/cli/src/utils/parse-cli-filters.ts
+++ b/packages/cli/src/utils/parse-cli-filters.ts
@@ -40,7 +40,10 @@ function parseCommaSeparated(
 export function parseCLIFilters(
   data: any,
   cliConfig?: {
-    deploy?: { serverlessIncompatible?: string[] }
+    deploy?: {
+      serverlessIncompatible?: string[]
+      defaultTarget?: 'serverless' | 'server'
+    }
     namedFilters?: Record<string, InspectorFilters>
   }
 ): CLIFilters {
@@ -136,6 +139,7 @@ export function parseCLIFilters(
   )
   if (filters.target || filters.excludeTarget) {
     filters.serverlessIncompatible = cliConfig?.deploy?.serverlessIncompatible
+    filters.defaultTarget = cliConfig?.deploy?.defaultTarget
   }
 
   return filters

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -372,6 +372,12 @@ export type PikkuCLIInput = {
     providers: Record<string, string>
     defaultProvider?: string
     serverlessIncompatible?: string[]
+    /**
+     * Default deploy target for functions that don't declare an explicit
+     * `deploy` flag and don't use a serverless-incompatible service.
+     * Defaults to 'serverless'.
+     */
+    defaultTarget?: 'serverless' | 'server'
   }
 
   /** Named filter presets keyed by name, used via CLI --filter <name>. */

--- a/packages/inspector/src/types.ts
+++ b/packages/inspector/src/types.ts
@@ -263,6 +263,10 @@ export type InspectorFilters = {
   // to 'server'. Sourced from `pikku.config.json` →
   // `deploy.serverlessIncompatible`. Used only when deploy filters are set.
   serverlessIncompatible?: string[]
+  // Default deploy target for functions without an explicit `deploy` flag.
+  // Sourced from `pikku.config.json` → `deploy.defaultTarget`. Used only
+  // when deploy filters are set. Defaults to 'serverless'.
+  defaultTarget?: 'serverless' | 'server'
 }
 
 export type AddonConfig = {

--- a/packages/inspector/src/utils/filter-inspector-state.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.ts
@@ -340,9 +340,15 @@ export function filterInspectorState(
       ? new Set(filters.excludeTarget)
       : null
     const incompatible = new Set(filters.serverlessIncompatible ?? [])
+    const defaultTarget = filters.defaultTarget ?? 'serverless'
     keptByDeploy = new Set<string>()
     for (const [funcId, funcMeta] of Object.entries(state.functions.meta)) {
-      const target = resolveDeployTarget(funcMeta as any, incompatible, funcId)
+      const target = resolveDeployTarget(
+        funcMeta as any,
+        incompatible,
+        funcId,
+        defaultTarget
+      )
       if (allowed && !allowed.has(target)) continue
       if (excluded && excluded.has(target)) continue
       keptByDeploy.add(funcId)

--- a/packages/inspector/src/utils/resolve-deploy-target.test.ts
+++ b/packages/inspector/src/utils/resolve-deploy-target.test.ts
@@ -102,4 +102,34 @@ describe('resolveDeployTarget', () => {
       'server'
     )
   })
+
+  test('defaultTarget: server overrides the serverless default', () => {
+    assert.strictEqual(
+      resolveDeployTarget({}, new Set(), '<unknown>', 'server'),
+      'server'
+    )
+  })
+
+  test('explicit deploy flag wins over defaultTarget', () => {
+    assert.strictEqual(
+      resolveDeployTarget({ deploy: 'serverless' }, new Set(), 'fn', 'server'),
+      'serverless'
+    )
+    assert.strictEqual(
+      resolveDeployTarget({ deploy: 'server' }, new Set(), 'fn', 'serverless'),
+      'server'
+    )
+  })
+
+  test('serverlessIncompatible still forces server regardless of defaultTarget', () => {
+    assert.strictEqual(
+      resolveDeployTarget(
+        { services: { services: ['metaService'] } as any },
+        new Set(['metaService']),
+        'fn',
+        'serverless'
+      ),
+      'server'
+    )
+  })
 })

--- a/packages/inspector/src/utils/resolve-deploy-target.ts
+++ b/packages/inspector/src/utils/resolve-deploy-target.ts
@@ -29,7 +29,8 @@ export class IncompatibleDeployTargetError extends Error {
  *      - throw if the function explicitly declares `deploy: 'serverless'`
  *      - otherwise target is 'server'
  *   2. Explicit `funcMeta.deploy: 'serverless' | 'server'`
- *   3. Default 'serverless'
+ *   3. `defaultTarget` (sourced from `pikku.config.json` →
+ *      `deploy.defaultTarget`, falling back to 'serverless')
  *
  * Used both by the per-unit deploy analyzer (when bucketing functions
  * into deployment units) and by `filterInspectorState` (when
@@ -39,7 +40,8 @@ export class IncompatibleDeployTargetError extends Error {
 export function resolveDeployTarget(
   funcMeta: Pick<FunctionMeta, 'deploy' | 'services'>,
   serverlessIncompatible: Set<string>,
-  functionName = '<unknown>'
+  functionName = '<unknown>',
+  defaultTarget: 'serverless' | 'server' = 'serverless'
 ): 'serverless' | 'server' {
   // Service compatibility wins over the explicit flag — a serverless
   // bundle of a function that needs (e.g.) node:fs would crash at runtime.
@@ -59,5 +61,5 @@ export function resolveDeployTarget(
 
   if (funcMeta.deploy === 'server') return 'server'
   if (funcMeta.deploy === 'serverless') return 'serverless'
-  return 'serverless'
+  return defaultTarget
 }


### PR DESCRIPTION
## Summary

Adds a `deploy.defaultTarget` option to `pikku.config.json` so a project can override the framework's default deploy target for functions that don't declare their own `deploy` flag.

```jsonc
{
  "deploy": {
    "defaultTarget": "server"   // or "serverless" (the default)
  }
}
```

Today, a function with no explicit `deploy` flag (and no serverless-incompatible service) always resolves to `serverless`. This option lets a project flip that default to `server` (containers), while per-function `deploy` flags and `serverlessIncompatible` services still take precedence.

## Resolution order

1. A `serverlessIncompatible` service still forces `server` (and throws if the function explicitly declared `deploy: 'serverless'`).
2. A function's own `deploy: 'server' | 'serverless'` always wins.
3. Otherwise → `deploy.defaultTarget` (falls back to `serverless` when unset).

## Changes

- `resolveDeployTarget()` (`@pikku/inspector`) gains an optional `defaultTarget` fallback param.
- Threaded through `AnalyzerOptions` → build pipeline → `pikku deploy plan` / `pikku deploy apply`, sourced from `config.deploy?.defaultTarget`.
- Threaded through the `pikku all --target …` filter path (`InspectorFilters.defaultTarget` + `parseCLIFilters`) so target filtering stays consistent with what actually deploys.
- New `deploy.defaultTarget` type in `config.d.ts`; the gitignored `cli.schema.json` regenerates with the enum.

## Tests (TDD)

- `resolve-deploy-target.test.ts`: override works, explicit flag wins over the default, incompatible service still forces `server`. Verified red before the change, green after.
- `filter-parsing.test.ts`: config `defaultTarget` threads into filters when a `--target` filter is set, omitted otherwise.

All affected packages typecheck; inspector + filter-parsing suites pass.

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)