### PR TITLE
chore: upgrade monorepo to TypeScript 6

### DIFF
--- a/.changeset/typescript-6-upgrade.md
+++ b/.changeset/typescript-6-upgrade.md
@@ -1,0 +1,62 @@
+---
+"@pikku/addon-console": patch
+"@pikku/addon-graph": patch
+"@pikku/ai-vercel": patch
+"@pikku/ai-voice": patch
+"@pikku/assistant-ui": patch
+"@pikku/aws-services": patch
+"@pikku/azure-functions": patch
+"@pikku/backblaze": patch
+"@pikku/better-auth": patch
+"@pikku/bun-server": patch
+"@pikku/cli": patch
+"@pikku/cloudflare": patch
+"@pikku/console": patch
+"@pikku/core": patch
+"@pikku/cucumber": patch
+"@pikku/deploy-azure": patch
+"@pikku/deploy-cloudflare": patch
+"@pikku/deploy-serverless": patch
+"@pikku/deploy-standalone": patch
+"@pikku/express": patch
+"@pikku/express-middleware": patch
+"@pikku/fastify": patch
+"@pikku/fastify-plugin": patch
+"@pikku/fetch": patch
+"@pikku/gateway-slack": patch
+"@pikku/inspector": patch
+"@pikku/jose": patch
+"@pikku/kysely": patch
+"@pikku/kysely-bun-sqlite": patch
+"@pikku/kysely-mysql": patch
+"@pikku/kysely-node-sqlite": patch
+"@pikku/kysely-postgres": patch
+"@pikku/kysely-sqlite": patch
+"@pikku/lambda": patch
+"@pikku/mantine": patch
+"@pikku/modelcontextprotocol": patch
+"@pikku/mongodb": patch
+"@pikku/next": patch
+"@pikku/node-http-server": patch
+"@pikku/openapi-parser": patch
+"@pikku/openapi-to-zod-schema": patch
+"@pikku/paraglide": patch
+"@pikku/pino": patch
+"@pikku/queue-bullmq": patch
+"@pikku/queue-pg-boss": patch
+"@pikku/react": patch
+"@pikku/redis": patch
+"@pikku/schedule": patch
+"@pikku/schema-ajv": patch
+"@pikku/schema-cfworker": patch
+"@pikku/tanstack-start": patch
+"@pikku/uws": patch
+"@pikku/uws-handler": patch
+"@pikku/websocket": patch
+"@pikku/ws": patch
+"create-pikku": patch
+---
+
+Upgrade to TypeScript 6 and raise the minimum Node.js version to 22.
+
+All packages now build against `typescript@^6.0.3` and declare `engines.node >= 22`. Internal tooling (`ts-json-schema-generator`, `zod-to-ts`) was bumped to TypeScript 6-compatible releases.

--- a/.changeset/typescript-6-upgrade.md
+++ b/.changeset/typescript-6-upgrade.md
@@ -1,4 +1,5 @@
 ---
+"@pikku/browser": patch
 "@pikku/addon-console": patch
 "@pikku/addon-graph": patch
 "@pikku/ai-vercel": patch

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,6 +13,10 @@ coverage:
 ignore:
   - "packages/cli/src/functions/db/postgres/**"
   - "packages/inspector/src/utils/workflow/dsl/extract-dsl-workflow.ts"
+  # Compile-only wiring aggregator — imported for type-checking, never executed
+  # at runtime (the verifier boots via the generated bootstrap), so it has no
+  # coverable lines.
+  - "verifiers/functions/src/index.ts"
 
 flags:
   unit:

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -58,7 +58,7 @@
     "postgres": "^3.4.8",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "typescript": "~5.8.0",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/e2e/packages/emails/package.json
+++ b/e2e/packages/emails/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@pikku/cli": "*",
     "@pikku/core": "*",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4"
   },
   "private": true

--- a/e2e/packages/functions/package.json
+++ b/e2e/packages/functions/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "@pikku/core": "*",
-    "typescript": "~5.8.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/e2e/packages/hmac-signer/package.json
+++ b/e2e/packages/hmac-signer/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@pikku/cli": "*",
     "@pikku/core": "*",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4"
   },
   "private": true

--- a/e2e/packages/oauth-api/package.json
+++ b/e2e/packages/oauth-api/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@pikku/cli": "*",
     "@pikku/core": "*",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4"
   },
   "private": true

