### PR TITLE
Pikku Strands

### DIFF
--- a/.changeset/inspector-rpc-type-cast.md
+++ b/.changeset/inspector-rpc-type-cast.md
@@ -1,0 +1,10 @@
+---
+'@pikku/inspector': patch
+---
+
+feat(inspector): add PKU940 — block type casts on rpc.invoke() calls
+
+The inspector now emits a critical PKU940 error when `rpc.invoke()` is called
+with an `as` cast on an argument (`rpc.invoke('fn', data as any)`) or when its
+result is cast (`rpc.invoke('fn', data) as any`). Both patterns defeat Pikku's
+generated type safety and are rejected at build time.

--- a/.changeset/skills-trim-references.md
+++ b/.changeset/skills-trim-references.md
@@ -1,0 +1,26 @@
+---
+'@pikku/cli': patch
+---
+
+docs(skills): trim always-loaded skill context by splitting bulky reference material on demand
+
+The `skill` tool injects the whole `SKILL.md` into the agent's context on every
+load, so large rarely-needed reference blocks were paid for on every invocation.
+Carved the nine heaviest skills: kept the Agent Operating Procedure, decision
+rules, common-path guidance and one canonical example inline; moved exhaustive
+option tables, full API/manifest references, and off-common-path recipes into
+`references/*.md` that the agent reads on demand, each linked by an explicit
+pointer line so no knowledge becomes invisible. Net knowledge loss is zero —
+only location and verbosity changed.
+
+- pikku-testing 636→328 (cucumber/BDD reference split out)
+- pikku-workflow 334→168 (also reconciled a substantial drift between the OSS
+  and bundled copies — merged the union of unique facts before deduping)
+- pikku-services 293→210, pikku-http 318→226, pikku-addon 331→238,
+  pikku-middleware 283→226, pikku-realtime 286→236, pikku-cli 281→195,
+  pikku-concepts 286→229 (wired the previously-dead `concept-mapping.md`)
+
+Also makes Zod the only *documented* function form: the generic
+`pikkuFunc<In,Out>` overload still exists in code but is dropped from the
+generated function-type JSDoc and the concept skills, so generated scaffolds and
+docs show only the `input:`/`output:` Zod-schema form.

--- a/.changeset/workflow-queued-flag.md
+++ b/.changeset/workflow-queued-flag.md
@@ -1,0 +1,24 @@
+---
+'@pikku/core': patch
+'@pikku/inspector': patch
+'@pikku/cli': patch
+---
+
+refactor(workflow): replace `inline: false` with `workflowQueued: true` on function meta
+
+The per-function workflow dispatch flag has been renamed from the confusing
+negative `inline: false` to the explicit positive `workflowQueued: true`.
+Two companion fields are also added: `workflowRetries` and `workflowTimeout`
+as function-level equivalents of the per-call-site `NodeOptions` fields.
+
+**Breaking change (patch — flag was undocumented):** rename `inline: false`
+to `workflowQueued: true` on any `pikkuSessionlessFunc` / `pikkuFunc` that
+dispatches its workflow steps via the queue.
+
+**Behaviour change:** a step marked `workflowQueued: true` now throws if no
+queue service is configured, instead of silently falling back to inline
+execution.
+
+**Bug fix:** `post-process.ts` was registering `wf-step-*` queues for every
+workflow step node; it now only registers them for steps that are actually
+`workflowQueued: true`, avoiding spurious queue resource allocation.

--- a/benchmarks/bench-workflow.ts
+++ b/benchmarks/bench-workflow.ts
@@ -51,7 +51,7 @@ const STEPS = arg('--steps', MODE === 'inline' ? 20 : 16)
 
 const WORKFLOW_NAME = 'benchWorkflow'
 const STEP_RPC = 'benchStep' // default → runs inline
-const STEP_QUEUED_RPC = 'benchStepQueued' // inline: false → dispatched to the queue
+const STEP_QUEUED_RPC = 'benchStepQueued' // workflowQueued: true → dispatched to the queue
 
 // Per-step attempt counter, keyed by the run-stable `${wfId}:${stepIdx}`. The
 // step throws while its count is within its assigned `failTimes`, then succeeds
@@ -94,14 +94,14 @@ const flakyStep = async (
   return randomPayload(data.stepIdx + count)
 }
 
