### PR TITLE
feat(cli): native Bun.build bundler + runtime DI split for deploy & dev

### DIFF
--- a/.changeset/bun-node-bundler-split.md
+++ b/.changeset/bun-node-bundler-split.md
@@ -1,0 +1,26 @@
+---
+'@pikku/cli': patch
+---
+
+feat(cli): native Bun.build bundler + runtime DI split for deploy & dev
+
+Deploys and `pikku dev` now use a runtime-appropriate implementation chosen once
+via dependency injection, instead of inline `typeof Bun` checks.
+
+- **Bundler**: a `Bundler` interface with a shared `BaseBundler` (dead-module
+  stubbing, dependency extraction, package.json + hashing) and two backends —
+  `NodeBundler` (esbuild) and `BunBundler` (native `Bun.build`). Under bun the
+  deploy bundle now resolves bun's `.bun` store / per-workspace symlinks natively
+  (esbuild's `nodePaths` walk assumes a hoisted root and failed there). Bun's
+  metafile omits external imports, so externals are captured via the resolve
+  plugin to drive per-unit dependency extraction. Full identifier minification is
+  used under bun (safe — pikku's error→status reflection compares same-class
+  instances and workflow exceptions hardcode `.name`).
+- **Dev server**: a `DevServerRunner` interface with `NodeServerRunner`
+  (`@pikku/node-http-server` + `ws`) and `BunServerRunner` (`@pikku/bun-server`),
+  each also supplying the runtime's EventHub.
+- The runtime is resolved once in `services.ts`; `bundler` and `devServerRunner`
+  are injected singletons. No `typeof Bun` branches remain in the pipeline or the
+  dev command.
+- Also removes a redundant `as` cast on an `rpc.invoke()` result (PKU940) now
+  that the generated map types the output.

--- a/packages/cli/src/deploy/build-pipeline.ts
+++ b/packages/cli/src/deploy/build-pipeline.ts
@@ -13,8 +13,8 @@ import type { InspectorState } from '@pikku/inspector'
 import { analyzeDeployment } from './analyzer/index.js'
 import type { DeploymentManifest } from './analyzer/manifest.js'
 import { generatePerUnitCodegen } from './codegen/per-unit-codegen.js'
-import { bundleUnits } from './bundler/index.js'
-import type { BundleResult } from './bundler/index.js'
+import type { Bundler } from './bundler/bundler.interface.js'
+import type { BundleResult } from './bundler/types.js'
 import type { ProviderAdapter } from './provider-adapter.js'
 import {
   generateServerEntrySource,
@@ -86,6 +86,8 @@ export async function runBuildPipeline(options: {
   /** Emit sourcemaps + per-unit `metafile.json` (debug-only). Default false. */
   debugArtifacts?: boolean
   logger: BuildLogger
+  /** Runtime-specific bundler (esbuild for node, Bun.build for bun). */
+  bundler: Bundler
 }): Promise<BuildPipelineResult> {
   const {
     projectDir,
@@ -95,6 +97,7 @@ export async function runBuildPipeline(options: {
     getEntryContext,
     debugArtifacts,
     logger,
+    bundler,
   } = options
   const deployDir = options.deployDir ?? join(projectDir, '.deploy')
   const providerDir = join(deployDir, provider.deployDirName)
@@ -146,7 +149,7 @@ export async function runBuildPipeline(options: {
     const entryFiles = new Map<string, string>()
     entryFiles.set(unitName, entryPath)
 
-    const bundleResult = await bundleUnits(
+    const bundleResult = await bundler.bundleUnits(
       projectDir,
       manifest,
       entryFiles,
@@ -302,7 +305,7 @@ export async function runBuildPipeline(options: {
         ...manifest,
         units: manifest.units.filter((u) => u.target !== 'server'),
       }
-      const result = await bundleUnits(
+      const result = await bundler.bundleUnits(
         projectDir,
         serverlessManifestForBundle,
         serverlessEntryFiles,
@@ -334,7 +337,7 @@ export async function runBuildPipeline(options: {
         ...manifest,
         units: manifest.units.filter((u) => u.target === 'server'),
       }
-      const result = await bundleUnits(
+      const result = await bundler.bundleUnits(
         projectDir,
         serverManifestForBundle,
         serverEntryFiles,

--- a/packages/cli/src/deploy/bundler/bun-bundler.ts
+++ b/packages/cli/src/deploy/bundler/bun-bundler.ts
@@ -1,0 +1,190 @@
+/**
+ * Bun (Bun.build) bundler backend.
+ *
+ * Used when the CLI runs under Bun (bun projects). Bun resolves its own `.bun`
+ * store / per-workspace symlinks natively — esbuild's `nodePaths` walk assumes a
+ * hoisted root and can't — so no esbuild dependency is needed. Bun's metafile
+ * does NOT record external imports, so externals are captured via the resolve
+ * plugin instead (that capture drives per-unit dependency extraction).
+ */
+
+import { writeFile } from 'node:fs/promises'
+
+import { BaseBundler } from './bundler.js'
+import type { CompileInput, CompileResult } from './bundler.interface.js'
+
+/**
+ * Minimal typing for the subset of Bun's bundler API used here. The CLI does not
+ * depend on `@types/bun` (it also runs under Node), so the `Bun` global is
+ * accessed through this structural type rather than the ambient one.
+ */
+interface BunBuildArtifact {
+  kind: string
+  text(): Promise<string>
+}
+interface BunBuildResult {
+  success: boolean
+  logs: unknown[]
+  outputs: BunBuildArtifact[]
+  metafile?: unknown
+}
+interface BunPlugin {
+  name: string
+  setup(build: {
+    onResolve(
+      opts: { filter: RegExp; namespace?: string },
+      cb: (args: {
+        path: string
+        importer: string
+      }) =>
+        | { path: string; namespace?: string; external?: boolean }
+        | undefined
+    ): void
+    onLoad(
+      opts: { filter: RegExp; namespace?: string },
+      cb: () => { contents: string; loader: string }
+    ): void
+  }): void
+}
+interface BunBuildApi {
+  build(opts: {
+    entrypoints: string[]
+    target?: 'browser' | 'node' | 'bun'
+    format?: 'esm' | 'cjs' | 'iife'
+    minify?:
+      | boolean
+      | { whitespace?: boolean; identifiers?: boolean; syntax?: boolean }
+    sourcemap?: 'none' | 'linked' | 'external' | 'inline'
+    define?: Record<string, string>
+    banner?: string
+    external?: string[]
+    metafile?: boolean
+    plugins?: BunPlugin[]
+  }): Promise<BunBuildResult>
+}
+
+function getBun(): BunBuildApi {
+  const bun = (globalThis as { Bun?: BunBuildApi }).Bun
+  if (!bun) {
+    throw new Error('BunBundler used outside the Bun runtime')
+  }
+  return bun
+}
+
+const pkgHead = (spec: string): string =>
+  spec.startsWith('@')
+    ? spec.split('/').slice(0, 2).join('/')
+    : spec.split('/')[0]
+
+/**
+ * Unified resolve plugin. Bun resolves its `.bun` store natively, so this plugin
+ * only replicates the option-driven behaviour the esbuild backend gets for free:
+ *   - `aliases`: rewrite bare builtins to their `node:`-prefixed form (CF's
+ *     nodejs_compat_v2 only resolves prefixed imports).
+ *   - stub patterns (dead services + provider `stubModules`): empty module.
+ *   - `externals`: keep external (node:*, cloudflare:*, declared npm deps) and
+ *     CAPTURE the real npm package names — Bun's metafile omits external
+ *     imports, so capture is how per-unit dependency extraction works.
+ */
+function createBunResolvePlugin(opts: {
+  aliases?: Record<string, string>
+  externals: string[]
+  stubPatterns: RegExp[]
+  captured: Set<string>
+}): BunPlugin {
+  const { aliases, externals, stubPatterns, captured } = opts
+  const externalMatchers = externals.map((pat) => {
+    if (pat.endsWith('*')) {
+      const prefix = pat.slice(0, -1)
+      return (s: string) => s.startsWith(prefix)
+    }
+    return (s: string) => s === pat || s.startsWith(pat + '/')
+  })
+  return {
+    name: 'pikku-bun-resolve',
+    setup(build) {
+      build.onResolve({ filter: /.*/ }, (args) => {
+        let path = args.path
+        // Relative / absolute → let Bun resolve natively.
+        if (path.startsWith('.') || path.startsWith('/')) return
+        // Builtin alias (e.g. crypto → node:crypto).
+        if (aliases && aliases[path]) path = aliases[path]
+        // Dead/stubbed modules → empty module.
+        if (stubPatterns.some((re) => re.test(path))) {
+          return { path, namespace: 'pikku-stub' }
+        }
+        // node: builtins are always external (covers aliased builtins on CF).
+        if (path.startsWith('node:')) return { path, external: true }
+        // Provider externals (cloudflare:*, declared npm deps).
+        if (externalMatchers.some((m) => m(path))) {
+          // Only real npm packages are install-time deps (skip scheme imports).
+          if (!path.includes(':')) captured.add(pkgHead(path))
+          return { path, external: true }
+        }
+        // Everything else → Bun bundles it (resolving the .bun store natively).
+        return
+      })
+      build.onLoad({ filter: /.*/, namespace: 'pikku-stub' }, () => ({
+        contents: 'export {}',
+        loader: 'js',
+      }))
+    },
+  }
+}
+
+export class BunBundler extends BaseBundler {
+  protected async compile(input: CompileInput): Promise<CompileResult> {
+    const captured = new Set<string>()
+    const result = await getBun().build({
+      entrypoints: [input.entryPath],
+      target: input.platform === 'node' ? 'node' : 'browser',
+      format: input.format === 'cjs' ? 'cjs' : 'esm',
+      // identifiers:true is safe — pikku's only name-based reflection
+      // (error→status mapping) compares a class against an instance of the SAME
+      // (consistently-renamed) class, and workflow exceptions hardcode their
+      // `.name` string. So full minification preserves correctness.
+      minify: { whitespace: true, syntax: true, identifiers: true },
+      sourcemap: input.sourcemap ? 'external' : 'none',
+      define: input.define,
+      banner: input.bannerJs,
+      external: input.externals,
+      metafile: input.emitMetafile,
+      plugins: [
+        createBunResolvePlugin({
+          aliases: input.aliases,
+          externals: input.externals,
+          stubPatterns: input.deadPatterns,
+          captured,
+        }),
+      ],
+    })
+    if (!result.success) {
+      throw new Error(
+        `Bun.build failed for unit "${input.unitName}":\n` +
+          result.logs.map((l) => String(l)).join('\n')
+      )
+    }
+
+    const entryArtifact =
+      result.outputs.find((o) => o.kind === 'entry-point') ?? result.outputs[0]
+    await writeFile(input.bundlePath, await entryArtifact.text(), 'utf-8')
+    if (input.sourcemap) {
+      const mapArtifact = result.outputs.find((o) => o.kind === 'sourcemap')
+      if (mapArtifact) {
+        await writeFile(
+          `${input.bundlePath}.map`,
+          await mapArtifact.text(),
+          'utf-8'
+        )
+      }
+    }
+
+    return {
+      externalPackages: captured,
+      metafileJson:
+        input.emitMetafile && result.metafile
+          ? JSON.stringify(result.metafile, null, 2)
+          : undefined,
+    }
+  }
+}

--- a/packages/cli/src/deploy/bundler/bundler.interface.ts
+++ b/packages/cli/src/deploy/bundler/bundler.interface.ts
@@ -1,0 +1,69 @@
+/**
+ * Bundler abstraction.
+ *
+ * A `Bundler` turns a deployment manifest's units into self-contained bundles.
+ * The shared orchestration (dead-module stubbing, dependency extraction,
+ * package.json + hashing) lives in `BaseBundler`; each runtime supplies only the
+ * compile step via a `Bundler` implementation (esbuild for node, Bun.build for
+ * bun). The runtime is resolved once in `services.ts` and injected — no
+ * `typeof Bun` checks in the pipeline.
+ */
+
+import type {
+  DeploymentManifest,
+  DeploymentUnit,
+  BundleOutput,
+} from './types.js'
+
+/**
+ * Inputs the shared orchestration hands to a backend's runtime-specific compile
+ * step. The backend writes `bundlePath` (and `${bundlePath}.map` when
+ * `sourcemap`) itself and returns the external packages + optional metafile.
+ */
+export interface CompileInput {
+  unitName: string
+  entryPath: string
+  bundlePath: string
+  projectDir: string
+  platform: 'node' | 'neutral' | 'browser'
+  format: 'esm' | 'cjs'
+  externals: string[]
+  aliases?: Record<string, string>
+  define?: Record<string, string>
+  /** ESM require/__filename/__dirname shim, or undefined when not needed. */
+  bannerJs?: string
+  sourcemap: boolean
+  emitMetafile: boolean
+  /** Regexes for modules to replace with an empty `export {}` module. */
+  deadPatterns: RegExp[]
+}
+
+export interface CompileResult {
+  /** Real npm package names kept external — drive the unit's package.json. */
+  externalPackages: Set<string>
+  /** Stringified metafile when `emitMetafile` was set; otherwise undefined. */
+  metafileJson?: string
+}
+
+export interface BundleUnitsOptions {
+  externals?: string[]
+  aliases?: Record<string, string>
+  define?: Record<string, string>
+  platform?: 'node' | 'neutral' | 'browser'
+  format?: 'esm' | 'cjs'
+  noRequireShim?: boolean
+  sourcemap?: boolean
+  emitMetafile?: boolean
+  stubModules?: string[]
+  resolveOutputDir?: (unit: DeploymentUnit, baseOutputDir: string) => string
+}
+
+export interface Bundler {
+  bundleUnits(
+    projectDir: string,
+    manifest: DeploymentManifest,
+    entryFiles: Map<string, string>,
+    outputDir?: string,
+    options?: BundleUnitsOptions
+  ): Promise<BundleOutput>
+}

--- a/packages/cli/src/deploy/bundler/bundler.ts
+++ b/packages/cli/src/deploy/bundler/bundler.ts
@@ -1,31 +1,39 @@
 /**
- * Main esbuild bundling pipeline for Pikku.
+ * Shared bundling orchestration for Pikku deploys.
  *
- * For each deployment unit in a DeploymentManifest, this module:
- * 1. Takes a pre-generated entry point (provided by the deploy provider)
- * 2. Runs esbuild with bundle:true, npm packages external
- * 3. Stubs Node.js-only gen files that aren't needed by this unit
- * 4. Parses the metafile to extract external dependencies
- * 5. Generates a minimal package.json with exact versions
- * 6. Writes all artifacts to `<outputDir>/<unit-name>/`
+ * `BaseBundler` performs everything that is runtime-independent for each
+ * deployment unit:
+ * 1. Take a pre-generated entry point (provided by the deploy provider)
+ * 2. Stub gen files / npm modules not needed by this unit
+ * 3. Delegate the actual compile to a runtime backend (`compile`)
+ * 4. Resolve external dependency versions into a minimal package.json
+ * 5. Write all artifacts to `<outputDir>/<unit-name>/` and hash them
+ *
+ * The runtime-specific compile step lives in `NodeBundler` (esbuild) and
+ * `BunBundler` (Bun.build); the right one is injected from `services.ts`.
  */
 
-import { build, type Plugin } from 'esbuild'
 import { writeFile, mkdir, stat, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createHash } from 'node:crypto'
 
 import {
-  extractDependencies,
+  resolveExternalVersions,
   generateMinimalPackageJson,
 } from './dep-extractor.js'
 import type {
-  DeploymentManifest,
   DeploymentUnit,
+  DeploymentManifest,
   BundleResult,
   BundleError,
   BundleOutput,
 } from './types.js'
+import type {
+  Bundler,
+  BundleUnitsOptions,
+  CompileInput,
+  CompileResult,
+} from './bundler.interface.js'
 
 /**
  * Mapping of service name -> gen file pattern that should be stubbed
@@ -84,292 +92,195 @@ async function getDeadGenFilePatterns(
   return patterns
 }
 
-/**
- * esbuild plugin that stubs gen files for services not needed by this unit.
- * This prevents Node.js-only modules (e.g. LocalMetaService which uses fs)
- * from being pulled into serverless worker bundles via dynamic imports.
- */
-function createDeadModuleStubPlugin(patterns: RegExp[]): Plugin {
-  return {
-    name: 'pikku-dead-module-stub',
-    setup(build) {
-      if (patterns.length === 0) return
-      const combined = new RegExp(patterns.map((p) => p.source).join('|'))
-      build.onResolve({ filter: combined }, (args) => ({
-        path: args.path,
-        namespace: 'pikku-stub',
-      }))
-      build.onLoad({ filter: /.*/, namespace: 'pikku-stub' }, () => ({
-        contents: 'export {}',
-        loader: 'js',
-      }))
-    },
-  }
-}
-
 const BUNDLE_FILENAME = 'bundle.js'
 const METAFILE_FILENAME = 'metafile.json'
 const PACKAGE_JSON_FILENAME = 'package.json'
 const EXACT_DEPENDENCIES_FILENAME = 'exact-dependencies.json'
 
-interface BundleUnitOptions {
-  unit: DeploymentUnit
-  entryPath: string
-  unitOutputDir: string
-  projectDir: string
-  externals?: string[]
-  aliases?: Record<string, string>
-  define?: Record<string, string>
-  platform?: 'node' | 'neutral' | 'browser'
-  format?: 'esm' | 'cjs'
-  noRequireShim?: boolean
-  /** Emit a `.js.map` sourcemap next to the bundle (debug-only). Default false. */
-  sourcemap?: boolean
-  /** Persist esbuild's metafile to `metafile.json` (debug-only). Default false. */
-  emitMetafile?: boolean
-  /** Regex sources for modules to stub to `export {}` (provider runtime never runs them). */
-  stubModules?: string[]
-}
-
 /**
- * Bundles a single deployment unit using esbuild.
- *
- * Produces three files in the unit output directory:
- * - bundle.js: The bundled code (user code only, external deps as bare imports)
- * - metafile.json: esbuild's metafile for analysis
- * - package.json: Minimal manifest with only the external deps this unit needs
+ * Runtime-independent bundling orchestration. Subclasses implement only
+ * `compile` — the actual esbuild / Bun.build invocation.
  */
-async function bundleUnit(options: BundleUnitOptions): Promise<BundleResult> {
-  const {
-    unit,
-    entryPath,
-    unitOutputDir,
-    projectDir,
-    externals,
-    aliases,
-    define,
-    platform,
-    format,
-    sourcemap,
-    emitMetafile,
-    stubModules,
-  } = options
+export abstract class BaseBundler implements Bundler {
+  /**
+   * Runtime-specific compile step: write `input.bundlePath` (and its `.map`
+   * when `input.sourcemap`) and return the external packages + optional
+   * metafile JSON.
+   */
+  protected abstract compile(input: CompileInput): Promise<CompileResult>
 
-  await mkdir(unitOutputDir, { recursive: true })
+  async bundleUnits(
+    projectDir: string,
+    manifest: DeploymentManifest,
+    entryFiles: Map<string, string>,
+    outputDir?: string,
+    options?: BundleUnitsOptions
+  ): Promise<BundleOutput> {
+    const buildDir = outputDir ?? join(projectDir, '.deploy', 'build')
+    const results: BundleResult[] = []
+    const errors: BundleError[] = []
 
-  const bundlePath = join(unitOutputDir, BUNDLE_FILENAME)
-  const metafilePath = join(unitOutputDir, METAFILE_FILENAME)
-  const packageJsonPath = join(unitOutputDir, PACKAGE_JSON_FILENAME)
-  const exactDependenciesPath = join(unitOutputDir, EXACT_DEPENDENCIES_FILENAME)
+    if (manifest.units.length === 0) {
+      return { results, errors }
+    }
 
-  // Determine which gen files to stub based on per-unit service requirements,
-  // plus any provider-supplied module stubs (modules the provider's runtime
-  // never executes — e.g. the `postgres` driver on CF Workers, which use a
-  // libsql/Turso dialect; the postgres branch is URL-gated and never taken).
-  const deadPatterns = await getDeadGenFilePatterns(unitOutputDir)
-  for (const source of stubModules ?? []) {
-    deadPatterns.push(new RegExp(source))
-  }
+    for (const unit of manifest.units) {
+      const entryPath = entryFiles.get(unit.name)
+      if (!entryPath) {
+        errors.push({
+          unitName: unit.name,
+          error: `No entry point provided for unit "${unit.name}"`,
+        })
+        continue
+      }
 
-  // Run esbuild — inline everything into a self-contained bundle.
-  // Only Node built-ins are kept external (CF Workers provides them).
-  // The stub plugin replaces gen files for unused services with empty
-  // modules, preventing Node.js-only code from entering the bundle.
-  // Resolve node_modules paths up the directory tree for workspace packages
-  const nodePaths: string[] = []
-  let dir = projectDir
-  while (true) {
-    const nm = join(dir, 'node_modules')
-    nodePaths.push(nm)
-    const parent = join(dir, '..')
-    if (parent === dir) break
-    dir = parent
-  }
+      const unitOutputDir = options?.resolveOutputDir
+        ? options.resolveOutputDir(unit, buildDir)
+        : join(buildDir, unit.name)
 
-  // For ESM + node platform, CJS deps may use require() / __filename / __dirname
-  // for builtins or to locate native addons (the `bindings` package, used
-  // transitively by `pg` and many others, calls `__filename` directly). esbuild
-  // wraps require() as __require() which fails at runtime in ESM, and leaves
-  // `__filename` / `__dirname` as undefined references. The banner shims all
-  // three via createRequire / fileURLToPath so CJS builtins resolve and native-
-  // addon loaders find their .node files.
-  // Skipped when the provider opts out via `noRequireShim` (e.g. CF Workers
-  // — `import.meta.url` is undefined there, so the shim crashes at boot).
-  const resolvedFormat = format ?? 'esm'
-  const banner =
-    resolvedFormat === 'esm' &&
-    (platform ?? 'node') === 'node' &&
-    !options.noRequireShim
-      ? {
-          js: `import { createRequire as __pikkuCreateRequire } from 'node:module'; import { fileURLToPath as __pikkuFileURLToPath } from 'node:url'; import { dirname as __pikkuDirname } from 'node:path'; const require = __pikkuCreateRequire(import.meta.url); const __filename = __pikkuFileURLToPath(import.meta.url); const __dirname = __pikkuDirname(__filename);`,
-        }
-      : undefined
+      try {
+        const result = await this.bundleUnit(
+          unit,
+          entryPath,
+          unitOutputDir,
+          projectDir,
+          options ?? {}
+        )
+        results.push(result)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        errors.push({ unitName: unit.name, error: message })
+      }
+    }
 
-  const result = await build({
-    entryPoints: [entryPath],
-    bundle: true,
-    absWorkingDir: projectDir,
-    nodePaths,
-    platform: platform ?? 'node',
-    format: resolvedFormat,
-    banner,
-    metafile: true,
-    target: 'es2022',
-    outfile: bundlePath,
-    // Minify every deploy bundle — esbuild output ships straight to the runtime
-    // (CF Workers / container), tsc is never the bundler. keepNames preserves
-    // Function.name / constructor.name so name-based reflection still works.
-    minify: true,
-    keepNames: true,
-    sourcemap: sourcemap ?? false,
-    logLevel: 'warning',
-    loader: { '.ts': 'ts' },
-    external: externals ?? ['node:*'],
-    alias: aliases,
-    define,
-    plugins: [createDeadModuleStubPlugin(deadPatterns)],
-  })
-
-  // Always produced in-memory (drives dependency extraction); only persisted
-  // when requested — it's large (~1.6MB/unit) and never needed at runtime.
-  if (emitMetafile) {
-    const metafileJson = JSON.stringify(result.metafile, null, 2)
-    await writeFile(metafilePath, metafileJson, 'utf-8')
-  }
-
-  // Extract dependencies and generate minimal package.json
-  const { exactDependencies, exactOptionalDependencies } =
-    await extractDependencies(result.metafile, projectDir)
-  const packageJson = generateMinimalPackageJson(
-    unit.name,
-    exactDependencies,
-    exactOptionalDependencies
-  )
-  await writeFile(
-    packageJsonPath,
-    JSON.stringify(packageJson, null, 2),
-    'utf-8'
-  )
-  await writeFile(
-    exactDependenciesPath,
-    JSON.stringify(
-      {
-        dependencies: Object.fromEntries(
-          Object.entries(exactDependencies).sort(([a], [b]) =>
-            a.localeCompare(b)
-          )
-        ),
-        optionalDependencies: Object.fromEntries(
-          Object.entries(exactOptionalDependencies).sort(([a], [b]) =>
-            a.localeCompare(b)
-          )
-        ),
-      },
-      null,
-      2
-    ),
-    'utf-8'
-  )
-
-  // Get bundle size
-  const bundleStat = await stat(bundlePath)
-  const bundleContents = await readFile(bundlePath)
-  const bundleHash = createHash('sha256').update(bundleContents).digest('hex')
-  const exactDependenciesHash = createHash('sha256')
-    .update(
-      JSON.stringify({
-        dependencies: Object.entries(exactDependencies).sort(([a], [b]) =>
-          a.localeCompare(b)
-        ),
-        optionalDependencies: Object.entries(exactOptionalDependencies).sort(
-          ([a], [b]) => a.localeCompare(b)
-        ),
-      })
-    )
-    .digest('hex')
-
-  return {
-    unitName: unit.name,
-    bundlePath,
-    packageJsonPath,
-    exactDependenciesPath,
-    metafilePath,
-    bundleSizeBytes: bundleStat.size,
-    bundleHash,
-    exactDependenciesHash,
-    exactDependencies,
-    exactOptionalDependencies,
-  }
-}
-
-/**
- * Bundles all deployment units defined in a DeploymentManifest.
- *
- * Entry points must be pre-generated by the provider-specific package
- * (e.g. @pikku/deploy-cloudflare) and passed in as entryFiles.
- *
- * @param projectDir - Root directory of the Pikku project
- * @param manifest - The deployment manifest describing all units
- * @param entryFiles - Map of unit name -> entry file path (generated by the deploy provider)
- * @param outputDir - Base output directory (defaults to `<projectDir>/.deploy/build`)
- */
-export async function bundleUnits(
-  projectDir: string,
-  manifest: DeploymentManifest,
-  entryFiles: Map<string, string>,
-  outputDir?: string,
-  options?: {
-    externals?: string[]
-    aliases?: Record<string, string>
-    define?: Record<string, string>
-    platform?: 'node' | 'neutral' | 'browser'
-    format?: 'esm' | 'cjs'
-    noRequireShim?: boolean
-    sourcemap?: boolean
-    emitMetafile?: boolean
-    stubModules?: string[]
-    resolveOutputDir?: (unit: DeploymentUnit, baseOutputDir: string) => string
-  }
-): Promise<BundleOutput> {
-  const buildDir = outputDir ?? join(projectDir, '.deploy', 'build')
-  const results: BundleResult[] = []
-  const errors: BundleError[] = []
-
-  if (manifest.units.length === 0) {
     return { results, errors }
   }
 
-  for (const unit of manifest.units) {
-    const entryPath = entryFiles.get(unit.name)
-    if (!entryPath) {
-      errors.push({
-        unitName: unit.name,
-        error: `No entry point provided for unit "${unit.name}"`,
-      })
-      continue
+  private async bundleUnit(
+    unit: DeploymentUnit,
+    entryPath: string,
+    unitOutputDir: string,
+    projectDir: string,
+    options: BundleUnitsOptions
+  ): Promise<BundleResult> {
+    await mkdir(unitOutputDir, { recursive: true })
+
+    const bundlePath = join(unitOutputDir, BUNDLE_FILENAME)
+    const metafilePath = join(unitOutputDir, METAFILE_FILENAME)
+    const packageJsonPath = join(unitOutputDir, PACKAGE_JSON_FILENAME)
+    const exactDependenciesPath = join(
+      unitOutputDir,
+      EXACT_DEPENDENCIES_FILENAME
+    )
+
+    // Determine which gen files to stub based on per-unit service requirements,
+    // plus any provider-supplied module stubs (modules the provider's runtime
+    // never executes — e.g. the `postgres` driver on CF Workers, which use a
+    // libsql/Turso dialect; the postgres branch is URL-gated and never taken).
+    const deadPatterns = await getDeadGenFilePatterns(unitOutputDir)
+    for (const source of options.stubModules ?? []) {
+      deadPatterns.push(new RegExp(source))
     }
 
-    const unitOutputDir = options?.resolveOutputDir
-      ? options.resolveOutputDir(unit, buildDir)
-      : join(buildDir, unit.name)
+    const platform = options.platform ?? 'node'
+    const format = options.format ?? 'esm'
+    const externals = options.externals ?? ['node:*']
+    const sourcemap = options.sourcemap ?? false
+    const emitMetafile = options.emitMetafile ?? false
 
-    try {
-      const result = await bundleUnit({
-        unit,
-        entryPath,
-        unitOutputDir,
-        projectDir,
-        ...options,
-      })
-      results.push(result)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      errors.push({
-        unitName: unit.name,
-        error: message,
-      })
+    // For ESM + node platform, CJS deps may use require() / __filename /
+    // __dirname for builtins or to locate native addons (the `bindings`
+    // package, used transitively by `pg`, calls `__filename` directly). esbuild
+    // wraps require() as __require() which fails at runtime in ESM, and leaves
+    // `__filename` / `__dirname` as undefined references. The banner shims all
+    // three so CJS builtins resolve and native-addon loaders find their .node
+    // files. Skipped when the provider opts out via `noRequireShim` (e.g. CF
+    // Workers — `import.meta.url` is undefined there, so the shim crashes).
+    const bannerJs =
+      format === 'esm' && platform === 'node' && !options.noRequireShim
+        ? `import { createRequire as __pikkuCreateRequire } from 'node:module'; import { fileURLToPath as __pikkuFileURLToPath } from 'node:url'; import { dirname as __pikkuDirname } from 'node:path'; const require = __pikkuCreateRequire(import.meta.url); const __filename = __pikkuFileURLToPath(import.meta.url); const __dirname = __pikkuDirname(__filename);`
+        : undefined
+
+    const { externalPackages, metafileJson } = await this.compile({
+      unitName: unit.name,
+      entryPath,
+      bundlePath,
+      projectDir,
+      platform,
+      format,
+      externals,
+      aliases: options.aliases,
+      define: options.define,
+      bannerJs,
+      sourcemap,
+      emitMetafile,
+      deadPatterns,
+    })
+
+    // Metafile is large (~1.6MB/unit) and never needed at runtime — only
+    // persisted for debugging.
+    if (emitMetafile && metafileJson) {
+      await writeFile(metafilePath, metafileJson, 'utf-8')
+    }
+
+    // Extract dependencies and generate minimal package.json
+    const { exactDependencies, exactOptionalDependencies } =
+      await resolveExternalVersions(externalPackages, projectDir)
+    const packageJson = generateMinimalPackageJson(
+      unit.name,
+      exactDependencies,
+      exactOptionalDependencies
+    )
+    await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf-8')
+    await writeFile(
+      exactDependenciesPath,
+      JSON.stringify(
+        {
+          dependencies: Object.fromEntries(
+            Object.entries(exactDependencies).sort(([a], [b]) =>
+              a.localeCompare(b)
+            )
+          ),
+          optionalDependencies: Object.fromEntries(
+            Object.entries(exactOptionalDependencies).sort(([a], [b]) =>
+              a.localeCompare(b)
+            )
+          ),
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    )
+
+    // Get bundle size + hashes
+    const bundleStat = await stat(bundlePath)
+    const bundleContents = await readFile(bundlePath)
+    const bundleHash = createHash('sha256').update(bundleContents).digest('hex')
+    const exactDependenciesHash = createHash('sha256')
+      .update(
+        JSON.stringify({
+          dependencies: Object.entries(exactDependencies).sort(([a], [b]) =>
+            a.localeCompare(b)
+          ),
+          optionalDependencies: Object.entries(exactOptionalDependencies).sort(
+            ([a], [b]) => a.localeCompare(b)
+          ),
+        })
+      )
+      .digest('hex')
+
+    return {
+      unitName: unit.name,
+      bundlePath,
+      packageJsonPath,
+      exactDependenciesPath,
+      metafilePath,
+      bundleSizeBytes: bundleStat.size,
+      bundleHash,
+      exactDependenciesHash,
+      exactDependencies,
+      exactOptionalDependencies,
     }
   }
-
-  return { results, errors }
 }

--- a/packages/cli/src/deploy/bundler/dep-extractor.ts
+++ b/packages/cli/src/deploy/bundler/dep-extractor.ts
@@ -285,21 +285,19 @@ async function resolveVersion(
 }
 
 /**
- * Given an esbuild metafile, extracts all external packages and resolves
- * their versions from the project's dependency files.
+ * Resolves exact versions for a set of external package names.
  *
- * Returns a record of package name to exact version, suitable for
- * writing into a minimal package.json.
+ * Shared by both bundler backends: esbuild derives the set from its metafile
+ * (`extractExternalPackages`), while the Bun.build backend captures it via a
+ * resolve plugin (Bun's metafile does not record external imports).
  */
-export async function extractDependencies(
-  metafile: Metafile,
+export async function resolveExternalVersions(
+  externalPackages: Set<string>,
   projectDir: string
 ): Promise<{
   exactDependencies: Record<string, string>
   exactOptionalDependencies: Record<string, string>
 }> {
-  const externalPackages = extractExternalPackages(metafile)
-
   if (externalPackages.size === 0) {
     return { exactDependencies: {}, exactOptionalDependencies: {} }
   }
@@ -333,6 +331,20 @@ export async function extractDependencies(
   }
 
   return { exactDependencies, exactOptionalDependencies }
+}
+
+/**
+ * Given an esbuild metafile, extracts all external packages and resolves
+ * their versions from the project's dependency files.
+ */
+export async function extractDependencies(
+  metafile: Metafile,
+  projectDir: string
+): Promise<{
+  exactDependencies: Record<string, string>
+  exactOptionalDependencies: Record<string, string>
+}> {
+  return resolveExternalVersions(extractExternalPackages(metafile), projectDir)
 }
 
 /**

--- a/packages/cli/src/deploy/bundler/index.ts
+++ b/packages/cli/src/deploy/bundler/index.ts
@@ -1,7 +1,11 @@
-export { bundleUnits } from './bundler.js'
+export { BaseBundler } from './bundler.js'
+export { NodeBundler } from './node-bundler.js'
+export { BunBundler } from './bun-bundler.js'
+export type { Bundler, BundleUnitsOptions } from './bundler.interface.js'
 export {
   extractDependencies,
   extractExternalPackages,
+  resolveExternalVersions,
   parsePackageName,
   generateMinimalPackageJson,
 } from './dep-extractor.js'

--- a/packages/cli/src/deploy/bundler/node-bundler.ts
+++ b/packages/cli/src/deploy/bundler/node-bundler.ts
@@ -1,0 +1,85 @@
+/**
+ * Node (esbuild) bundler backend.
+ *
+ * Used when the CLI runs under Node (yarn/npm projects). esbuild resolves deps
+ * via `nodePaths` walking up the directory tree, which assumes a flat, hoisted
+ * `node_modules` — exactly what yarn/npm produce. For bun's per-workspace
+ * symlink layout use `BunBundler` instead (selected in `services.ts`).
+ */
+
+import { build, type Plugin } from 'esbuild'
+import { join } from 'node:path'
+
+import { extractExternalPackages } from './dep-extractor.js'
+import { BaseBundler } from './bundler.js'
+import type { CompileInput, CompileResult } from './bundler.interface.js'
+
+/**
+ * esbuild plugin that stubs gen files / modules not needed by this unit,
+ * preventing Node-only modules (e.g. LocalMetaService using fs) from being
+ * pulled into serverless worker bundles via dynamic imports.
+ */
+function createDeadModuleStubPlugin(patterns: RegExp[]): Plugin {
+  return {
+    name: 'pikku-dead-module-stub',
+    setup(build) {
+      if (patterns.length === 0) return
+      const combined = new RegExp(patterns.map((p) => p.source).join('|'))
+      build.onResolve({ filter: combined }, (args) => ({
+        path: args.path,
+        namespace: 'pikku-stub',
+      }))
+      build.onLoad({ filter: /.*/, namespace: 'pikku-stub' }, () => ({
+        contents: 'export {}',
+        loader: 'js',
+      }))
+    },
+  }
+}
+
+export class NodeBundler extends BaseBundler {
+  protected async compile(input: CompileInput): Promise<CompileResult> {
+    // Resolve node_modules paths up the directory tree for workspace packages.
+    const nodePaths: string[] = []
+    let dir = input.projectDir
+    while (true) {
+      nodePaths.push(join(dir, 'node_modules'))
+      const parent = join(dir, '..')
+      if (parent === dir) break
+      dir = parent
+    }
+
+    const result = await build({
+      entryPoints: [input.entryPath],
+      bundle: true,
+      absWorkingDir: input.projectDir,
+      nodePaths,
+      platform: input.platform,
+      format: input.format,
+      banner: input.bannerJs ? { js: input.bannerJs } : undefined,
+      metafile: true,
+      target: 'es2022',
+      outfile: input.bundlePath,
+      // Minify every deploy bundle — esbuild output ships straight to the
+      // runtime (CF Workers / container), tsc is never the bundler. keepNames
+      // preserves Function.name / constructor.name so name-based reflection
+      // still works.
+      minify: true,
+      keepNames: true,
+      sourcemap: input.sourcemap,
+      logLevel: 'warning',
+      loader: { '.ts': 'ts' },
+      external: input.externals,
+      alias: input.aliases,
+      define: input.define,
+      plugins: [createDeadModuleStubPlugin(input.deadPatterns)],
+    })
+
+    return {
+      externalPackages: extractExternalPackages(result.metafile),
+      metafileJson: input.emitMetafile
+        ? JSON.stringify(result.metafile, null, 2)
+        : undefined,
+    }
+  }
+}

--- a/packages/cli/src/fabric/functions/llm-key.function.ts
+++ b/packages/cli/src/fabric/functions/llm-key.function.ts
@@ -40,10 +40,7 @@ export const FabricLLMKey = pikkuSessionlessFunc({
     }
 
     const rpc = getFabricRPC({ apiUrl: ctx.apiUrl, token: ctx.token })
-    const result = (await rpc.invoke('getDeveloperLiteLLMKey', {})) as {
-      proxyUrl: string
-      apiKey: string
-    }
+    const result = await rpc.invoke('getDeveloperLiteLLMKey', {})
     const format: 'text' | 'env' | 'shell' | 'json' = shell
       ? 'shell'
       : env

--- a/packages/cli/src/functions/commands/deploy-apply.ts
+++ b/packages/cli/src/functions/commands/deploy-apply.ts
@@ -270,7 +270,7 @@ export const deployApply = pikkuSessionlessFunc<
   },
   void
 >({
-  func: async ({ logger, config, getInspectorState }, data) => {
+  func: async ({ logger, config, getInspectorState, bundler }, data) => {
     const projectDir = config.rootDir
     const provider = await resolveProvider(config, data?.provider, {
       runtime: data?.runtime,
@@ -316,6 +316,7 @@ export const deployApply = pikkuSessionlessFunc<
       outDir: config.outDir,
       debugArtifacts: data?.debugArtifacts ?? false,
       logger,
+      bundler,
     })
 
     if (buildResult.manifest.units.length === 0) {

--- a/packages/cli/src/functions/commands/deploy-plan.ts
+++ b/packages/cli/src/functions/commands/deploy-plan.ts
@@ -60,7 +60,7 @@ export const deployPlan = pikkuSessionlessFunc<
   },
   void
 >({
-  func: async ({ logger, config, getInspectorState }, data) => {
+  func: async ({ logger, config, getInspectorState, bundler }, data) => {
     const projectDir = config.rootDir
     const inspectorState = await getInspectorState(true)
     const projectId = await resolveProjectId(projectDir)
@@ -79,6 +79,7 @@ export const deployPlan = pikkuSessionlessFunc<
       outDir: config.outDir,
       debugArtifacts: data?.debugArtifacts ?? false,
       logger,
+      bundler,
     })
 
     if (result.manifest.units.length === 0) {

--- a/packages/cli/src/functions/commands/dev.ts
+++ b/packages/cli/src/functions/commands/dev.ts
@@ -19,14 +19,10 @@ import {
 import { stopSingletonServices } from '@pikku/core'
 import { pikkuState } from '@pikku/core/internal'
 import { LocalMetaService } from '@pikku/core/services/local-meta'
-import { LocalEventHubService } from '@pikku/core/channel/local'
 import {
   LocalContent,
   type LocalContentConfig,
 } from '@pikku/core/services/local-content'
-import { pikkuWebsocketHandler } from '@pikku/ws'
-import { PikkuNodeHTTPServer } from '@pikku/node-http-server'
-import { WebSocketServer } from 'ws'
 import { InMemorySchedulerService } from '@pikku/schedule'
 import {
   resolveDb,
@@ -43,7 +39,7 @@ export const dev = pikkuSessionlessFunc<
 >({
   remote: true,
   func: async (
-    { logger, config, getInspectorState, variables },
+    { logger, config, getInspectorState, variables, devServerRunner },
     { port, watch, hmr },
     { rpc }
   ) => {
@@ -262,20 +258,10 @@ export const dev = pikkuSessionlessFunc<
           variables,
         })
       : undefined
-    // When the CLI itself runs under bun (e.g. the compiled brew binary), serve
-    // over @pikku/bun-server (native Bun.serve WebSockets) instead of the node
-    // http server + ws package. The bun runtime is dynamically imported so a
-    // node-run CLI never loads it. The same BunEventHubService instance is
-    // shared with the singleton services so function-side broadcasts reach the
-    // sockets the transport holds.
-    const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined'
-    const bun = isBun
-      ? await (async () => {
-          const mod = await import('@pikku/bun-server')
-          return { mod, eventHub: new mod.BunEventHubService() }
-        })()
-      : null
-    const eventHub = bun ? bun.eventHub : new LocalEventHubService()
+    // The dev server runner (node http+ws, or bun-server) is resolved by DI in
+    // services.ts. Its EventHub is shared into the singleton services so
+    // function-side broadcasts reach the sockets the transport holds.
+    const eventHub = await devServerRunner.createEventHub()
     const inMemoryServices = {
       logger: devLogger,
       ...(aiAgentRunner ? { aiAgentRunner } : {}),
@@ -303,40 +289,15 @@ export const dev = pikkuSessionlessFunc<
       getInspectorState,
     })
 
-    let wss: WebSocketServer | undefined
-    let pikkuServer: {
-      init(): Promise<void>
-      start(): Promise<void>
-      stop(): Promise<void>
-    }
-    if (bun) {
-      pikkuServer = new bun.mod.PikkuBunServer(
-        {
-          ...userConfig,
-          hostname: bindHostname,
-          port: resolvedPort,
-          content: localContentConfig,
-        },
-        logger,
-        { eventHub: bun.eventHub }
-      )
-    } else {
-      wss = new WebSocketServer({ noServer: true })
-      pikkuServer = new PikkuNodeHTTPServer(
-        {
-          ...userConfig,
-          hostname: bindHostname,
-          port: resolvedPort,
-          content: localContentConfig,
-        },
-        logger,
-        {
-          configureServer: (httpServer) => {
-            pikkuWebsocketHandler({ server: httpServer, wss: wss!, logger })
-          },
-        }
-      )
-    }
+    const pikkuServer = devServerRunner.createServer(
+      {
+        ...userConfig,
+        hostname: bindHostname,
+        port: resolvedPort,
+        content: localContentConfig,
+      },
+      logger
+    )
 
     await pikkuServer.init()
     await schedulerService.start()
@@ -351,11 +312,6 @@ export const dev = pikkuSessionlessFunc<
         await stopSingletonServices()
         await configWatcher?.close()
         await watcher?.close()
-        if (wss) {
-          await new Promise<void>((resolve, reject) =>
-            wss!.close((err) => (err ? reject(err) : resolve()))
-          )
-        }
         await pikkuServer.stop()
       } finally {
         process.exit(0)

--- a/packages/cli/src/server/bun-server-runner.ts
+++ b/packages/cli/src/server/bun-server-runner.ts
@@ -10,6 +10,7 @@
 import type { EventHubService } from '@pikku/core'
 import type { Logger } from '@pikku/core/services'
 import type { BunEventHubService } from '@pikku/bun-server'
+import type * as BunServer from '@pikku/bun-server'
 
 import type {
   DevServerRunner,
@@ -18,7 +19,7 @@ import type {
 } from './dev-server-runner.interface.js'
 
 export class BunServerRunner implements DevServerRunner {
-  private mod?: typeof import('@pikku/bun-server')
+  private mod?: typeof BunServer
   private eventHub?: BunEventHubService
 
   async createEventHub(): Promise<EventHubService<any>> {

--- a/packages/cli/src/server/bun-server-runner.ts
+++ b/packages/cli/src/server/bun-server-runner.ts
@@ -1,0 +1,38 @@
+/**
+ * Bun dev server runner — `@pikku/bun-server` (native `Bun.serve` WebSockets).
+ * Used when the CLI runs under Bun. The bun-server module is dynamically
+ * imported so a node-run CLI never loads its bun-only code; types are pulled via
+ * `import type` (erased at runtime). The same BunEventHubService instance is
+ * shared with singleton services so function-side broadcasts reach the sockets
+ * the transport holds.
+ */
+
+import type { EventHubService } from '@pikku/core'
+import type { Logger } from '@pikku/core/services'
+import type { BunEventHubService } from '@pikku/bun-server'
+
+import type {
+  DevServerRunner,
+  DevServerInstance,
+  DevServerConfig,
+} from './dev-server-runner.interface.js'
+
+export class BunServerRunner implements DevServerRunner {
+  private mod?: typeof import('@pikku/bun-server')
+  private eventHub?: BunEventHubService
+
+  async createEventHub(): Promise<EventHubService<any>> {
+    this.mod = await import('@pikku/bun-server')
+    this.eventHub = new this.mod.BunEventHubService()
+    return this.eventHub
+  }
+
+  createServer(config: DevServerConfig, logger: Logger): DevServerInstance {
+    if (!this.mod || !this.eventHub) {
+      throw new Error('createEventHub() must be called before createServer()')
+    }
+    return new this.mod.PikkuBunServer(config, logger, {
+      eventHub: this.eventHub,
+    })
+  }
+}

--- a/packages/cli/src/server/dev-server-runner.interface.ts
+++ b/packages/cli/src/server/dev-server-runner.interface.ts
@@ -1,0 +1,35 @@
+/**
+ * Dev server runner abstraction.
+ *
+ * The `pikku dev` server differs by runtime: under Node it's
+ * `@pikku/node-http-server` + the `ws` WebSocketServer; under Bun it's
+ * `@pikku/bun-server` (native `Bun.serve` WebSockets). Both also supply the
+ * EventHub that is shared into singleton services so function-side broadcasts
+ * reach the transport's sockets. The right runner is resolved once in
+ * `services.ts` and injected — no `typeof Bun` checks in the dev command.
+ */
+
+import type { EventHubService } from '@pikku/core'
+import type { Logger } from '@pikku/core/services'
+import type { NodeHTTPServerConfig } from '@pikku/node-http-server'
+
+export interface DevServerInstance {
+  init(): Promise<void>
+  start(): Promise<void>
+  /** Full teardown — closes the server and any owned WebSocket server. */
+  stop(): Promise<void>
+}
+
+/** Config shape both runtimes accept (Core config + host/port/content). */
+export type DevServerConfig = NodeHTTPServerConfig
+
+export interface DevServerRunner {
+  /**
+   * Create the EventHub for this runtime. Shared into singleton services so
+   * function-side broadcasts reach the transport's sockets. Must be called
+   * once before `createServer`.
+   */
+  createEventHub(): Promise<EventHubService<any>>
+  /** Create the dev HTTP/WS server. Must be called after `createEventHub`. */
+  createServer(config: DevServerConfig, logger: Logger): DevServerInstance
+}

--- a/packages/cli/src/server/node-server-runner.ts
+++ b/packages/cli/src/server/node-server-runner.ts
@@ -1,0 +1,43 @@
+/**
+ * Node dev server runner — `@pikku/node-http-server` + the `ws` WebSocketServer.
+ * Used when the CLI runs under Node. Owns the WebSocketServer so teardown
+ * (close ws then the http server) is encapsulated in the returned instance.
+ */
+
+import type { EventHubService } from '@pikku/core'
+import type { Logger } from '@pikku/core/services'
+import { LocalEventHubService } from '@pikku/core/channel/local'
+import { PikkuNodeHTTPServer } from '@pikku/node-http-server'
+import { pikkuWebsocketHandler } from '@pikku/ws'
+import { WebSocketServer } from 'ws'
+
+import type {
+  DevServerRunner,
+  DevServerInstance,
+  DevServerConfig,
+} from './dev-server-runner.interface.js'
+
+export class NodeServerRunner implements DevServerRunner {
+  async createEventHub(): Promise<EventHubService<any>> {
+    return new LocalEventHubService()
+  }
+
+  createServer(config: DevServerConfig, logger: Logger): DevServerInstance {
+    const wss = new WebSocketServer({ noServer: true })
+    const server = new PikkuNodeHTTPServer(config, logger, {
+      configureServer: (httpServer) => {
+        pikkuWebsocketHandler({ server: httpServer, wss, logger })
+      },
+    })
+    return {
+      init: () => server.init(),
+      start: () => server.start(),
+      stop: async () => {
+        await new Promise<void>((resolve, reject) =>
+          wss.close((err) => (err ? reject(err) : resolve()))
+        )
+        await server.stop()
+      },
+    }
+  }
+}

--- a/packages/cli/src/services.ts
+++ b/packages/cli/src/services.ts
@@ -37,6 +37,10 @@ import { existsSync } from 'fs'
 import { readFile, writeFile } from 'fs/promises'
 import { loadManifest } from './utils/contract-versions.js'
 import { join } from 'path'
+import { NodeBundler } from './deploy/bundler/node-bundler.js'
+import { BunBundler } from './deploy/bundler/bun-bundler.js'
+import { NodeServerRunner } from './server/node-server-runner.js'
+import { BunServerRunner } from './server/bun-server-runner.js'
 import { parseCLIFilters } from './utils/parse-cli-filters.js'
 
 const DIAGNOSTIC_CODE_TO_LINT_KEY: Record<
@@ -374,6 +378,11 @@ export const createSingletonServices: CreateSingletonServices<
 
   const workflowService = new InMemoryWorkflowService()
 
+  // Resolve the runtime ONCE here, then inject runtime-specific implementations.
+  // Keeping the check in this single place avoids `typeof Bun` branches leaking
+  // into the deploy pipeline / dev command.
+  const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined'
+
   return {
     config,
     logger,
@@ -382,6 +391,8 @@ export const createSingletonServices: CreateSingletonServices<
     audit: new NoopAuditService(),
     getInspectorState,
     workflowService,
+    bundler: isBun ? new BunBundler() : new NodeBundler(),
+    devServerRunner: isBun ? new BunServerRunner() : new NodeServerRunner(),
   }
 }
 

--- a/packages/cli/types/application-types.d.ts
+++ b/packages/cli/types/application-types.d.ts
@@ -8,6 +8,8 @@ import type {
 import type { CLILogger } from '../src/services/cli-logger.service.js'
 import type { PikkuCLIConfig } from '../types/config.d.ts'
 import type { InspectorState } from '@pikku/inspector'
+import type { Bundler } from '../src/deploy/bundler/bundler.interface.js'
+import type { DevServerRunner } from '../src/server/dev-server-runner.interface.js'
 
 export interface Config extends CoreConfig<PikkuCLIConfig> {
   // Preloaded inspector state from stateInput file (if provided)
@@ -22,6 +24,10 @@ export interface SingletonServices extends CoreSingletonServices<Config> {
     setupOnly?: boolean,
     bootstrapMode?: boolean
   ) => Promise<InspectorState>
+  /** Runtime-specific deploy bundler (esbuild for node, Bun.build for bun). */
+  bundler: Bundler
+  /** Runtime-specific dev server runner (node http+ws, or bun-server). */
+  devServerRunner: DevServerRunner
 }
 
 export interface Services extends CoreServices<SingletonServices> {}


### PR DESCRIPTION
## What

Splits the deploy bundler and dev-server into runtime-appropriate implementations chosen **once** via DI, instead of inline `typeof Bun` checks. Fixes deploy-bundle dependency resolution under Bun's workspace layout (the `.bun` content-addressed store + per-workspace symlinks that esbuild's `nodePaths` walk can't resolve).

## Bundler (`src/deploy/bundler/`)
- `Bundler` interface + shared `BaseBundler` (dead-module stubbing, dependency extraction, package.json + hashing).
- `NodeBundler` (esbuild) and `BunBundler` (native `Bun.build`).
- Under bun the deploy bundle resolves bun's store/symlinks natively. Bun's metafile omits external imports, so externals are captured via the resolve plugin to drive per-unit dependency extraction.
- Full identifier minification under bun (safe — error→status reflection compares same-class instances; workflow exceptions hardcode `.name`).

## Dev server (`src/server/`)
- `DevServerRunner` interface with `NodeServerRunner` (`@pikku/node-http-server` + `ws`) and `BunServerRunner` (`@pikku/bun-server`), each supplying the runtime's EventHub.

## Wiring
- Runtime resolved once in `services.ts`; `bundler` + `devServerRunner` are injected singletons. No `typeof Bun` branches left in the pipeline or dev command.
- Also drops a redundant `as` cast on an `rpc.invoke()` result (PKU940).

Includes a `patch` changeset for `@pikku/cli`.