--- a/e2e/packages/todos/package.json
+++ b/e2e/packages/todos/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@pikku/cli": "*",
     "@pikku/core": "*",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4"
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -81,14 +81,14 @@
   },
   "dependencies": {
     "@changesets/cli": "^2.31.0",
-    "typescript": "~6.0.3"
+    "typescript": "^6.0.3"
   },
   "resolutions": {
     "esbuild": "0.27.2",
     "pikkufabric": "portal:/Users/yasser/git/pikku/fabric"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "lint-staged": {
     "*.ts": [

--- a/packages/addon/pikku-console/package.json
+++ b/packages/addon/pikku-console/package.json
@@ -44,7 +44,7 @@
     "@pikku/cli": "^0.12.50",
     "@pikku/core": "^0.12.37",
     "oauth2-mock-server": "^7.1.1",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "json-schema": "^0.4.0",

--- a/packages/addon/pikku-console/tsconfig.json
+++ b/packages/addon/pikku-console/tsconfig.json
@@ -14,6 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "noImplicitAny": false,
+    "types": ["node"],
     "paths": {
       "#pikku": ["./.pikku/pikku-types.gen.ts"]
     }

--- a/packages/addon/pikku-graph/package.json
+++ b/packages/addon/pikku-graph/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@pikku/cli": "^0.12.46",
     "@pikku/core": "*",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4"
   },
   "dependencies": {

--- a/packages/addon/pikku-graph/tsconfig.json
+++ b/packages/addon/pikku-graph/tsconfig.json
@@ -13,6 +13,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "types": ["node"],
     "paths": {
       "#pikku": ["./.pikku/pikku-types.gen.ts"]
     }

--- a/packages/assistant-ui/package.json
+++ b/packages/assistant-ui/package.json
@@ -32,6 +32,6 @@
     "@types/react-dom": "^19",
     "react": "^19",
     "react-dom": "^19",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/assistant-ui/tsconfig.cjs.json
+++ b/packages/assistant-ui/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
+    "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "outDir": "dist/cjs",
     "target": "es2015",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,13 +49,13 @@
     "path-to-regexp": "^8.3.0",
     "pg": "^8.13.0",
     "tinyglobby": "^0.2.12",
-    "ts-json-schema-generator": "^2.5.0",
+    "ts-json-schema-generator": "2.9.1-next.16",
     "tsx": "^4.21.0",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "ws": "^8.18.0",
     "yaml": "^2.8.2",
     "zod": "^4.3.6",
-    "zod-to-ts": "^2.0.0"
+    "zod-to-ts": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^24.11.0",
@@ -69,7 +69,7 @@
     "cli.schema.json"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "exports": {
     ".": "./dist/bin/pikku.js"

--- a/packages/client-fetch/package.json
+++ b/packages/client-fetch/package.json
@@ -25,9 +25,9 @@
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/packages/client-fetch/tsconfig.cjs.json
+++ b/packages/client-fetch/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
+    "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "outDir": "dist/cjs",
     "target": "es2015",

--- a/packages/client-websocket/package.json
+++ b/packages/client-websocket/package.json
@@ -25,12 +25,12 @@
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "optionalDependencies": {
     "ws": "^8.19.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }

--- a/packages/client-websocket/src/core-pikku-websocket.ts
+++ b/packages/client-websocket/src/core-pikku-websocket.ts
@@ -48,7 +48,7 @@ export class CorePikkuWebsocket {
     this.ws.send(JSON.stringify(data))
   }
 
-  public sendBinary(data: ArrayBuffer | Uint8Array) {
+  public sendBinary(data: ArrayBuffer | Uint8Array<ArrayBuffer>) {
     this.ws.send(data)
   }
 

--- a/packages/client-websocket/src/index.test.ts
+++ b/packages/client-websocket/src/index.test.ts
@@ -3,9 +3,52 @@ import { describe, test } from 'node:test'
 
 import { CorePikkuRouteHandler, CorePikkuWebsocket } from './index.js'
 
+const createMockWebSocket = () => {
+  const sent: unknown[] = []
+  const ws = {
+    binaryType: '',
+    onmessage: null as unknown,
+    send: (data: unknown) => {
+      sent.push(data)
+    },
+  }
+  return { ws: ws as unknown as WebSocket, sent }
+}
+
 describe('@pikku/websocket', () => {
   test('exports the public websocket client API', () => {
     assert.equal(typeof CorePikkuWebsocket, 'function')
     assert.equal(typeof CorePikkuRouteHandler, 'function')
+  })
+
+  test('send serialises the payload as JSON', () => {
+    const { ws, sent } = createMockWebSocket()
+    const client = new CorePikkuWebsocket(ws)
+
+    client.send({ hello: 'world' })
+
+    assert.deepEqual(sent, [JSON.stringify({ hello: 'world' })])
+  })
+
+  test('sendBinary forwards an ArrayBuffer unchanged', () => {
+    const { ws, sent } = createMockWebSocket()
+    const client = new CorePikkuWebsocket(ws)
+    const buffer = new ArrayBuffer(8)
+
+    client.sendBinary(buffer)
+
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0], buffer)
+  })
+
+  test('sendBinary forwards a Uint8Array view unchanged', () => {
+    const { ws, sent } = createMockWebSocket()
+    const client = new CorePikkuWebsocket(ws)
+    const view = new Uint8Array([1, 2, 3])
+
+    client.sendBinary(view)
+
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0], view)
   })
 })

--- a/packages/client-websocket/tsconfig.cjs.json
+++ b/packages/client-websocket/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
+    "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "outDir": "dist/cjs",
     "target": "es2015",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -90,7 +90,7 @@
     "postcss-preset-mantine": "^1.18.0",
     "postcss-simple-vars": "^7",
     "react-router": "^7",
-    "typescript": "^5",
+    "typescript": "^6.0.3",
     "vite": "^8.0.11"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,9 +63,9 @@
   "devDependencies": {
     "@types/node": "^24.11.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/node": "^22.13.1",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "typescript": "^6.0.3"
   },
   "type": "module",
   "exports": {

--- a/packages/create/tsconfig.json
+++ b/packages/create/tsconfig.json
@@ -1,13 +1,15 @@
 {
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ESNext",
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/cucumber/package.json
+++ b/packages/cucumber/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/deploy/deploy-azure/package.json
+++ b/packages/deploy/deploy-azure/package.json
@@ -8,7 +8,7 @@
     "tsc": "tsc --noEmit"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/deploy/deploy-cloudflare/package.json
+++ b/packages/deploy/deploy-cloudflare/package.json
@@ -8,7 +8,7 @@
     "tsc": "tsc --noEmit"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/deploy/deploy-serverless/package.json
+++ b/packages/deploy/deploy-serverless/package.json
@@ -8,7 +8,7 @@
     "tsc": "tsc --noEmit"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/deploy/deploy-standalone/package.json
+++ b/packages/deploy/deploy-standalone/package.json
@@ -8,7 +8,7 @@
     "tsc": "tsc --noEmit"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/frontend/mantine/package.json
+++ b/packages/frontend/mantine/package.json
@@ -32,6 +32,6 @@
     "@types/react": "^19",
     "react": "^19",
     "react-dom": "^19",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/frontend/mantine/tsconfig.cjs.json
+++ b/packages/frontend/mantine/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
+    "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "outDir": "dist/cjs",
     "target": "es2015",

--- a/packages/frontend/react/package.json
+++ b/packages/frontend/react/package.json
@@ -31,6 +31,6 @@
     "@types/react-dom": "^19",
     "react": "^19",
     "react-dom": "^19",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/frontend/react/tsconfig.cjs.json
+++ b/packages/frontend/react/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
+    "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "outDir": "dist/cjs",
     "target": "es2015",

--- a/packages/gateways/slack/package.json
+++ b/packages/gateways/slack/package.json
@@ -21,7 +21,7 @@
     "@slack/web-api": "^7.9.1"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -38,16 +38,16 @@
     "@pikku/core": "^0.12.42",
     "openapi-types": "^12.1.3",
     "path-to-regexp": "^8.3.0",
-    "ts-json-schema-generator": "^2.5.0",
+    "ts-json-schema-generator": "2.9.1-next.16",
     "tsx": "^4.21.0",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6",
-    "zod-to-ts": "^2.0.0"
+    "zod-to-ts": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^24.11.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -21,6 +21,6 @@
     "yaml": "^2.7.1"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/openapi-to-zod-schema/package.json
+++ b/packages/openapi-to-zod-schema/package.json
@@ -14,10 +14,10 @@
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/paraglide/package.json
+++ b/packages/paraglide/package.json
@@ -37,7 +37,7 @@
     }
   },
   "devDependencies": {
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "vite": "^7"
   }
 }

--- a/packages/paraglide/tsconfig.cjs.json
+++ b/packages/paraglide/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
+    "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "outDir": "dist/cjs",
     "target": "es2015",

--- a/packages/pikku/package.json
+++ b/packages/pikku/package.json
@@ -20,10 +20,10 @@
     "@pikku/schema-ajv": "^0.12.2"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/runtimes/aws-lambda/package.json
+++ b/packages/runtimes/aws-lambda/package.json
@@ -35,9 +35,9 @@
     "@aws-sdk/client-lambda": "^3.1000.0",
     "@aws-sdk/client-sqs": "^3.1000.0",
     "@types/aws-lambda": "^8.10.161",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/packages/runtimes/azure-functions/package.json
+++ b/packages/runtimes/azure-functions/package.json
@@ -20,10 +20,10 @@
     "@pikku/core": "^0.12.1"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "dependencies": {
     "@azure/functions": "4.11.2",

--- a/packages/runtimes/bun-server/package.json
+++ b/packages/runtimes/bun-server/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "bun": ">=1.0.0"

--- a/packages/runtimes/cloudflare/package.json
+++ b/packages/runtimes/cloudflare/package.json
@@ -47,10 +47,10 @@
     "@vitest/runner": "^4.1.9",
     "@vitest/snapshot": "^4.1.9",
     "kysely": "^0.29.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/packages/runtimes/express-middleware/package.json
+++ b/packages/runtimes/express-middleware/package.json
@@ -28,10 +28,10 @@
     "@types/express": "^5",
     "@types/express-serve-static-core": "^5.1.1",
     "express": "^5",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "dependencies": {
     "cookie": "^1.1.1"

--- a/packages/runtimes/express-server/package.json
+++ b/packages/runtimes/express-server/package.json
@@ -34,10 +34,10 @@
     "raw-body": "^3.0.2"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/runtimes/fastify-plugin/package.json
+++ b/packages/runtimes/fastify-plugin/package.json
@@ -25,13 +25,13 @@
   "devDependencies": {
     "fastify": "^5.8.2",
     "fastify-plugin": "^5.1.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "cookie": "^1.1.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/runtimes/fastify-server/package.json
+++ b/packages/runtimes/fastify-server/package.json
@@ -27,10 +27,10 @@
   "devDependencies": {
     "@pikku/core": "^0.12.9",
     "fastify": "^5.8.2",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/runtimes/modelcontextprotocol/package.json
+++ b/packages/runtimes/modelcontextprotocol/package.json
@@ -25,10 +25,10 @@
     "@modelcontextprotocol/sdk": "1.27.1"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "exports": {
     ".": {

--- a/packages/runtimes/next/package.json
+++ b/packages/runtimes/next/package.json
@@ -40,9 +40,9 @@
     "next": "15.5.12",
     "react": "^19",
     "react-dom": "^19",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/packages/runtimes/node-http-server/package.json
+++ b/packages/runtimes/node-http-server/package.json
@@ -29,10 +29,10 @@
   "devDependencies": {
     "@pikku/core": "^0.12.30",
     "@pikku/modelcontextprotocol": "^0.12.4",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/runtimes/tanstack-start/package.json
+++ b/packages/runtimes/tanstack-start/package.json
@@ -32,9 +32,9 @@
     "better-auth": "^1.6.19",
     "react": "^19",
     "react-dom": "^19",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/packages/runtimes/uws-handler/package.json
+++ b/packages/runtimes/uws-handler/package.json
@@ -29,9 +29,9 @@
     "picoquery": "^2.5.0"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/packages/runtimes/uws-server/package.json
+++ b/packages/runtimes/uws-server/package.json
@@ -31,9 +31,9 @@
   },
   "devDependencies": {
     "@pikku/core": "^0.12.24",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/packages/runtimes/ws/package.json
+++ b/packages/runtimes/ws/package.json
@@ -23,10 +23,10 @@
   },
   "devDependencies": {
     "@types/ws": "^8",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "dependencies": {
     "cookie": "^1.1.1"

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -22,10 +22,10 @@
   },
   "devDependencies": {
     "@types/node": "^24.11.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "dependencies": {
     "cron": "^4.4.0",

--- a/packages/services/ai-vercel/package.json
+++ b/packages/services/ai-vercel/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "ai": "^6.0.105",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   }
 }

--- a/packages/services/ai-voice/package.json
+++ b/packages/services/ai-voice/package.json
@@ -25,6 +25,6 @@
     "@pikku/core": "^0.12.35"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/services/aws-services/package.json
+++ b/packages/services/aws-services/package.json
@@ -37,9 +37,9 @@
     "@aws-sdk/s3-request-presigner": "^3.1000.0",
     "@types/sinon": "^21.0.0",
     "sinon": "^21.0.1",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/packages/services/backblaze/package.json
+++ b/packages/services/backblaze/package.json
@@ -20,6 +20,6 @@
     "@pikku/core": "^0.12.20"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/services/better-auth/package.json
+++ b/packages/services/better-auth/package.json
@@ -31,7 +31,7 @@
     "jose": "^6.1.3",
     "kysely": "^0.29.0",
     "nanostores": "^1.1.1",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/services/browser/package.json
+++ b/packages/services/browser/package.json
@@ -28,6 +28,9 @@
   },
   "devDependencies": {
     "puppeteer-core": "22.13.1",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/services/jose/package.json
+++ b/packages/services/jose/package.json
@@ -20,7 +20,7 @@
     "jose": "^6.1.3"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/services/kysely-bun-sqlite/package.json
+++ b/packages/services/kysely-bun-sqlite/package.json
@@ -24,6 +24,6 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/services/kysely-mysql/package.json
+++ b/packages/services/kysely-mysql/package.json
@@ -18,7 +18,7 @@
     "kysely": "^0.29.0"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/src/index.js"

--- a/packages/services/kysely-node-sqlite/package.json
+++ b/packages/services/kysely-node-sqlite/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@pikku/core": "^0.12.34",
     "@types/node": "^22",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/src/index.js"

--- a/packages/services/kysely-postgres/package.json
+++ b/packages/services/kysely-postgres/package.json
@@ -20,7 +20,7 @@
     "postgres": "^3.4.8"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/src/index.js"

--- a/packages/services/kysely-sqlite/package.json
+++ b/packages/services/kysely-sqlite/package.json
@@ -18,7 +18,7 @@
     "kysely": "^0.29.0"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/src/index.js"

--- a/packages/services/kysely/package.json
+++ b/packages/services/kysely/package.json
@@ -31,7 +31,7 @@
     "kysely-codegen": "^0.20.0",
     "kysely-postgres-js": "^3.0.0",
     "postgres": "^3.4.8",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/src/index.js"

--- a/packages/services/mongodb/package.json
+++ b/packages/services/mongodb/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "mongodb": "^6.12.0",
     "mongodb-memory-server": "^10.4.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/src/index.js"

--- a/packages/services/pino/package.json
+++ b/packages/services/pino/package.json
@@ -18,7 +18,7 @@
     "pino": "^9.5.0"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/services/queue-bullmq/package.json
+++ b/packages/services/queue-bullmq/package.json
@@ -22,7 +22,7 @@
     "ioredis": "^5.10.0"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/services/queue-pg-boss/package.json
+++ b/packages/services/queue-pg-boss/package.json
@@ -21,7 +21,7 @@
     "pg-boss": "^12.14.0"
   },
   "devDependencies": {
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/services/redis/package.json
+++ b/packages/services/redis/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/ioredis-mock": "^8",
     "ioredis-mock": "^8.13.1",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/src/index.js"

--- a/packages/services/schema-ajv/package.json
+++ b/packages/services/schema-ajv/package.json
@@ -25,10 +25,10 @@
     "ajv-formats": "^3.0.1"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "exports": {
     ".": "./dist/index.js"

--- a/packages/services/schema-cfworker/package.json
+++ b/packages/services/schema-cfworker/package.json
@@ -21,10 +21,10 @@
     "@pikku/core": "^0.12.9"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "dependencies": {
     "@cfworker/json-schema": "^4.1.1"

--- a/templates/ai-postgres/package.json
+++ b/templates/ai-postgres/package.json
@@ -24,7 +24,7 @@
     "kysely-postgres-js": "^3.0.0",
     "postgres": "^3.4.8",
     "tsx": "^4.21.0",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/templates/aws-lambda-websocket/package.json
+++ b/templates/aws-lambda-websocket/package.json
@@ -38,7 +38,7 @@
     "serverless-esbuild": "^1.57.0",
     "serverless-offline": "^14.5.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.mjs"

--- a/templates/aws-lambda/package.json
+++ b/templates/aws-lambda/package.json
@@ -33,7 +33,7 @@
     "serverless-offline": "^14.5.0",
     "serverless-offline-sqs": "^8.0.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./dist/index.mjs"

--- a/templates/bullmq/package.json
+++ b/templates/bullmq/package.json
@@ -18,7 +18,7 @@
     "@pikku/queue-bullmq": "^0.12.3",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@types/node": "^24"

--- a/templates/bun/package.json
+++ b/templates/bun/package.json
@@ -17,7 +17,7 @@
     "@pikku/core": "^0.12.42",
     "@pikku/schedule": "^0.12.2",
     "tslib": "^2.8.1",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/templates/cli/package.json
+++ b/templates/cli/package.json
@@ -27,6 +27,6 @@
     "@pikku/cli": "^0.12.59",
     "@types/node": "^24",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/templates/cloudflare-websocket/package.json
+++ b/templates/cloudflare-websocket/package.json
@@ -19,7 +19,7 @@
     "@cloudflare/workers-types": "^4.20260317.1",
     "@types/node": "^24",
     "@types/ws": "^8",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "wrangler": "^4.78.0"
   }
 }

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260317.1",
     "@types/node": "^24",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "wrangler": "^4.78.0"
   }
 }

--- a/templates/express-middleware/package.json
+++ b/templates/express-middleware/package.json
@@ -18,7 +18,7 @@
     "@types/express-serve-static-core": "^5.1.1",
     "@types/node": "^24",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "build": "tsc -b",

--- a/templates/express/package.json
+++ b/templates/express/package.json
@@ -18,7 +18,7 @@
     "pino-pretty": "^13.1.3",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@types/node": "^24",

--- a/templates/fastify-plugin/package.json
+++ b/templates/fastify-plugin/package.json
@@ -19,7 +19,7 @@
     "fastify-plugin": "^5.1.0",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@types/node": "^24",

--- a/templates/fastify/package.json
+++ b/templates/fastify/package.json
@@ -17,7 +17,7 @@
     "fastify": "^5.8.2",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@types/node": "^24"

--- a/templates/function-addon/package.json
+++ b/templates/function-addon/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@pikku/cli": "^0.12.0",
     "@pikku/core": "^0.12.0",
-    "typescript": "^5.7.2",
+    "typescript": "^6.0.3",
     "zod": "^4"
   }
 }

--- a/templates/functions/package.json
+++ b/templates/functions/package.json
@@ -39,7 +39,7 @@
     "serverless-offline": "^14.5.0",
     "serverless-offline-sqs": "^8.0.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "wrangler": "^4.78.0"
   },
   "scripts": {

--- a/templates/mcp-server/package.json
+++ b/templates/mcp-server/package.json
@@ -19,7 +19,7 @@
     "@pikku/cli": "^0.12.1",
     "@types/node": "^24.11.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "@pikku/core": "^0.12.1",

--- a/templates/nextjs/package.json
+++ b/templates/nextjs/package.json
@@ -34,6 +34,6 @@
     "@types/react-dom": "^19",
     "postcss": "^8",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5"
+    "typescript": "^6.0.3"
   }
 }

--- a/templates/pg-boss/package.json
+++ b/templates/pg-boss/package.json
@@ -18,7 +18,7 @@
     "@pikku/queue-pg-boss": "^0.12.4",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@types/node": "^24"

--- a/templates/remote-rpc-pg/package.json
+++ b/templates/remote-rpc-pg/package.json
@@ -25,7 +25,7 @@
     "postgres": "^3.4.8",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@pikku/cli": "^0.12.59",

--- a/templates/remote-rpc-redis/package.json
+++ b/templates/remote-rpc-redis/package.json
@@ -23,7 +23,7 @@
     "pino-pretty": "^13.1.3",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@pikku/cli": "^0.12.59",

--- a/templates/uws/package.json
+++ b/templates/uws/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/node": "^24",
     "@types/ws": "^8",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./src/start.ts"

--- a/templates/workflows-bullmq/package.json
+++ b/templates/workflows-bullmq/package.json
@@ -20,7 +20,7 @@
     "@pikku/redis": "^0.12.9",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@pikku/cli": "^0.12.59",

--- a/templates/workflows-pg-boss/package.json
+++ b/templates/workflows-pg-boss/package.json
@@ -23,7 +23,7 @@
     "postgres": "^3.4.8",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@pikku/cli": "^0.12.59",

--- a/templates/ws/package.json
+++ b/templates/ws/package.json
@@ -17,7 +17,7 @@
     "@pikku/ws": "^0.12.2",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "ws": "^8.19.0"
   },
   "devDependencies": {

--- a/verifiers/addon-registry/consumer/package.json
+++ b/verifiers/addon-registry/consumer/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@pikku/cli": "*",
     "@types/node": "^24",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "zod": "^4"
   }
 }

