### PR TITLE
fix(workflow): surface suspend steps in plannedSteps with readable display names

### DIFF
--- a/.changeset/workflow-suspend-planned-steps.md
+++ b/.changeset/workflow-suspend-planned-steps.md
@@ -1,0 +1,23 @@
+---
+'@pikku/core': patch
+'@pikku/inspector': patch
+---
+
+fix(workflow): include suspend steps in plannedSteps with readable displayName
+
+`workflow.suspend(reason)` calls now appear in the static `plannedSteps` ladder
+produced by `deriveWorkflowPlan`. Previously the inspector ignored them, so the
+runtime's `__workflow_suspend:<reason>` steps had no planned counterpart and
+the UI appended them as orphans at the bottom of the step list instead of
+showing them at the correct position.
+
+Changes:
+- `WorkflowPlannedStep` gains an optional `displayName` field — the human-
+  readable label to show in the UI (falls back to `stepName` when absent).
+- New `SuspendStepMeta` type added to `WorkflowStepMeta`.
+- Inspector extracts `workflow.suspend('reason')` calls and emits a
+  `SuspendStepMeta` step with `type: 'suspend'` and `reason`.
+- `collectNamedSteps` maps a suspend step to
+  `{ stepName: '__workflow_suspend:<reason>', displayName: '<reason>' }`,
+  matching the key the runtime stores so the UI can overlay live status
+  onto the planned position.

