### PR TITLE
feat(inspector): warn when JSON/JSONB columns have no concrete tsType

### DIFF
--- a/.changeset/inspector-json-tstype-warning.md
+++ b/.changeset/inspector-json-tstype-warning.md
@@ -1,0 +1,14 @@
+---
+'@pikku/cli': patch
+---
+
+feat(inspector): warn (non-blocking) when a JSON/JSONB column has no concrete tsType
+
+DB codegen typed every JSON/JSONB column as `unknown` unless a `tsType`
+annotation was set, silently erasing type-safety at every call site. The
+codegen now emits a non-blocking warning (via the existing `warnings[]`
+channel) whenever a JSON/JSONB column resolves to `unknown`/`any` — including
+when it is only annotated `kind: 'json'`, or explicitly `tsType: 'unknown'`
+(allowed but discouraged). The message names the column, the resolved type, and
+the exact annotation to add, so it is actionable by a developer or an AI. A
+concrete `tsType` (e.g. `TicketSpec`) silences it.

--- a/packages/cli/src/functions/db/db-codegen.test.ts
+++ b/packages/cli/src/functions/db/db-codegen.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { generateSchemaTypes } from './db-codegen.js'
+import type { DbIntrospector, ColumnInfo } from './db-introspector.js'
+
+function col(
+  partial: Partial<ColumnInfo> & { name: string; type: string }
+): ColumnInfo {
+  return { notNull: true, pk: false, defaultValue: null, ...partial }
+}
+
+function fakeIntrospector(columns: ColumnInfo[]): DbIntrospector {
+  return {
+    async listTables() {
+      return ['app.widget']
+    },
+    async getColumns() {
+      return columns
+    },
+    async getForeignKeys() {
+      return []
+    },
+    async listEnums() {
+      return []
+    },
+    async close() {},
+  }
+}
+
+async function run(
+  columns: ColumnInfo[],
+  annotations?: Record<string, Record<string, unknown>>
+) {
+  const dir = mkdtempSync(join(tmpdir(), 'db-codegen-'))
+  if (annotations) {
+    mkdirSync(join(dir, 'db'), { recursive: true })
+    writeFileSync(
+      join(dir, 'db', 'annotations.gen.json'),
+      JSON.stringify(annotations),
+      'utf8'
+    )
+  }
+  return generateSchemaTypes(fakeIntrospector(columns), {
+    outFile: join(dir, 'schema.d.ts'),
+    coercionFile: join(dir, 'coercion.gen.ts'),
+    dialect: 'postgres',
+    rootDir: dir,
+  })
+}
+
+const jsonWarning = (column: string) =>
+  new RegExp(`Column "widget\\.${column}" is .*JSON/JSONB columns need`, 'i')
+
+test('warns when a jsonb column has no tsType (degrades to unknown)', async () => {
+  const result = await run([col({ name: 'spec', type: 'jsonb' })])
+  assert.ok(
+    result.warnings.some((w) => jsonWarning('spec').test(w)),
+    `expected a json-type warning, got: ${JSON.stringify(result.warnings)}`
+  )
+})
+
+test('warns when a json column is only annotated kind: json (still unknown)', async () => {
+  const result = await run([col({ name: 'spec', type: 'jsonb' })], {
+    widget: { spec: { kind: 'json' } },
+  })
+  assert.ok(
+    result.warnings.some((w) => jsonWarning('spec').test(w)),
+    `expected a json-type warning, got: ${JSON.stringify(result.warnings)}`
+  )
+})
+
+test('warns when a json column is explicitly typed unknown (allowed but discouraged)', async () => {
+  const result = await run([col({ name: 'spec', type: 'jsonb' })], {
+    widget: { spec: { kind: 'json', tsType: 'unknown' } },
+  })
+  assert.ok(
+    result.warnings.some((w) => jsonWarning('spec').test(w)),
+    `expected a json-type warning, got: ${JSON.stringify(result.warnings)}`
+  )
+})
+
+test('does not warn when a json column has a concrete tsType', async () => {
+  const result = await run([col({ name: 'spec', type: 'jsonb' })], {
+    widget: { spec: { kind: 'json', tsType: 'WidgetSpec' } },
+  })
+  assert.ok(
+    !result.warnings.some((w) => jsonWarning('spec').test(w)),
+    `expected no json-type warning, got: ${JSON.stringify(result.warnings)}`
+  )
+})
+
+test('does not warn for non-json columns', async () => {
+  const result = await run([
+    col({ name: 'name', type: 'text' }),
+    col({ name: 'count', type: 'integer' }),
+  ])
+  assert.equal(
+    result.warnings.filter((w) => /JSON\/JSONB columns need/.test(w)).length,
+    0
+  )
+})

--- a/packages/cli/src/functions/db/db-codegen.ts
+++ b/packages/cli/src/functions/db/db-codegen.ts
@@ -246,6 +246,24 @@ function emitInterface(
           ? { kind: typingKind, tsType: effectiveTsType }
           : null
 
+      // JSON/JSONB columns carry no inherent TypeScript shape — without a
+      // concrete `tsType` they degrade to `unknown`, erasing type-safety at
+      // every call site. Warn (non-blocking) so an AI or developer can give the
+      // column a real type. An explicit `tsType: 'unknown'`/`'any'` is allowed
+      // (the developer has acknowledged it) but is still flagged as discouraged.
+      const isJsonColumn =
+        col.type.toUpperCase().includes('JSON') || ann?.kind === 'json'
+      if (isJsonColumn) {
+        const resolved = selectBase(typeAnn, col)
+        if (resolved === 'unknown' || resolved === 'any') {
+          warnings.push(
+            `Column "${bare}.${col.name}" is ${col.type} and will be typed as ` +
+              `\`${resolved}\` — JSON/JSONB columns need a concrete TypeScript type. ` +
+              `In db/annotations.ts add: "${col.name}": { kind: 'json', tsType: 'YourType' }.`
+          )
+        }
+      }
+
       // A `format` validator refines the zod schema only and keeps the TS type
       // as `string`. It therefore applies only when the resolved select base is
       // plain `string`; on anything else (Date/Uuid/boolean/enum/unknown via


### PR DESCRIPTION
## Summary

JSON/JSONB columns degrade to `unknown` in the generated Kysely types unless a `tsType` annotation is supplied. That silently erases type-safety at every call site and forces `as never`/`as any` casts at write sites.

The DB codegen (`packages/cli/src/functions/db/db-codegen.ts`) now pushes a **non-blocking** warning to the existing `warnings[]` channel whenever a JSON/JSONB column resolves to `unknown`/`any`:

- no `tsType` (default → `unknown`)
- annotated `kind: 'json'` only (still `unknown`)
- explicit `tsType: 'unknown'`/`'any'` (allowed but discouraged)

A concrete `tsType` (e.g. `TicketSpec`) silences it. The message is AI-actionable — it names the column, the resolved type, and the exact `db/annotations.ts` entry to add:

```
Column "ticket.spec" is jsonb and will be typed as `unknown` — JSON/JSONB columns
need a concrete TypeScript type. In db/annotations.ts add: "spec": { kind: 'json', tsType: 'YourType' }.
```

Codegen still succeeds — the warning never blocks a build.

## Tests

`packages/cli/src/functions/db/db-codegen.test.ts` (new) covers all four states; TDD-verified (fails before the change, passes after).

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)