-const mkStepMeta = (funcId: string, inline?: boolean) =>
+const mkStepMeta = (funcId: string, workflowQueued?: boolean) =>
   ({
     pikkuFuncId: funcId,
     sessionless: true,
     permissions: [],
     inputSchemaName: null,
     outputSchemaName: null,
-    ...(inline === undefined ? {} : { inline }),
+    ...(workflowQueued === true ? { workflowQueued: true } : {}),
   }) as any
 
 function registerEngine(mode: Mode) {
@@ -124,11 +124,11 @@ function registerEngine(mode: Mode) {
   pikkuState(null, 'function', 'meta')[STEP_RPC] = mkStepMeta(STEP_RPC)
   addFunction(STEP_RPC, { func: flakyStep } as any)
 
-  // Same logic, but `inline: false` so it dispatches to the queue (mixed mode).
+  // Same logic, but `workflowQueued: true` so it dispatches to the queue (mixed mode).
   pikkuState(null, 'rpc', 'meta')[STEP_QUEUED_RPC] = STEP_QUEUED_RPC as any
   pikkuState(null, 'function', 'meta')[STEP_QUEUED_RPC] = mkStepMeta(
     STEP_QUEUED_RPC,
-    false
+    true
   )
   addFunction(STEP_QUEUED_RPC, { func: flakyStep } as any)
 

--- a/packages/cli/skills/pikku-addon/SKILL.md
+++ b/packages/cli/skills/pikku-addon/SKILL.md
@@ -102,65 +102,7 @@ export const createWireServices = pikkuAddonWireServices(
 npx pikku new addon
 ```
 
-### Package Structure
-
-```text
-my-addon/
-├── package.json               # Exports .pikku/* and dist/
-├── pikku.config.json          # addon: true + metadata
-├── tsconfig.json              # #pikku path mapping
-├── src/
-│   ├── services.ts            # createSingletonServices (required)
-│   └── functions/
-│       └── *.function.ts      # Function definitions
-├── types/
-│   └── application-types.d.ts # SingletonServices interface
-└── .pikku/                    # Generated (gitignored)
-```
-
-### pikku.config.json
-
-```json
-{
-  "tsconfig": "./tsconfig.json",
-  "srcDirectories": ["src", "types"],
-  "outDir": "./.pikku",
-  "addon": true,
-  "node": {
-    "displayName": "My Addon",
-    "description": "What this addon does",
-    "categories": ["General"]
-  }
-}
-```
-
-### package.json (key fields)
-
-```json
-{
-  "name": "@my-org/addon-todos",
-  "imports": {
-    "#pikku": "./.pikku/pikku-types.gen.ts",
-    "#pikku/*": "./.pikku/*"
-  },
-  "exports": {
-    ".": { "types": "./dist/src/index.d.ts", "import": "./dist/src/index.js" },
-    "./.pikku/*": "./.pikku/*",
-    "./.pikku/pikku-metadata.gen.json": "./.pikku/pikku-metadata.gen.json",
-    "./.pikku/rpc/pikku-rpc-wirings-map.internal.gen.js": {
-      "types": "./.pikku/rpc/pikku-rpc-wirings-map.internal.gen.d.ts"
-    }
-  },
-  "files": ["dist", ".pikku"],
-  "peerDependencies": {
-    "@pikku/core": "*"
-  },
-  "scripts": {
-    "pikku": "pikku all",
-    "build": "tsc && cp -r .pikku dist/"
-  }
-}
-```
+This generates `package.json` (exports `.pikku/*` + `dist/`), `pikku.config.json` (`addon: true`), `tsconfig.json` (`#pikku` path mapping), `src/services.ts`, `src/functions/`, and `types/application-types.d.ts`. For the full file contents/exports you rarely hand-edit, read `references/addon-package-manifest.md`.
 
 ### Services
 
@@ -200,6 +142,13 @@ export const addTodo = pikkuSessionlessFunc({
     return todoStore.add(title)
   },
 })
+```
+
+Optional approval gating (e.g. for agent tools) — add `approvalRequired: true` plus an `approvalDescription` resolver:
+
+```typescript
+approvalRequired: true,
+approvalDescription: async (_services, { title }) => `Add a todo called "${title}"`,
 ```
 
 ### Build
@@ -251,6 +200,23 @@ wireHTTP({
 })
 ```
 
+Or batch multiple addon routes with `defineHTTPRoutes` + `wireHTTPRoutes`:
+
+```typescript
+import { wireHTTPRoutes, defineHTTPRoutes, addon } from '#pikku'
+
+const todoRoutes = defineHTTPRoutes({
+  tags: ['todos'],
+  auth: false,
+  routes: {
+    list: { method: 'get', route: '/todos', func: addon('todos:listTodos') },
+    add: { method: 'post', route: '/todos', func: addon('todos:addTodo') },
+  },
+})
+
+wireHTTPRoutes({ basePath: '/api', routes: { todos: todoRoutes } })
+```
+
 ### Use in AI Agents
 
 ```typescript
@@ -268,63 +234,5 @@ export const todoAgent = pikkuAIAgent({
     addon('todos:deleteTodo'),
   ],
   maxSteps: 5,
-})
-```
-
-## Complete Example
-
-```typescript
-// --- ADDON PACKAGE: @my-org/addon-todos ---
-
-// src/services.ts
-import { pikkuAddonServices } from '#pikku'
-
-export const createSingletonServices = pikkuAddonServices(async () => {
-  return { todoStore: new TodoStore() }
-})
-
-// src/functions/listTodos.function.ts
-export const listTodos = pikkuSessionlessFunc({
-  description: 'List all todos',
-  func: async ({ todoStore }) => {
-    return { todos: todoStore.list() }
-  },
-})
-
-// src/functions/addTodo.function.ts
-export const addTodo = pikkuSessionlessFunc({
-  description: 'Add a new todo',
-  approvalRequired: true,
-  approvalDescription: async (_services, { title }) => {
-    return `Add a todo called "${title}"`
-  },
-  input: z.object({ title: z.string() }),
-  output: z.object({ id: z.string(), title: z.string() }),
-  func: async ({ todoStore }, { title }) => {
-    return todoStore.add(title)
-  },
-})
-
-// --- CONSUMING PROJECT ---
-
-// wirings/addons.wirings.ts
-import { wireAddon } from '#pikku'
-wireAddon({ name: 'todos', package: '@my-org/addon-todos' })
-
-// wirings/api.http.ts
-import { wireHTTPRoutes, defineHTTPRoutes, addon } from '#pikku'
-
-const todoRoutes = defineHTTPRoutes({
-  tags: ['todos'],
-  auth: false,
-  routes: {
-    list: { method: 'get', route: '/todos', func: addon('todos:listTodos') },
-    add: { method: 'post', route: '/todos', func: addon('todos:addTodo') },
-  },
-})
-
-wireHTTPRoutes({
-  basePath: '/api',
-  routes: { todos: todoRoutes },
 })
 ```

--- a/packages/cli/skills/pikku-addon/references/addon-package-manifest.md
+++ b/packages/cli/skills/pikku-addon/references/addon-package-manifest.md
@@ -1,0 +1,63 @@
+# Addon Package Manifest Reference
+
+`npx pikku new addon` scaffolds these files. You rarely hand-edit them — consult this when wiring exports or config by hand.
+
+## Package Structure
+
+```text
+my-addon/
+├── package.json               # Exports .pikku/* and dist/
+├── pikku.config.json          # addon: true + metadata
+├── tsconfig.json              # #pikku path mapping
+├── src/
+│   ├── services.ts            # createSingletonServices (required)
+│   └── functions/
+│       └── *.function.ts      # Function definitions
+├── types/
+│   └── application-types.d.ts # SingletonServices interface
+└── .pikku/                    # Generated (gitignored)
+```
+
+## pikku.config.json
+
+```json
+{
+  "tsconfig": "./tsconfig.json",
+  "srcDirectories": ["src", "types"],
+  "outDir": "./.pikku",
+  "addon": true,
+  "node": {
+    "displayName": "My Addon",
+    "description": "What this addon does",
+    "categories": ["General"]
+  }
+}
+```
+
+## package.json (key fields)
+
+```json
+{
+  "name": "@my-org/addon-todos",
+  "imports": {
+    "#pikku": "./.pikku/pikku-types.gen.ts",
+    "#pikku/*": "./.pikku/*"
+  },
+  "exports": {
+    ".": { "types": "./dist/src/index.d.ts", "import": "./dist/src/index.js" },
+    "./.pikku/*": "./.pikku/*",
+    "./.pikku/pikku-metadata.gen.json": "./.pikku/pikku-metadata.gen.json",
+    "./.pikku/rpc/pikku-rpc-wirings-map.internal.gen.js": {
+      "types": "./.pikku/rpc/pikku-rpc-wirings-map.internal.gen.d.ts"
+    }
+  },
+  "files": ["dist", ".pikku"],
+  "peerDependencies": {
+    "@pikku/core": "*"
+  },
+  "scripts": {
+    "pikku": "pikku all",
+    "build": "tsc && cp -r .pikku dist/"
+  }
+}
+```

--- a/packages/cli/skills/pikku-cli/SKILL.md
+++ b/packages/cli/skills/pikku-cli/SKILL.md
@@ -172,110 +172,24 @@ wireCLI({
 
 ### Custom Renderers
 
+A renderer receives `(services, data)` where `data` is the func's output. Set `render` on `wireCLI` as the program-wide default; set `render` on a `pikkuCLICommand` to override it for that command.
+
 ```typescript
 const todoRenderer = pikkuCLIRender<{ todo: Todo }>((_services, { todo }) => {
   console.log(`✓ Created: ${todo.text} (priority: ${todo.priority})`)
 })
 
-const todosRenderer = pikkuCLIRender<{ todos: Todo[] }>(
-  (_services, { todos }) => {
-    todos.forEach((t, i) => {
-      const check = t.completed ? '✓' : ' '
-      console.log(`  ${i + 1}. ${t.text}  ${check}`)
-    })
-  }
-)
-
-// Default renderer for program, override per-command
 wireCLI({
   program: 'todos',
-  render: jsonRenderer,
+  render: jsonRenderer, // default for all commands
   commands: {
-    add: pikkuCLICommand({
-      func: createTodo,
-      render: todoRenderer, // Overrides jsonRenderer
-    }),
+    add: pikkuCLICommand({ func: createTodo, render: todoRenderer }), // overrides jsonRenderer
   },
 })
 ```
+
+The func's input is the positional `parameters` plus `options`, merged (e.g. `parameters: '<username> <email>'` + an `admin` option → func input `{ username, email, admin }`).
 
 ## Complete Example
 
-```typescript
-// functions/admin.functions.ts
-export const createUser = pikkuFunc({
-  title: 'Create User',
-  func: async ({ db }, { username, email, admin }) => {
-    const user = await db.createUser({
-      username,
-      email,
-      role: admin ? 'admin' : 'user',
-    })
-    return { user }
-  },
-})
-
-export const listUsers = pikkuSessionlessFunc({
-  title: 'List Users',
-  func: async ({ db }, { limit }) => {
-    return { users: await db.listUsers(limit || 50) }
-  },
-})
-
-export const deleteUser = pikkuFunc({
-  title: 'Delete User',
-  func: async ({ db }, { username }) => {
-    await db.deleteUser(username)
-    return { deleted: username }
-  },
-})
-
-// wirings/cli.wiring.ts
-const userRenderer = pikkuCLIRender<{ user: User }>((_services, { user }) => {
-  console.log(`Created user: ${user.username} (${user.email}) [${user.role}]`)
-})
-
-const usersRenderer = pikkuCLIRender<{ users: User[] }>(
-  (_services, { users }) => {
-    console.log(`Users (${users.length}):`)
-    users.forEach((u) =>
-      console.log(`  ${u.username} <${u.email}> [${u.role}]`)
-    )
-  }
-)
-
-wireCLI({
-  program: 'admin',
-  commands: {
-    user: {
-      description: 'User management',
-      subcommands: {
-        create: pikkuCLICommand({
-          parameters: '<username> <email>',
-          func: createUser,
-          render: userRenderer,
-          options: {
-            admin: {
-              description: 'Create as admin',
-              short: 'a',
-              default: false,
-            },
-          },
-        }),
-        list: pikkuCLICommand({
-          func: listUsers,
-          render: usersRenderer,
-          options: {
-            limit: { description: 'Max results', short: 'l' },
-          },
-        }),
-        delete: pikkuCLICommand({
-          parameters: '<username>',
-          func: deleteUser,
-          description: 'Delete a user',
-        }),
-      },
-    },
-  },
-})
-```
+For a full functions + renderers + nested-subcommand wiring walkthrough, see `references/complete-example.md`.

--- a/packages/cli/skills/pikku-cli/references/complete-example.md
+++ b/packages/cli/skills/pikku-cli/references/complete-example.md
@@ -1,0 +1,82 @@
+# Complete CLI Example
+
+End-to-end: functions + renderers + nested-subcommand wiring. Note how each func's input is the positional `parameters` plus `options`, merged (e.g. `parameters: '<username> <email>'` + option `admin` → func input `{ username, email, admin }`).
+
+```typescript
+// functions/admin.functions.ts
+export const createUser = pikkuFunc({
+  title: 'Create User',
+  func: async ({ db }, { username, email, admin }) => {
+    const user = await db.createUser({
+      username,
+      email,
+      role: admin ? 'admin' : 'user',
+    })
+    return { user }
+  },
+})
+
+export const listUsers = pikkuSessionlessFunc({
+  title: 'List Users',
+  func: async ({ db }, { limit }) => {
+    return { users: await db.listUsers(limit || 50) }
+  },
+})
+
+export const deleteUser = pikkuFunc({
+  title: 'Delete User',
+  func: async ({ db }, { username }) => {
+    await db.deleteUser(username)
+    return { deleted: username }
+  },
+})
+
+// wirings/cli.wiring.ts
+const userRenderer = pikkuCLIRender<{ user: User }>((_services, { user }) => {
+  console.log(`Created user: ${user.username} (${user.email}) [${user.role}]`)
+})
+
+const usersRenderer = pikkuCLIRender<{ users: User[] }>(
+  (_services, { users }) => {
+    console.log(`Users (${users.length}):`)
+    users.forEach((u) =>
+      console.log(`  ${u.username} <${u.email}> [${u.role}]`)
+    )
+  }
+)
+
+wireCLI({
+  program: 'admin',
+  commands: {
+    user: {
+      description: 'User management',
+      subcommands: {
+        create: pikkuCLICommand({
+          parameters: '<username> <email>',
+          func: createUser,
+          render: userRenderer,
+          options: {
+            admin: {
+              description: 'Create as admin',
+              short: 'a',
+              default: false,
+            },
+          },
+        }),
+        list: pikkuCLICommand({
+          func: listUsers,
+          render: usersRenderer,
+          options: {
+            limit: { description: 'Max results', short: 'l' },
+          },
+        }),
+        delete: pikkuCLICommand({
+          parameters: '<username>',
+          func: deleteUser,
+          description: 'Delete a user',
+        }),
+      },
+    },
+  },
+})
+```

--- a/packages/cli/skills/pikku-concepts/SKILL.md
+++ b/packages/cli/skills/pikku-concepts/SKILL.md
@@ -53,42 +53,32 @@ The function never imports Express, never reads `req.body`, never touches `ws.se
 
 ## Concept Mapping: Generic Backend → Pikku
 
-| Generic Backend Concept                 | Pikku Equivalent                                                | Skill             |
-| --------------------------------------- | --------------------------------------------------------------- | ----------------- |
-| **Controller / Route Handler**          | `pikkuFunc` / `pikkuSessionlessFunc`                            | (this skill)      |
-| **Route definition** (`GET /users/:id`) | `wireHTTP({ route, method, func })`                             | `pikku-http`      |
-| **Middleware** (Express/Koa-style)      | `pikkuMiddleware`                                               | `pikku-security`  |
-| **Auth Guard / Auth Middleware**        | `authBearer()` / `authCookie()` / `authApiKey()`                | `pikku-security`  |
-| **Authorization / Permissions**         | `pikkuPermission` / `pikkuAuth`                                 | `pikku-security`  |
-| **DTO / Request Validation**            | Standard Schema (Zod, Valibot, ArkType)                         | (this skill)      |
-| **Dependency Injection**                | `pikkuServices` (singleton) + `pikkuWireServices` (per-request) | `pikku-services`  |
-| **WebSocket handlers**                  | `wireChannel`                                                   | `pikku-websocket` |
-| **Job Queue workers**                   | `wireQueueWorker`                                               | `pikku-queue`     |
-| **Cron / Scheduled tasks**              | `wireScheduler`                                                 | `pikku-cron`      |
-| **Module / Feature grouping**           | Tags + wiring files                                             | (this skill)      |
-| **Error handling**                      | Throw typed errors (`NotFoundError`, `ForbiddenError`)          | (this skill)      |
-| **Type-safe API client**                | `npx pikku prebuild` generates clients                          | (this skill)      |
-| **Secrets / Config**                    | `wireSecret`, `wireVariable`, `services.variables`              | `pikku-config`    |
+Controllers/routes → `pikkuFunc`; middleware/auth/permissions → `pikku-security`; DI → `pikku-services`; transports (HTTP/WS/queue/cron) → their `wire*` + skill. For the full Generic Backend → Pikku mapping table (with side-by-side code examples), read `references/concept-mapping.md`.
 
 ## Functions
 
 Three main function types:
 
 ```typescript
-// Requires authentication — receives session in wire context
-const updateTodo = pikkuFunc<UpdateInput, TodoOutput>(
-  async (services, data, wire) => {
+// Requires authentication — receives session in wire context.
+// input/output are Zod schemas; the data + return types are inferred from them.
+const updateTodo = pikkuFunc({
+  input: UpdateTodoInput,
+  output: TodoOutput,
+  func: async (services, data, wire) => {
     const session = await wire.session.get()
     return services.todoStore.update(data.id, data)
-  }
-)
+  },
+})
 
 // No authentication required
-const listTodos = pikkuSessionlessFunc<ListInput, TodoListOutput>(
-  async (services, data) => {
+const listTodos = pikkuSessionlessFunc({
+  input: ListTodosInput,
+  output: TodoListOutput,
+  func: async (services, data) => {
     return { todos: services.todoStore.list(data.filters) }
-  }
-)
+  },
+})
 
 // No input or output (for scheduled tasks, lifecycle hooks)
 const cleanup = pikkuVoidFunc(async (services) => {
@@ -96,23 +86,7 @@ const cleanup = pikkuVoidFunc(async (services) => {
 })
 ```
 
-Config object form (recommended):
-
-```typescript
-const createTodo = pikkuSessionlessFunc({
-  title: 'Create Todo',
-  description: 'Create a new todo item',
-  input: CreateTodoInputSchema,
-  output: CreateTodoOutputSchema,
-  func: async ({ logger, todoStore }, { title, priority }) => {
-    const todo = todoStore.createTodo(title, priority)
-    logger.info(`Created todo: ${todo.id}`)
-    return { todo }
-  },
-})
-```
-
-Full config options:
+Services can be destructured inline in the `func` signature (e.g. `async ({ logger, todoStore }, { title }) => ...`). Full config options:
 
 ```typescript
 pikkuFunc({
@@ -243,33 +217,7 @@ expect(result.todos).toHaveLength(3)
 
 ## Available Packages
 
-### Runtime Adapters
-
-| Package                       | Use Case                              |
-| ----------------------------- | ------------------------------------- |
-| `@pikku/express-server`       | Express standalone server             |
-| `@pikku/express-middleware`   | Express as middleware in existing app |
-| `@pikku/fastify-server`       | Fastify standalone                    |
-| `@pikku/fastify-plugin`       | Fastify plugin                        |
-| `@pikku/next`                 | Next.js API routes                    |
-| `@pikku/aws-lambda`           | AWS Lambda handlers                   |
-| `@pikku/cloudflare`           | Cloudflare Workers                    |
-| `@pikku/uws-server`           | uWebSockets.js (high perf)            |
-| `@pikku/modelcontextprotocol` | MCP server                            |
-
-### Service Packages
-
-| Package                  | Provides                                             |
-| ------------------------ | ---------------------------------------------------- |
-| `@pikku/jose`            | JWT (sign/verify) via jose library                   |
-| `@pikku/schema-ajv`      | Schema validation via AJV                            |
-| `@pikku/schema-cfworker` | Schema validation for Cloudflare                     |
-| `@pikku/pino`            | Structured logging via Pino                          |
-| `@pikku/kysely`          | Type-safe SQL via Kysely (PostgreSQL, SQLite, MySQL) |
-| `@pikku/redis`           | Redis client                                         |
-| `@pikku/queue-bullmq`    | Job queues via BullMQ                                |
-| `@pikku/queue-pg-boss`   | Job queues via PgBoss                                |
-| `@pikku/aws-services`    | AWS SDK (SQS, DynamoDB, etc.)                        |
+Pikku ships runtime adapters (`@pikku/express-server`, `@pikku/fastify-server`, `@pikku/next`, `@pikku/aws-lambda`, `@pikku/cloudflare`, `@pikku/uws-server`, `@pikku/modelcontextprotocol`, ...) and service packages (`@pikku/jose`, `@pikku/schema-ajv`, `@pikku/pino`, `@pikku/kysely`, `@pikku/redis`, `@pikku/queue-bullmq`, `@pikku/queue-pg-boss`, ...). For the full list with use cases, read `references/packages.md`.
 
 ## Key Differences from Traditional Frameworks
 

--- a/packages/cli/skills/pikku-concepts/references/concept-mapping.md
+++ b/packages/cli/skills/pikku-concepts/references/concept-mapping.md
@@ -1,6 +1,25 @@
 # Concept Mapping: Generic Backend → Pikku
 
-Side-by-side code examples showing how common backend patterns translate to Pikku.
+Authoritative mapping table plus side-by-side code examples showing how common backend patterns translate to Pikku.
+
+## Quick Reference Table
+
+| Generic Backend Concept                 | Pikku Equivalent                                                | Skill             |
+| --------------------------------------- | --------------------------------------------------------------- | ----------------- |
+| **Controller / Route Handler**          | `pikkuFunc` / `pikkuSessionlessFunc`                            | `pikku-concepts`  |
+| **Route definition** (`GET /users/:id`) | `wireHTTP({ route, method, func })`                             | `pikku-http`      |
+| **Middleware** (Express/Koa-style)      | `pikkuMiddleware`                                               | `pikku-security`  |
+| **Auth Guard / Auth Middleware**        | `authBearer()` / `authCookie()` / `authApiKey()`                | `pikku-security`  |
+| **Authorization / Permissions**         | `pikkuPermission` / `pikkuAuth`                                 | `pikku-security`  |
+| **DTO / Request Validation**            | Standard Schema (Zod, Valibot, ArkType)                         | `pikku-concepts`  |
+| **Dependency Injection**                | `pikkuServices` (singleton) + `pikkuWireServices` (per-request) | `pikku-services`  |
+| **WebSocket handlers**                  | `wireChannel`                                                   | `pikku-websocket` |
+| **Job Queue workers**                   | `wireQueueWorker`                                               | `pikku-queue`     |
+| **Cron / Scheduled tasks**              | `wireScheduler`                                                 | `pikku-cron`      |
+| **Module / Feature grouping**           | Tags + wiring files                                             | `pikku-concepts`  |
+| **Error handling**                      | Throw typed errors (`NotFoundError`, `ForbiddenError`)          | `pikku-concepts`  |
+| **Type-safe API client**                | `npx pikku prebuild` generates clients                          | `pikku-concepts`  |
+| **Secrets / Config**                    | `wireSecret`, `wireVariable`, `services.variables`              | `pikku-config`    |
 
 ## Route Handler / Controller → pikkuFunc
 
@@ -21,14 +40,17 @@ class TodoController {
 **Pikku:**
 
 ```typescript
-// Function knows nothing about HTTP
-const createTodo = pikkuSessionlessFunc<CreateTodoInput, TodoOutput>(
-  async ({ todoStore, logger }, { title, priority }) => {
+// Function knows nothing about HTTP.
+// input/output are Zod schemas; the data + return types are inferred from them.
+const createTodo = pikkuSessionlessFunc({
+  input: CreateTodoInput,
+  output: TodoOutput,
+  func: async ({ todoStore, logger }, { title, priority }) => {
     const todo = todoStore.createTodo(title, priority)
     logger.info(`Created todo: ${todo.id}`)
     return { todo }
-  }
-)
+  },
+})
 
 // Wiring (separate file) - grouped with defineHTTPRoutes
 export const todoRoutes = defineHTTPRoutes({
@@ -68,13 +90,15 @@ async getUser(req: Request, res: Response) {
 **Pikku:**
 
 ```typescript
-// All sources merged into a single typed `data` object
-const getUser = pikkuSessionlessFunc<
-  { id: string; fields?: string },
-  UserOutput
->(async (services, { id, fields }) => {
-  // id comes from route param, fields from query - function doesn't care
-  return { user: await services.db.getUser(id, fields) }
+// All sources merged into a single typed `data` object.
+// input/output are Zod schemas; the data + return types are inferred from them.
+const getUser = pikkuSessionlessFunc({
+  input: z.object({ id: z.string(), fields: z.string().optional() }),
+  output: UserOutput,
+  func: async (services, { id, fields }) => {
+    // id comes from route param, fields from query - function doesn't care
+    return { user: await services.db.getUser(id, fields) }
+  },
 })
 
 wireHTTP({ method: 'get', route: '/users/:id', func: getUser, auth: false })

--- a/packages/cli/skills/pikku-concepts/references/packages.md
+++ b/packages/cli/skills/pikku-concepts/references/packages.md
@@ -1,0 +1,29 @@
+# Available Pikku Packages
+
+## Runtime Adapters
+
+| Package                       | Use Case                              |
+| ----------------------------- | ------------------------------------- |
+| `@pikku/express-server`       | Express standalone server             |
+| `@pikku/express-middleware`   | Express as middleware in existing app |
+| `@pikku/fastify-server`       | Fastify standalone                    |
+| `@pikku/fastify-plugin`       | Fastify plugin                        |
+| `@pikku/next`                 | Next.js API routes                    |
+| `@pikku/aws-lambda`           | AWS Lambda handlers                   |
+| `@pikku/cloudflare`           | Cloudflare Workers                    |
+| `@pikku/uws-server`           | uWebSockets.js (high perf)            |
+| `@pikku/modelcontextprotocol` | MCP server                            |
+
+## Service Packages
+
+| Package                  | Provides                                             |
+| ------------------------ | ---------------------------------------------------- |
+| `@pikku/jose`            | JWT (sign/verify) via jose library                   |
+| `@pikku/schema-ajv`      | Schema validation via AJV                            |
+| `@pikku/schema-cfworker` | Schema validation for Cloudflare                     |
+| `@pikku/pino`            | Structured logging via Pino                          |
+| `@pikku/kysely`          | Type-safe SQL via Kysely (PostgreSQL, SQLite, MySQL) |
+| `@pikku/redis`           | Redis client                                         |
+| `@pikku/queue-bullmq`    | Job queues via BullMQ                                |
+| `@pikku/queue-pg-boss`   | Job queues via PgBoss                                |
+| `@pikku/aws-services`    | AWS SDK (SQS, DynamoDB, etc.)                        |

--- a/packages/cli/skills/pikku-http/SKILL.md
+++ b/packages/cli/skills/pikku-http/SKILL.md
@@ -34,67 +34,14 @@ Follow existing patterns you find (naming, tag usage, file organization). See `p
 
 ## API Reference
 
-### `wireHTTP(config)`
+- `wireHTTP(config)` (from `@pikku/core/http`) — wire one function to one endpoint.
+- `defineHTTPRoutes(config)` + `wireHTTPRoutes(config)` (from `.pikku/pikku-types.gen.js`) — group routes with shared config; composable/nestable.
 
-Wire a single function to an HTTP endpoint.
+Function input/output types come from the function's own `input:`/`output:` zod schemas — never declared in the wiring. Route `:params`, query params, and body are merged into the function's `data` arg (see Data Flow).
 
-```typescript
-import { wireHTTP } from '@pikku/core/http'
+Config cascading across groups: `basePath` concatenates down the chain, `tags` merge (union), `auth` child overrides parent.
 
-wireHTTP({
-  method: 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head',
-  route: string,          // e.g. '/books/:bookId' — :params become data fields
-  func: PikkuFunc,        // The function to call
-  auth?: boolean,         // Override default auth (true = require session)
-  tags?: string[],        // For grouping, middleware targeting
-  permissions?: Record<string, PikkuPermission | PikkuPermission[]>,
-  middleware?: PikkuMiddleware[],
-  sse?: boolean,          // Enable Server-Sent Events
-  contentType?: 'xml' | 'json',  // Response content type
-  timeout?: number,       // Request timeout in ms
-  headers?: HTTPHeadersSchema,   // Expected headers schema
-  docs?: HTTPRouteDocsConfig,    // OpenAPI docs config
-})
-```
-
-### `defineHTTPRoutes(config)` + `wireHTTPRoutes(config)`
-
-Group routes with shared configuration. Groups are composable and nestable.
-
-```typescript
-import { defineHTTPRoutes, wireHTTPRoutes } from '.pikku/pikku-types.gen.js'
-
-const routes = defineHTTPRoutes({
-  basePath?: string,       // Prepended to all route paths
-  tags?: string[],         // Applied to all routes in group
-  auth?: boolean,          // Default auth for all routes (overridable per-route)
-  middleware?: PikkuMiddleware[],
-  routes: {
-    [key: string]: {
-      method: string,
-      route: string,
-      func: PikkuFunc,
-      auth?: boolean,      // Override group auth
-      permissions?: Record<string, PikkuPermission | PikkuPermission[]>,
-      middleware?: PikkuMiddleware[],
-    }
-  }
-})
-
-wireHTTPRoutes({
-  basePath?: string,       // Top-level prefix (e.g. '/api/v1')
-  middleware?: PikkuMiddleware[],
-  routes: {
-    [key: string]: ReturnType<typeof defineHTTPRoutes>,
-  }
-})
-```
-
-Config cascading rules:
-
-- `basePath` — concatenates down the chain
-- `tags` — merge (union)
-- `auth` — child overrides parent
+For the full option tables (every `wireHTTP` field, the `defineHTTPRoutes`/`wireHTTPRoutes` config shape), read `references/http-options.md`.
 
 ### `addHTTPMiddleware(pattern, middlewares)`
 
@@ -137,7 +84,7 @@ wireHTTP({
 const booksRoutes = defineHTTPRoutes({
   tags: ['books'],
   routes: {
-    list: { method: 'get', route: '/books', func: listBooks, auth: false },
+    list: { method: 'get', route: '/books', func: listBooks, auth: false }, // per-route override
     get: { method: 'get', route: '/books/:bookId', func: getBook },
     create: { method: 'post', route: '/books', func: createBook },
     delete: { method: 'delete', route: '/books/:bookId', func: deleteBook },
@@ -145,24 +92,19 @@ const booksRoutes = defineHTTPRoutes({
 })
 
 const todosRoutes = defineHTTPRoutes({
-  auth: false,
+  auth: false, // group-level default, overridable per-route
   tags: ['todos'],
   routes: {
     list: { method: 'get', route: '/todos', func: listTodos },
-    create: { method: 'post', route: '/todos', func: createTodo },
-    get: { method: 'get', route: '/todos/:id', func: getTodo },
   },
 })
 
 wireHTTPRoutes({
   basePath: '/api/v1',
   middleware: [cors()],
-  routes: {
-    books: booksRoutes,
-    todos: todosRoutes,
-  },
+  routes: { books: booksRoutes, todos: todosRoutes },
 })
-// Results in: GET /api/v1/books, POST /api/v1/books, etc.
+// Results in: GET /api/v1/books, POST /api/v1/books, GET /api/v1/todos, etc.
 ```
 
 ### Auth & Permissions
@@ -258,60 +200,27 @@ const deleted = await pikkuFetch.delete('/api/v1/books/:bookId', {
 
 ## Complete Example
 
+Functions live in their own files (one per file) and supply behavior + `permissions`; the wiring file imports them and wires routes. Sessionless funcs need no session; `pikkuFunc` does.
+
 ```typescript
 // functions/books.functions.ts
 import { pikkuFunc, pikkuSessionlessFunc } from '#pikku'
 
 export const listBooks = pikkuSessionlessFunc({
   title: 'List Books',
-  func: async ({ db }, { limit }) => {
-    return { books: await db.listBooks(limit) }
-  },
+  func: async ({ db }, { limit }) => ({ books: await db.listBooks(limit) }),
 })
 
 export const getBook = pikkuFunc({
   title: 'Get Book',
   description: 'Retrieve a book by ID',
-  func: async ({ db }, { bookId }) => {
-    return await db.getBook(bookId)
-  },
+  func: async ({ db }, { bookId }) => await db.getBook(bookId),
   permissions: { user: isAuthenticated },
 })
 
-export const createBook = pikkuFunc({
-  title: 'Create Book',
-  func: async ({ db }, { title, author }) => {
-    return await db.createBook({ title, author })
-  },
-})
-
-export const deleteBook = pikkuFunc({
-  title: 'Delete Book',
-  func: async ({ db }, { bookId }) => {
-    await db.deleteBook(bookId)
-    return { deleted: true }
-  },
-})
-
-// wirings/books.http.ts
-import { defineHTTPRoutes, wireHTTPRoutes } from '.pikku/pikku-types.gen.js'
+// wirings/books.http.ts — same defineHTTPRoutes/wireHTTPRoutes shape as the Route Groups example above
 import { addHTTPMiddleware } from '@pikku/core/http'
 import { cors, authBearer } from '@pikku/core/middleware'
-
-const booksRoutes = defineHTTPRoutes({
-  tags: ['books'],
-  routes: {
-    list: { method: 'get', route: '/books', func: listBooks, auth: false },
-    get: { method: 'get', route: '/books/:bookId', func: getBook },
-    create: { method: 'post', route: '/books', func: createBook },
-    delete: { method: 'delete', route: '/books/:bookId', func: deleteBook },
-  },
-})
-
-wireHTTPRoutes({
-  basePath: '/api',
-  routes: { books: booksRoutes },
-})
 
 addHTTPMiddleware('*', [cors(), authBearer()])
 ```

--- a/packages/cli/skills/pikku-http/references/http-options.md
+++ b/packages/cli/skills/pikku-http/references/http-options.md
@@ -1,0 +1,57 @@
+# wireHTTP / defineHTTPRoutes / wireHTTPRoutes — full option reference
+
+## `wireHTTP(config)`
+
+Wire a single function to an HTTP endpoint. Import from `@pikku/core/http`.
+
+| Option | Type | Notes |
+| --- | --- | --- |
+| `method` | `'get' \| 'post' \| 'put' \| 'patch' \| 'delete' \| 'head'` | HTTP verb |
+| `route` | `string` | e.g. `/books/:bookId` — `:params` become `data` fields |
+| `func` | `PikkuFunc` | The function to call |
+| `auth?` | `boolean` | Override default auth (`true` = require session) |
+| `tags?` | `string[]` | For grouping, middleware targeting |
+| `permissions?` | `Record<string, PikkuPermission \| PikkuPermission[]>` | Permission checks |
+| `middleware?` | `PikkuMiddleware[]` | Per-route middleware |
+| `sse?` | `boolean` | Enable Server-Sent Events |
+| `contentType?` | `'xml' \| 'json'` | Response content type |
+| `timeout?` | `number` | Request timeout in ms |
+| `headers?` | `HTTPHeadersSchema` | Expected headers schema |
+| `docs?` | `HTTPRouteDocsConfig` | OpenAPI docs config |
+
+## `defineHTTPRoutes(config)` + `wireHTTPRoutes(config)`
+
+Group routes with shared configuration. Groups are composable and nestable. Import from `.pikku/pikku-types.gen.js`.
+
+```typescript
+const routes = defineHTTPRoutes({
+  basePath?: string,       // Prepended to all route paths
+  tags?: string[],         // Applied to all routes in group
+  auth?: boolean,          // Default auth for all routes (overridable per-route)
+  middleware?: PikkuMiddleware[],
+  routes: {
+    [key: string]: {
+      method: string,
+      route: string,
+      func: PikkuFunc,
+      auth?: boolean,      // Override group auth
+      permissions?: Record<string, PikkuPermission | PikkuPermission[]>,
+      middleware?: PikkuMiddleware[],
+    }
+  }
+})
+
+wireHTTPRoutes({
+  basePath?: string,       // Top-level prefix (e.g. '/api/v1')
+  middleware?: PikkuMiddleware[],
+  routes: {
+    [key: string]: ReturnType<typeof defineHTTPRoutes>,
+  }
+})
+```
+
+Config cascading rules:
+
+- `basePath` — concatenates down the chain
+- `tags` — merge (union)
+- `auth` — child overrides parent

--- a/packages/cli/skills/pikku-middleware/SKILL.md
+++ b/packages/cli/skills/pikku-middleware/SKILL.md
@@ -77,20 +77,17 @@ wireHTTP({
 
 ## Global Middleware (`addGlobalMiddleware`)
 
-`addGlobalMiddleware` registers middleware that runs before everything else — across every wire type: HTTP, Queue, Channel, Trigger, Scheduler, Workflow, Agent, CLI, MCP. Use it for cross-cutting concerns like telemetry that must wrap every invocation regardless of transport.
+Runs before everything else, across every wire type: HTTP, Queue, Channel, Trigger, Scheduler, Workflow, Agent, CLI, MCP. Use it for cross-cutting concerns (e.g. telemetry) that must wrap every invocation regardless of transport.
 
 ```typescript
 import { addGlobalMiddleware } from '@pikku/core'
 import { telemetryOuter, telemetryInner } from '@pikku/core/middleware'
 
-// Outer telemetry: wraps the full call (highest priority)
-addGlobalMiddleware([telemetryOuter({ environmentId: env.STAGE_ID })])
-
-// Inner telemetry: closest to the function body (lowest priority)
-addGlobalMiddleware([telemetryInner({ environmentId: env.STAGE_ID })])
+addGlobalMiddleware([telemetryOuter({ environmentId: env.STAGE_ID })])  // wraps the full call
+addGlobalMiddleware([telemetryInner({ environmentId: env.STAGE_ID })])  // closest to the function body
 ```
 
-`telemetryOuter` ships with `priority: 'highest'` and `telemetryInner` with `priority: 'lowest'` — so even if both are added in the same call, priority sorting places outer first regardless of array order.
+`telemetryOuter` ships with `priority: 'highest'`, `telemetryInner` with `priority: 'lowest'` — so priority sorting places outer first regardless of array/call order.
 
 ## HTTP & Prefix Middleware (`addHTTPMiddleware`)
 
@@ -165,15 +162,13 @@ const earlyMiddleware = pikkuMiddleware({
 })
 ```
 
-Within the same priority level, registration order is preserved. Priority is the primary sort key — use it when a middleware must run before or after others regardless of registration order (e.g. telemetry wrapping everything, session extraction before auth checks).
+Priority is the primary sort key; within the same level, registration order is preserved. Use priority when a middleware must run before/after others regardless of registration order (e.g. telemetry wrapping everything, session extraction before auth checks).
 
-## Common Patterns
+## Service-to-Service Bearer Auth (canonical pattern)
 
-### Service-to-Service Bearer Auth
+A server that exposes RPCs only to a trusted caller (e.g. an API calling a machine-agent). Auth lives in a tag middleware — NOT in the function body. Authorization/permission checks belong in the `permissions` field (see `pikku-permissions`), never inside `func`.
 
-The canonical pattern for a server that exposes RPCs only to a trusted caller (e.g. an API calling a machine-agent):
-
-**On the server (the service being called):**
+**On the server (the service being called):** tag the function, register a `pikkuMiddleware` that reads the `Authorization` header on that tag.
 
 ```typescript
 // lib/host-token.ts
@@ -217,63 +212,11 @@ export const myFunc = pikkuSessionlessFunc({
 })
 ```
 
-**On the client (the caller):**
+**On the client (the caller):** use the generated `RPCInvoke` type — never hand-write a `fetch` wrapper's types. See `references/middleware-patterns.md`.
 
-Use the generated `RPCInvoke` type from `.pikku/rpc/pikku-rpc-wirings-map.gen.d.ts` — never hand-write the input/output types:
+## More patterns
 
-```typescript
-import type { RPCInvoke } from '../../backends/my-service/.pikku/rpc/pikku-rpc-wirings-map.gen.d.js'
-
-export function getServiceRPC(baseUrl: string, token: string): RPCInvoke {
-  return async (name: string, data?: unknown) => {
-    const res = await fetch(`${baseUrl}/rpc/${String(name)}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({ data: data ?? {} }),
-    })
-    if (!res.ok) {
-      const text = await res.text().catch(() => '')
-      throw new Error(`rpc ${String(name)} failed: ${res.status} ${text}`)
-    }
-    return res.json()
-  } as RPCInvoke
-}
-```
-
-### Session-Setting Middleware
-
-```typescript
-const apiKeyAuth = pikkuMiddleware(async ({ kysely }, { http, setSession, session }, next) => {
-  if (session) return next()  // already authenticated
-
-  const header = http?.request?.header?.('x-api-key')
-  if (!header) return next()
-
-  const row = await kysely.selectFrom('apiKey').select('userId').where('key', '=', header).executeTakeFirst()
-  if (row) setSession?.({ userId: row.userId })
-
-  return next()
-})
-
-addTagMiddleware('api-key-auth', [apiKeyAuth])
-```
-
-Functions tagged `'api-key-auth'` with `auth: true` reject requests without a valid key; those with `auth: false` can inspect the session but won't reject.
-
-### Request Logging / Audit
-
-```typescript
-const auditLog = pikkuMiddleware(async ({ logger, db }, wire, next) => {
-  const start = Date.now()
-  await next()
-  await db.createAuditLog({ duration: Date.now() - start })
-})
-
-addHTTPMiddleware('/admin/*', [auditLog])
-```
+`references/middleware-patterns.md` covers the client-side `RPCInvoke` caller, session-setting middleware (set a session from an API key), and request logging / audit middleware.
 
 ## After Changes
 

--- a/packages/cli/skills/pikku-middleware/references/middleware-patterns.md
+++ b/packages/cli/skills/pikku-middleware/references/middleware-patterns.md
@@ -1,0 +1,61 @@
+# Middleware Patterns (extended)
+
+Detailed, less-common middleware recipes. The common-path bearer-auth pattern lives inline in SKILL.md; this file holds the client-side caller, session-setting, and audit recipes.
+
+## Service-to-Service: the client (caller) side
+
+Use the generated `RPCInvoke` type from `.pikku/rpc/pikku-rpc-wirings-map.gen.d.ts` — never hand-write the input/output types:
+
+```typescript
+import type { RPCInvoke } from '../../backends/my-service/.pikku/rpc/pikku-rpc-wirings-map.gen.d.js'
+
+export function getServiceRPC(baseUrl: string, token: string): RPCInvoke {
+  return async (name: string, data?: unknown) => {
+    const res = await fetch(`${baseUrl}/rpc/${String(name)}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ data: data ?? {} }),
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new Error(`rpc ${String(name)} failed: ${res.status} ${text}`)
+    }
+    return res.json()
+  } as RPCInvoke
+}
+```
+
+## Session-Setting Middleware
+
+```typescript
+const apiKeyAuth = pikkuMiddleware(async ({ kysely }, { http, setSession, session }, next) => {
+  if (session) return next()  // already authenticated
+
+  const header = http?.request?.header?.('x-api-key')
+  if (!header) return next()
+
+  const row = await kysely.selectFrom('apiKey').select('userId').where('key', '=', header).executeTakeFirst()
+  if (row) setSession?.({ userId: row.userId })
+
+  return next()
+})
+
+addTagMiddleware('api-key-auth', [apiKeyAuth])
+```
+
+Functions tagged `'api-key-auth'` with `auth: true` reject requests without a valid key; those with `auth: false` can inspect the session but won't reject.
+
+## Request Logging / Audit
+
+```typescript
+const auditLog = pikkuMiddleware(async ({ logger, db }, wire, next) => {
+  const start = Date.now()
+  await next()
+  await db.createAuditLog({ duration: Date.now() - start })
+})
+
+addHTTPMiddleware('/admin/*', [auditLog])
+```

--- a/packages/cli/skills/pikku-realtime/SKILL.md
+++ b/packages/cli/skills/pikku-realtime/SKILL.md
@@ -16,16 +16,13 @@ Use this skill as an execution checklist, not reference material.
 4. Validate with the narrowest relevant command first, then run `pikku-verify` or `pikku all` when functions, wirings, schemas, or generated clients may have changed.
 5. If validation fails, fix the source cause and rerun validation. Do not paper over generated errors by editing generated files.
 
-Most realtime UI is just typed pub/sub: a server pushes `todo-created`, the
-client renders it. Pikku's realtime feature ships exactly that, two ways:
+Most realtime UI is just typed pub/sub: a server pushes `todo-created`, the client
+renders it. Pikku ships exactly that, two ways — both use the same `EventHubService`
+and the same publish call, so choose by transport, not by code shape:
 
 - **WebSocket** at `/events` — one connection, many topic subscriptions.
-- **SSE** at `GET /events/:topic` — one connection per topic, auto-cleanup
-  on disconnect. Good for environments where WebSocket is blocked or for
-  trivially streaming one topic.
-
-Both transports use the same `EventHubService` and the same publish call.
-Choose by transport, not by code shape.
+- **SSE** at `GET /events/:topic` — one connection per topic, auto-cleanup on
+  disconnect. Good when WebSocket is blocked or for trivially streaming one topic.
 
 ## 1. Declare your topics
 
@@ -41,28 +38,24 @@ export type EventHubTopics = {
 }
 ```
 
-Reference it in `application-types.d.ts`:
+Reference it in `application-types.d.ts` and instantiate it in `services.ts`:
 
 ```ts
+// application-types.d.ts
 import type { EventHubService } from '@pikku/core/channel'
 import type { EventHubTopics } from './eventhub-topics.js'
 
 export interface SingletonServices extends CoreSingletonServices<Config> {
   eventHub?: EventHubService<EventHubTopics>
-  // ...
 }
-```
 
-And instantiate it in `services.ts`:
-
-```ts
+// services.ts
 import { LocalEventHubService } from '@pikku/core/channel'
-// ...
 const eventHub = new LocalEventHubService<EventHubTopics>()
 ```
 
-(For multi-instance deployments use `CloudflareEventHubService` /
-`LambdaEventHubService` / `UWSEventHubService` instead — same interface.)
+For multi-instance deployments use `CloudflareEventHubService` /
+`LambdaEventHubService` / `UWSEventHubService` instead — same interface.
 
 ## 2. Enable the server side
 
@@ -71,14 +64,12 @@ yarn pikku enable events           # auth required by default
 yarn pikku enable events --noAuth  # public events
 ```
 
-This sets `scaffold.events` in `pikku.config.json`. The next `pikku all`
-generates `events.gen.ts` in your scaffold dir, which wires:
+This sets `scaffold.events` in `pikku.config.json`. The next `pikku all` generates
+`events.gen.ts` in your scaffold dir, wiring (using whatever `eventHub` is in your
+singletons — you write neither by hand):
 
 - A WebSocket channel at `/events` handling `{action: 'subscribe' | 'unsubscribe', topic}` messages.
 - An SSE handler at `GET /events/:topic`.
-
-You don't write either by hand. They use whatever `eventHub` service is
-in your singletons.
 
 ## 3. Generate the typed client
 
@@ -87,7 +78,6 @@ Add to `pikku.config.json`:
 ```jsonc
 {
   "clientFiles": {
-    // ...
     "realtimeFile": "packages/sdk/src/pikku/realtime.gen.ts",
     // Optional: full type inference for subscribe/unsubscribe
     "realtimeEventHubTopicsImport": "../../../functions/types/eventhub-topics.js#EventHubTopics",
@@ -95,8 +85,8 @@ Add to `pikku.config.json`:
 }
 ```
 
-Run `pikku all` (or `pikku realtime` to regenerate just this file). The
-generated file exports two surfaces:
+Run `pikku all` (or `pikku realtime` to regenerate just this file). The generated
+file exports two surfaces:
 
 ```ts
 export class PikkuRealtime {
@@ -112,13 +102,15 @@ export function subscribeToTopicViaSSE<K extends keyof EventHubTopics>(
 ```
 
 Without `realtimeEventHubTopicsImport`, the client falls back to
-`Record<string, unknown>` — usable but untyped. Set the import for full
-typed subscribe/unsubscribe.
+`Record<string, unknown>` — usable but untyped. Set the import for full typed
+subscribe/unsubscribe.
 
 ## 4. Publish events from a function
 
-The `/events` channel listens for client subscriptions; the eventHub fans
-out publishes. Functions publish like this:
+The `/events` channel listens for client subscriptions; the eventHub fans out
+publishes. Envelope the payload with `topic` so the client dispatcher works; the
+`null` channelId means "broadcast to all subscribers" (pass a specific channel id
+to exclude/include a single connection):
 
 ```ts
 import { pikkuFunc } from '#pikku'
@@ -128,47 +120,35 @@ export const createTodo = pikkuFunc({
   output: CreateTodoOutput,
   func: async ({ kysely, eventHub }, data) => {
     const todo = await kysely
-      .insertInto('todos')
-      .values(data)
-      .returningAll()
+      .insertInto('todos').values(data).returningAll()
       .executeTakeFirstOrThrow()
 
     if (eventHub) {
-      // Envelope the payload with `topic` so the client dispatcher works.
       await eventHub.publish('todo-created', null, {
         topic: 'todo-created',
         data: { todo },
       })
     }
-
     return { id: todo.id }
   },
 })
 ```
 
-The `null` channelId means "broadcast to all subscribers." Pass a
-specific channel id to exclude/include a single connection.
-
 A thin helper removes the duplication:
 
 ```ts
 async function publishEvent<K extends keyof EventHubTopics>(
-  hub: EventHubService<EventHubTopics>,
-  topic: K,
-  data: EventHubTopics[K]
+  hub: EventHubService<EventHubTopics>, topic: K, data: EventHubTopics[K]
 ) {
   return hub.publish(topic, null, { topic, data })
 }
-
-// usage:
-await publishEvent(eventHub, 'todo-created', { todo })
+// usage: await publishEvent(eventHub, 'todo-created', { todo })
 ```
 
 ## 5. Wire it up — share fetch with PikkuRPC
 
-`PikkuRealtime` mirrors `PikkuRPC`: it wraps the same `PikkuFetch`, so
-server URL + auth are configured **once** and shared across HTTP, RPC,
-and realtime transports.
+`PikkuRealtime` mirrors `PikkuRPC`: it wraps the same `PikkuFetch`, so server URL +
+auth are configured **once** and shared across HTTP, RPC, and realtime transports.
 
 ```tsx
 import { createPikku, PikkuProvider } from '@pikku/react'
@@ -185,9 +165,7 @@ const pikku = createPikku(
 // pikku.fetch / pikku.rpc / pikku.realtime — all share the same fetch.
 
 createRoot(document.getElementById('root')!).render(
-  <PikkuProvider pikku={pikku}>
-    <App />
-  </PikkuProvider>
+  <PikkuProvider pikku={pikku}><App /></PikkuProvider>
 )
 ```
 
@@ -200,64 +178,38 @@ realtime.setPikkuFetch(pikku.fetch) // inherits serverUrl + auth
 
 ## 6. Subscribe from React
 
+Subscribe inside `useEffect` (never the render path, or you create a subscription
+per render). `subscribe` returns an unsubscribe function; SSE's `subscribeToTopic`
+returns a handle with `close()`:
+
 ```tsx
 import { useEffect, useState } from 'react'
 
 function TodoList() {
-  const { realtime } = usePikku() // assuming you expose a hook over your context
+  const { realtime } = usePikku() // a hook over your context
   const [todos, setTodos] = useState<Todo[]>([])
 
   useEffect(() => {
-    const off = realtime.subscribe('todo-created', ({ todo }) => {
-      setTodos((prev) => [...prev, todo])
-    })
+    // WebSocket multi-topic:
+    const off = realtime.subscribe('todo-created', ({ todo }) =>
+      setTodos((prev) => [...prev, todo]))
     return off
+
+    // Single-topic SSE (auto-cleanup on close) instead:
+    // const sub = realtime.subscribeToTopic('todo-created', ({ todo }) =>
+    //   setTodos((prev) => [...prev, todo]))
+    // return () => sub.close()
   }, [realtime])
 
-  return (
-    <ul>
-      {todos.map((t) => (
-        <li key={t.id}>{t.title}</li>
-      ))}
-    </ul>
-  )
+  return <ul>{todos.map((t) => <li key={t.id}>{t.title}</li>)}</ul>
 }
 ```
 
-Single-topic SSE (auto-cleanup on close):
+## Other SSE / WebSocket routes
 
-```tsx
-useEffect(() => {
-  const sub = realtime.subscribeToTopic('todo-created', ({ todo }) => {
-    setTodos((prev) => [...prev, todo])
-  })
-  return () => sub.close()
-}, [realtime])
-```
-
-## Subscribing to other SSE / WebSocket routes
-
-Same client also handles generic SSE + channel routes — use the path,
-the base URL is inherited from PikkuFetch:
-
-```ts
-// Any sse: true HTTP route
-const sub = realtime.subscribeToSSE<{ progress: number }>(
-  `/workflow-run/${runId}/stream`,
-  (event) => setProgress(event.progress)
-)
-// later: sub.close()
-
-// Any wireChannel — open a raw socket, wrap in PikkuWebSocket for typed I/O
-const ws = realtime.connectToChannel('/ws/kanban')
-const typed = new PikkuWebSocket<'kanban-live'>(ws)
-typed.getRoute('command').subscribe('message', (data) => {
-  /* ... */
-})
-```
-
-Discover what's available with `pikku meta clients --json` — `channels`
-and any HTTP `sse: true` routes are listed there.
+The same client also subscribes to generic `sse: true` routes and raw `wireChannel`
+sockets (`subscribeToSSE`, `connectToChannel`). See
+[references/other-routes.md](references/other-routes.md).
 
 ## When to pick which transport
 
@@ -268,18 +220,17 @@ and any HTTP `sse: true` routes are listed there.
 | Bidirectional (client also sends messages) | **PikkuRealtime**             |
 | WebSockets blocked by infra                | **subscribeToTopicViaSSE**    |
 
-Both auto-clean on the server (the eventHub's `onChannelClosed` hook
-unsubscribes all topics for the dead channel id). Don't write manual
-cleanup unless you're unsubscribing partway through a session.
+Both auto-clean on the server (the eventHub's `onChannelClosed` hook unsubscribes
+all topics for the dead channel id). Don't write manual cleanup unless you're
+unsubscribing partway through a session.
 
 ## What NOT to do
 
-- Don't call `eventHub.publish(topic, ..., rawData)` without the
-  `{topic, data}` envelope — clients use `topic` to dispatch handlers.
-- Don't create your own `/events` channel by hand — `pikku enable events`
-  already does it correctly with disconnect cleanup.
-- Don't subscribe inside the render path — use `useEffect`. Otherwise
-  you'll create a subscription per render.
-- Don't subscribe to topics that don't exist in `EventHubTopics`. The
-  generated client's types prevent it; if you find yourself reaching for
-  `as any` to subscribe to a string, declare the topic first.
+- Don't call `eventHub.publish(topic, ..., rawData)` without the `{topic, data}`
+  envelope — clients use `topic` to dispatch handlers.
+- Don't create your own `/events` channel by hand — `pikku enable events` already
+  does it correctly with disconnect cleanup.
+- Don't subscribe inside the render path — use `useEffect`.
+- Don't subscribe to topics that don't exist in `EventHubTopics`. The generated
+  client's types prevent it; if you reach for `as any` to subscribe to a string,
+  declare the topic first.

--- a/packages/cli/skills/pikku-realtime/references/other-routes.md
+++ b/packages/cli/skills/pikku-realtime/references/other-routes.md
@@ -1,0 +1,23 @@
+# Subscribing to other SSE / WebSocket routes
+
+The same `PikkuRealtime` client also handles generic SSE + channel routes (not just
+`/events` topics). Use the path; the base URL is inherited from `PikkuFetch`.
+
+```ts
+// Any `sse: true` HTTP route
+const sub = realtime.subscribeToSSE<{ progress: number }>(
+  `/workflow-run/${runId}/stream`,
+  (event) => setProgress(event.progress)
+)
+// later: sub.close()
+
+// Any wireChannel — open a raw socket, wrap in PikkuWebSocket for typed I/O
+const ws = realtime.connectToChannel('/ws/kanban')
+const typed = new PikkuWebSocket<'kanban-live'>(ws)
+typed.getRoute('command').subscribe('message', (data) => {
+  /* ... */
+})
+```
+
+Discover what's available with `pikku meta clients --json` — `channels` and any HTTP
+`sse: true` routes are listed there.

--- a/packages/cli/skills/pikku-services/SKILL.md
+++ b/packages/cli/skills/pikku-services/SKILL.md
@@ -18,7 +18,7 @@ Use this skill as an execution checklist, not reference material.
 4. Validate with the narrowest relevant command first, then run `pikku-verify` or `pikku all` when functions, wirings, schemas, or generated clients may have changed.
 5. If validation fails, fix the source cause and rerun validation. Do not paper over generated errors by editing generated files.
 
-Pikku uses factory functions for dependency injection. Singleton services are created once at startup. Wire services are created fresh per request/job/command.
+Pikku uses factory functions for dependency injection. Singleton services are created once at startup; wire services are created fresh per request/job/command. See `pikku-concepts` for the core mental model.
 
 ## Before You Start
 
@@ -27,47 +27,44 @@ pikku info functions --verbose   # See which services existing functions use
 pikku info tags --verbose        # Understand project organization
 ```
 
-See `pikku-concepts` for the core mental model.
-
 ## API Reference
 
-### `pikkuServices(factory)`
-
-Create singleton services — instantiated once at server startup.
+### `pikkuServices(factory)` — singleton services (created once at startup)
 
 ```typescript
 import { pikkuServices } from '#pikku'
+import { ConsoleLogger } from '@pikku/core/services'
+import { JoseJWTService } from '@pikku/jose'
 
-const createSingletonServices = pikkuServices(
+export const createSingletonServices = pikkuServices(
   async (config, existingServices?) => {
     // config: your CoreConfig object
     // existingServices: optional, for chaining factories
-    return {
-      config,
-      logger: Logger,
-      jwt: JWTService,
-      database: DatabasePool,
-      // ...any custom services
-    }
+    const logger = new ConsoleLogger()
+    const database = new DatabasePool(config.database)
+    await database.connect()
+    const jwt = new JoseJWTService(
+      async () => [{ id: 'my-key', value: config.jwtSecret }],
+      logger
+    )
+    return { config, logger, database, jwt, books: new BookService() }
   }
 )
 ```
 
-### `pikkuWireServices(factory)`
-
-Create per-request services — fresh instance for each HTTP request, queue job, CLI command, etc.
+### `pikkuWireServices(factory)` — per-request services (fresh per HTTP request, queue job, CLI command, etc.)
 
 ```typescript
 import { pikkuWireServices } from '#pikku'
 
-const createWireServices = pikkuWireServices(
+export const createWireServices = pikkuWireServices(
   async (singletonServices, wire) => {
     // singletonServices: all singleton services
     // wire: transport context (session, channel, etc.)
     // Pikku merges these with singleton services automatically
     return {
-      userSession: UserSessionService,
-      dbTransaction: DatabaseTransaction,
+      userSession: createUserSessionService(wire),
+      dbTransaction: new DatabaseTransaction(singletonServices.database),
     }
   }
 )
@@ -75,10 +72,9 @@ const createWireServices = pikkuWireServices(
 
 ### Auto-Generated Service Manifest
 
-After `npx pikku prebuild`, Pikku generates a manifest of which services are actually used:
+After `npx pikku prebuild`, Pikku generates `.pikku/pikku-services.gen.ts`, a manifest of which services are actually used by wired functions:
 
 ```typescript
-// .pikku/pikku-services.gen.ts (auto-generated)
 export const requiredSingletonServices = {
   database: true, // used by getUser, deleteUser
   audit: true, // used by deleteUser
@@ -95,47 +91,9 @@ export type RequiredSingletonServices = Pick<
 
 ## Usage Patterns
 
-### Basic Singleton Services
-
-```typescript
-const createSingletonServices = pikkuServices(
-  async (config, existingServices) => {
-    const logger = new ConsoleLogger()
-    const database = new DatabasePool(config.database)
-    await database.connect()
-
-    const jwt = new JoseJWTService(
-      async () => [{ id: 'my-key', value: JWT_SECRET }],
-      logger
-    )
-
-    return {
-      config,
-      logger,
-      database,
-      jwt,
-      books: new BookService(),
-    }
-  }
-)
-```
-
-### Per-Request Wire Services
-
-```typescript
-const createWireServices = pikkuWireServices(
-  async (singletonServices, wire) => {
-    return {
-      userSession: createUserSessionService(wire),
-      dbTransaction: new DatabaseTransaction(singletonServices.database),
-    }
-  }
-)
-```
-
 ### Using Services in Functions
 
-**Every service must be declared in `SingletonServices` (or `Services`) in `application-types.d.ts`.** Never access a service via a body-level cast (`services as typeof services & { myService: MyService }`) — that means the type is missing. Add the import and the field to `SingletonServices`, then destructure inline in the function signature. The inspector emits `SERVICES_NOT_DESTRUCTURED` and tree-shaking breaks when the first param is a plain identifier rather than an object pattern.
+**Every service must be declared in `SingletonServices` (or `Services`) in `application-types.d.ts`.** Never access a service via a body-level cast (`services as typeof services & { myService: MyService }`) — that means the type is missing. Add the import and the field to `SingletonServices`, then destructure inline in the function signature. The inspector emits `SERVICES_NOT_DESTRUCTURED` and tree-shaking breaks when the first param is a plain identifier rather than an object pattern. Never `new` a service inside a function — services arrive only via injection.
 
 ```typescript
 // ✅ Correct — inline destructure, no cast
@@ -143,8 +101,7 @@ const getUser = pikkuFunc({
   title: 'Get User',
   func: async ({ db, logger, jwt }, { userId }) => {
     logger.info('Fetching user', { userId })
-    const user = await db.getUser(userId)
-    return { user }
+    return { user: await db.getUser(userId) }
   },
 })
 
@@ -159,7 +116,7 @@ const getUser = pikkuFunc({
 
 ### Dynamic Import Optimization
 
-Use the generated manifest to conditionally import heavy dependencies:
+Use the generated manifest to conditionally import heavy dependencies — only the services actually wired get instantiated:
 
 ```typescript
 import { requiredSingletonServices } from '.pikku/pikku-services.gen.js'
@@ -184,38 +141,7 @@ const createSingletonServices = pikkuServices(async (config) => {
 
 ### Audit Wire Service
 
-`createInvocationAudit` creates a per-request `InvocationAuditLog` that buffers audit events in memory and flushes them as a batch when the function-runner calls `closeWireServices` at the end of the request. If `singletonServices.audit` is not configured (local dev without Fabric), it returns a no-op `DisabledInvocationAudit` — no crash, events are silently dropped.
-
-Pair with `createAuditedKysely` to auto-capture every Kysely query as an audit event.
-
-```typescript
-// services.ts
-import { createInvocationAudit } from '@pikku/core/services'
-import { createAuditedKysely } from '@pikku/kysely'
-
-export const createWireServices = pikkuWireServices(async (singletonServices, wire) => {
-  const audit = createInvocationAudit(singletonServices.audit, wire)
-  const kysely = singletonServices.kysely
-    ? createAuditedKysely(singletonServices.kysely, { audit })
-    : undefined
-  return { audit, ...(kysely ? { kysely } : {}) }
-})
-```
-
-The `audit` wire service is typed as `AuditLog` (from `@pikku/core`). Functions that emit custom events use it directly:
-
-```typescript
-const deleteUser = pikkuFunc({
-  func: async ({ audit }, { userId }) => {
-    await audit.audit({ type: 'user.deleted', actor_user_id: userId })
-    // ...
-  },
-})
-```
-
-`closeWireServices` (called automatically by the function-runner) invokes `audit.close()` → `singletonServices.audit.write(batch)` → platform-specific flush (e.g. CF Queue, libsql INSERT). No manual flushing needed.
-
-> **Fabric note:** Fabric provisions the audit queue and consumer worker automatically. The audit table schema is in `db/sqlite/0003-audit.sql` (starter-template). Run `pikku fabric validate` to confirm the migration is in place.
+`createInvocationAudit` + `createAuditedKysely` add per-request audit buffering that flushes on request close (no-op if `audit` is unconfigured). For the full pattern, no-op behavior, custom-event usage, and Fabric notes, read `references/audit-wire-service.md`.
 
 ### Built-in Services
 
@@ -240,22 +166,14 @@ import { JoseJWTService } from '@pikku/jose'
 // Custom service
 class TodoStore {
   private todos: Map<string, Todo> = new Map()
-
   async create(title: string, priority: string) {
     const todo = { id: crypto.randomUUID(), title, priority, completed: false }
     this.todos.set(todo.id, todo)
     return todo
   }
-
-  async get(id: string) {
-    return this.todos.get(id)
-  }
-  async list() {
-    return [...this.todos.values()]
-  }
-  async delete(id: string) {
-    this.todos.delete(id)
-  }
+  async get(id: string) { return this.todos.get(id) }
+  async list() { return [...this.todos.values()] }
+  async delete(id: string) { this.todos.delete(id) }
 }
 
 export const createSingletonServices = pikkuServices(async (config) => {
@@ -264,7 +182,6 @@ export const createSingletonServices = pikkuServices(async (config) => {
     async () => [{ id: 'my-key', value: config.jwtSecret }],
     logger
   )
-
   return {
     config,
     logger,

--- a/packages/cli/skills/pikku-services/references/audit-wire-service.md
+++ b/packages/cli/skills/pikku-services/references/audit-wire-service.md
@@ -1,0 +1,34 @@
+# Audit Wire Service
+
+`createInvocationAudit` creates a per-request `InvocationAuditLog` that buffers audit events in memory and flushes them as a batch when the function-runner calls `closeWireServices` at the end of the request. If `singletonServices.audit` is not configured (local dev without Fabric), it returns a no-op `DisabledInvocationAudit` — no crash, events are silently dropped.
+
+Pair with `createAuditedKysely` to auto-capture every Kysely query as an audit event.
+
+```typescript
+// services.ts
+import { createInvocationAudit } from '@pikku/core/services'
+import { createAuditedKysely } from '@pikku/kysely'
+
+export const createWireServices = pikkuWireServices(async (singletonServices, wire) => {
+  const audit = createInvocationAudit(singletonServices.audit, wire)
+  const kysely = singletonServices.kysely
+    ? createAuditedKysely(singletonServices.kysely, { audit })
+    : undefined
+  return { audit, ...(kysely ? { kysely } : {}) }
+})
+```
+
+The `audit` wire service is typed as `AuditLog` (from `@pikku/core`). Functions that emit custom events use it directly:
+
+```typescript
+const deleteUser = pikkuFunc({
+  func: async ({ audit }, { userId }) => {
+    await audit.audit({ type: 'user.deleted', actor_user_id: userId })
+    // ...
+  },
+})
+```
+
+`closeWireServices` (called automatically by the function-runner) invokes `audit.close()` → `singletonServices.audit.write(batch)` → platform-specific flush (e.g. CF Queue, libsql INSERT). No manual flushing needed.
+
+> **Fabric note:** Fabric provisions the audit queue and consumer worker automatically. The audit table schema is in `db/sqlite/0003-audit.sql` (starter-template). Run `pikku fabric validate` to confirm the migration is in place.

--- a/packages/cli/skills/pikku-testing/SKILL.md
+++ b/packages/cli/skills/pikku-testing/SKILL.md
@@ -23,130 +23,25 @@ Pikku functions are pure business logic — no HTTP, no framework — making the
 ## Before You Start
 
 ```bash
-pikku info functions --verbose   # See existing functions and their middleware/permissions
-pikku info middleware --verbose  # See middleware applied
+pikku info functions --verbose   # existing functions + their middleware/permissions
+pikku info middleware --verbose  # middleware applied
 ```
 
-## Personas and Named Data — Never Inline JSON
+## Cucumber / BDD (feature files)
 
-**Never put JSON, inline tables, or raw values inside `.feature` files.** Feature files are for human-readable scenarios. All test data belongs in typed maps that step definitions look up by name.
-
-`@pikku/cucumber` exports `PersonaData<T>` for this purpose — a typed map that throws a clear error when a name is missing.
-
-### Personas
-
-A **persona** is a named user: their login credentials plus the session they hold after authenticating. Define all personas in one file:
-
-```ts
-// tests/tests/support/personas.ts
-import { PersonaData } from '@pikku/cucumber'
-
-export const logins = new PersonaData({
-  yasser: { email: 'yasser@example.com', password: 'hunter2' },
-  guest:  { email: 'guest@example.com',  password: 'guest123' },
-})
-```
-
-A persona step logs in and stores the session in the world so every subsequent call by that persona carries it automatically:
-
-```ts
-// tests/tests/support/steps/auth.steps.ts
-import { Given } from '@cucumber/cucumber'
-import { logins } from '../personas.js'
-
-Given('{string} logs in', async function (name: string) {
-  await this.call(name, 'auth:login', logins.get(name))
-  const { token } = this.lastResult as { token: string }
-  this.setSession(name, { token })
-})
-```
-
-### Named Domain Data
-
-Use a separate `PersonaData` map for each domain concept. Name entries after real-world meaning, not technical fields:
-
-```ts
-// tests/tests/support/data/cards.ts
-import { PersonaData } from '@pikku/cucumber'
-
-export const cards = new PersonaData({
-  'writing a blog post': { title: 'Writing a blog post', columnId: 'backlog' },
-  'fix the login bug':   { title: 'Fix the login bug',   columnId: 'in-progress' },
-})
-```
-
-Steps resolve the name and make the call — the feature file never sees raw data:
-
-```ts
-// tests/tests/support/steps/card.steps.ts
-import { When, Then } from '@cucumber/cucumber'
-import assert from 'node:assert/strict'
-import { cards } from '../data/cards.js'
-
-When('{string} creates a card for {string}', async function (persona: string, cardName: string) {
-  await this.call(persona, 'kanban:createCard', cards.get(cardName))
-})
-
-When('{string} gets the card {string}', async function (persona: string, cardName: string) {
-  const { title } = cards.get(cardName)
-  await this.call(persona, 'kanban:getCard', { title })
-})
-
-// "the newly created card" — checks the live result against the data map entry
-// AND any server-assigned fields (id, createdAt) are present
-Then('the result is the newly created card {string}', function (cardName: string) {
-  const expected = cards.get(cardName)
-  const result = this.lastResult as typeof expected & { id: string; createdAt: string }
-  assert.equal(result.title, expected.title)
-  assert.equal(result.columnId, expected.columnId)
-  assert.ok(result.id, 'expected server-assigned id')
-  assert.ok(result.createdAt, 'expected server-assigned createdAt')
-})
-```
-
-The feature file reads naturally:
-
-```gherkin
-Feature: Card management
-
-  Scenario: Create and retrieve a card
-    Given 'yasser' logs in
-    When 'yasser' creates a card for 'writing a blog post'
-    And 'yasser' gets the card 'writing a blog post'
-    Then the result is the newly created card 'writing a blog post'
-```
-
-### File layout
-
-```
-tests/tests/support/
-  personas.ts          ← logins PersonaData (one per project)
-  data/
-    cards.ts           ← cards PersonaData
-    users.ts           ← users PersonaData
-  steps/
-    auth.steps.ts      ← login / logout steps
-    card.steps.ts      ← card CRUD steps
-```
-
-Keep one `PersonaData` instance per domain concept. Steps import only what they need — no cross-domain coupling.
+When writing `.feature` files, the golden rule: **never put JSON, inline tables, or raw values inside `.feature` files** — all test data goes in typed `PersonaData<T>` maps (from `@pikku/cucumber`) that step definitions look up by name. For personas, named domain data, the support file layout, and the full set of BDD anti-patterns, read `references/cucumber-bdd-testing.md`.
 
 ## Coverage-Driven Test Writing
 
 When asked to improve or fill test coverage, start with the AI prompt from the coverage command:
 
 ```bash
-# Run tests and emit an AI-ready prompt listing every uncovered/partial function
-pikku tests coverage --ai-out coverage-prompt.md
-
-# Or skip re-running if you already have fresh coverage data
-pikku tests coverage --no-run --ai-out coverage-prompt.md
-
-# Pipe directly to stdout (e.g. to paste into a chat)
-pikku tests coverage --ai-out -
+pikku tests coverage --ai-out coverage-prompt.md     # run tests + emit AI-ready prompt of uncovered/partial functions
+pikku tests coverage --no-run --ai-out coverage-prompt.md   # skip re-running, use existing coverage data
+pikku tests coverage --ai-out -                      # pipe to stdout
 ```
 
-The prompt lists each function that needs work with its status (`uncovered`/`partial`), coverage ratio, missed line numbers, and source file path. Use it as your starting point:
+The prompt lists each function needing work with status (`uncovered`/`partial`), coverage ratio, missed line numbers, and source path. Use it as your starting point:
 
 1. Read the prompt to know which functions need Gherkin scenarios.
 2. Run `pikku meta functions list` or `pikku meta context` to get input/output schemas for those functions.
@@ -157,22 +52,27 @@ See `pikku-concepts` for the core mental model.
 
 ## Test Runner Setup
 
-Pikku uses Node.js built-in test runner with tsx for TypeScript:
+Pikku uses the Node.js built-in test runner with tsx for TypeScript:
 
 ```bash
 node --import tsx --test src/**/*.test.ts
 ```
-
-Standard test file:
 
 ```typescript
 import { describe, test, beforeEach } from 'node:test'
 import assert from 'node:assert'
 ```
 
+A reusable mock logger / singleton services bag used throughout the examples below:
+
+```typescript
+const mockLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+const mockSingletonServices = { logger: mockLogger /* + any services your funcs need */ } as any
+```
+
 ## Level 1: Direct Function Invocation
 
-The simplest approach — call `func` directly with mock services:
+The simplest approach — call `func` directly with mock services. Tests pure business logic: no middleware, permissions, or validation.
 
 ```typescript
 import { describe, test } from 'node:test'
@@ -181,62 +81,31 @@ import assert from 'node:assert'
 describe('createTodo', () => {
   test('should create a todo', async () => {
     const mockServices = {
-      todoStore: {
-        add: async (title: string) => ({
-          id: '1',
-          title,
-          completed: false,
-        }),
-      },
+      todoStore: { add: async (title: string) => ({ id: '1', title, completed: false }) },
     }
-
-    const result = await createTodo.func(mockServices as any, {
-      title: 'Buy milk',
-    })
-
+    const result = await createTodo.func(mockServices as any, { title: 'Buy milk' })
     assert.equal(result.title, 'Buy milk')
     assert.equal(result.completed, false)
   })
 })
 ```
 
-This tests pure business logic — no middleware, no permissions, no validation.
-
 ## Level 2: `runPikkuFunc` (Full Pipeline)
 
-Tests the function through Pikku's middleware, permissions, and schema validation pipeline:
+Tests the function through Pikku's middleware, permissions, and schema-validation pipeline. Always `resetPikkuState()` in `beforeEach`. Register function metadata into `pikkuState(null, 'function', 'meta')`, register the function with `addFunction`, then invoke with `runPikkuFunc`.
 
 ```typescript
-import { runPikkuFunc } from '@pikku/core'
-import { addFunction, addMiddleware, addPermission } from '@pikku/core'
+import { runPikkuFunc, addFunction, addMiddleware, addPermission } from '@pikku/core'
 import { resetPikkuState, pikkuState } from '@pikku/core'
 
-beforeEach(() => {
-  resetPikkuState()
-})
+beforeEach(() => resetPikkuState())
 
 test('should run function with middleware', async () => {
-  const mockSingletonServices = {
-    logger: {
-      info: () => {},
-      warn: () => {},
-      error: () => {},
-      debug: () => {},
-    },
-  } as any
-
-  // Register function metadata
   pikkuState(null, 'function', 'meta')['myFunc'] = {
-    pikkuFuncId: 'myFunc',
-    inputSchemaName: null,
-    outputSchemaName: null,
+    pikkuFuncId: 'myFunc', inputSchemaName: null, outputSchemaName: null,
   }
-
-  // Register the function
   addFunction('myFunc', {
-    func: async (services, data) => {
-      return { greeting: `Hello ${data.name}` }
-    },
+    func: async (services, data) => ({ greeting: `Hello ${data.name}` }),
   })
 
   const result = await runPikkuFunc('rpc', 'test-wire', 'myFunc', {
@@ -253,40 +122,25 @@ test('should run function with middleware', async () => {
 
 ### Testing Middleware Execution Order
 
+Middleware runs: wiring tags → wiring → func tags → func. Register tag middleware with `addMiddleware(tag, [...])`, reference func tags in the meta's `middleware: [{ type: 'tag', tag }]`, pass wiring middleware via `wireMiddleware` and inherited tags via `inheritedMiddleware`.
+
 ```typescript
 test('middleware runs in order: wiring tags -> wiring -> func tags -> func', async () => {
-  const mockSingletonServices = {
-    logger: {
-      info: () => {},
-      warn: () => {},
-      error: () => {},
-      debug: () => {},
-    },
-  } as any
-
   const order: string[] = []
-
   const createMiddleware =
     (name: string) => async (services: any, wire: any, next: Function) => {
-      order.push(name)
-      await next()
+      order.push(name); await next()
     }
 
   addMiddleware('apiTag', [createMiddleware('apiTag')])
   addMiddleware('funcTag', [createMiddleware('funcTag')])
 
   pikkuState(null, 'function', 'meta')['myFunc'] = {
-    pikkuFuncId: 'myFunc',
-    inputSchemaName: null,
-    outputSchemaName: null,
+    pikkuFuncId: 'myFunc', inputSchemaName: null, outputSchemaName: null,
     middleware: [{ type: 'tag', tag: 'funcTag' }],
   }
-
   addFunction('myFunc', {
-    func: async () => {
-      order.push('main')
-      return 'ok'
-    },
+    func: async () => { order.push('main'); return 'ok' },
     middleware: [createMiddleware('funcMiddleware')],
     tags: ['funcTag'],
   })
@@ -301,40 +155,22 @@ test('middleware runs in order: wiring tags -> wiring -> func tags -> func', asy
     wire: {},
   })
 
-  assert.deepEqual(order, [
-    'apiTag',
-    'wiringMiddleware',
-    'funcTag',
-    'funcMiddleware',
-    'main',
-  ])
+  assert.deepEqual(order, ['apiTag', 'wiringMiddleware', 'funcTag', 'funcMiddleware', 'main'])
 })
 ```
 
 ### Testing Permissions
 
+Register a denying permission with `addPermission(tag, [...])` and reference it in the meta's `permissions`.
+
 ```typescript
 test('should reject when permission fails', async () => {
-  const mockSingletonServices = {
-    logger: {
-      info: () => {},
-      warn: () => {},
-      error: () => {},
-      debug: () => {},
-    },
-  } as any
-
-  addPermission('admin', [
-    async () => false, // Always deny
-  ])
+  addPermission('admin', [async () => false]) // always deny
 
   pikkuState(null, 'function', 'meta')['adminFunc'] = {
-    pikkuFuncId: 'adminFunc',
-    inputSchemaName: null,
-    outputSchemaName: null,
+    pikkuFuncId: 'adminFunc', inputSchemaName: null, outputSchemaName: null,
     permissions: [{ type: 'tag', tag: 'admin' }],
   }
-
   addFunction('adminFunc', { func: async () => 'secret' })
 
   await assert.rejects(
@@ -352,46 +188,30 @@ test('should reject when permission fails', async () => {
 
 ## Level 3: Integration Testing (HTTP)
 
-Test the full HTTP stack using the `fetch` export:
+Test the full HTTP stack using the `fetch` export. Set singleton services and factories into state, register route metadata + function, then `wireHTTP`.
 
 ```typescript
 import { fetch, wireHTTP } from '@pikku/core/http'
 import { resetPikkuState, pikkuState, addFunction } from '@pikku/core'
 
-const mockSingletonServices = {
-  logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
-} as any
-
-const listTodos = {
-  func: async () => ({ todos: [{ id: '1', title: 'Test todo' }] }),
-}
+const listTodos = { func: async () => ({ todos: [{ id: '1', title: 'Test todo' }] }) }
 
 beforeEach(() => {
   resetPikkuState()
-
-  // Set up singleton services in state
   pikkuState(null, 'package', 'singletonServices', mockSingletonServices)
-  pikkuState(null, 'package', 'factories', {
-    createWireServices: async () => ({}),
-  })
+  pikkuState(null, 'package', 'factories', { createWireServices: async () => ({}) })
 })
 
 test('GET /todos returns todo list', async () => {
-  // Register route metadata and function
-  pikkuState(null, 'http', 'meta')['get'] =
-    pikkuState(null, 'http', 'meta')['get'] || {}
+  pikkuState(null, 'http', 'meta')['get'] = pikkuState(null, 'http', 'meta')['get'] || {}
   pikkuState(null, 'http', 'meta')['get']['/todos'] = {
-    pikkuFuncId: 'listTodos',
-    method: 'get',
-    route: '/todos',
+    pikkuFuncId: 'listTodos', method: 'get', route: '/todos',
   }
   addFunction('listTodos', listTodos)
   wireHTTP({ method: 'get', route: '/todos', func: listTodos })
 
-  const request = new Request('http://localhost/todos')
-  const response = await fetch(request)
+  const response = await fetch(new Request('http://localhost/todos'))
   const data = await response.json()
-
   assert.equal(response.status, 200)
   assert.ok(Array.isArray(data.todos))
 })
@@ -410,7 +230,6 @@ describe('LocalVariablesService', () => {
   test('should get and set variables', () => {
     const service = new LocalVariablesService({ API_KEY: 'test-key' })
     assert.equal(service.get('API_KEY'), 'test-key')
-
     service.set('NEW_KEY', 'value')
     assert.equal(service.get('NEW_KEY'), 'value')
   })
@@ -419,7 +238,7 @@ describe('LocalVariablesService', () => {
 
 ## Testing with Real Services (Verifier Pattern)
 
-For integration testing with a running server:
+For integration testing with a running server, build real services via `pikkuServices`/`pikkuWireServices` and bootstrap a server:
 
 ```typescript
 // services.ts — real service setup for tests
@@ -431,7 +250,6 @@ export const createSingletonServices = pikkuServices(async (config) => {
   const secrets = new LocalSecretService(variables)
   return { config, variables, secrets, logger: new ConsoleLogger() }
 })
-
 export const createWireServices = pikkuWireServices(async () => ({}))
 ```
 
@@ -442,51 +260,22 @@ import { createSingletonServices, createWireServices } from './services.js'
 
 const config = {}
 const singletonServices = await createSingletonServices(config)
-const server = new PikkuFastifyServer(
-  config,
-  singletonServices,
-  createWireServices
-)
+const server = new PikkuFastifyServer(config, singletonServices, createWireServices)
 await server.init()
 await server.start()
 ```
 
 ## Common Patterns
 
-### Mock Logger
-
-```typescript
-const mockLogger = {
-  info: () => {},
-  warn: () => {},
-  error: () => {},
-  debug: () => {},
-}
-```
-
-### Mock Singleton Services
-
-```typescript
-const mockSingletonServices = {
-  logger: mockLogger,
-  todoStore: new InMemoryTodoStore(),
-  // Add whatever services your functions need
-} as any
-```
-
-### Reset State Between Tests
-
-Always reset pikku state in `beforeEach` to isolate tests:
+- **Mock logger / singleton services** — see the reusable bag defined under "Test Runner Setup".
+- **Reset state between tests** — always `resetPikkuState()` in `beforeEach` to isolate tests.
 
 ```typescript
 import { resetPikkuState } from '@pikku/core'
-
-beforeEach(() => {
-  resetPikkuState()
-})
+beforeEach(() => resetPikkuState())
 ```
 
-### Async Error Assertions
+- **Async error assertions**:
 
 ```typescript
 await assert.rejects(
@@ -503,9 +292,7 @@ export const createTodo = pikkuSessionlessFunc({
   description: 'Create a todo',
   input: z.object({ title: z.string().min(1) }),
   output: z.object({ id: z.string(), title: z.string() }),
-  func: async ({ todoStore }, { title }) => {
-    return todoStore.add(title)
-  },
+  func: async ({ todoStore }, { title }) => todoStore.add(title),
 })
 
 // functions/todos.test.ts
@@ -514,123 +301,28 @@ import assert from 'node:assert'
 
 class MockTodoStore {
   private todos: any[] = []
-
   async add(title: string) {
     const todo = { id: String(this.todos.length + 1), title, completed: false }
     this.todos.push(todo)
     return todo
   }
-
-  async list() {
-    return this.todos
-  }
+  async list() { return this.todos }
 }
 
 describe('createTodo', () => {
   let todoStore: MockTodoStore
-
-  beforeEach(() => {
-    todoStore = new MockTodoStore()
-  })
+  beforeEach(() => { todoStore = new MockTodoStore() })
 
   test('creates a todo with the given title', async () => {
-    const result = await createTodo.func({ todoStore } as any, {
-      title: 'Buy milk',
-    })
-
+    const result = await createTodo.func({ todoStore } as any, { title: 'Buy milk' })
     assert.equal(result.id, '1')
     assert.equal(result.title, 'Buy milk')
   })
 
   test('increments IDs', async () => {
     await createTodo.func({ todoStore } as any, { title: 'First' })
-    const second = await createTodo.func({ todoStore } as any, {
-      title: 'Second',
-    })
-
+    const second = await createTodo.func({ todoStore } as any, { title: 'Second' })
     assert.equal(second.id, '2')
   })
-})
-```
-
-## Anti-Patterns
-
-### Inline data in feature files
-
-**Wrong** — raw values and JSON in `.feature` files make scenarios brittle and unreadable:
-
-```gherkin
-When I call 'kanban:createCard' with {"title": "My card", "columnId": "backlog"}
-And I call 'kanban:getCard' with {"title": "My card"}
-Then the result title is "My card"
-```
-
-**Right** — named references resolved by step definitions:
-
-```gherkin
-When 'yasser' creates a card for 'writing a blog post'
-And 'yasser' gets the card 'writing a blog post'
-Then the result is the newly created card 'writing a blog post'
-```
-
-### Feature-coupled step definitions
-
-Steps tied to one feature can't be reused and cause duplication. Organise by **domain concept**, not by feature:
-
-```
-Wrong:                          Right:
-steps/
-  edit_work_experience.ts  →    steps/
-  edit_languages.ts        →      auth.steps.ts
-  edit_education.ts        →      profile.steps.ts
-                                  card.steps.ts
-```
-
-Name step files after the domain they cover. A login step belongs in `auth.steps.ts` regardless of which feature needs it.
-
-### Conjunction steps
-
-Don't combine multiple actions into a single step — it makes reuse impossible:
-
-```gherkin
-# Wrong — two actions in one step
-Given 'yasser' is logged in and has created a card
-```
-
-```gherkin
-# Right — atomic steps, composable via And
-Given 'yasser' logs in
-And 'yasser' creates a card for 'writing a blog post'
-```
-
-Use `And` / `But` for a reason: each step should do exactly one thing.
-
-### Asserting in When steps
-
-`When` steps perform actions; `Then` steps assert outcomes. Mixing them hides intent:
-
-```gherkin
-# Wrong
-When 'yasser' creates a card and the title is 'writing a blog post'
-
-# Right
-When 'yasser' creates a card for 'writing a blog post'
-Then the call succeeds
-```
-
-### Hard-coding persona data in step definitions
-
-Credentials and test inputs embedded in step code can't be reused across scenarios and break when data changes:
-
-```ts
-// Wrong
-Given('{string} logs in', async function (name: string) {
-  await this.call(name, 'auth:login', { email: 'yasser@example.com', password: 'hunter2' })
-})
-
-// Right — look up from PersonaData
-Given('{string} logs in', async function (name: string) {
-  await this.call(name, 'auth:login', logins.get(name))
-  this.setSession(name, (this.lastResult as { token: string }))
 })
 ```

--- a/packages/cli/skills/pikku-testing/references/cucumber-bdd-testing.md
+++ b/packages/cli/skills/pikku-testing/references/cucumber-bdd-testing.md
@@ -1,0 +1,176 @@
+# Cucumber / BDD Testing with `@pikku/cucumber`
+
+## Personas and Named Data — Never Inline JSON
+
+**Never put JSON, inline tables, or raw values inside `.feature` files.** Feature files are for human-readable scenarios; all test data belongs in typed maps that step definitions look up by name.
+
+`@pikku/cucumber` exports `PersonaData<T>` — a typed map that throws a clear error when a name is missing.
+
+### Personas
+
+A **persona** is a named user: login credentials plus the session held after authenticating. Define all personas in one file:
+
+```ts
+// tests/tests/support/personas.ts
+import { PersonaData } from '@pikku/cucumber'
+
+export const logins = new PersonaData({
+  yasser: { email: 'yasser@example.com', password: 'hunter2' },
+  guest:  { email: 'guest@example.com',  password: 'guest123' },
+})
+```
+
+A persona step logs in and stores the session in the world so every subsequent call by that persona carries it automatically:
+
+```ts
+// tests/tests/support/steps/auth.steps.ts
+import { Given } from '@cucumber/cucumber'
+import { logins } from '../personas.js'
+
+Given('{string} logs in', async function (name: string) {
+  await this.call(name, 'auth:login', logins.get(name))
+  const { token } = this.lastResult as { token: string }
+  this.setSession(name, { token })
+})
+```
+
+### Named Domain Data
+
+Use a separate `PersonaData` map per domain concept. Name entries after real-world meaning, not technical fields:
+
+```ts
+// tests/tests/support/data/cards.ts
+import { PersonaData } from '@pikku/cucumber'
+
+export const cards = new PersonaData({
+  'writing a blog post': { title: 'Writing a blog post', columnId: 'backlog' },
+  'fix the login bug':   { title: 'Fix the login bug',   columnId: 'in-progress' },
+})
+```
+
+Steps resolve the name and make the call — the feature file never sees raw data:
+
+```ts
+// tests/tests/support/steps/card.steps.ts
+import { When, Then } from '@cucumber/cucumber'
+import assert from 'node:assert/strict'
+import { cards } from '../data/cards.js'
+
+When('{string} creates a card for {string}', async function (persona: string, cardName: string) {
+  await this.call(persona, 'kanban:createCard', cards.get(cardName))
+})
+
+When('{string} gets the card {string}', async function (persona: string, cardName: string) {
+  const { title } = cards.get(cardName)
+  await this.call(persona, 'kanban:getCard', { title })
+})
+
+// "the newly created card" — checks the live result against the data map entry
+// AND any server-assigned fields (id, createdAt) are present
+Then('the result is the newly created card {string}', function (cardName: string) {
+  const expected = cards.get(cardName)
+  const result = this.lastResult as typeof expected & { id: string; createdAt: string }
+  assert.equal(result.title, expected.title)
+  assert.equal(result.columnId, expected.columnId)
+  assert.ok(result.id, 'expected server-assigned id')
+  assert.ok(result.createdAt, 'expected server-assigned createdAt')
+})
+```
+
+The feature file reads naturally:
+
+```gherkin
+Feature: Card management
+
+  Scenario: Create and retrieve a card
+    Given 'yasser' logs in
+    When 'yasser' creates a card for 'writing a blog post'
+    And 'yasser' gets the card 'writing a blog post'
+    Then the result is the newly created card 'writing a blog post'
+```
+
+### File layout
+
+```
+tests/tests/support/
+  personas.ts          ← logins PersonaData (one per project)
+  data/
+    cards.ts           ← cards PersonaData
+    users.ts           ← users PersonaData
+  steps/
+    auth.steps.ts      ← login / logout steps
+    card.steps.ts      ← card CRUD steps
+```
+
+Keep one `PersonaData` instance per domain concept. Steps import only what they need — no cross-domain coupling.
+
+## Anti-Patterns
+
+### Inline data in feature files
+
+Raw values/JSON in `.feature` files make scenarios brittle and unreadable. Use named references resolved by step definitions instead.
+
+```gherkin
+# Wrong
+When I call 'kanban:createCard' with {"title": "My card", "columnId": "backlog"}
+Then the result title is "My card"
+
+# Right
+When 'yasser' creates a card for 'writing a blog post'
+Then the result is the newly created card 'writing a blog post'
+```
+
+### Feature-coupled step definitions
+
+Steps tied to one feature can't be reused and cause duplication. Organise by **domain concept**, not by feature. Name step files after the domain they cover — a login step belongs in `auth.steps.ts` regardless of which feature needs it.
+
+```
+Wrong:                          Right:
+steps/                          steps/
+  edit_work_experience.ts         auth.steps.ts
+  edit_languages.ts               profile.steps.ts
+  edit_education.ts               card.steps.ts
+```
+
+### Conjunction steps
+
+Don't combine multiple actions into a single step — it makes reuse impossible. Use `And` / `But`: each step does exactly one thing.
+
+```gherkin
+# Wrong — two actions in one step
+Given 'yasser' is logged in and has created a card
+
+# Right — atomic, composable
+Given 'yasser' logs in
+And 'yasser' creates a card for 'writing a blog post'
+```
+
+### Asserting in When steps
+
+`When` steps perform actions; `Then` steps assert outcomes. Mixing them hides intent.
+
+```gherkin
+# Wrong
+When 'yasser' creates a card and the title is 'writing a blog post'
+
+# Right
+When 'yasser' creates a card for 'writing a blog post'
+Then the call succeeds
+```
+
+### Hard-coding persona data in step definitions
+
+Credentials/test inputs embedded in step code can't be reused and break when data changes — look them up from `PersonaData`.
+
+```ts
+// Wrong
+Given('{string} logs in', async function (name: string) {
+  await this.call(name, 'auth:login', { email: 'yasser@example.com', password: 'hunter2' })
+})
+
+// Right
+Given('{string} logs in', async function (name: string) {
+  await this.call(name, 'auth:login', logins.get(name))
+  this.setSession(name, (this.lastResult as { token: string }))
+})
+```

--- a/packages/cli/skills/pikku-workflow/SKILL.md
+++ b/packages/cli/skills/pikku-workflow/SKILL.md
@@ -12,247 +12,129 @@ installGroups: [core]
 
 Use this skill as an execution checklist, not reference material.
 
-1. Discover before editing. Prefer OpenCode tools such as `pikku-meta` when available; otherwise run the relevant `pikku meta ... --json` command and inspect only the focused output you need.
-2. Identify the source files that own the behavior. Do not start by reading generated output, `.pikku`, `node_modules`, vendored packages, or broad build artifacts.
-3. Make the smallest source change that satisfies the task. Keep generated files generated, and avoid hand-editing SDKs, schema output, or typegen.
-4. Validate with the narrowest relevant command first, then run `pikku-verify` or `pikku all` when functions, wirings, schemas, or generated clients may have changed.
-5. If validation fails, fix the source cause and rerun validation. Do not paper over generated errors by editing generated files.
-
-Build durable, multi-step workflows with automatic retry, sleep, suspend/resume, and parallel execution. Steps are cached for replay safety.
-
-## Before You Start
-
-```bash
-pikku info functions --verbose   # See existing functions that can be workflow steps
-pikku info tags --verbose        # Understand project organization
-```
+1. Capture baseline. Run `pikku-verify` (or `pikku all`) BEFORE writing code; note existing errors — only NEW errors are yours to fix.
+2. Discover before editing. Prefer `pikku-meta` / `pikku info functions --verbose` and `pikku info tags --verbose` to see functions usable as steps and project organization; inspect only the focused output you need.
+3. Identify the source files that own the behavior. Do not start from generated output, `.pikku`, `node_modules`, vendored packages, or build artifacts.
+4. Make the smallest source change. Keep generated files generated — never hand-edit SDKs, schema output, or typegen to paper over errors; fix the source cause.
+5. Validate with the narrowest relevant command, then re-run `pikku-verify`. If only files you did not touch still error, those are pre-existing — leave them unless asked.
+6. Call `pikku-workflow-view` only when `pikku-verify` fully passes (codegen AND type check both green) — never after a partial pass.
 
 See `pikku-concepts` for the core mental model.
 
-## API Reference
+Build durable, multi-step workflows with automatic retry, sleep, suspend/resume, and parallel execution. Steps are cached for replay safety.
 
-### `pikkuWorkflowFunc<TInput, TOutput>(fn)`
+## Choosing the right factory
+
+| Factory | When to use | Step-graph view? |
+|---|---|---|
+| `pikkuWorkflowFunc` | **Default for all new workflows.** Sequential + conditional logic; DSL mode (serialisable, replay-safe). ALL `const`/`let` declarations must be at the top level of the function body (not inside blocks). | ✅ Yes |
+| `pikkuWorkflowGraph` | DAG / fan-out with nodes and typed refs between them. | ✅ Yes |
+| `pikkuWorkflowComplexFunc` | Escape hatch only — arbitrary TypeScript, no top-level restriction (e.g. dynamic inline functions the DSL extractor cannot handle). | ❌ No (loses step-graph view) |
+
+**Default to `pikkuWorkflowFunc`.** Use `pikkuWorkflowGraph` ONLY with explicit user approval AND only for a genuine cyclic dependency or Node.js-only import DSL cannot express. Use `pikkuWorkflowComplexFunc` ONLY with explicit user approval — a last-resort escape hatch. Never switch to either just to dodge a PKU641 error; restructure the code instead.
+
+### PKU641 — DSL static analysis error
+
+`pikkuWorkflowFunc` statically analyzes the body: **every `const`/`let` must be top-level, not inside any block (`if`, `for`, `while`, …).** Assignments inside blocks are fine — only declarations trigger it.
 
 ```typescript
-import { pikkuWorkflowFunc } from '#pikku'
+// ❌ PKU641 — declaration inside block
+if (priority === 'high') {
+  const bugCard = await workflow.do(...)
+}
 
-const myWorkflow = pikkuWorkflowFunc<InputType, OutputType>(
-  async (services, data, { workflow }) => {
-    // workflow.do(), workflow.sleep(), workflow.suspend()
-    return result
-  }
-)
+// ✅ hoist the declaration, assign inside the block
+let bugCard: Awaited<ReturnType<typeof workflow.do>>
+if (priority === 'high') {
+  bugCard = await workflow.do(...)
+}
 ```
 
-### Workflow Step Types
+## Import path
 
 ```typescript
-// RPC step — run a named Pikku function as a step
-// workflow.do(stepName, funcName, data, options?)
-const result = await workflow.do(
-  'Create profile',
-  'createUserProfile',
-  {
-    email: data.email,
+// CORRECT — workflow factories come from the generated types file
+import { pikkuWorkflowFunc, pikkuWorkflowGraph, pikkuWorkflowComplexFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+// WRONG — '#pikku' does not re-export them (TS2305)
+import { pikkuWorkflowFunc } from '#pikku'
+```
+
+## Defining a workflow
+
+Declare input/output as Zod schemas (like any function) — never TypeScript generic params (no `pikkuWorkflowFunc<In, Out>(...)`; that skips runtime validation). `data` is typed from the input schema.
+
+```typescript
+import { z } from 'zod'
+import { pikkuWorkflowFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+const ProcessOrderInput = z.object({ orderId: z.string(), amount: z.number() })
+const ProcessOrderOutput = z.object({ status: z.string(), discount: z.number().optional() })
+
+export const processOrder = pikkuWorkflowFunc({
+  description: 'Process an order through payment and fulfillment',
+  tags: ['orders'],
+  input: ProcessOrderInput,
+  output: ProcessOrderOutput,
+  func: async (services, data, { workflow }) => {
+    // Declare ALL variables at top level — even those only assigned in branches (PKU641)
+    let discount: number | undefined
+    let status: string
+
+    if (data.amount > 1000) {
+      const d = await workflow.do('Apply bulk discount', 'calcDiscount', { amount: data.amount })
+      discount = d.discountPercent
+    }
+
+    const payment = await workflow.do('Charge', 'chargePayment', {
+      orderId: data.orderId,
+      amount: discount ? data.amount * (1 - discount / 100) : data.amount,
+    })
+
+    if (payment.success) {
+      await workflow.do('Fulfill', 'fulfillOrder', { orderId: data.orderId })
+      status = 'fulfilled'
+    } else {
+      status = 'payment-failed'
+    }
+
+    return { status, discount }
   },
-  { retries: 3, retryDelay: '1s' }
-)
+})
+```
+
+### Workflow step types
+
+```typescript
+// RPC step — run a registered Pikku function as a step (opts: retries, retryDelay, description)
+const result = await workflow.do('Step name', 'rpcFunctionName', { ...data }, { retries: 3, retryDelay: '1s' })
 
 // Inline closure step — immediate execution, cached for replay
-// workflow.do(stepName, asyncFn)
-const result = await workflow.do('Generate message', async () => {
-  return `Welcome, ${data.email}!`
-})
-```
+const msg = await workflow.do('Generate', async () => `Welcome, ${data.email}!`)
 
-### Step execution: inline vs queue dispatch
-
-Whether a step runs **inline** (same process/session, no queue round-trip) or is **dispatched to the queue** is decided **purely by the step's function** — there is no workflow-level or per-call `inline` flag.
-
-- **Steps default to inline.** Most steps don't need their own worker; running them inline avoids a queue round-trip per step, so a normally-started workflow executes its whole chain in one orchestrator pass.
-- **`inline: false` opts a function out.** Set `inline: false` on the **function config** (`pikkuFunc` / `pikkuSessionlessFunc`, same level as `auth`/`expose`) to dispatch that step via the queue — for expensive/long-running steps that deserve their own worker, retry isolation, and concurrency limits. It is **not** a `workflow.do(...)` option (those are only `retries`/`retryDelay`/`description`).
-
-The rule (`dispatchStep`):
-
-| Function `inline` | `queueService` present? | Result |
-|---|---|---|
-| default / `true` | any | **inline** |
-| `false` | yes | **queued** (own worker) |
-| `false` | no | **inline + a `logger.warn`** (misconfiguration: can't dispatch) |
-
-```typescript
-// Push this one expensive step onto the queue; every other step stays inline:
-export const renderLargeReport = pikkuSessionlessFunc({
-  inline: false, // dispatch via queue instead of running inline
-  input: ReportInput,
-  output: ReportOutput,
-  func: async (services, data) => { /* ... */ },
-})
-```
-
-- **Run-level `inline` is separate** and only controls whether the *whole run* executes in-process without queue infrastructure (it's set automatically when there is no `queueService`, or via `startWorkflow(..., { inline: true })`). It governs sleep handling, **not** per-step dispatch — step dispatch is always per-function.
-- `inline: false` requires a `queueService`; without one the step still runs (so the workflow progresses) but emits a `logger.warn` so the misconfiguration is visible.
-
-// Sleep — durable pause (duration: '5min', '1h', '30s', '1d')
+// Sleep — durable pause (duration: '30s', '5min', '1h', '1d')
 await workflow.sleep('Wait 5 minutes', '5min')
 
-// Suspend — pause until externally resumed
+// Suspend — pause until externally resumed (e.g. awaiting approval), then continue
 await workflow.suspend('Awaiting approval')
 ```
 
-### Choosing the right wrapper
-
-| Wrapper | When to use |
-|---|---|
-| `pikkuWorkflowFunc` | **Default.** Use for all new workflows. DSL mode — serialisable, replay-safe. |
-| `pikkuWorkflowComplexFunc` | **Only with explicit user approval.** For workflows with patterns the DSL extractor cannot handle (e.g. dynamic inline functions). Not a general escape hatch — restructure first. |
-| `pikkuWorkflowGraph` | **Only with explicit user approval.** For genuine DAGs where there is a cyclic dependency between nodes or a Node.js-only import DSL cannot express. |
-
-**Conditional results** — the correct DSL pattern when a step only runs under some condition:
-
-```typescript
-// ✅ Declare at top level, assign inside block
-let result: { id: string } | null = null
-if (input.createFoo) {
-  result = await workflow.do('Create foo', 'createFoo', { ... })
-}
-// Use result?.id downstream
-
-// ❌ Do NOT declare const inside a block — DSL forbids block-scoped declarations
-// ❌ Do NOT switch to pikkuWorkflowComplexFunc to avoid the restriction
-```
-
-### `pikkuWorkflowGraph(config)` — DAG Workflows
-
-```typescript
-import { pikkuWorkflowGraph } from '#pikku'
-
-pikkuWorkflowGraph({
-  description: 'Onboard a new user',
-  nodes: {
-    createProfile: 'createUserProfile', // nodeName → Pikku function name
-    sendWelcome: 'sendEmail',
-  },
-  config: {
-    createProfile: {
-      next: ['sendWelcome'], // Nodes to run after this one (parallel)
-    },
-    sendWelcome: {
-      input: (ref) => ({
-        // Transform input using refs to prior node outputs
-        to: ref('createProfile', 'email'),
-        subject: 'Welcome!',
-      }),
-    },
-  },
-})
-```
-
-### HTTP Workflow Wiring
-
-```typescript
-// Start a workflow
-wireHTTP({
-  method: 'post',
-  route: '/workflow/onboard',
-  func: workflowStart('workflowName'),
-})
-
-// Execute workflow steps (called by orchestrator)
-wireHTTP({
-  method: 'post',
-  route: '/workflow/onboard/run',
-  func: workflow('workflowName'),
-})
-
-// Check workflow status
-wireHTTP({
-  method: 'get',
-  route: '/workflow/status/:runId',
-  func: workflowStatus('workflowName'),
-})
-```
-
-## Usage Patterns
-
-### Sequential Workflow
-
-```typescript
-const onboardUser = pikkuWorkflowFunc<
-  { email: string; userId: string },
-  { success: boolean }
->(async ({}, data, { workflow }) => {
-  const user = await workflow.do('Create profile', 'createUserProfile', {
-    email: data.email,
-    userId: data.userId,
-  })
-
-  const message = await workflow.do(
-    'Generate welcome',
-    async () => `Welcome, ${data.email}!`
-  )
-
-  await workflow.sleep('Wait 5 minutes', '5min')
-
-  await workflow.do('Send email', 'sendEmail', {
-    to: data.email,
-    subject: 'Welcome!',
-    body: message,
-  })
-
-  return { success: true }
-})
-```
-
-### Parallel Execution (Fan-out)
+### Parallel fan-out
 
 ```typescript
 const users = await Promise.all(
-  data.userIds.map(
-    async (userId) =>
-      await workflow.do(`Get user ${userId}`, 'userGet', { userId })
-  )
+  data.userIds.map((userId) => workflow.do(`Fetch user ${userId}`, 'getUser', { userId }))
 )
 ```
 
-### Retry with Backoff
+### Graph workflow (DAG)
+
+`pikkuWorkflowGraph` derives types from the RPC map — no explicit `input`/`output`. Nodes map `nodeName → Pikku function name`; `config.<node>.next` lists nodes to run after it (in parallel); `config.<node>.input: (ref) => ...` transforms input using refs to prior node outputs.
 
 ```typescript
-const payment = await workflow.do(
-  'Process payment',
-  'processPayment',
-  { amount: 100 },
-  { retries: 3, retryDelay: '1s' }
-)
-```
+import { pikkuWorkflowGraph } from '#pikku/workflow/pikku-workflow-types.gen.js'
 
-### Conditional Branching
-
-```typescript
-if (user.plan === 'pro') {
-  await workflow.do('Apply discount', 'applyDiscount', { userId })
-}
-```
-
-### Suspend and Resume
-
-```typescript
-const approval = pikkuWorkflowFunc<
-  { requestId: string },
-  { approved: boolean }
->(async ({}, data, { workflow }) => {
-  await workflow.do('Submit request', 'submitRequest', data)
-  await workflow.suspend('Awaiting approval')
-  // Workflow pauses here until externally resumed
-  const result = await workflow.do('Check result', 'getApprovalResult', data)
-  return { approved: result.approved }
-})
-```
-
-### Graph Workflow (DAG)
-
-```typescript
-const userOnboarding = pikkuWorkflowGraph({
+export const userOnboarding = pikkuWorkflowGraph({
   description: 'Onboard a new user',
   nodes: {
     createProfile: 'createUserProfile',
@@ -260,75 +142,27 @@ const userOnboarding = pikkuWorkflowGraph({
     setupDefaults: 'createDefaultTodos',
   },
   config: {
-    createProfile: {
-      next: ['sendWelcome', 'setupDefaults'], // Run in parallel
-    },
+    createProfile: { next: ['sendWelcome', 'setupDefaults'] }, // run in parallel
     sendWelcome: {
-      input: (ref) => ({
-        to: ref('createProfile', 'email'),
-        subject: 'Welcome!',
-      }),
+      input: (ref) => ({ to: ref('createProfile', 'email'), subject: 'Welcome!' }),
     },
   },
 })
 ```
 
-## Complete Example
+## File conventions
 
-```typescript
-// functions/onboarding.workflow.ts
-export const onboardUser = pikkuWorkflowFunc<
-  { email: string; userId: string; plan: string },
-  { success: boolean }
->(async ({}, data, { workflow }) => {
-  // Step 1: Create user profile
-  const user = await workflow.do('Create profile', 'createUserProfile', {
-    email: data.email,
-    userId: data.userId,
-  })
+- Place workflows in `packages/functions/src/wirings/*.workflow.ts`; export the variable so the inspector discovers it (no manual registration).
+- HTTP start/run/status routes are auto-scaffolded via `scaffold.workflow` in `pikku.config.json`.
 
-  // Step 2: Set up defaults based on plan
-  if (data.plan === 'pro') {
-    await workflow.do('Apply pro features', 'enableProFeatures', {
-      userId: data.userId,
-    })
-  }
+## Step dispatch & HTTP wiring
 
-  // Step 3: Send welcome email
-  await workflow.do('Send welcome', 'sendEmail', {
-    to: data.email,
-    subject: 'Welcome!',
-    body: `Welcome to our platform, ${user.name}!`,
-  })
+For per-step inline-vs-queue dispatch (`inline: false` and the `dispatchStep` rules), the manual `workflowStart`/`workflow`/`workflowStatus` HTTP wirings, and a suspend/resume example, read `references/workflow-reference.md`.
 
-  // Step 4: Wait then send follow-up
-  await workflow.sleep('Wait 1 day', '1d')
+## After writing
 
-  await workflow.do('Send follow-up', 'sendEmail', {
-    to: data.email,
-    subject: 'Getting started',
-    body: 'Here are some tips to get started...',
-  })
-
-  return { success: true }
-})
-
-// wirings/workflow.wiring.ts
-wireHTTP({
-  method: 'post',
-  route: '/onboard',
-  func: workflowStart('onboardUser'),
-})
-
-wireHTTP({
-  method: 'post',
-  route: '/onboard/run',
-  func: workflow('onboardUser'),
-})
-
-wireHTTP({
-  method: 'get',
-  route: '/onboard/status/:runId',
-  func: workflowStatus('onboardUser'),
-})
-```
+1. `pikku-verify` (codegen + tsc).
+2. PKU641 → a `const`/`let` is inside a block; hoist it to the top of the function body.
+3. Import errors → use `#pikku/workflow/pikku-workflow-types.gen.js`, not `#pikku`.
+4. Type errors only in files you did not touch → pre-existing template errors; safe to ignore.
+5. Both green → call `pikku-workflow-view` with the workflow name.

--- a/packages/cli/skills/pikku-workflow/references/workflow-reference.md
+++ b/packages/cli/skills/pikku-workflow/references/workflow-reference.md
@@ -1,0 +1,63 @@
+# Pikku Workflow Reference
+
+## Step execution: inline vs queue dispatch
+
+Whether a step runs **inline** (same process/session, no queue round-trip) or is **dispatched to the queue** is decided **purely by the step's function** — there is no workflow-level or per-call `inline` flag. `workflow.do(...)` options are only `retries`/`retryDelay`/`description`.
+
+- **Steps default to inline.** Most steps don't need their own worker; running them inline avoids a queue round-trip per step, so a normally-started workflow executes its whole chain in one orchestrator pass.
+- **`inline: false` opts a function out.** Set `inline: false` on the **function config** (`pikkuFunc` / `pikkuSessionlessFunc`, same level as `auth`/`expose`) to dispatch that step via the queue — for expensive/long-running steps that deserve their own worker, retry isolation, and concurrency limits.
+- **Run-level `inline` is separate** and only controls whether the *whole run* executes in-process without queue infrastructure (set automatically when there is no `queueService`, or via `startWorkflow(..., { inline: true })`). It governs sleep handling, not per-step dispatch.
+
+The rule (`dispatchStep`):
+
+| Function `inline` | `queueService` present? | Result |
+|---|---|---|
+| default / `true` | any | **inline** |
+| `false` | yes | **queued** (own worker) |
+| `false` | no | **inline + a `logger.warn`** (misconfiguration: can't dispatch) |
+
+```typescript
+// Push this one expensive step onto the queue; every other step stays inline:
+export const renderLargeReport = pikkuSessionlessFunc({
+  inline: false, // dispatch via queue instead of running inline
+  input: ReportInput,
+  output: ReportOutput,
+  func: async (services, data) => { /* ... */ },
+})
+```
+
+`inline: false` requires a `queueService`; without one the step still runs (so the workflow progresses) but emits a `logger.warn` so the misconfiguration is visible.
+
+## HTTP workflow wiring (manual)
+
+Usually auto-scaffolded via `scaffold.workflow`. To wire by hand:
+
+```typescript
+// Start a workflow
+wireHTTP({ method: 'post', route: '/onboard', func: workflowStart('onboardUser') })
+
+// Execute workflow steps (called by the orchestrator)
+wireHTTP({ method: 'post', route: '/onboard/run', func: workflow('onboardUser') })
+
+// Check workflow status
+wireHTTP({ method: 'get', route: '/onboard/status/:runId', func: workflowStatus('onboardUser') })
+```
+
+## Suspend / resume example
+
+```typescript
+import { z } from 'zod'
+import { pikkuWorkflowFunc } from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+export const approval = pikkuWorkflowFunc({
+  description: 'Submit a request and wait for approval',
+  input: z.object({ requestId: z.string() }),
+  output: z.object({ approved: z.boolean() }),
+  func: async (services, data, { workflow }) => {
+    await workflow.do('Submit request', 'submitRequest', data)
+    await workflow.suspend('Awaiting approval') // pauses here until externally resumed
+    const result = await workflow.do('Check result', 'getApprovalResult', data)
+    return { approved: result.approved }
+  },
+})
+```

--- a/packages/cli/src/deploy/analyzer/analyzer.ts
+++ b/packages/cli/src/deploy/analyzer/analyzer.ts
@@ -520,11 +520,11 @@ function buildWorkflows(
 
       const stepUnitName = toSafeKebab(node.rpcName)
       // Step dispatch is decided per-function: a step runs inline unless its
-      // function opts out with `inline: false` (then it dispatches via queue).
+      // function is marked `workflowQueued: true` (then it dispatches via queue).
       const stepFuncId = rpcMeta[node.rpcName] ?? node.rpcName
       const stepFuncMeta =
         functionsMeta[stepFuncId] ?? functionsMeta[node.rpcName]
-      const isInline = stepFuncMeta?.inline !== false
+      const isInline = stepFuncMeta?.workflowQueued !== true
 
       steps.push({
         name: node.stepName ?? nodeId,

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -66,7 +66,6 @@ import {
   FabricAddonVerify,
   renderAddonVerify,
 } from './functions/addon-verify.function.js'
-import { removed } from './lib/output.js'
 
 export const fabricCommands = defineCLICommands({
   validate: pikkuCLICommand({

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -147,6 +147,7 @@ export const fabricCommands = defineCLICommands({
       publish: pikkuCLICommand({
         parameters: '[dir]',
         func: FabricPublish,
+        render: renderAddonVerify,
         description:
           'Publish the addon in this directory to the community registry (pack + upload)',
         options: {

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -62,7 +62,11 @@ import {
 import { FabricSmoke, renderSmoke } from './functions/smoke.function.js'
 import { FabricPublish } from './functions/publish.function.js'
 import { FabricAdd } from './functions/add.function.js'
-import { FabricAddonVerify } from './functions/addon-verify.function.js'
+import {
+  FabricAddonVerify,
+  renderAddonVerify,
+} from './functions/addon-verify.function.js'
+import { removed } from './lib/output.js'
 
 export const fabricCommands = defineCLICommands({
   validate: pikkuCLICommand({
@@ -139,26 +143,7 @@ export const fabricCommands = defineCLICommands({
         func: FabricAddonVerify,
         description:
           'Verify an addon directory is correctly built and ready to publish',
-        render: (result) => {
-          const tick = '✓'
-          const cross = '✗'
-          console.log(
-            `\nAddon: ${result.packageName ?? '(unknown)'}@${result.version ?? '?'}`
-          )
-          console.log(`Dir:   ${result.addonDir}\n`)
-          for (const c of result.checks) {
-            const icon = c.ok ? tick : cross
-            const detail = c.detail ? `  ${c.detail}` : ''
-            console.log(`  ${icon} ${c.name}${detail}`)
-          }
-          console.log('')
-          if (result.ok) {
-            console.log('  Ready to publish.')
-          } else {
-            console.log('  Fix the errors above before publishing.')
-            process.exitCode = 1
-          }
-        },
+        render: renderAddonVerify,
       }),
       publish: pikkuCLICommand({
         parameters: '[dir]',

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -62,6 +62,7 @@ import {
 import { FabricSmoke, renderSmoke } from './functions/smoke.function.js'
 import { FabricPublish } from './functions/publish.function.js'
 import { FabricAdd } from './functions/add.function.js'
+import { FabricAddonVerify } from './functions/addon-verify.function.js'
 
 export const fabricCommands = defineCLICommands({
   validate: pikkuCLICommand({
@@ -133,6 +134,32 @@ export const fabricCommands = defineCLICommands({
   addon: {
     description: 'Publish and install Fabric community-registry addons',
     subcommands: {
+      verify: pikkuCLICommand({
+        parameters: '[dir]',
+        func: FabricAddonVerify,
+        description:
+          'Verify an addon directory is correctly built and ready to publish',
+        render: (result) => {
+          const tick = '✓'
+          const cross = '✗'
+          console.log(
+            `\nAddon: ${result.packageName ?? '(unknown)'}@${result.version ?? '?'}`
+          )
+          console.log(`Dir:   ${result.addonDir}\n`)
+          for (const c of result.checks) {
+            const icon = c.ok ? tick : cross
+            const detail = c.detail ? `  ${c.detail}` : ''
+            console.log(`  ${icon} ${c.name}${detail}`)
+          }
+          console.log('')
+          if (result.ok) {
+            console.log('  Ready to publish.')
+          } else {
+            console.log('  Fix the errors above before publishing.')
+            process.exitCode = 1
+          }
+        },
+      }),
       publish: pikkuCLICommand({
         parameters: '[dir]',
         func: FabricPublish,

--- a/packages/cli/src/fabric/functions/addon-verify.function.ts
+++ b/packages/cli/src/fabric/functions/addon-verify.function.ts
@@ -175,7 +175,10 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
   },
 })
 
-export function renderAddonVerify(result: FabricAddonVerifyOutput): void {
+export function renderAddonVerify(
+  _s: unknown,
+  result: FabricAddonVerifyOutput
+): void {
   console.log(
     `\n${dim('Addon:')} ${result.packageName ?? '(unknown)'}@${result.version ?? '?'}`
   )

--- a/packages/cli/src/fabric/functions/addon-verify.function.ts
+++ b/packages/cli/src/fabric/functions/addon-verify.function.ts
@@ -60,7 +60,6 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
       detail,
     })
 
-    // 1. package.json
     const pkgResult = await readJsonSafe<{
       name?: string
       version?: string
@@ -96,7 +95,6 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
       checks.push(pass('files field', '"dist" included'))
     }
 
-    // 2. pikku.config.json with addon: true
     const pikkuConfigResult = await readJsonSafe<{ addon?: boolean }>(
       join(addonDir, 'pikku.config.json')
     )
@@ -113,7 +111,6 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
       checks.push(pass('pikku.config.json', 'addon: true'))
     }
 
-    // 3. dist/ built
     if (!existsSync(join(addonDir, 'dist'))) {
       checks.push(fail('dist/', 'not found — run build first'))
       return {
@@ -126,7 +123,6 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
     }
     checks.push(pass('dist/'))
 
-    // 4. dist/.pikku/ (generated metadata)
     const distPikku = join(addonDir, 'dist', '.pikku')
     if (!existsSync(distPikku)) {
       checks.push(
@@ -145,7 +141,6 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
     }
     checks.push(pass('dist/.pikku/'))
 
-    // 5. At least one exported function
     const funcsMetaResult = await readJsonSafe<Record<string, unknown>>(
       join(distPikku, 'function', 'pikku-functions-meta.gen.json')
     )
@@ -168,20 +163,17 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
       )
     }
 
-    // 6. JSON schemas (advisory — addons without custom types have none)
     const schemasDir = join(distPikku, 'schemas', 'schemas')
     checks.push(
       pass('schemas dir', existsSync(schemasDir) ? 'present' : 'empty (ok)')
     )
 
-    // 7. README
     if (!existsSync(join(addonDir, 'README.md'))) {
       checks.push(fail('README.md', 'missing'))
     } else {
       checks.push(pass('README.md'))
     }
 
-    // 8. icon (advisory)
     const consoleMetaResult = await readJsonSafe<{
       package?: { icon?: string }
     }>(join(distPikku, 'console', 'pikku-addon-meta.gen.json'))

--- a/packages/cli/src/fabric/functions/addon-verify.function.ts
+++ b/packages/cli/src/fabric/functions/addon-verify.function.ts
@@ -1,0 +1,172 @@
+import { z } from 'zod'
+import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
+
+const CheckSchema = z.object({
+  name: z.string(),
+  ok: z.boolean(),
+  detail: z.string().optional(),
+})
+type Check = z.infer<typeof CheckSchema>
+
+export const FabricAddonVerifyInput = z.object({
+  dir: z.string().optional(),
+})
+
+export const FabricAddonVerifyOutput = z.object({
+  ok: z.boolean(),
+  addonDir: z.string(),
+  packageName: z.string().optional(),
+  version: z.string().optional(),
+  checks: z.array(CheckSchema),
+})
+
+async function readJsonSafe<T>(path: string): Promise<T | null> {
+  if (!existsSync(path)) return null
+  try {
+    return JSON.parse(await readFile(path, 'utf8')) as T
+  } catch {
+    return null
+  }
+}
+
+export const FabricAddonVerify = pikkuSessionlessFunc({
+  description:
+    'Verify an addon directory is correctly built and ready to publish',
+  input: FabricAddonVerifyInput,
+  output: FabricAddonVerifyOutput,
+  func: async (_services, { dir }) => {
+    const addonDir = resolve(dir ?? process.cwd())
+    const checks: Check[] = []
+
+    const pass = (name: string, detail?: string): Check => ({
+      name,
+      ok: true,
+      detail,
+    })
+    const fail = (name: string, detail: string): Check => ({
+      name,
+      ok: false,
+      detail,
+    })
+
+    // 1. package.json
+    const pkg = await readJsonSafe<{
+      name?: string
+      version?: string
+      files?: string[]
+    }>(join(addonDir, 'package.json'))
+    if (!pkg) {
+      checks.push(fail('package.json', 'not found'))
+      return { ok: false, addonDir, checks }
+    }
+    checks.push(pass('package.json'))
+
+    if (!pkg.name) checks.push(fail('package name', 'missing name field'))
+    else checks.push(pass('package name', pkg.name))
+
+    if (!pkg.version)
+      checks.push(fail('package version', 'missing version field'))
+    else checks.push(pass('package version', pkg.version))
+
+    if (!pkg.files?.includes('dist')) {
+      checks.push(fail('files field', 'must include "dist"'))
+    } else {
+      checks.push(pass('files field', '"dist" included'))
+    }
+
+    // 2. pikku.config.json with addon: true
+    const pikkuConfig = await readJsonSafe<{ addon?: boolean }>(
+      join(addonDir, 'pikku.config.json')
+    )
+    if (!pikkuConfig) {
+      checks.push(fail('pikku.config.json', 'not found'))
+    } else if (!pikkuConfig.addon) {
+      checks.push(fail('pikku.config.json', 'addon: true not set'))
+    } else {
+      checks.push(pass('pikku.config.json', 'addon: true'))
+    }
+
+    // 3. dist/ built
+    if (!existsSync(join(addonDir, 'dist'))) {
+      checks.push(fail('dist/', 'not found — run build first'))
+      return {
+        ok: false,
+        addonDir,
+        packageName: pkg.name,
+        version: pkg.version,
+        checks,
+      }
+    }
+    checks.push(pass('dist/'))
+
+    // 4. dist/.pikku/ (generated metadata)
+    const distPikku = join(addonDir, 'dist', '.pikku')
+    if (!existsSync(distPikku)) {
+      checks.push(
+        fail(
+          'dist/.pikku/',
+          'missing — build script must run `cp -r .pikku dist/`'
+        )
+      )
+      return {
+        ok: false,
+        addonDir,
+        packageName: pkg.name,
+        version: pkg.version,
+        checks,
+      }
+    }
+    checks.push(pass('dist/.pikku/'))
+
+    // 5. At least one exported function
+    const funcsMeta = await readJsonSafe<Record<string, unknown>>(
+      join(distPikku, 'function', 'pikku-functions-meta.gen.json')
+    )
+    const funcCount = funcsMeta ? Object.keys(funcsMeta).length : 0
+    if (funcCount === 0) {
+      checks.push(
+        fail(
+          'functions',
+          'no functions found in dist/.pikku/function/pikku-functions-meta.gen.json'
+        )
+      )
+    } else {
+      checks.push(
+        pass(
+          'functions',
+          `${funcCount} function${funcCount === 1 ? '' : 's'} exported`
+        )
+      )
+    }
+
+    // 6. JSON schemas (advisory — addons without custom types have none)
+    const schemasDir = join(distPikku, 'schemas', 'schemas')
+    checks.push(
+      pass('schemas dir', existsSync(schemasDir) ? 'present' : 'empty (ok)')
+    )
+
+    // 7. README
+    if (!existsSync(join(addonDir, 'README.md'))) {
+      checks.push(fail('README.md', 'missing'))
+    } else {
+      checks.push(pass('README.md'))
+    }
+
+    // 8. icon (advisory)
+    const consoleMeta = await readJsonSafe<{ package?: { icon?: string } }>(
+      join(distPikku, 'console', 'pikku-addon-meta.gen.json')
+    )
+    const icon = consoleMeta?.package?.icon
+    if (!icon) {
+      checks.push({ name: 'icon', ok: true, detail: 'none (optional)' })
+    } else {
+      checks.push(pass('icon', icon.slice(0, 40)))
+    }
+
+    const ok = checks.every((c) => c.ok)
+    return { ok, addonDir, packageName: pkg.name, version: pkg.version, checks }
+  },
+})

--- a/packages/cli/src/fabric/functions/addon-verify.function.ts
+++ b/packages/cli/src/fabric/functions/addon-verify.function.ts
@@ -16,16 +16,16 @@ export const FabricAddonVerifyInput = z.object({
   dir: z.string().optional(),
 })
 
-export type FabricAddonVerifyOutput = z.infer<
-  typeof FabricAddonVerifyOutputSchema
->
-const FabricAddonVerifyOutputSchema = z.object({
+export const FabricAddonVerifyOutputSchema = z.object({
   ok: z.boolean(),
   addonDir: z.string(),
   packageName: z.string().optional(),
   version: z.string().optional(),
   checks: z.array(CheckSchema),
 })
+export type FabricAddonVerifyOutput = z.infer<
+  typeof FabricAddonVerifyOutputSchema
+>
 
 async function readJsonSafe<T>(path: string): Promise<T | null> {
   if (!existsSync(path)) return null

--- a/packages/cli/src/fabric/functions/addon-verify.function.ts
+++ b/packages/cli/src/fabric/functions/addon-verify.function.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
+import { added, removed, dim } from '../lib/output.js'
 
 const CheckSchema = z.object({
   name: z.string(),
@@ -15,7 +16,10 @@ export const FabricAddonVerifyInput = z.object({
   dir: z.string().optional(),
 })
 
-export const FabricAddonVerifyOutput = z.object({
+export type FabricAddonVerifyOutput = z.infer<
+  typeof FabricAddonVerifyOutputSchema
+>
+const FabricAddonVerifyOutputSchema = z.object({
   ok: z.boolean(),
   addonDir: z.string(),
   packageName: z.string().optional(),
@@ -36,7 +40,7 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
   description:
     'Verify an addon directory is correctly built and ready to publish',
   input: FabricAddonVerifyInput,
-  output: FabricAddonVerifyOutput,
+  output: FabricAddonVerifyOutputSchema,
   func: async (_services, { dir }) => {
     const addonDir = resolve(dir ?? process.cwd())
     const checks: Check[] = []
@@ -170,3 +174,23 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
     return { ok, addonDir, packageName: pkg.name, version: pkg.version, checks }
   },
 })
+
+export function renderAddonVerify(result: FabricAddonVerifyOutput): void {
+  console.log(
+    `\n${dim('Addon:')} ${result.packageName ?? '(unknown)'}@${result.version ?? '?'}`
+  )
+  console.log(`${dim('Dir:  ')} ${result.addonDir}\n`)
+  for (const c of result.checks) {
+    const icon = c.ok ? added('✓') : removed('✗')
+    const label = c.ok ? c.name : removed(c.name)
+    const detail = c.detail ? `  ${dim(c.detail)}` : ''
+    console.log(`  ${icon} ${label}${detail}`)
+  }
+  console.log('')
+  if (result.ok) {
+    console.log(added('  Ready to publish.'))
+  } else {
+    console.log(removed('  Fix the errors above before publishing.'))
+    process.exitCode = 1
+  }
+}

--- a/packages/cli/src/fabric/functions/addon-verify.function.ts
+++ b/packages/cli/src/fabric/functions/addon-verify.function.ts
@@ -27,12 +27,16 @@ export type FabricAddonVerifyOutput = z.infer<
   typeof FabricAddonVerifyOutputSchema
 >
 
-async function readJsonSafe<T>(path: string): Promise<T | null> {
-  if (!existsSync(path)) return null
+type JsonResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; reason: 'missing' | 'invalid' }
+
+async function readJsonSafe<T>(path: string): Promise<JsonResult<T>> {
+  if (!existsSync(path)) return { ok: false, reason: 'missing' }
   try {
-    return JSON.parse(await readFile(path, 'utf8')) as T
+    return { ok: true, value: JSON.parse(await readFile(path, 'utf8')) as T }
   } catch {
-    return null
+    return { ok: false, reason: 'invalid' }
   }
 }
 
@@ -57,16 +61,22 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
     })
 
     // 1. package.json
-    const pkg = await readJsonSafe<{
+    const pkgResult = await readJsonSafe<{
       name?: string
       version?: string
       files?: string[]
     }>(join(addonDir, 'package.json'))
-    if (!pkg) {
-      checks.push(fail('package.json', 'not found'))
+    if (!pkgResult.ok) {
+      checks.push(
+        fail(
+          'package.json',
+          pkgResult.reason === 'missing' ? 'not found' : 'invalid JSON'
+        )
+      )
       return { ok: false, addonDir, checks }
     }
     checks.push(pass('package.json'))
+    const pkg = pkgResult.value
 
     if (!pkg.name) checks.push(fail('package name', 'missing name field'))
     else checks.push(pass('package name', pkg.name))
@@ -75,19 +85,29 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
       checks.push(fail('package version', 'missing version field'))
     else checks.push(pass('package version', pkg.version))
 
-    if (!pkg.files?.includes('dist')) {
-      checks.push(fail('files field', 'must include "dist"'))
+    const hasDistInFiles = pkg.files?.some(
+      (f) => f === 'dist' || f === 'dist/' || f.startsWith('dist/')
+    )
+    if (!hasDistInFiles) {
+      checks.push(
+        fail('files field', 'must include "dist" (or "dist/", "dist/**/*")')
+      )
     } else {
       checks.push(pass('files field', '"dist" included'))
     }
 
     // 2. pikku.config.json with addon: true
-    const pikkuConfig = await readJsonSafe<{ addon?: boolean }>(
+    const pikkuConfigResult = await readJsonSafe<{ addon?: boolean }>(
       join(addonDir, 'pikku.config.json')
     )
-    if (!pikkuConfig) {
-      checks.push(fail('pikku.config.json', 'not found'))
-    } else if (!pikkuConfig.addon) {
+    if (!pikkuConfigResult.ok) {
+      checks.push(
+        fail(
+          'pikku.config.json',
+          pikkuConfigResult.reason === 'missing' ? 'not found' : 'invalid JSON'
+        )
+      )
+    } else if (!pikkuConfigResult.value.addon) {
       checks.push(fail('pikku.config.json', 'addon: true not set'))
     } else {
       checks.push(pass('pikku.config.json', 'addon: true'))
@@ -126,10 +146,12 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
     checks.push(pass('dist/.pikku/'))
 
     // 5. At least one exported function
-    const funcsMeta = await readJsonSafe<Record<string, unknown>>(
+    const funcsMetaResult = await readJsonSafe<Record<string, unknown>>(
       join(distPikku, 'function', 'pikku-functions-meta.gen.json')
     )
-    const funcCount = funcsMeta ? Object.keys(funcsMeta).length : 0
+    const funcCount = funcsMetaResult.ok
+      ? Object.keys(funcsMetaResult.value).length
+      : 0
     if (funcCount === 0) {
       checks.push(
         fail(
@@ -160,10 +182,12 @@ export const FabricAddonVerify = pikkuSessionlessFunc({
     }
 
     // 8. icon (advisory)
-    const consoleMeta = await readJsonSafe<{ package?: { icon?: string } }>(
-      join(distPikku, 'console', 'pikku-addon-meta.gen.json')
-    )
-    const icon = consoleMeta?.package?.icon
+    const consoleMetaResult = await readJsonSafe<{
+      package?: { icon?: string }
+    }>(join(distPikku, 'console', 'pikku-addon-meta.gen.json'))
+    const icon = consoleMetaResult.ok
+      ? consoleMetaResult.value.package?.icon
+      : undefined
     if (!icon) {
       checks.push({ name: 'icon', ok: true, detail: 'none (optional)' })
     } else {

--- a/packages/cli/src/fabric/functions/publish.function.ts
+++ b/packages/cli/src/fabric/functions/publish.function.ts
@@ -6,10 +6,7 @@ import { tmpdir } from 'node:os'
 import { execFileSync } from 'node:child_process'
 import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
 import { resolveApiContext } from '../lib/config.js'
-import {
-  renderAddonVerify,
-  type FabricAddonVerifyOutput,
-} from './addon-verify.function.js'
+import { renderAddonVerify } from './addon-verify.function.js'
 
 export const FabricPublishInput = z.object({
   dir: z.string().optional(),
@@ -37,9 +34,7 @@ export const FabricPublish = pikkuSessionlessFunc({
   input: FabricPublishInput,
   output: FabricPublishOutput,
   func: async (_services, { dir, apiUrl: apiUrlOverride }, { rpc }) => {
-    const verification = (await rpc.invoke('FabricAddonVerify', {
-      dir,
-    })) as FabricAddonVerifyOutput
+    const verification = await rpc.invoke('FabricAddonVerify', { dir })
     renderAddonVerify(verification)
     if (!verification.ok) {
       throw new Error(

--- a/packages/cli/src/fabric/functions/publish.function.ts
+++ b/packages/cli/src/fabric/functions/publish.function.ts
@@ -78,7 +78,7 @@ export const FabricPublish = pikkuSessionlessFunc({
 
     // 1. presigned upload URL (short-lived)
     const { uploadUrl, artifactKey } = await post(
-      '/registry/packages/publish-url',
+      '/registry/addons/publish-url',
       { packageName: pkg.name, version: pkg.version }
     )
 
@@ -89,7 +89,7 @@ export const FabricPublish = pikkuSessionlessFunc({
       throw new Error(`upload failed → ${put.status}: ${await put.text()}`)
 
     // 3. finalize — server reads the artifact back, extracts meta, indexes it
-    const entry = await post('/registry/packages/publish', { artifactKey })
+    const entry = await post('/registry/addons/publish', { artifactKey })
 
     const publisher: string | null = entry.publisher?.name ?? null
     console.log(

--- a/packages/cli/src/fabric/functions/publish.function.ts
+++ b/packages/cli/src/fabric/functions/publish.function.ts
@@ -35,7 +35,7 @@ export const FabricPublish = pikkuSessionlessFunc({
   output: FabricPublishOutput,
   func: async (_services, { dir, apiUrl: apiUrlOverride }, { rpc }) => {
     const verification = await rpc.invoke('FabricAddonVerify', { dir })
-    renderAddonVerify(verification)
+    renderAddonVerify(undefined, verification)
     if (!verification.ok) {
       throw new Error(
         'Addon verification failed — fix the errors above before publishing.'

--- a/packages/cli/src/fabric/functions/publish.function.ts
+++ b/packages/cli/src/fabric/functions/publish.function.ts
@@ -6,6 +6,10 @@ import { tmpdir } from 'node:os'
 import { execFileSync } from 'node:child_process'
 import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
 import { resolveApiContext } from '../lib/config.js'
+import {
+  renderAddonVerify,
+  type FabricAddonVerifyOutput,
+} from './addon-verify.function.js'
 
 export const FabricPublishInput = z.object({
   dir: z.string().optional(),
@@ -32,7 +36,17 @@ export const FabricPublish = pikkuSessionlessFunc({
   description: 'Publish a package directory to the Fabric community registry.',
   input: FabricPublishInput,
   output: FabricPublishOutput,
-  func: async (_services, { dir, apiUrl: apiUrlOverride }) => {
+  func: async (_services, { dir, apiUrl: apiUrlOverride }, { rpc }) => {
+    const verification = (await rpc.invoke('FabricAddonVerify', {
+      dir,
+    })) as FabricAddonVerifyOutput
+    renderAddonVerify(verification)
+    if (!verification.ok) {
+      throw new Error(
+        'Addon verification failed — fix the errors above before publishing.'
+      )
+    }
+
     const ctx = await resolveApiContext({ apiUrlOverride })
     if (!ctx.token)
       throw new Error('Not logged in. Run `pikku fabric login` first.')
@@ -72,7 +86,8 @@ export const FabricPublish = pikkuSessionlessFunc({
         headers,
         body: JSON.stringify(body),
       })
-      if (!r.ok) throw new Error(`POST ${path} → ${r.status}: ${await r.text()}`)
+      if (!r.ok)
+        throw new Error(`POST ${path} → ${r.status}: ${await r.text()}`)
       return r.json() as Promise<any>
     }
 

--- a/packages/cli/src/fabric/functions/publish.function.ts
+++ b/packages/cli/src/fabric/functions/publish.function.ts
@@ -6,7 +6,6 @@ import { tmpdir } from 'node:os'
 import { execFileSync } from 'node:child_process'
 import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
 import { resolveApiContext } from '../lib/config.js'
-import { renderAddonVerify } from './addon-verify.function.js'
 
 export const FabricPublishInput = z.object({
   dir: z.string().optional(),
@@ -33,9 +32,9 @@ export const FabricPublish = pikkuSessionlessFunc({
   description: 'Publish a package directory to the Fabric community registry.',
   input: FabricPublishInput,
   output: FabricPublishOutput,
-  func: async (_services, { dir, apiUrl: apiUrlOverride }, { rpc }) => {
+  func: async (_services, { dir, apiUrl: apiUrlOverride }, { rpc, cli }) => {
     const verification = await rpc.invoke('FabricAddonVerify', { dir })
-    renderAddonVerify(undefined, verification)
+    await cli?.channel.send(verification)
     if (!verification.ok) {
       throw new Error(
         'Addon verification failed — fix the errors above before publishing.'

--- a/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
+++ b/packages/cli/src/functions/wirings/functions/serialize-function-types.ts
@@ -387,26 +387,14 @@ export type PikkuFunctionConfigWithSchema<
  * Creates a Pikku function that can be either session-aware or sessionless.
  * This is the main function wrapper for creating API endpoints.
  *
- * Supports two patterns:
- * 1. Generic types: \`pikkuFunc<Input, Output>({ func: ... })\`
- * 2. Zod schemas: \`pikkuFunc({ input: z.object(...), output: z.object(...), func: ... })\`
+ * Define the input and output with Zod schemas — the function's types are
+ * inferred from them, and the schemas double as runtime validation.
  *
- * @template In - Input type for the function (inferred from schema if provided)
- * @template Out - Output type for the function (inferred from schema if provided)
- * @param func - Function definition, either direct function or configuration object
+ * @param config - Function definition with \`input\`/\`output\` Zod schemas and \`func\`.
  * @returns The normalized configuration object
  *
  * @example
  * \`\`\`typescript
- * // Pattern 1: Using generic types
- * const createUser = pikkuFunc<{name: string, email: string}, {id: number}>({
- *   func: async ({db}, input) => {
- *     const user = await db.users.create(input)
- *     return { id: user.id }
- *   }
- * })
- *
- * // Pattern 2: Using Zod schemas (types inferred automatically)
  * const createUserInput = z.object({ name: z.string(), email: z.string() })
  * const createUserOutput = z.object({ id: z.number() })
  *
@@ -498,25 +486,14 @@ export type PikkuFunctionSessionlessConfigWithSchema<
  * Creates a sessionless Pikku function that doesn't require user authentication.
  * Use this for public endpoints, webhooks, or background tasks.
  *
- * Supports two patterns:
- * 1. Generic types: \`pikkuSessionlessFunc<Input, Output>({ func: ... })\`
- * 2. Zod schemas: \`pikkuSessionlessFunc({ input: z.object(...), func: ... })\`
+ * Define the input and output with Zod schemas — the function's types are
+ * inferred from them, and the schemas double as runtime validation.
  *
- * @template In - Input type for the function (inferred from schema if provided)
- * @template Out - Output type for the function (inferred from schema if provided)
- * @param func - Function definition, either direct function or configuration object
+ * @param config - Function definition with \`input\`/\`output\` Zod schemas and \`func\`.
  * @returns The normalized configuration object
  *
  * @example
  * \`\`\`typescript
- * // Pattern 1: Using generic types
- * const healthCheck = pikkuSessionlessFunc<void, {status: string}>({
- *   func: async ({logger}) => {
- *     return { status: 'healthy' }
- *   }
- * })
- *
- * // Pattern 2: Using Zod schemas
  * const greetInput = z.object({ name: z.string() })
  * const greetOutput = z.object({ message: z.string() })
  *

--- a/packages/core/src/function/functions.types.ts
+++ b/packages/core/src/function/functions.types.ts
@@ -295,8 +295,12 @@ export type CorePikkuFunctionConfig<
   readonly?: boolean
   deploy?: 'serverless' | 'server' | 'auto'
   approvalRequired?: boolean
-  /** When false, workflow steps calling this function are dispatched via the queue instead of running inline. Defaults to true (inline). */
-  inline?: boolean
+  /** When true, workflow steps calling this function are dispatched via the queue. No queue service configured is a hard error. Defaults to false (inline). */
+  workflowQueued?: boolean
+  /** Number of retry attempts when this function is used as a workflow step. */
+  workflowRetries?: number
+  /** Timeout for this function when used as a workflow step (e.g. '30s', '5m'). */
+  workflowTimeout?: string
   audit?:
     | boolean
     | {

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -119,8 +119,12 @@ export type FunctionRuntimeMeta = {
   readonly?: boolean
   deploy?: 'serverless' | 'server' | 'auto'
   sessionless?: boolean
-  /** When false, workflow steps calling this function are dispatched via the queue. Defaults to true (inline). */
-  inline?: boolean
+  /** When true, workflow steps calling this function are dispatched via the queue. No queue service configured is a hard error. */
+  workflowQueued?: boolean
+  /** Retry count when this function is used as a workflow step. */
+  workflowRetries?: number
+  /** Timeout when this function is used as a workflow step (e.g. '30s', '5m'). */
+  workflowTimeout?: string
   version?: number
   approvalRequired?: boolean
   approvalDescription?: string

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
@@ -126,19 +126,19 @@ describe('pikku-workflow-service run-level inline', () => {
 describe('pikku-workflow-service per-function step dispatch', () => {
   // Expose the protected dispatchStep so we can assert the dispatch decision
   // in isolation: a step queues only when its function opts out of inline
-  // execution (inline: false).
+  // execution (workflowQueued: true).
   class TestWorkflowService extends InMemoryWorkflowService {
     public callDispatchStep(rpcName: string) {
       return this.dispatchStep('run-1', 'step-1', rpcName, {})
     }
   }
 
-  const setupFunction = (rpcName: string, inline?: boolean) => {
+  const setupFunction = (rpcName: string, workflowQueued?: boolean) => {
     pikkuState(null, 'rpc', 'meta')[rpcName] = rpcName as any
     pikkuState(null, 'function', 'meta')[rpcName] = {
       pikkuFuncId: rpcName,
       sessionless: true,
-      ...(inline === undefined ? {} : { inline }),
+      ...(workflowQueued === undefined ? {} : { workflowQueued }),
     } as any
   }
 
@@ -166,7 +166,7 @@ describe('pikku-workflow-service per-function step dispatch', () => {
     cleanup('defaultInlineStep')
   })
 
-  test('inline: false step IS dispatched to the queue when a queueService exists', async () => {
+  test('workflowQueued: true step IS dispatched to the queue when a queueService exists', async () => {
     const ws = new TestWorkflowService()
     let queued = false
     pikkuState(null, 'package', 'singletonServices', {
@@ -178,36 +178,25 @@ describe('pikku-workflow-service per-function step dispatch', () => {
       },
     } as any)
 
-    setupFunction('queuedStep', false)
+    setupFunction('queuedStep', true)
     const dispatched = await ws.callDispatchStep('queuedStep')
-    assert.equal(dispatched, true, 'inline:false step should dispatch')
-    assert.equal(queued, true, 'inline:false step should queue')
+    assert.equal(dispatched, true, 'workflowQueued step should dispatch')
+    assert.equal(queued, true, 'workflowQueued step should queue')
     cleanup('queuedStep')
   })
 
-  test('inline: false step warns and runs inline when no queueService is configured', async () => {
+  test('workflowQueued: true step throws when no queueService is configured', async () => {
     const ws = new TestWorkflowService()
-    let warned = false
     pikkuState(null, 'package', 'singletonServices', {
-      logger: {
-        error() {},
-        info() {},
-        warn: () => {
-          warned = true
-        },
-        debug() {},
-      },
+      logger: { error() {}, info() {}, warn() {}, debug() {} },
       // no queueService
     } as any)
 
-    setupFunction('queuedStepNoQueue', false)
-    const dispatched = await ws.callDispatchStep('queuedStepNoQueue')
-    assert.equal(
-      dispatched,
-      false,
-      'falls back to inline when no queue service'
+    setupFunction('queuedStepNoQueue', true)
+    await assert.rejects(
+      () => ws.callDispatchStep('queuedStepNoQueue'),
+      /workflowQueued: true.*no queue service/i
     )
-    assert.equal(warned, true, 'should warn about the misconfiguration')
     cleanup('queuedStepNoQueue')
   })
 })

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -982,29 +982,22 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepOptions?: WorkflowStepOptions,
     fromStepName?: string
   ): Promise<boolean> {
-    // Step execution is decided purely by the function's `inline` flag (default
-    // true). Only a function explicitly marked `inline: false` dispatches via
-    // the queue. The run-level inline state is intentionally NOT consulted
-    // here: default steps run inline even inside a queue-dispatched run, so a
-    // normally-started workflow executes its steps in one orchestrator-worker
-    // pass instead of one queue round-trip per step.
+    // Step execution is decided purely by the function's `workflowQueued` flag
+    // (default false). Only a function explicitly marked `workflowQueued: true`
+    // dispatches via the queue. If the queue service is not configured that is
+    // a hard error — there is no inline fallback.
     const functionsMeta = pikkuState(null, 'function', 'meta')
     const rpcFuncId = pikkuState(null, 'rpc', 'meta')[rpcName]
     const rpcMeta =
       typeof rpcFuncId === 'string' ? functionsMeta[rpcFuncId] : undefined
-    const forceQueue = rpcMeta?.inline === false
+    const forceQueue = rpcMeta?.workflowQueued === true
     if (!forceQueue) {
       return false
     }
-    // The function opted out of inline execution (`inline: false`) but no queue
-    // service is configured to dispatch it. Fall back to inline so the workflow
-    // still progresses, but warn loudly — silently swallowing this hides a real
-    // misconfiguration (the step won't get its own worker/retry isolation).
     if (!getSingletonServices()?.queueService) {
-      getSingletonServices()?.logger.warn(
-        `Workflow step '${stepName}' (function '${rpcName}') is marked 'inline: false' but no queue service is configured — running it inline instead of dispatching to a queue.`
+      throw new Error(
+        `Workflow step '${stepName}' (function '${rpcName}') is marked 'workflowQueued: true' but no queue service is configured.`
       )
-      return false
     }
     try {
       await getSingletonServices()!.queueService!.add(

--- a/packages/core/src/wirings/workflow/workflow-dispatch-durability.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-dispatch-durability.test.ts
@@ -5,13 +5,13 @@ import { InMemoryWorkflowService } from '../../services/in-memory-workflow-servi
 import { pikkuState } from '../../pikku-state.js'
 import { WorkflowDispatchException } from './pikku-workflow-service.js'
 
-// Register an `inline: false` function so the workflow's `do()` routes the step
-// through the queue (dispatchStep) instead of running it inline.
+// Register a `workflowQueued: true` function so the workflow's `do()` routes
+// the step through the queue (dispatchStep) instead of running it inline.
 function registerDispatchedFn(rpcName: string): void {
   const funcId = `fn:${rpcName}`
   pikkuState(null, 'rpc', 'meta', { [rpcName]: funcId } as any)
   pikkuState(null, 'function', 'meta', {
-    [funcId]: { inline: false },
+    [funcId]: { workflowQueued: true },
   } as any)
 }
 

--- a/packages/inspector/src/add/add-functions.ts
+++ b/packages/inspector/src/add/add-functions.ts
@@ -392,7 +392,9 @@ export const addFunctions: AddWiring = (
   let deploy: 'serverless' | 'server' | 'auto' | undefined
   let approvalRequired: boolean | undefined
   let approvalDescription: string | undefined
-  let inline: boolean | undefined
+  let workflowQueued: boolean | undefined
+  let workflowRetries: number | undefined
+  let workflowTimeout: string | undefined
   let version: number | undefined
   let objectNode: ts.ObjectLiteralExpression | undefined
   let nodeDisplayName: string | null = null
@@ -488,7 +490,9 @@ export const addFunctions: AddWiring = (
     approvalRequired = getPropertyValue(firstArg, 'approvalRequired') as
       | boolean
       | undefined
-    inline = getPropertyValue(firstArg, 'inline') as boolean | undefined
+    workflowQueued = getPropertyValue(firstArg, 'workflowQueued') as boolean | undefined
+    workflowRetries = getPropertyValue(firstArg, 'workflowRetries') as number | undefined
+    workflowTimeout = getPropertyValue(firstArg, 'workflowTimeout') as string | undefined
 
     // Extract approvalDescription identifier reference
     for (const prop of firstArg.properties) {
@@ -1027,7 +1031,9 @@ export const addFunctions: AddWiring = (
     deploy: deploy || undefined,
     approvalRequired: approvalRequired || undefined,
     approvalDescription: approvalDescription || undefined,
-    inline: inline === false ? false : undefined,
+    workflowQueued: workflowQueued === true ? true : undefined,
+    workflowRetries: workflowRetries ?? undefined,
+    workflowTimeout: workflowTimeout ?? undefined,
     implementationHash,
     version,
     title,

--- a/packages/inspector/src/add/add-rpc-invocations.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.ts
@@ -86,19 +86,26 @@ export function addRPCInvocations(
       ts.isIdentifier(expression.expression) &&
       expression.expression.text === 'rpc'
     ) {
-      if (hasTypeCast(outerParent(node))) {
-        logger.critical(
-          ErrorCode.RPC_INVOCATION_TYPE_CAST,
-          `rpc.invoke() result is type-cast — remove the 'as' expression and rely on Pikku's generated types`
-        )
-      }
+      // Skip PKU940 for generated files — they may contain intentional casts
+      // (e.g. the paginated useInfiniteQuery hook in pikku-react-query.gen.ts).
+      const sourceFileName = node.getSourceFile().fileName
+      const isGenerated =
+        sourceFileName.endsWith('.gen.ts') || sourceFileName.endsWith('.gen.js')
+      if (!isGenerated) {
+        if (hasTypeCast(outerParent(node))) {
+          logger.critical(
+            ErrorCode.RPC_INVOCATION_TYPE_CAST,
+            `rpc.invoke() result is type-cast — remove the 'as' expression and rely on Pikku's generated types`
+          )
+        }
 
-      const castArg = findCastArg(args)
-      if (castArg) {
-        logger.critical(
-          ErrorCode.RPC_INVOCATION_TYPE_CAST,
-          `rpc.invoke() has a type cast on an argument — remove the 'as' expression and rely on Pikku's generated types`
-        )
+        const castArg = findCastArg(args)
+        if (castArg) {
+          logger.critical(
+            ErrorCode.RPC_INVOCATION_TYPE_CAST,
+            `rpc.invoke() has a type cast on an argument — remove the 'as' expression and rely on Pikku's generated types`
+          )
+        }
       }
 
       const [firstArg] = args

--- a/packages/inspector/src/add/add-rpc-invocations.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.ts
@@ -1,5 +1,16 @@
 import * as ts from 'typescript'
 import type { InspectorState, InspectorLogger } from '../types.js'
+import { ErrorCode } from '../error-codes.js'
+
+function hasTypeCast(node: ts.Node): boolean {
+  return ts.isAsExpression(node) || ts.isTypeAssertionExpression(node)
+}
+
+function findCastArg(
+  args: ts.NodeArray<ts.Expression>
+): ts.Expression | undefined {
+  return args.find(hasTypeCast)
+}
 
 /**
  * Helper to extract namespace from a namespaced function reference like 'ext:hello'
@@ -67,6 +78,21 @@ export function addRPCInvocations(
       ts.isIdentifier(expression.expression) &&
       expression.expression.text === 'rpc'
     ) {
+      if (hasTypeCast(node.parent)) {
+        logger.critical(
+          ErrorCode.RPC_INVOCATION_TYPE_CAST,
+          `rpc.invoke() result is type-cast — remove the 'as' expression and rely on Pikku's generated types`
+        )
+      }
+
+      const castArg = findCastArg(args)
+      if (castArg) {
+        logger.critical(
+          ErrorCode.RPC_INVOCATION_TYPE_CAST,
+          `rpc.invoke() has a type cast on an argument — remove the 'as' expression and rely on Pikku's generated types`
+        )
+      }
+
       const [firstArg] = args
       if (firstArg) {
         if (ts.isStringLiteral(firstArg)) {

--- a/packages/inspector/src/add/add-rpc-invocations.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.ts
@@ -6,6 +6,14 @@ function hasTypeCast(node: ts.Node): boolean {
   return ts.isAsExpression(node) || ts.isTypeAssertionExpression(node)
 }
 
+function outerParent(node: ts.Node): ts.Node {
+  let p = node.parent
+  while (p && (ts.isAwaitExpression(p) || ts.isParenthesizedExpression(p))) {
+    p = p.parent
+  }
+  return p
+}
+
 function findCastArg(
   args: ts.NodeArray<ts.Expression>
 ): ts.Expression | undefined {
@@ -78,7 +86,7 @@ export function addRPCInvocations(
       ts.isIdentifier(expression.expression) &&
       expression.expression.text === 'rpc'
     ) {
-      if (hasTypeCast(node.parent)) {
+      if (hasTypeCast(outerParent(node))) {
         logger.critical(
           ErrorCode.RPC_INVOCATION_TYPE_CAST,
           `rpc.invoke() result is type-cast — remove the 'as' expression and rely on Pikku's generated types`

--- a/packages/inspector/src/add/rpc-type-cast.test.ts
+++ b/packages/inspector/src/add/rpc-type-cast.test.ts
@@ -1,0 +1,123 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { inspect } from '../inspector.js'
+import { ErrorCode } from '../error-codes.js'
+import type { InspectorLogger } from '../types.js'
+
+function makeLogger() {
+  const criticals: Array<{ code: ErrorCode; message: string }> = []
+  const logger: InspectorLogger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    diagnostic: ({ code, message }) => criticals.push({ code, message }),
+    critical: (code, message) => criticals.push({ code, message }),
+    hasCriticalErrors: () => criticals.length > 0,
+  }
+  return { logger, criticals }
+}
+
+async function runInspect(sourceCode: string) {
+  const tmpDir = await mkdtemp(join(tmpdir(), 'pikku-rpc-cast-test-'))
+  const file = join(tmpDir, 'funcs.ts')
+  await writeFile(file, sourceCode)
+  const { logger, criticals } = makeLogger()
+  try {
+    await inspect(logger, [file], { rootDir: tmpDir })
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true })
+  }
+  return criticals
+}
+
+describe('RPC type-cast check — PKU940', () => {
+  test('flags rpc.invoke() with an as-cast on an argument', async () => {
+    const criticals = await runInspect(`
+declare const rpc: { invoke: (name: string, data: unknown) => Promise<unknown> }
+export async function doWork() {
+  return rpc.invoke('someFunction', { id: 1 } as any)
+}
+`)
+    const hit = criticals.find(
+      (c) => c.code === ErrorCode.RPC_INVOCATION_TYPE_CAST
+    )
+    assert.ok(hit, `Expected PKU940 but got: ${JSON.stringify(criticals)}`)
+  })
+
+  test('flags rpc.invoke() with an angle-bracket cast on an argument', async () => {
+    const criticals = await runInspect(`
+declare const rpc: { invoke: (name: string, data: unknown) => Promise<unknown> }
+export async function doWork() {
+  return rpc.invoke('someFunction', <any>{ id: 1 })
+}
+`)
+    const hit = criticals.find(
+      (c) => c.code === ErrorCode.RPC_INVOCATION_TYPE_CAST
+    )
+    assert.ok(hit, `Expected PKU940 but got: ${JSON.stringify(criticals)}`)
+  })
+
+  test('flags rpc.invoke() result cast with as any', async () => {
+    const criticals = await runInspect(`
+declare const rpc: { invoke: (name: string, data: unknown) => Promise<unknown> }
+export async function doWork() {
+  return (rpc.invoke('someFunction', { id: 1 }) as any)
+}
+`)
+    const hit = criticals.find(
+      (c) => c.code === ErrorCode.RPC_INVOCATION_TYPE_CAST
+    )
+    assert.ok(hit, `Expected PKU940 but got: ${JSON.stringify(criticals)}`)
+  })
+
+  test('flags rpc.invoke() result cast with as never', async () => {
+    const criticals = await runInspect(`
+declare const rpc: { invoke: (name: string, data: unknown) => Promise<unknown> }
+export async function doWork() {
+  return (rpc.invoke('someFunction', { id: 1 }) as never)
+}
+`)
+    const hit = criticals.find(
+      (c) => c.code === ErrorCode.RPC_INVOCATION_TYPE_CAST
+    )
+    assert.ok(hit, `Expected PKU940 but got: ${JSON.stringify(criticals)}`)
+  })
+
+  test('does not flag a clean rpc.invoke() call', async () => {
+    const criticals = await runInspect(`
+declare const rpc: { invoke: (name: string, data: unknown) => Promise<unknown> }
+export async function doWork() {
+  return rpc.invoke('someFunction', { id: 1 })
+}
+`)
+    const hit = criticals.find(
+      (c) => c.code === ErrorCode.RPC_INVOCATION_TYPE_CAST
+    )
+    assert.equal(
+      hit,
+      undefined,
+      `Expected no PKU940 but got: ${JSON.stringify(hit)}`
+    )
+  })
+
+  test('does not flag as-casts on unrelated calls', async () => {
+    const criticals = await runInspect(`
+declare function otherFn(data: unknown): Promise<unknown>
+export async function doWork() {
+  return otherFn({ id: 1 } as any)
+}
+`)
+    const hit = criticals.find(
+      (c) => c.code === ErrorCode.RPC_INVOCATION_TYPE_CAST
+    )
+    assert.equal(
+      hit,
+      undefined,
+      `Expected no PKU940 but got: ${JSON.stringify(hit)}`
+    )
+  })
+})

--- a/packages/inspector/src/error-codes.ts
+++ b/packages/inspector/src/error-codes.ts
@@ -88,6 +88,9 @@ export enum ErrorCode {
   // Addon authoring errors
   ADDON_WIRING_NOT_ALLOWED = 'PKU920',
   ADDON_CONTRACT_HANDLERS_NOT_ALLOWED = 'PKU921',
+
+  // RPC safety errors
+  RPC_INVOCATION_TYPE_CAST = 'PKU940',
 }
 
 /**

--- a/packages/inspector/src/error-codes.ts
+++ b/packages/inspector/src/error-codes.ts
@@ -89,7 +89,6 @@ export enum ErrorCode {
   ADDON_WIRING_NOT_ALLOWED = 'PKU920',
   ADDON_CONTRACT_HANDLERS_NOT_ALLOWED = 'PKU921',
 
-  // RPC safety errors
   RPC_INVOCATION_TYPE_CAST = 'PKU940',
 }
 

--- a/packages/inspector/src/utils/filter-inspector-state.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.ts
@@ -1068,10 +1068,10 @@ export function filterInspectorState(
   }
 
   // Step dispatch is decided purely per-function: a workflow step runs via the
-  // queue only when its function opts out of inline execution (inline: false).
-  // Such a unit needs workflowService + queueService injected even though the
-  // function itself doesn't reference them. Check the ORIGINAL graph meta
-  // (before filtering pruned it).
+  // queue only when its function is marked `workflowQueued: true`. Such a unit
+  // needs workflowService + queueService injected even though the function
+  // itself doesn't reference them. Check the ORIGINAL graph meta (before
+  // filtering pruned it).
   const survivingFuncIds = new Set(Object.keys(filteredState.functions.meta))
   const resolveFuncId = (rpcName: string): string =>
     filteredState.rpc.internalMeta[rpcName] ??
@@ -1087,8 +1087,8 @@ export function filterInspectorState(
       if (!survivingFuncIds.has(funcId) && !survivingFuncIds.has(rpcName))
         continue
       const funcMeta = (filteredState.functions.meta[funcId] ??
-        filteredState.functions.meta[rpcName]) as { inline?: boolean }
-      if (funcMeta?.inline === false) {
+        filteredState.functions.meta[rpcName]) as { workflowQueued?: boolean }
+      if (funcMeta?.workflowQueued === true) {
         filteredState.serviceAggregation.requiredServices.add('workflowService')
         filteredState.serviceAggregation.requiredServices.add('queueService')
       }

--- a/packages/inspector/src/utils/post-process.ts
+++ b/packages/inspector/src/utils/post-process.ts
@@ -290,10 +290,17 @@ export function aggregateRequiredServices(
       }
     }
 
-    // Per-step queues
+    // Per-step queues — only for steps explicitly marked workflowQueued: true
     for (const node of Object.values(graph.nodes)) {
       if (!('rpcName' in node) || !node.rpcName) continue
       const rpcName = node.rpcName as string
+      const funcId =
+        state.rpc?.internalMeta?.[rpcName] ??
+        state.rpc?.exposedMeta?.[rpcName] ??
+        rpcName
+      const funcMeta = (state.functions.meta[funcId] ??
+        state.functions.meta[rpcName]) as { workflowQueued?: boolean }
+      if (funcMeta?.workflowQueued !== true) continue
       const stepQueueName = `wf-step-${toKebab(rpcName)}`
       if (!state.queueWorkers.meta[stepQueueName]) {
         state.queueWorkers.meta[stepQueueName] = {

--- a/packages/inspector/src/utils/workflow/graph/workflow-graph.types.ts
+++ b/packages/inspector/src/utils/workflow/graph/workflow-graph.types.ts
@@ -87,8 +87,6 @@ export interface NodeOptions {
   retryDelay?: string
   /** Timeout for node execution (e.g., '30s', '5m') */
   timeout?: string
-  /** If true, execute via queue (async). Default: false (inline) */
-  async?: boolean
 }
 
 /**

--- a/verifiers/treeshaking/test-scenarios.ts
+++ b/verifiers/treeshaking/test-scenarios.ts
@@ -171,7 +171,7 @@ export const scenarios: TestScenario[] = [
     name: 'Wire: queue',
     filter: '--wires=queue',
     expectedSingletonServices: ['email', 'logger', 'notification', 'secrets'],
-    expectedWireServices: ['userContext'],
+    expectedWireServices: [],
     description: 'Only queue worker services should be included',
     expectedGeneratedFiles: {
       bootstrap: {
@@ -219,7 +219,7 @@ export const scenarios: TestScenario[] = [
     name: 'HTTP Method: GET',
     filter: '--httpMethods=GET',
     expectedSingletonServices: ['email', 'logger', 'notification', 'secrets'],
-    expectedWireServices: ['userContext'],
+    expectedWireServices: [],
     description: 'No GET routes exist, only email/logger from session creation',
   },
 
@@ -249,7 +249,7 @@ export const scenarios: TestScenario[] = [
       'secrets',
       'storage',
     ],
-    expectedWireServices: ['userContext', 'userPreferences'],
+    expectedWireServices: ['userPreferences'],
     description: 'Only payment routes',
   },
   {
@@ -288,7 +288,7 @@ export const scenarios: TestScenario[] = [
     name: 'Directory: src/nonexistent',
     filter: '--directories=src/nonexistent',
     expectedSingletonServices: ['email', 'logger', 'notification', 'secrets'],
-    expectedWireServices: ['userContext'],
+    expectedWireServices: [],
     description:
       'No wirings in nonexistent directory, only email/logger from session creation',
   },

--- a/verifiers/workflows/src/workflows/retry-idempotency.functions.ts
+++ b/verifiers/workflows/src/workflows/retry-idempotency.functions.ts
@@ -1,7 +1,7 @@
 /**
  * UNHAPPY-PATH workflows for retry + idempotency.
  *
- * Steps are `inline: false` so they dispatch through the real queue (pg-boss /
+ * Steps are `workflowQueued: true` so they dispatch through the real queue (pg-boss /
  * bullmq) and are retried by queue redelivery — the durability path. Each step
  * records its `invocationId` / `stepId` / `attemptCount` into the shared tracker
  * so the runner can assert exactly what happened under failure.
@@ -18,7 +18,7 @@ export const flakyStep = pikkuSessionlessFunc<
   { trackerKey: string; failTimes: number },
   { ok: boolean }
 >({
-  inline: false,
+  workflowQueued: true,
   func: async ({ logger }, data, { workflowStep }) => {
     tracker.record(data.trackerKey, {
       invocationId: workflowStep!.invocationId,
@@ -45,7 +45,7 @@ export const idempotentStep = pikkuSessionlessFunc<
   { trackerKey: string; failTimes: number },
   { ok: boolean }
 >({
-  inline: false,
+  workflowQueued: true,
   func: async ({ logger }, data, { workflowStep }) => {
     const invocationId = workflowStep!.invocationId
     tracker.record(data.trackerKey, {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `fabric addon verify` command to validate addons before publishing.
  * Added build-time detection for unsafe type casts around `rpc.invoke()`, emitting a critical `PKU940` error.
  * Improved the dev server and bundling pipeline to select Bun vs Node implementations at runtime.
  * Introduced `workflowQueued` for workflow step dispatch control.
* **Bug Fixes**
  * Publishing now runs addon verification first and stops on failures.
  * Addon publishing uses the correct registry endpoints for addon uploads and finalization.
  * Queued workflow execution now requires a configured queue service (and failures surface immediately).
* **Tests / Documentation**
  * Added coverage for the `PKU940` rule and refreshed related skills/reference docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->