--- a/verifiers/addon-registry/source/package.json
+++ b/verifiers/addon-registry/source/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@pikku/cli": "*",
     "@pikku/core": "*",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "zod": "^4"
   }
 }

--- a/verifiers/addon/package.json
+++ b/verifiers/addon/package.json
@@ -15,7 +15,7 @@
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "tsx": "^4.21.0",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "zod": "^4"
   },
   "scripts": {

--- a/verifiers/better-auth/package.json
+++ b/verifiers/better-auth/package.json
@@ -20,7 +20,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^24",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "tsc": "tsc",

--- a/verifiers/binary/package.json
+++ b/verifiers/binary/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/verifiers/bun-server/package.json
+++ b/verifiers/bun-server/package.json
@@ -17,7 +17,7 @@
     "@types/node": "^24",
     "@types/ws": "^8",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "tsc": "tsc",

--- a/verifiers/classification/package.json
+++ b/verifiers/classification/package.json
@@ -9,7 +9,7 @@
     "@pikku/inspector": "workspace:*",
     "@types/node": "^24",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "test": "yarn tsx --test src/tests/codegen.assert.ts src/tests/codegen-postgres.assert.ts src/tests/audit.assert.ts src/tests/pii-gate.assert.ts"

--- a/verifiers/deploy-azure/package.json
+++ b/verifiers/deploy-azure/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/verifiers/deploy-cloudflare/package.json
+++ b/verifiers/deploy-cloudflare/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/verifiers/deploy-serverless/package.json
+++ b/verifiers/deploy-serverless/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/verifiers/deploy-standalone/package.json
+++ b/verifiers/deploy-standalone/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/verifiers/dev-bun/package.json
+++ b/verifiers/dev-bun/package.json
@@ -12,6 +12,6 @@
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "tsx": "^4",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/verifiers/functions/package.json
+++ b/verifiers/functions/package.json
@@ -28,7 +28,7 @@
     "react": "^19",
     "react-dom": "^19",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "build": "tsc -b",

--- a/verifiers/functions/src/index.ts
+++ b/verifiers/functions/src/index.ts
@@ -4,16 +4,16 @@
 import './functions/http/http.wiring.js'
 import './functions/http/sse.wiring.js'
 import './functions/http/progressive-enhancement.wiring.js'
-import './functions/http/external.wiring.js'
+import './functions/http/addon.wiring.js'
 import './functions/http/zod.wiring.js'
 
 // Channel wirings
 import './functions/channel/channel.wiring.js'
-import './functions/channel/channel-external.wiring.js'
+import './functions/channel/channel-addon.wiring.js'
 
 // CLI wirings
 import './functions/cli/cli.wiring.js'
-import './functions/cli/cli-external.wiring.js'
+import './functions/cli/cli-addon.wiring.js'
 
 // MCP wirings
 import './functions/mcp/mcp.wiring.js'
@@ -31,4 +31,5 @@ import './functions/rpc/rpc.wiring.js'
 import './functions/trigger/trigger.wiring.js'
 
 // Workflow wirings
-import './functions/workflow/workflow.wiring.js'
+import './functions/workflow/workflow.functions.js'
+import './functions/workflow/workflow.graph.js'

--- a/verifiers/gateway/package.json
+++ b/verifiers/gateway/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/verifiers/hmr/package.json
+++ b/verifiers/hmr/package.json
@@ -14,7 +14,7 @@
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "tsc": "tsc",

--- a/verifiers/middleware-and-permissions/package.json
+++ b/verifiers/middleware-and-permissions/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "zod": "^4"
   }
 }