--- a/packages/core/src/wirings/workflow/dsl/index.ts
+++ b/packages/core/src/wirings/workflow/dsl/index.ts
@@ -21,6 +21,7 @@ export type {
   InlineStepMeta,
   SleepStepMeta,
   CancelStepMeta,
+  SuspendStepMeta,
   SwitchCaseMeta,
   SwitchStepMeta,
   FilterStepMeta,

--- a/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
+++ b/packages/core/src/wirings/workflow/dsl/workflow-dsl.types.ts
@@ -240,6 +240,15 @@ export interface SwitchStepMeta {
 }
 
 /**
+ * Suspend step metadata (workflow.suspend())
+ */
+export interface SuspendStepMeta {
+  type: 'suspend'
+  /** Reason string passed to workflow.suspend() — becomes the durable step key */
+  reason: string
+}
+
+/**
  * Filter step metadata (array.filter)
  */
 export interface FilterStepMeta {
@@ -283,6 +292,7 @@ export type WorkflowStepMeta =
   | InlineStepMeta
   | SleepStepMeta
   | CancelStepMeta
+  | SuspendStepMeta
   | SwitchStepMeta
   | FilterStepMeta
   | ArrayPredicateStepMeta

--- a/packages/core/src/wirings/workflow/index.ts
+++ b/packages/core/src/wirings/workflow/index.ts
@@ -101,6 +101,7 @@ export type {
   InlineStepMeta,
   SleepStepMeta,
   CancelStepMeta,
+  SuspendStepMeta,
   SetStepMeta,
   SwitchCaseMeta,
   SwitchStepMeta,

--- a/packages/core/src/wirings/workflow/workflow.types.ts
+++ b/packages/core/src/wirings/workflow/workflow.types.ts
@@ -54,8 +54,10 @@ export interface WorkflowServiceConfig {
 }
 
 export interface WorkflowPlannedStep {
-  /** Human-readable step label for UI timeline */
+  /** Durable step key — matches the runtime step name stored in the DB */
   stepName: string
+  /** Optional human-readable label for the UI timeline (falls back to stepName) */
+  displayName?: string
 }
 
 /**

--- a/packages/core/src/wirings/workflow/workflow.types.ts
+++ b/packages/core/src/wirings/workflow/workflow.types.ts
@@ -24,6 +24,7 @@ export type {
   InlineStepMeta,
   SleepStepMeta,
   CancelStepMeta,
+  SuspendStepMeta,
   SetStepMeta,
   SwitchCaseMeta,
   SwitchStepMeta,

--- a/packages/inspector/src/utils/workflow/derive-workflow-plan.test.ts
+++ b/packages/inspector/src/utils/workflow/derive-workflow-plan.test.ts
@@ -120,19 +120,21 @@ describe('deriveWorkflowPlan', () => {
     assert.deepEqual(plan.plannedSteps, [{ stepName: 'a' }])
   })
 
-  test('suspend steps appear in the plan with __workflow_suspend: key and reason as displayName', () => {
+  test('suspend steps appear in the plan with __workflow_suspend: key and sentence-case displayName', () => {
     const plan = deriveWorkflowPlan([
       rpc('build'),
       { type: 'suspend', reason: 'building' } as WorkflowStepMeta,
       rpc('publish'),
       { type: 'suspend', reason: 'awaiting_approval' } as WorkflowStepMeta,
+      { type: 'suspend', reason: 'building-image' } as WorkflowStepMeta,
     ])
     assert.equal(plan.deterministic, true)
     assert.deepEqual(plan.plannedSteps, [
       { stepName: 'build' },
-      { stepName: '__workflow_suspend:building', displayName: 'building' },
+      { stepName: '__workflow_suspend:building', displayName: 'Building' },
       { stepName: 'publish' },
-      { stepName: '__workflow_suspend:awaiting_approval', displayName: 'awaiting_approval' },
+      { stepName: '__workflow_suspend:awaiting_approval', displayName: 'Awaiting approval' },
+      { stepName: '__workflow_suspend:building-image', displayName: 'Building image' },
     ])
   })
 })

--- a/packages/inspector/src/utils/workflow/derive-workflow-plan.test.ts
+++ b/packages/inspector/src/utils/workflow/derive-workflow-plan.test.ts
@@ -119,4 +119,20 @@ describe('deriveWorkflowPlan', () => {
     assert.equal(plan.deterministic, true)
     assert.deepEqual(plan.plannedSteps, [{ stepName: 'a' }])
   })
+
+  test('suspend steps appear in the plan with __workflow_suspend: key and reason as displayName', () => {
+    const plan = deriveWorkflowPlan([
+      rpc('build'),
+      { type: 'suspend', reason: 'building' } as WorkflowStepMeta,
+      rpc('publish'),
+      { type: 'suspend', reason: 'awaiting_approval' } as WorkflowStepMeta,
+    ])
+    assert.equal(plan.deterministic, true)
+    assert.deepEqual(plan.plannedSteps, [
+      { stepName: 'build' },
+      { stepName: '__workflow_suspend:building', displayName: 'building' },
+      { stepName: 'publish' },
+      { stepName: '__workflow_suspend:awaiting_approval', displayName: 'awaiting_approval' },
+    ])
+  })
 })

--- a/packages/inspector/src/utils/workflow/derive-workflow-plan.ts
+++ b/packages/inspector/src/utils/workflow/derive-workflow-plan.ts
@@ -68,6 +68,16 @@ function collectNamedSteps(steps: WorkflowStepMeta[]): WorkflowPlannedStep[] {
       case 'sleep':
         planned.push({ stepName: step.stepName })
         break
+      case 'suspend':
+        // Runtime stores the suspend step as `__workflow_suspend:${reason}`.
+        // We surface it in the planned ladder with a readable displayName so
+        // the UI shows it in the right position instead of appending it at the
+        // bottom as an unrecognised orphan.
+        planned.push({
+          stepName: `__workflow_suspend:${step.reason}`,
+          displayName: step.reason,
+        })
+        break
       case 'parallel':
         for (const child of step.children) {
           planned.push({ stepName: child.stepName })

--- a/packages/inspector/src/utils/workflow/derive-workflow-plan.ts
+++ b/packages/inspector/src/utils/workflow/derive-workflow-plan.ts
@@ -58,6 +58,16 @@ function containsConditional(steps: WorkflowStepMeta[]): boolean {
   return steps.some((step) => step.type === 'branch' || step.type === 'switch')
 }
 
+/**
+ * Turn an internal snake/kebab reason key into a sentence-case display label.
+ * e.g. "awaiting_approval" → "Awaiting approval", "building-image" → "Building image"
+ */
+function reasonToLabel(reason: string): string {
+  return reason
+    .replace(/[-_]/g, ' ')
+    .replace(/^(.)/, (c) => c.toUpperCase())
+}
+
 /** Flatten named steps (rpc/inline/sleep/parallel children) in source order. */
 function collectNamedSteps(steps: WorkflowStepMeta[]): WorkflowPlannedStep[] {
   const planned: WorkflowPlannedStep[] = []
@@ -75,7 +85,7 @@ function collectNamedSteps(steps: WorkflowStepMeta[]): WorkflowPlannedStep[] {
         // bottom as an unrecognised orphan.
         planned.push({
           stepName: `__workflow_suspend:${step.reason}`,
-          displayName: step.reason,
+          displayName: reasonToLabel(step.reason),
         })
         break
       case 'parallel':

--- a/packages/inspector/src/utils/workflow/dsl/extract-dsl-workflow.ts
+++ b/packages/inspector/src/utils/workflow/dsl/extract-dsl-workflow.ts
@@ -7,6 +7,7 @@ import type {
   ParallelGroupStepMeta,
   FanoutStepMeta,
   CancelStepMeta,
+  SuspendStepMeta,
   SetStepMeta,
   SwitchStepMeta,
   SwitchCaseMeta,
@@ -21,6 +22,7 @@ import type {
 import {
   isWorkflowDoCall,
   isWorkflowSleepCall,
+  isWorkflowSuspendCall,
   isThrowCancelException,
   extractCancelReason,
   isParallelFanout,
@@ -512,6 +514,10 @@ function extractExpressionStatement(
       return extractSleepStep(call, context)
     }
 
+    if (isWorkflowSuspendCall(call, context.checker)) {
+      return extractSuspendStep(call, context)
+    }
+
     // Check for parallel group or fanout
     if (isParallelFanout(call)) {
       return extractParallelFanout(call, context)
@@ -692,6 +698,31 @@ function extractSleepStep(
   } catch (error) {
     context.errors.push({
       message: `Failed to extract sleep step: ${error instanceof Error ? error.message : String(error)}`,
+      node: call,
+    })
+    return null
+  }
+}
+
+/**
+ * Extract suspend step from workflow.suspend() call
+ */
+function extractSuspendStep(
+  call: ts.CallExpression,
+  context: ExtractionContext
+): SuspendStepMeta | null {
+  const args = call.arguments
+  if (args.length < 1) return null
+
+  try {
+    const reason = extractStringLiteral(args[0], context.checker)
+    return {
+      type: 'suspend',
+      reason,
+    }
+  } catch (error) {
+    context.errors.push({
+      message: `Failed to extract suspend step: ${error instanceof Error ? error.message : String(error)}`,
       node: call,
     })
     return null

--- a/packages/inspector/src/utils/workflow/dsl/patterns.ts
+++ b/packages/inspector/src/utils/workflow/dsl/patterns.ts
@@ -43,6 +43,25 @@ export function isWorkflowSleepCall(
 }
 
 /**
+ * Check if a call expression is workflow.suspend()
+ */
+export function isWorkflowSuspendCall(
+  node: ts.CallExpression,
+  _checker: ts.TypeChecker
+): boolean {
+  if (!ts.isPropertyAccessExpression(node.expression)) {
+    return false
+  }
+
+  const propAccess = node.expression
+  return (
+    propAccess.name.text === 'suspend' &&
+    ts.isIdentifier(propAccess.expression) &&
+    propAccess.expression.text === 'workflow'
+  )
+}
+
+/**
  * Check if a throw statement throws WorkflowCancelledException
  * Matches: throw new WorkflowCancelledException(...) or throw WorkflowCancelledException(...)
  */


### PR DESCRIPTION
## Summary

- `workflow.suspend(reason)` calls were not extracted by the inspector, so the runtime's `__workflow_suspend:<reason>` steps had no planned counterpart — the UI appended them as orphans at the bottom of the step ladder instead of showing them at the correct position
- Adds `SuspendStepMeta` type and wires it through the DSL extractor + planner
- Adds optional `displayName` to `WorkflowPlannedStep` so UIs get a human-readable label without parsing the internal key
- `reasonToLabel` converts snake/kebab keys to sentence case: `awaiting_approval` → `"Awaiting approval"`, `building-image` → `"Building image"`

## Changes

- `@pikku/core`: add `SuspendStepMeta`, add `displayName?: string` to `WorkflowPlannedStep`
- `@pikku/inspector`: detect `workflow.suspend(reason)` in DSL extractor, emit `{ stepName: '__workflow_suspend:<reason>', displayName: '<sentence-cased reason>' }` in `plannedSteps`
- New test covering suspend steps in `derive-workflow-plan.test.ts`

## Test plan

- [ ] `node --import tsx/esm packages/inspector/src/utils/workflow/derive-workflow-plan.test.ts` — 8/8 pass
- [ ] Deploy a CF workflow with `workflow.suspend()` calls and confirm the step ladder renders them in position with readable labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow plans now show suspended steps in the right place, with clearer labels.
  * Suspend reasons are displayed in a more readable format for the UI timeline.

* **Bug Fixes**
  * Fixed suspended steps being treated as missing or misplaced in workflow planning views.
  * Improved step ordering and labeling for workflows that include suspension points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->