--- a/verifiers/middleware-and-permissions/src/index.ts
+++ b/verifiers/middleware-and-permissions/src/index.ts
@@ -1,3 +1,8 @@
 // Import all wirings to register them
-import './functions/http.wire.js'
-import './wirings/rpc.js'
+import './functions/agent.wiring.js'
+import './functions/channel.wiring.js'
+import './functions/cli.wiring.js'
+import './functions/http.wiring.js'
+import './functions/mcp.wiring.js'
+import './functions/queue.wiring.js'
+import './functions/scheduler.wiring.js'

--- a/verifiers/next-better-auth/package.json
+++ b/verifiers/next-better-auth/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tsx": "^4.21.0",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "pikku": "pikku",

--- a/verifiers/secrets/package.json
+++ b/verifiers/secrets/package.json
@@ -15,7 +15,7 @@
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "tsx": "^4.20.6",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "build": "tsc -b",

--- a/verifiers/secrets/tsconfig.json
+++ b/verifiers/secrets/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
+    "types": ["node"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/verifiers/tanstack-start-better-auth/package.json
+++ b/verifiers/tanstack-start-better-auth/package.json
@@ -32,7 +32,7 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6",
     "tsx": "^4.21.0",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "vite": "^8.0.11"
   },
   "scripts": {

--- a/verifiers/treeshaking/package.json
+++ b/verifiers/treeshaking/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "zod": "^4"
   }
 }

--- a/verifiers/types/package.json
+++ b/verifiers/types/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
-    "typescript": "^5.9",
+    "typescript": "^6.0.3",
     "zod": "^4"
   },
   "scripts": {

--- a/verifiers/variables/package.json
+++ b/verifiers/variables/package.json
@@ -15,7 +15,7 @@
     "@pikku/cli": "workspace:*",
     "@types/node": "^24",
     "tsx": "^4.20.6",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "build": "tsc -b",

--- a/verifiers/workflows/package.json
+++ b/verifiers/workflows/package.json
@@ -21,7 +21,7 @@
     "@pikku/inspector": "workspace:*",
     "@types/node": "^24",
     "tsx": "^4.20.6",
-    "typescript": "^5.9"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "build": "tsc -b",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5772,7 +5772,7 @@ __metadata:
   resolution: "@pikku/browser@workspace:packages/services/browser"
   dependencies:
     puppeteer-core: "npm:22.13.1"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     puppeteer-core: 22.13.1
   peerDependenciesMeta:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5586,7 +5586,7 @@ __metadata:
     json-schema: "npm:^0.4.0"
     oauth2-mock-server: "npm:^7.1.1"
     open: "npm:^10.0.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.37
   languageName: unknown
@@ -5598,7 +5598,7 @@ __metadata:
   dependencies:
     "@pikku/cli": "npm:*"
     "@pikku/core": "npm:*"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4"
   peerDependencies:
     "@pikku/core": "*"
@@ -5613,7 +5613,7 @@ __metadata:
     "@pikku/cli": "npm:^0.12.46"
     "@pikku/core": "npm:*"
     dayjs: "npm:^1.11.19"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4"
   peerDependencies:
     "@pikku/core": "*"
@@ -5627,7 +5627,7 @@ __metadata:
   dependencies:
     "@pikku/cli": "npm:*"
     "@pikku/core": "npm:*"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4"
   peerDependencies:
     "@pikku/core": "*"
@@ -5641,7 +5641,7 @@ __metadata:
   dependencies:
     "@pikku/cli": "npm:*"
     "@pikku/core": "npm:*"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4"
   peerDependencies:
     "@pikku/core": "*"
@@ -5655,7 +5655,7 @@ __metadata:
   dependencies:
     "@pikku/cli": "npm:*"
     "@pikku/core": "npm:*"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4"
   peerDependencies:
     "@pikku/core": "*"
@@ -5668,7 +5668,7 @@ __metadata:
   resolution: "@pikku/ai-vercel@workspace:packages/services/ai-vercel"
   dependencies:
     ai: "npm:^6.0.105"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4.3.6"
   peerDependencies:
     "@pikku/core": ^0.12.35
@@ -5680,7 +5680,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/ai-voice@workspace:packages/services/ai-voice"
   dependencies:
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.35
   languageName: unknown
@@ -5696,7 +5696,7 @@ __metadata:
     react: "npm:^19"
     react-dom: "npm:^19"
     react-markdown: "npm:^10.1.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     react: ^18 || ^19
     react-dom: ^18 || ^19
@@ -5714,7 +5714,7 @@ __metadata:
     "@aws-sdk/s3-request-presigner": "npm:^3.1000.0"
     "@types/sinon": "npm:^21.0.0"
     sinon: "npm:^21.0.1"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@aws-sdk/client-s3": ^3.732.0
     "@aws-sdk/client-secrets-manager": ^3.714.0
@@ -5731,7 +5731,7 @@ __metadata:
   dependencies:
     "@azure/functions": "npm:4.11.2"
     "@azure/storage-queue": "npm:^12.25.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.1
   languageName: unknown
@@ -5741,7 +5741,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/backblaze@workspace:packages/services/backblaze"
   dependencies:
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.20
   languageName: unknown
@@ -5760,7 +5760,7 @@ __metadata:
     jose: "npm:^6.1.3"
     kysely: "npm:^0.29.0"
     nanostores: "npm:^1.1.1"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.36
     better-auth: ^1.6.0
@@ -5772,7 +5772,7 @@ __metadata:
   resolution: "@pikku/bun-server@workspace:packages/runtimes/bun-server"
   dependencies:
     "@types/bun": "npm:latest"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.38
   languageName: unknown
@@ -5809,13 +5809,13 @@ __metadata:
     path-to-regexp: "npm:^8.3.0"
     pg: "npm:^8.13.0"
     tinyglobby: "npm:^0.2.12"
-    ts-json-schema-generator: "npm:^2.5.0"
+    ts-json-schema-generator: "npm:2.9.1-next.16"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     ws: "npm:^8.18.0"
     yaml: "npm:^2.8.2"
     zod: "npm:^4.3.6"
-    zod-to-ts: "npm:^2.0.0"
+    zod-to-ts: "npm:^2.1.0"
   bin:
     pikku: dist/bin/pikku.js
   languageName: unknown
@@ -5833,7 +5833,7 @@ __metadata:
     "@vitest/snapshot": "npm:^4.1.9"
     kysely: "npm:^0.29.0"
     kysely-d1: "npm:^0.4.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.9"
   peerDependencies:
     "@pikku/core": ^0.12.38
@@ -5903,7 +5903,7 @@ __metadata:
     react-router: "npm:^7"
     reactflow: "npm:^11.11.4"
     remark-gfm: "npm:^4.0.1"
-    typescript: "npm:^5"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.11"
   languageName: unknown
   linkType: soft
@@ -5920,7 +5920,7 @@ __metadata:
     path-to-regexp: "npm:^8.3.0"
     picoquery: "npm:^2.5.0"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -5930,7 +5930,7 @@ __metadata:
   dependencies:
     "@pikku/fetch": "npm:^0.12.4"
     "@types/node": "npm:^25.6.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.36
   languageName: unknown
@@ -5940,7 +5940,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/deploy-azure@workspace:packages/deploy/deploy-azure"
   dependencies:
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -5948,7 +5948,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/deploy-cloudflare@workspace:packages/deploy/deploy-cloudflare"
   dependencies:
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -5956,7 +5956,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/deploy-serverless@workspace:packages/deploy/deploy-serverless"
   dependencies:
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -5964,7 +5964,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/deploy-standalone@workspace:packages/deploy/deploy-standalone"
   dependencies:
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -5975,7 +5975,7 @@ __metadata:
     "@pikku/better-auth": "workspace:*"
     "@pikku/core": "npm:*"
     better-auth: "npm:^1.6.19"
-    typescript: "npm:~5.8.0"
+    typescript: "npm:^6.0.3"
     zod: "npm:*"
   peerDependencies:
     "@pikku/core": "*"
@@ -6018,7 +6018,7 @@ __metadata:
     postgres: "npm:^3.4.8"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:~5.8.0"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4.3.6"
   languageName: unknown
   linkType: soft
@@ -6032,7 +6032,7 @@ __metadata:
     "@types/express-serve-static-core": "npm:^5.1.1"
     cookie: "npm:^1.1.1"
     express: "npm:^5"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.3
     "@types/express": ^5
@@ -6056,7 +6056,7 @@ __metadata:
     cors: "npm:^2.8.6"
     express: "npm:^5"
     raw-body: "npm:^3.0.2"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.18
   languageName: unknown
@@ -6069,7 +6069,7 @@ __metadata:
     cookie: "npm:^1.1.1"
     fastify: "npm:^5.8.2"
     fastify-plugin: "npm:^5.1.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.3
     fastify: ^5.8.2
@@ -6084,7 +6084,7 @@ __metadata:
     "@pikku/core": "npm:^0.12.9"
     "@pikku/fastify-plugin": "npm:^0.12.2"
     fastify: "npm:^5.8.2"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.9
     fastify: ^5.8.2
@@ -6095,7 +6095,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/fetch@workspace:packages/client-fetch"
   dependencies:
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6104,7 +6104,7 @@ __metadata:
   resolution: "@pikku/gateway-slack@workspace:packages/gateways/slack"
   dependencies:
     "@slack/web-api": "npm:^7.9.1"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.9
   languageName: unknown
@@ -6119,11 +6119,11 @@ __metadata:
     "@types/node": "npm:^24.11.0"
     openapi-types: "npm:^12.1.3"
     path-to-regexp: "npm:^8.3.0"
-    ts-json-schema-generator: "npm:^2.5.0"
+    ts-json-schema-generator: "npm:2.9.1-next.16"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4.3.6"
-    zod-to-ts: "npm:^2.0.0"
+    zod-to-ts: "npm:^2.1.0"
   languageName: unknown
   linkType: soft
 
@@ -6132,7 +6132,7 @@ __metadata:
   resolution: "@pikku/jose@workspace:packages/services/jose"
   dependencies:
     jose: "npm:^6.1.3"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.9
   languageName: unknown
@@ -6146,7 +6146,7 @@ __metadata:
     "@pikku/kysely-sqlite": "npm:^0.12.0"
     "@types/bun": "npm:latest"
     kysely: "npm:^0.29.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6157,7 +6157,7 @@ __metadata:
     "@pikku/core": "npm:^0.12.15"
     "@pikku/kysely": "npm:^0.12.16"
     kysely: "npm:^0.29.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6170,7 +6170,7 @@ __metadata:
     "@pikku/kysely-sqlite": "npm:^0.12.6"
     "@types/node": "npm:^22"
     kysely: "npm:^0.29.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.34
   languageName: unknown
@@ -6185,7 +6185,7 @@ __metadata:
     kysely: "npm:^0.29.0"
     kysely-postgres-js: "npm:^3.0.0"
     postgres: "npm:^3.4.8"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6196,7 +6196,7 @@ __metadata:
     "@pikku/core": "npm:^0.12.21"
     "@pikku/kysely": "npm:^0.12.16"
     kysely: "npm:^0.29.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6210,7 +6210,7 @@ __metadata:
     kysely-codegen: "npm:^0.20.0"
     kysely-postgres-js: "npm:^3.0.0"
     postgres: "npm:^3.4.8"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.39
   bin:
@@ -6226,7 +6226,7 @@ __metadata:
     "@aws-sdk/client-lambda": "npm:^3.1000.0"
     "@aws-sdk/client-sqs": "npm:^3.1000.0"
     "@types/aws-lambda": "npm:^8.10.161"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@aws-sdk/client-apigatewaymanagementapi": ^3.713.0
     "@aws-sdk/client-lambda": ^3.713.0
@@ -6246,7 +6246,7 @@ __metadata:
     "@types/react": "npm:^19"
     react: "npm:^19"
     react-dom: "npm:^19"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@mantine/core": ^8 || ^9
     "@mantine/hooks": ^8 || ^9
@@ -6261,7 +6261,7 @@ __metadata:
   resolution: "@pikku/modelcontextprotocol@workspace:packages/runtimes/modelcontextprotocol"
   dependencies:
     "@modelcontextprotocol/sdk": "npm:1.27.1"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.9
   languageName: unknown
@@ -6273,7 +6273,7 @@ __metadata:
   dependencies:
     mongodb: "npm:^6.12.0"
     mongodb-memory-server: "npm:^10.4.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.39
   languageName: unknown
@@ -6294,7 +6294,7 @@ __metadata:
     prettier: "npm:3.8.3"
     tsx: "npm:^4.21.0"
     typedoc: "npm:^0.28.19"
-    typescript: "npm:~6.0.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6311,7 +6311,7 @@ __metadata:
     next: "npm:15.5.12"
     react: "npm:^19"
     react-dom: "npm:^19"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/better-auth": ^0.12.8
     "@pikku/core": ^0.12.21
@@ -6327,7 +6327,7 @@ __metadata:
   dependencies:
     "@pikku/core": "npm:^0.12.30"
     "@pikku/modelcontextprotocol": "npm:^0.12.4"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.30
     "@pikku/modelcontextprotocol": ^0.12.4
@@ -6341,7 +6341,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/openapi-parser@workspace:packages/openapi-parser"
   dependencies:
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     yaml: "npm:^2.7.1"
   languageName: unknown
   linkType: soft
@@ -6350,7 +6350,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/openapi-to-zod-schema@workspace:packages/openapi-to-zod-schema"
   dependencies:
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6358,7 +6358,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/paraglide@workspace:packages/paraglide"
   dependencies:
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     vite: "npm:^7"
   peerDependencies:
     vite: ^5 || ^6 || ^7
@@ -6374,7 +6374,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/pino@workspace:packages/services/pino"
   dependencies:
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.1
     pino: ^9.5.0
@@ -6387,7 +6387,7 @@ __metadata:
   dependencies:
     bullmq: "npm:^5.70.1"
     ioredis: "npm:^5.10.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.38
   languageName: unknown
@@ -6398,7 +6398,7 @@ __metadata:
   resolution: "@pikku/queue-pg-boss@workspace:packages/services/queue-pg-boss"
   dependencies:
     pg-boss: "npm:^12.14.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.38
   languageName: unknown
@@ -6413,7 +6413,7 @@ __metadata:
     "@types/react-dom": "npm:^19"
     react: "npm:^19"
     react-dom: "npm:^19"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     react: ^18 || ^19
     react-dom: ^18 || ^19
@@ -6427,7 +6427,7 @@ __metadata:
     "@types/ioredis-mock": "npm:^8"
     ioredis: "npm:^5.10.0"
     ioredis-mock: "npm:^8.13.1"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.39
   languageName: unknown
@@ -6440,7 +6440,7 @@ __metadata:
     "@types/node": "npm:^24.11.0"
     cron: "npm:^4.4.0"
     cron-schedule: "npm:^5.0.4"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.2
   languageName: unknown
@@ -6452,7 +6452,7 @@ __metadata:
   dependencies:
     ajv: "npm:^8.18.0"
     ajv-formats: "npm:^3.0.1"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.9
   languageName: unknown
@@ -6463,7 +6463,7 @@ __metadata:
   resolution: "@pikku/schema-cfworker@workspace:packages/services/schema-cfworker"
   dependencies:
     "@cfworker/json-schema": "npm:^4.1.1"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.9
   languageName: unknown
@@ -6479,7 +6479,7 @@ __metadata:
     better-auth: "npm:^1.6.19"
     react: "npm:^19"
     react-dom: "npm:^19"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/better-auth": ^0.12.8
     "@pikku/core": ^0.12.34
@@ -6504,7 +6504,7 @@ __metadata:
     kysely-postgres-js: "npm:^3.0.0"
     postgres: "npm:^3.4.8"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4.3.6"
   languageName: unknown
   linkType: soft
@@ -6534,7 +6534,7 @@ __metadata:
     serverless-offline: "npm:^14.5.0"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6560,7 +6560,7 @@ __metadata:
     serverless-offline-sqs: "npm:^8.0.0"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6573,7 +6573,7 @@ __metadata:
     "@types/node": "npm:^24"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6586,7 +6586,7 @@ __metadata:
     "@pikku/schedule": "npm:^0.12.2"
     "@types/bun": "npm:latest"
     tslib: "npm:^2.8.1"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6600,7 +6600,7 @@ __metadata:
     "@pikku/websocket": "npm:^0.12.1"
     "@types/node": "npm:^24"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6613,7 +6613,7 @@ __metadata:
     "@pikku/core": "npm:^0.12.42"
     "@types/node": "npm:^24"
     "@types/ws": "npm:^8"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     wrangler: "npm:^4.78.0"
   languageName: unknown
   linkType: soft
@@ -6626,7 +6626,7 @@ __metadata:
     "@pikku/cloudflare": "npm:^0.12.12"
     "@pikku/core": "npm:^0.12.42"
     "@types/node": "npm:^24"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     wrangler: "npm:^4.78.0"
   languageName: unknown
   linkType: soft
@@ -6647,7 +6647,7 @@ __metadata:
     cookie-parser: "npm:^1.4.7"
     express: "npm:^5"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6662,7 +6662,7 @@ __metadata:
     pino-pretty: "npm:^13.1.3"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6678,7 +6678,7 @@ __metadata:
     fastify-plugin: "npm:^5.1.0"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6692,7 +6692,7 @@ __metadata:
     fastify: "npm:^5.8.2"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6702,7 +6702,7 @@ __metadata:
   dependencies:
     "@pikku/cli": "npm:^0.12.0"
     "@pikku/core": "npm:^0.12.0"
-    typescript: "npm:^5.7.2"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4"
   peerDependencies:
     "@pikku/core": ^0.12.0
@@ -6746,7 +6746,7 @@ __metadata:
     serverless-offline: "npm:^14.5.0"
     serverless-offline-sqs: "npm:^8.0.0"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     wrangler: "npm:^4.78.0"
     ws: "npm:^8.19.0"
     zod: "npm:^4"
@@ -6762,7 +6762,7 @@ __metadata:
     "@pikku/modelcontextprotocol": "npm:^0.12.1"
     "@types/node": "npm:^24.11.0"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6788,7 +6788,7 @@ __metadata:
     tailwindcss: "npm:^4.2.1"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6801,7 +6801,7 @@ __metadata:
     "@types/node": "npm:^24"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6822,7 +6822,7 @@ __metadata:
     postgres: "npm:^3.4.8"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6841,7 +6841,7 @@ __metadata:
     pino-pretty: "npm:^13.1.3"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6856,7 +6856,7 @@ __metadata:
     "@types/ws": "npm:^8"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     ws: "npm:^8.19.0"
   languageName: unknown
   linkType: soft
@@ -6874,7 +6874,7 @@ __metadata:
     "@types/node": "npm:^24"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6894,7 +6894,7 @@ __metadata:
     postgres: "npm:^3.4.8"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6908,7 +6908,7 @@ __metadata:
     "@types/ws": "npm:^8"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     ws: "npm:^8.19.0"
   languageName: unknown
   linkType: soft
@@ -6919,7 +6919,7 @@ __metadata:
   dependencies:
     cookie: "npm:^1.1.1"
     picoquery: "npm:^2.5.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.27
     uWebSockets.js: "*"
@@ -6934,7 +6934,7 @@ __metadata:
     "@pikku/uws-handler": "npm:^0.12.2"
     "@types/qs": "npm:^6"
     qs: "npm:^6.15.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     uWebSockets.js: "uNetworking/uWebSockets.js#v20.68.0"
   peerDependencies:
     "@pikku/core": ^0.12.24
@@ -6956,7 +6956,7 @@ __metadata:
     "@pikku/templates-function-addon": "workspace:*"
     "@types/node": "npm:^24"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4"
   languageName: unknown
   linkType: soft
@@ -6976,7 +6976,7 @@ __metadata:
     better-sqlite3: "npm:^12.10.0"
     kysely: "npm:^0.29.0"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6986,7 +6986,7 @@ __metadata:
   dependencies:
     "@pikku/cli": "workspace:*"
     "@types/node": "npm:^24"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7001,7 +7001,7 @@ __metadata:
     "@types/node": "npm:^24"
     "@types/ws": "npm:^8"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     ws: "npm:^8.19.0"
   languageName: unknown
   linkType: soft
@@ -7016,7 +7016,7 @@ __metadata:
     "@pikku/inspector": "workspace:*"
     "@types/node": "npm:^24"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7026,7 +7026,7 @@ __metadata:
   dependencies:
     "@pikku/cli": "workspace:*"
     "@types/node": "npm:^24"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7036,7 +7036,7 @@ __metadata:
   dependencies:
     "@pikku/cli": "workspace:*"
     "@types/node": "npm:^24"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7046,7 +7046,7 @@ __metadata:
   dependencies:
     "@pikku/cli": "workspace:*"
     "@types/node": "npm:^24"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7056,7 +7056,7 @@ __metadata:
   dependencies:
     "@pikku/cli": "workspace:*"
     "@types/node": "npm:^24"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7067,7 +7067,7 @@ __metadata:
     "@pikku/cli": "workspace:*"
     "@types/node": "npm:^24"
     tsx: "npm:^4"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7092,7 +7092,7 @@ __metadata:
     react: "npm:^19"
     react-dom: "npm:^19"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     ws: "npm:^8.19.0"
     zod: "npm:^4"
   languageName: unknown
@@ -7105,7 +7105,7 @@ __metadata:
     "@pikku/cli": "workspace:*"
     "@pikku/core": "workspace:*"
     "@types/node": "npm:^24"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7118,7 +7118,7 @@ __metadata:
     "@pikku/schema-cfworker": "workspace:*"
     "@types/node": "npm:^24"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7130,7 +7130,7 @@ __metadata:
     "@pikku/core": "workspace:*"
     "@pikku/templates-function-addon": "workspace:*"
     "@types/node": "npm:^24"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4"
   languageName: unknown
   linkType: soft
@@ -7156,7 +7156,7 @@ __metadata:
     react: "npm:^19"
     react-dom: "npm:^19"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7169,7 +7169,7 @@ __metadata:
     "@pikku/schema-cfworker": "workspace:*"
     "@types/node": "npm:^24"
     tsx: "npm:^4.20.6"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4"
   languageName: unknown
   linkType: soft
@@ -7198,7 +7198,7 @@ __metadata:
     react: "npm:^19"
     react-dom: "npm:^19"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.11"
   languageName: unknown
   linkType: soft
@@ -7211,7 +7211,7 @@ __metadata:
     "@pikku/core": "workspace:*"
     "@pikku/templates-function-addon": "workspace:*"
     "@types/node": "npm:^24"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4"
   languageName: unknown
   linkType: soft
@@ -7224,7 +7224,7 @@ __metadata:
     "@pikku/core": "workspace:*"
     "@pikku/templates-function-addon": "workspace:*"
     "@types/node": "npm:^24"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4"
   languageName: unknown
   linkType: soft
@@ -7238,7 +7238,7 @@ __metadata:
     "@pikku/schema-cfworker": "workspace:*"
     "@types/node": "npm:^24"
     tsx: "npm:^4.20.6"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     zod: "npm:^4"
   languageName: unknown
   linkType: soft
@@ -7259,7 +7259,7 @@ __metadata:
     kysely-postgres-js: "npm:^3.0.0"
     postgres: "npm:^3.4.8"
     tsx: "npm:^4.20.6"
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7267,7 +7267,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/websocket@workspace:packages/client-websocket"
   dependencies:
-    typescript: "npm:^5.9"
+    typescript: "npm:^6.0.3"
     ws: "npm:^8.19.0"
   dependenciesMeta:
     ws:
@@ -7281,7 +7281,7 @@ __metadata:
   dependencies:
     "@types/ws": "npm:^8"
     cookie: "npm:^1.1.1"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.9
     ws: ^8.18.0
@@ -14429,7 +14429,7 @@ __metadata:
     giget: "npm:^1.2.4"
     nanospinner: "npm:^1.2.2"
     tsx: "npm:^4.19.2"
-    typescript: "npm:^5.7.3"
+    typescript: "npm:^6.0.3"
   bin:
     create-pikku: dist/index.js
   languageName: unknown
@@ -16501,6 +16501,17 @@ __metadata:
     minipass: "npm:^7.1.2"
     path-scurry: "npm:^2.0.0"
   checksum: 10/de390721d29ee1c9ea41e40ec2aa0de2cabafa68022e237dc4297665a5e4d650776f2573191984ea1640aba1bf0ea34eddef2d8cbfbfc2ad24b5fb0af41d8846
+  languageName: node
+  linkType: hard
+
+"glob@npm:^13.0.6":
+  version: 13.0.6
+  resolution: "glob@npm:13.0.6"
+  dependencies:
+    minimatch: "npm:^10.2.2"
+    minipass: "npm:^7.1.3"
+    path-scurry: "npm:^2.0.2"
+  checksum: 10/201ad69e5f0aa74e1d8c00a481581f8b8c804b6a4fbfabeeb8541f5d756932800331daeba99b58fb9e4cd67e12ba5a7eba5b82fb476691588418060b84353214
   languageName: node
   linkType: hard
 
@@ -19370,6 +19381,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "minipass@npm:7.1.3"
+  checksum: 10/175e4d5e20980c3cd316ae82d2c031c42f6c746467d8b1905b51060a0ba4461441a0c25bb67c025fd9617f9a3873e152c7b543c6b5ac83a1846be8ade80dffd6
+  languageName: node
+  linkType: hard
+
 "minizlib@npm:^2.1.1":
   version: 2.1.2
   resolution: "minizlib@npm:2.1.2"
@@ -20588,6 +20606,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-scurry@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "path-scurry@npm:2.0.2"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10/2b4257422bcb870a4c2d205b3acdbb213a72f5e2250f61c80f79c9d014d010f82bdf8584441612c8e1fa4eb098678f5704a66fa8377d72646bad4be38e57a2c3
+  languageName: node
+  linkType: hard
+
 "path-to-regexp@npm:6.3.0":
   version: 6.3.0
   resolution: "path-to-regexp@npm:6.3.0"
@@ -20839,7 +20867,7 @@ __metadata:
     "@pikku/core": "npm:^0.12.2"
     "@pikku/jose": "npm:^0.12.1"
     "@pikku/schema-ajv": "npm:^0.12.2"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -23972,20 +24000,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-json-schema-generator@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "ts-json-schema-generator@npm:2.5.0"
+"ts-json-schema-generator@npm:2.9.1-next.16":
+  version: 2.9.1-next.16
+  resolution: "ts-json-schema-generator@npm:2.9.1-next.16"
   dependencies:
     "@types/json-schema": "npm:^7.0.15"
-    commander: "npm:^14.0.2"
+    commander: "npm:^14.0.3"
+    glob: "npm:^13.0.6"
     json5: "npm:^2.2.3"
     normalize-path: "npm:^3.0.0"
     safe-stable-stringify: "npm:^2.5.0"
     tslib: "npm:^2.8.1"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:>=5.9 <7"
   bin:
     ts-json-schema-generator: bin/ts-json-schema-generator.js
-  checksum: 10/009f79ea14c1b286b6e1493e54af9274e2605542d775c2fac7eb3db48ec442190acb99a8fb380ca440cd6582194d73f2e9523c6516c9575c49d73743986d4680
+  checksum: 10/59dc1bfa9cc615152cc9e336400e7990a75c214a950ea5dcfd68b33f9792a3f51935904f1fd22bab135413452f779038fe5e2d5b4689dfe40304708371155528
   languageName: node
   linkType: hard
 
@@ -24157,27 +24186,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5, typescript@npm:^5.7.2, typescript@npm:^5.7.3, typescript@npm:^5.9, typescript@npm:^5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~5.8.0":
-  version: 5.8.3
-  resolution: "typescript@npm:5.8.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/65c40944c51b513b0172c6710ee62e951b70af6f75d5a5da745cb7fab132c09ae27ffdf7838996e3ed603bb015dadd099006658046941bd0ba30340cc563ae92
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~6.0.3":
+"typescript@npm:>=5.9 <7, typescript@npm:^6.0.3":
   version: 6.0.3
   resolution: "typescript@npm:6.0.3"
   bin:
@@ -24187,27 +24196,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.9#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~5.8.0#optional!builtin<compat/typescript>":
-  version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/b9b1e73dabac5dc730c041325dbd9c99467c1b0d239f1b74ec3b90d831384af3e2ba973946232df670519147eb51a2c20f6f96163cea2b359f03de1e2091cc4f
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~6.0.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A>=5.9 <7#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
   version: 6.0.3
   resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
@@ -25524,13 +25513,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-to-ts@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "zod-to-ts@npm:2.0.0"
+"zod-to-ts@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "zod-to-ts@npm:2.1.0"
   peerDependencies:
-    typescript: ^5.0.0
+    typescript: ^5 || ^6
     zod: ^3.25.0 || ^4.0.0
-  checksum: 10/e684554efe2e90f99383a67b75476cf0e9ae4148d69f7d6b5ab80f03291a1b902e3a96f823cf65b17af3079521c15581aae62c6bf7c6839bbc247b8ec4037a77
+  checksum: 10/e49504bb45c6ae9a40a256ed2d2ad82ee2b53d75010929647fa86c93cc9358fd7b83dae2b7512ec507dc03dd93e5c45e069473afbf441abf36fdd4de5f5b4350
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Upgrades the whole monorepo to **TypeScript 6** and raises the minimum Node.js version to **22**.

## Changes

- **`typescript@^6.0.3`** across all 110 workspace `package.json` files
- **`engines.node` → `>=22`** everywhere (`@pikku/kysely-node-sqlite` kept at `>=22.10` for `node:sqlite` stability)
- **`ts-json-schema-generator` → `2.9.1-next.16`** — its typescript range widened to `>=5.9 <7`, so it now dedupes onto the single TS6 copy. This removes the duplicate-`typescript`-copy `ts.Program` type-identity error in `@pikku/inspector`.
- **`zod-to-ts` → `^2.1.0`** (peer is now `^5 || ^6`)
- **tsconfig fixes required by TS6:**
  - 6 `tsconfig.cjs.json` files get `"ignoreDeprecations": "6.0"` (`moduleResolution: node`/node10 is deprecated in TS6, removed in TS7)
  - `packages/create`: explicit `rootDir` (TS6 requires it when `outDir` is set) + `types: ["node"]` (standalone config no longer auto-discovers `@types/node` under TS6)
  - `addon-console` / `addon-graph`: `types: ["node"]`
- **One real code fix:** `@pikku/websocket` `sendBinary` param `Uint8Array` → `Uint8Array<ArrayBuffer>`, to satisfy TS6's tightened `WebSocket.send` (`BufferSource = ArrayBufferView<ArrayBuffer>`; bare `Uint8Array` now means `Uint8Array<ArrayBufferLike>`, which includes `SharedArrayBuffer`)

## Validation on TS6

| Check | Result |
|---|---|
| `yarn build:packages` | ✅ 0 errors |
| `yarn build:addons` | ✅ 0 errors |
| `yarn build` (full, incl. `yarn pikku` codegen running `ts-json-schema-generator` on TS6) | ✅ 0 errors |
| `yarn test` (core suite) | ✅ all pass |
| `yarn test:verifiers` | ✅ all pass except the **Bun-compiled-binary** target of `deploy-standalone` |

### Note on the one red verifier

`verifiers/deploy-standalone` fails only on its **Bun-compiled binary** runtime target (routes 404). This is **pre-existing and unrelated to the TS6 upgrade**:
- The **Node** target in the same verifier passes all runtime tests.
- This commit makes **zero source changes** to `bun-server`/`deploy-standalone` (only the 2-line `package.json` devDep/engines bumps), so the compiled binary's behavior is identical to `main`.
- It only surfaces locally because Bun is installed; the standalone→bun-binary work is a known separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded the project to TypeScript 6 across the repository.
  * Updated templates and generated packages to align with TypeScript 6 tooling.
* **Bug Fixes**
  * Improved TypeScript compatibility by suppressing deprecation warnings from the 6.x line.
  * Updated WebSocket binary payload typing for safer compilation.
* **Chores**
  * Raised the minimum supported Node.js version to 22 for affected packages.
  * Updated schema/codegen tooling versions used by the build toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->