### PR TITLE
Tree-shake addon registrations and services in per-unit deploy codegen

### DIFF
--- a/.changeset/addon-tree-shaking.md
+++ b/.changeset/addon-tree-shaking.md
@@ -1,6 +1,7 @@
 ---
 '@pikku/inspector': patch
 '@pikku/cli': patch
+'@pikku/core': patch
 ---
 
 Tree-shake addon registrations in filtered inspector states (per-unit deploy codegen).
@@ -9,3 +10,4 @@ Tree-shake addon registrations in filtered inspector states (per-unit deploy cod
 - Body-level `rpc.invoke()` targets are now tracked per source file (`rpc.invokedFunctionsByFile`) so wiring-level `ref()` targets no longer pin an addon into every unit.
 - `aggregateRequiredServices` computes addon parent services per used addon function (from the addon's shipped per-function `services` meta) instead of blanket-adding `addonRequiredParentServices` — and matches namespaced ids only, so bare project function names colliding with addon function names no longer force the blanket.
 - Addon builds keep per-function `services` in the shipped `pikku-functions-meta.gen.json` so parent projects can do the above; addons built before this fall back to the blanket.
+- HTTP route meta records `refTarget` for `ref('namespace:fn')`-wired routes, so per-unit filtering keeps the addon registration (and only that function's services) when the route deploys.

--- a/.changeset/addon-tree-shaking.md
+++ b/.changeset/addon-tree-shaking.md
@@ -1,0 +1,11 @@
+---
+'@pikku/inspector': patch
+'@pikku/cli': patch
+---
+
+Tree-shake addon registrations in filtered inspector states (per-unit deploy codegen).
+
+- `filterInspectorState` drops an addon's `wireAddonDeclarations`/`usedAddons` unless something kept actually references it (kept wiring targeting `namespace:*`, kept agent/MCP tool, or a body-level `rpc.invoke('namespace:*')` from a file that still contains a kept function). The generated per-unit bootstrap no longer imports unused addon package bootstraps — previously every deploy unit registered every addon's entire function surface, which pulled dev-only code (e.g. `@pikku/addon-console`'s static `node:fs` imports) into Cloudflare Worker bundles and failed upload with `No such module "node:fs"`.
+- Body-level `rpc.invoke()` targets are now tracked per source file (`rpc.invokedFunctionsByFile`) so wiring-level `ref()` targets no longer pin an addon into every unit.
+- `aggregateRequiredServices` computes addon parent services per used addon function (from the addon's shipped per-function `services` meta) instead of blanket-adding `addonRequiredParentServices` — and matches namespaced ids only, so bare project function names colliding with addon function names no longer force the blanket.
+- Addon builds keep per-function `services` in the shipped `pikku-functions-meta.gen.json` so parent projects can do the above; addons built before this fall back to the blanket.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -98,6 +98,7 @@ jobs:
         verifier:
           [
             addon,
+            addon-treeshake,
             classification,
             gateway,
             middleware-and-permissions,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,7 @@ jobs:
         verifier:
           [
             addon,
+            addon-treeshake,
             # binary,
             classification,
             gateway,

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ packages/cli/release/
 # addon-registry verifier install artifacts (shadcn copy + provenance)
 verifiers/addon-registry/consumer/addons/
 verifiers/addon-registry/consumer/pikku-addons.json
+.pikku-shake/

--- a/packages/cli/src/functions/wirings/console/pikku-command-nodes-meta.ts
+++ b/packages/cli/src/functions/wirings/console/pikku-command-nodes-meta.ts
@@ -101,9 +101,6 @@ export const pikkuNodesMeta = pikkuSessionlessFunc<void, boolean | undefined>({
       metaData.serverlessIncompatible = serverlessIncompatible
     }
 
-    // Consumers need the addon's parent-service declarations as data — the
-    // pikku-services.gen.js module import only works for compiled (dist)
-    // addons, not source-form workspace addons.
     if (hasParentServices) {
       metaData.requiredParentServices = state.addonRequiredParentServices
     }

--- a/packages/cli/src/functions/wirings/console/pikku-command-nodes-meta.ts
+++ b/packages/cli/src/functions/wirings/console/pikku-command-nodes-meta.ts
@@ -50,8 +50,10 @@ export const pikkuNodesMeta = pikkuSessionlessFunc<void, boolean | undefined>({
     const hasNodes = Object.keys(nodes.meta).length > 0
     const hasSecrets = secrets.definitions.length > 0
     const hasPackageMeta = !!addonMeta?.icon || !!addonMeta?.displayName
+    const hasParentServices =
+      (state.addonRequiredParentServices?.length ?? 0) > 0
 
-    if (!hasNodes && !hasSecrets && !hasPackageMeta) {
+    if (!hasNodes && !hasSecrets && !hasPackageMeta && !hasParentServices) {
       return undefined
     }
 
@@ -97,6 +99,13 @@ export const pikkuNodesMeta = pikkuSessionlessFunc<void, boolean | undefined>({
 
     if (serverlessIncompatible && serverlessIncompatible.length > 0) {
       metaData.serverlessIncompatible = serverlessIncompatible
+    }
+
+    // Consumers need the addon's parent-service declarations as data — the
+    // pikku-services.gen.js module import only works for compiled (dist)
+    // addons, not source-form workspace addons.
+    if (hasParentServices) {
+      metaData.requiredParentServices = state.addonRequiredParentServices
     }
 
     if (addonMetaJsonFile && (config.scaffold?.console || config.addon)) {

--- a/packages/cli/src/functions/wirings/functions/pikku-command-functions.ts
+++ b/packages/cli/src/functions/wirings/functions/pikku-command-functions.ts
@@ -20,9 +20,6 @@ export const pikkuFunctions = pikkuSessionlessFunc<void, boolean | undefined>({
       schema,
     } = config
 
-    // Write minimal JSON (runtime-only fields). Addon builds keep
-    // per-function `services` — parent-project codegen needs it to compute
-    // per-unit service flags.
     let minimalMeta = stripVerboseFields(functions.meta)
     if (config.addonName) {
       minimalMeta = reattachFunctionServices(minimalMeta, functions.meta)

--- a/packages/cli/src/functions/wirings/functions/pikku-command-functions.ts
+++ b/packages/cli/src/functions/wirings/functions/pikku-command-functions.ts
@@ -6,6 +6,7 @@ import { getFileImportRelativePath } from '../../../utils/file-import-path.js'
 import {
   stripVerboseFields,
   hasVerboseFields,
+  reattachFunctionServices,
 } from '../../../utils/strip-verbose-meta.js'
 
 export const pikkuFunctions = pikkuSessionlessFunc<void, boolean | undefined>({
@@ -19,8 +20,13 @@ export const pikkuFunctions = pikkuSessionlessFunc<void, boolean | undefined>({
       schema,
     } = config
 
-    // Write minimal JSON (runtime-only fields)
-    const minimalMeta = stripVerboseFields(functions.meta)
+    // Write minimal JSON (runtime-only fields). Addon builds keep
+    // per-function `services` — parent-project codegen needs it to compute
+    // per-unit service flags.
+    let minimalMeta = stripVerboseFields(functions.meta)
+    if (config.addonName) {
+      minimalMeta = reattachFunctionServices(minimalMeta, functions.meta)
+    }
     await writeFileInDir(
       logger,
       functionsMetaJsonFile,

--- a/packages/cli/src/utils/strip-verbose-meta.test.ts
+++ b/packages/cli/src/utils/strip-verbose-meta.test.ts
@@ -1,6 +1,10 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
-import { stripVerboseFields, hasVerboseFields } from './strip-verbose-meta.js'
+import {
+  stripVerboseFields,
+  hasVerboseFields,
+  reattachFunctionServices,
+} from './strip-verbose-meta.js'
 
 describe('stripVerboseFields', () => {
   describe('function meta (record with pikkuFuncId)', () => {
@@ -152,5 +156,37 @@ describe('hasVerboseFields', () => {
       },
     }
     assert.strictEqual(hasVerboseFields(meta), true)
+  })
+})
+
+describe('reattachFunctionServices', () => {
+  test('restores services stripped from addon meta', () => {
+    const full = {
+      getSchema: {
+        pikkuFuncId: 'getSchema',
+        services: { optimized: true, services: ['metaService'] },
+        tags: ['console'],
+      },
+      noServices: { pikkuFuncId: 'noServices' },
+    } as any
+    const minimal = stripVerboseFields(full) as any
+    assert.strictEqual(minimal.getSchema.services, undefined)
+
+    const result = reattachFunctionServices(minimal, full) as any
+    assert.deepStrictEqual(result.getSchema.services, {
+      optimized: true,
+      services: ['metaService'],
+    })
+    // Other verbose fields stay stripped
+    assert.strictEqual(result.getSchema.tags, undefined)
+    assert.strictEqual(result.noServices.services, undefined)
+  })
+
+  test('ignores functions missing from the minimal meta', () => {
+    const result = reattachFunctionServices(
+      {} as any,
+      { ghost: { services: { optimized: true, services: ['kysely'] } } } as any
+    )
+    assert.deepStrictEqual(result, {})
   })
 })

--- a/packages/cli/src/utils/strip-verbose-meta.test.ts
+++ b/packages/cli/src/utils/strip-verbose-meta.test.ts
@@ -177,7 +177,6 @@ describe('reattachFunctionServices', () => {
       optimized: true,
       services: ['metaService'],
     })
-    // Other verbose fields stay stripped
     assert.strictEqual(result.getSchema.tags, undefined)
     assert.strictEqual(result.noServices.services, undefined)
   })

--- a/packages/cli/src/utils/strip-verbose-meta.ts
+++ b/packages/cli/src/utils/strip-verbose-meta.ts
@@ -211,13 +211,6 @@ function _stripVerboseFieldsInner<T>(obj: T): T {
   return result as T
 }
 
-/**
- * Re-attach per-function `services` onto a stripped meta object.
- *
- * Addon meta is consumed by parent-project codegen, which needs each
- * function's `services` to compute per-unit service flags — for an addon
- * build this is not a verbose field.
- */
 export function reattachFunctionServices<
   T extends Record<string, { services?: unknown }>,
 >(minimalMeta: T, fullMeta: T): T {

--- a/packages/cli/src/utils/strip-verbose-meta.ts
+++ b/packages/cli/src/utils/strip-verbose-meta.ts
@@ -212,6 +212,24 @@ function _stripVerboseFieldsInner<T>(obj: T): T {
 }
 
 /**
+ * Re-attach per-function `services` onto a stripped meta object.
+ *
+ * Addon meta is consumed by parent-project codegen, which needs each
+ * function's `services` to compute per-unit service flags — for an addon
+ * build this is not a verbose field.
+ */
+export function reattachFunctionServices<
+  T extends Record<string, { services?: unknown }>,
+>(minimalMeta: T, fullMeta: T): T {
+  for (const [id, meta] of Object.entries(fullMeta)) {
+    if (meta?.services && minimalMeta[id]) {
+      minimalMeta[id].services = meta.services
+    }
+  }
+  return minimalMeta
+}
+
+/**
  * Check if an object has any verbose fields that would be stripped
  */
 export function hasVerboseFields(obj: unknown): boolean {

--- a/packages/core/src/wirings/http/http.types.ts
+++ b/packages/core/src/wirings/http/http.types.ts
@@ -226,9 +226,6 @@ export type HTTPFunctionMetaInputTypes = {
 export type HTTPWiringMeta = CommonWireMeta & {
   route: string
   method: HTTPMethod
-  // Namespaced addon function this route dispatches to via ref('ns:fn').
-  // pikkuFuncId stays the inline context id; filtering/aggregation use this
-  // to keep the addon registration and its per-function services.
   refTarget?: string
   params?: string[]
   query?: string[]

--- a/packages/core/src/wirings/http/http.types.ts
+++ b/packages/core/src/wirings/http/http.types.ts
@@ -226,6 +226,10 @@ export type HTTPFunctionMetaInputTypes = {
 export type HTTPWiringMeta = CommonWireMeta & {
   route: string
   method: HTTPMethod
+  // Namespaced addon function this route dispatches to via ref('ns:fn').
+  // pikkuFuncId stays the inline context id; filtering/aggregation use this
+  // to keep the addon registration and its per-function services.
+  refTarget?: string
   params?: string[]
   query?: string[]
   inputTypes?: HTTPFunctionMetaInputTypes

--- a/packages/inspector/src/add/add-http-route.ts
+++ b/packages/inspector/src/add/add-http-route.ts
@@ -389,8 +389,13 @@ export function registerHTTPRoute({
     checker
   )
 
-  // Track used functions/middleware/permissions for service aggregation
+  // Track used functions/middleware/permissions for service aggregation.
+  // ref()-wired routes dispatch to the addon function at runtime — count the
+  // target as used so its addon registration and services aggregate too.
   state.serviceAggregation.usedFunctions.add(funcName)
+  if (refAddonTarget) {
+    state.serviceAggregation.usedFunctions.add(refAddonTarget)
+  }
   extractWireNames(middleware).forEach((name) =>
     state.serviceAggregation.usedMiddleware.add(name)
   )
@@ -415,6 +420,7 @@ export function registerHTTPRoute({
   state.http.files.add(sourceFile.fileName)
   state.http.meta[method][fullRoute] = {
     pikkuFuncId: funcName,
+    ...(refAddonTarget && { refTarget: refAddonTarget }),
     ...(packageName && { packageName }),
     route: fullRoute,
     sourceFile: sourceFile.fileName,

--- a/packages/inspector/src/add/add-http-route.ts
+++ b/packages/inspector/src/add/add-http-route.ts
@@ -389,9 +389,6 @@ export function registerHTTPRoute({
     checker
   )
 
-  // Track used functions/middleware/permissions for service aggregation.
-  // ref()-wired routes dispatch to the addon function at runtime — count the
-  // target as used so its addon registration and services aggregate too.
   state.serviceAggregation.usedFunctions.add(funcName)
   if (refAddonTarget) {
     state.serviceAggregation.usedFunctions.add(refAddonTarget)

--- a/packages/inspector/src/add/add-rpc-invocations.test.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.test.ts
@@ -69,7 +69,6 @@ export async function doWork() {
     })
     try {
       assert.ok(state.serviceAggregation.usedFunctions.has('ext:goodbye'))
-      // Non-namespaced invokes are covered by wiring meta — not added here
       assert.ok(!state.serviceAggregation.usedFunctions.has('localHelper'))
     } finally {
       await rm(dir, { recursive: true, force: true })
@@ -88,19 +87,16 @@ export async function doWork() {
     })
     try {
       const invoked = [...state.rpc.invokedFunctionsByFile.values()][0]!
-      assert.deepStrictEqual(
-        [...invoked].sort(),
-        ['console:getSchema', 'listTasks']
-      )
+      assert.deepStrictEqual([...invoked].sort(), [
+        'console:getSchema',
+        'listTasks',
+      ])
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
   })
 
   test('wiring-level ref() lands in invokedFunctions but NOT in the by-file map', async () => {
-    // ref() targets belong to their wiring — per-unit filtering must be able
-    // to distinguish them from body-level invocations, so they are
-    // deliberately excluded from invokedFunctionsByFile.
     const { state, dir } = await inspectFiles({
       'wiring.ts': `
 declare const ref: (name: string) => unknown

--- a/packages/inspector/src/add/add-rpc-invocations.test.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.test.ts
@@ -57,6 +57,25 @@ export const unrelated = () => 'no invocations here'
     }
   })
 
+  test('namespaced body invoke joins serviceAggregation.usedFunctions', async () => {
+    const { state, dir } = await inspectFiles({
+      'caller.ts': `
+declare const rpc: { invoke: (name: string, data?: unknown) => Promise<unknown> }
+export async function doWork() {
+  await rpc.invoke('ext:goodbye')
+  return rpc.invoke('localHelper')
+}
+`,
+    })
+    try {
+      assert.ok(state.serviceAggregation.usedFunctions.has('ext:goodbye'))
+      // Non-namespaced invokes are covered by wiring meta — not added here
+      assert.ok(!state.serviceAggregation.usedFunctions.has('localHelper'))
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   test('multiple invocations in one file accumulate under that file', async () => {
     const { state, dir } = await inspectFiles({
       'caller.ts': `

--- a/packages/inspector/src/add/add-rpc-invocations.test.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.test.ts
@@ -1,0 +1,98 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { inspect } from '../inspector.js'
+import type { InspectorLogger, InspectorState } from '../types.js'
+
+function makeLogger(): InspectorLogger {
+  return {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    diagnostic: () => {},
+    critical: () => {},
+    hasCriticalErrors: () => false,
+  }
+}
+
+async function inspectFiles(
+  files: Record<string, string>
+): Promise<{ state: InspectorState; dir: string }> {
+  const dir = await mkdtemp(join(tmpdir(), 'pikku-rpc-invocations-test-'))
+  const paths: string[] = []
+  for (const [name, source] of Object.entries(files)) {
+    const path = join(dir, name)
+    await writeFile(path, source)
+    paths.push(path)
+  }
+  const state = await inspect(makeLogger(), paths, { rootDir: dir })
+  return { state, dir }
+}
+
+describe('add-rpc-invocations — invokedFunctionsByFile', () => {
+  test('body-level rpc.invoke() is attributed to its source file', async () => {
+    const { state, dir } = await inspectFiles({
+      'caller.ts': `
+declare const rpc: { invoke: (name: string, data?: unknown) => Promise<unknown> }
+export async function doWork() {
+  return rpc.invoke('console:getSchema')
+}
+`,
+      'other.ts': `
+export const unrelated = () => 'no invocations here'
+`,
+    })
+    try {
+      assert.ok(state.rpc.invokedFunctions.has('console:getSchema'))
+      const byFile = state.rpc.invokedFunctionsByFile
+      assert.strictEqual(byFile.size, 1)
+      const [file, invoked] = [...byFile.entries()][0]!
+      assert.ok(file.endsWith('caller.ts'))
+      assert.deepStrictEqual([...invoked], ['console:getSchema'])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('multiple invocations in one file accumulate under that file', async () => {
+    const { state, dir } = await inspectFiles({
+      'caller.ts': `
+declare const rpc: { invoke: (name: string, data?: unknown) => Promise<unknown> }
+export async function doWork() {
+  await rpc.invoke('console:getSchema')
+  return rpc.invoke('listTasks')
+}
+`,
+    })
+    try {
+      const invoked = [...state.rpc.invokedFunctionsByFile.values()][0]!
+      assert.deepStrictEqual(
+        [...invoked].sort(),
+        ['console:getSchema', 'listTasks']
+      )
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('wiring-level ref() lands in invokedFunctions but NOT in the by-file map', async () => {
+    // ref() targets belong to their wiring — per-unit filtering must be able
+    // to distinguish them from body-level invocations, so they are
+    // deliberately excluded from invokedFunctionsByFile.
+    const { state, dir } = await inspectFiles({
+      'wiring.ts': `
+declare const ref: (name: string) => unknown
+export const routes = { stream: { func: ref('console:streamWorkflowRun') } }
+`,
+    })
+    try {
+      assert.ok(state.rpc.invokedFunctions.has('console:streamWorkflowRun'))
+      assert.strictEqual(state.rpc.invokedFunctionsByFile.size, 0)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/inspector/src/add/add-rpc-invocations.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.ts
@@ -132,6 +132,11 @@ export function addRPCInvocations(
           if (namespace) {
             logger.debug(`  → Addon detected: ${namespace}`)
             state.rpc.usedAddons.add(namespace)
+            // A body-level invoke is the only reference to an addon function
+            // that no wiring meta carries — count it as used so its services
+            // aggregate (full builds; filtered states recompute from
+            // invokedFunctionsByFile).
+            state.serviceAggregation.usedFunctions.add(functionRef)
           }
         }
         // Handle template literals like `function-${name}`

--- a/packages/inspector/src/add/add-rpc-invocations.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.ts
@@ -115,12 +115,6 @@ export function addRPCInvocations(
           logger.debug(`• Found RPC invocation: ${functionRef}`)
           state.rpc.invokedFunctions.add(functionRef)
 
-          // Body-level invocations, attributed to their source file. Unlike
-          // wiring-level ref() (whose target is carried by the wiring meta),
-          // this is the only record that a function BODY reaches another
-          // function — per-unit filtering uses it to keep addon
-          // registrations only in units whose kept code actually invokes
-          // the addon.
           let byFile = state.rpc.invokedFunctionsByFile.get(sourceFileName)
           if (!byFile) {
             byFile = new Set()
@@ -132,10 +126,6 @@ export function addRPCInvocations(
           if (namespace) {
             logger.debug(`  → Addon detected: ${namespace}`)
             state.rpc.usedAddons.add(namespace)
-            // A body-level invoke is the only reference to an addon function
-            // that no wiring meta carries — count it as used so its services
-            // aggregate (full builds; filtered states recompute from
-            // invokedFunctionsByFile).
             state.serviceAggregation.usedFunctions.add(functionRef)
           }
         }

--- a/packages/inspector/src/add/add-rpc-invocations.ts
+++ b/packages/inspector/src/add/add-rpc-invocations.ts
@@ -115,6 +115,19 @@ export function addRPCInvocations(
           logger.debug(`• Found RPC invocation: ${functionRef}`)
           state.rpc.invokedFunctions.add(functionRef)
 
+          // Body-level invocations, attributed to their source file. Unlike
+          // wiring-level ref() (whose target is carried by the wiring meta),
+          // this is the only record that a function BODY reaches another
+          // function — per-unit filtering uses it to keep addon
+          // registrations only in units whose kept code actually invokes
+          // the addon.
+          let byFile = state.rpc.invokedFunctionsByFile.get(sourceFileName)
+          if (!byFile) {
+            byFile = new Set()
+            state.rpc.invokedFunctionsByFile.set(sourceFileName, byFile)
+          }
+          byFile.add(functionRef)
+
           const namespace = extractNamespace(functionRef)
           if (namespace) {
             logger.debug(`  → Addon detected: ${namespace}`)

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -124,6 +124,7 @@ export function getInitialInspectorState(rootDir: string): InspectorState {
       exposedMeta: {},
       exposedFiles: new Map(),
       invokedFunctions: new Set(),
+      invokedFunctionsByFile: new Map(),
       usedAddons: new Set(),
       wireAddonDeclarations: new Map(),
       wireAddonFiles: new Set(),

--- a/packages/inspector/src/types.ts
+++ b/packages/inspector/src/types.ts
@@ -482,6 +482,11 @@ export interface InspectorState {
     exposedMeta: Record<string, string>
     exposedFiles: Map<string, { path: string; exportedName: string }>
     invokedFunctions: Set<string>
+    // Body-level rpc.invoke() targets keyed by the invoking source file —
+    // used by filterInspectorState to keep addon registrations only where
+    // kept code actually invokes the addon (wiring-level ref() targets are
+    // carried by the wiring meta instead).
+    invokedFunctionsByFile: Map<string, Set<string>>
     usedAddons: Set<string>
     wireAddonDeclarations: Map<
       string,

--- a/packages/inspector/src/types.ts
+++ b/packages/inspector/src/types.ts
@@ -482,10 +482,6 @@ export interface InspectorState {
     exposedMeta: Record<string, string>
     exposedFiles: Map<string, { path: string; exportedName: string }>
     invokedFunctions: Set<string>
-    // Body-level rpc.invoke() targets keyed by the invoking source file —
-    // used by filterInspectorState to keep addon registrations only where
-    // kept code actually invokes the addon (wiring-level ref() targets are
-    // carried by the wiring meta instead).
     invokedFunctionsByFile: Map<string, Set<string>>
     usedAddons: Set<string>
     wireAddonDeclarations: Map<

--- a/packages/inspector/src/utils/filter-inspector-state.test.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.test.ts
@@ -1819,6 +1819,22 @@ describe('addon bootstrap tree-shake', () => {
     assert.strictEqual(filtered.rpc.wireAddonDeclarations.size, 1)
   })
 
+  test('a kept-file body invoke joins the filtered usedFunctions', () => {
+    const state = withAddon((s) => {
+      s.rpc.invokedFunctionsByFile = new Map([
+        ['/test/project/src/api/users.ts', new Set(['console:getSchema'])],
+      ])
+    })
+    const filtered = filterInspectorState(
+      state,
+      { names: ['getUsers'] },
+      mockLogger
+    )
+    assert.ok(
+      filtered.serviceAggregation.usedFunctions.has('console:getSchema')
+    )
+  })
+
   test('drops an addon body-invoked only from filtered-out files', () => {
     const state = withAddon((s) => {
       s.rpc.invokedFunctionsByFile = new Map([

--- a/packages/inspector/src/utils/filter-inspector-state.test.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.test.ts
@@ -1668,8 +1668,6 @@ describe('addon bootstrap tree-shake', () => {
       ['console', { package: '@pikku/addon-console' }],
     ])
     state.rpc.usedAddons = new Set(['console'])
-    // Wiring-level ref() targets land in invokedFunctions but carry no
-    // caller file — they must NOT keep the addon on their own.
     state.rpc.invokedFunctions = new Set(['console:streamFunctionTests'])
     mutate?.(state)
     return state
@@ -1707,10 +1705,6 @@ describe('addon bootstrap tree-shake', () => {
   })
 
   test('keeps an addon when a kept route ref()-targets one of its functions', () => {
-    // Real inspector shape for `func: ref('console:streamFunctionTests')`:
-    // pikkuFuncId is a minted inline context id; the addon target lives in
-    // refTarget. The inline function meta has no services and no namespace —
-    // only refTarget links the route to the addon.
     const state = withAddon((s) => {
       s.http.meta.get['/function-tests/stream'] = {
         pikkuFuncId: 'http:get:/function-tests/stream',
@@ -1727,7 +1721,6 @@ describe('addon bootstrap tree-shake', () => {
     })
     const filtered = filterInspectorState(
       state,
-      // per-unit deploy codegen passes the minted inline id as the name
       { names: ['http:get:/function-tests/stream'] },
       mockLogger
     )
@@ -1838,10 +1831,7 @@ describe('addon bootstrap tree-shake', () => {
   test('drops an addon body-invoked only from filtered-out files', () => {
     const state = withAddon((s) => {
       s.rpc.invokedFunctionsByFile = new Map([
-        [
-          '/test/project/src/admin/settings.ts',
-          new Set(['console:getSchema']),
-        ],
+        ['/test/project/src/admin/settings.ts', new Set(['console:getSchema'])],
       ])
     })
     const filtered = filterInspectorState(
@@ -1887,7 +1877,9 @@ describe('invokedFunctionsByFile serialization', () => {
   test('deserializing legacy state without the field yields an empty Map', () => {
     const serialized = JSON.parse(
       JSON.stringify(
-        serializeInspectorState(getInitialInspectorState('/test/project') as any)
+        serializeInspectorState(
+          getInitialInspectorState('/test/project') as any
+        )
       )
     )
     delete serialized.rpc.invokedFunctionsByFile

--- a/packages/inspector/src/utils/filter-inspector-state.test.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.test.ts
@@ -234,6 +234,7 @@ function createMockInspectorState(): Omit<InspectorState, 'typesLookup'> {
       exposedMeta: {},
       exposedFiles: new Map(),
       invokedFunctions: new Set(),
+      invokedFunctionsByFile: new Map(),
     },
     mcpEndpoints: {
       toolsMeta: {
@@ -1655,5 +1656,128 @@ describe('addonServerlessIncompatible serialization roundtrip', () => {
     const restored = deserializeInspectorState(serialized)
     assert.ok(restored.addonServerlessIncompatible instanceof Map)
     assert.strictEqual(restored.addonServerlessIncompatible.size, 0)
+  })
+})
+
+describe('addon bootstrap tree-shake', () => {
+  const withAddon = (
+    mutate?: (state: Omit<InspectorState, 'typesLookup'>) => void
+  ) => {
+    const state = createMockInspectorState()
+    state.rpc.wireAddonDeclarations = new Map([
+      ['console', { package: '@pikku/addon-console' }],
+    ])
+    state.rpc.usedAddons = new Set(['console'])
+    // Wiring-level ref() targets land in invokedFunctions but carry no
+    // caller file — they must NOT keep the addon on their own.
+    state.rpc.invokedFunctions = new Set(['console:streamFunctionTests'])
+    mutate?.(state)
+    return state
+  }
+
+  test('drops an addon nothing kept references', () => {
+    const state = withAddon()
+    const filtered = filterInspectorState(
+      state,
+      { names: ['getUsers'] },
+      mockLogger
+    )
+    assert.strictEqual(filtered.rpc.wireAddonDeclarations.size, 0)
+    assert.strictEqual(filtered.rpc.usedAddons.size, 0)
+  })
+
+  test('keeps an addon when a kept wiring targets one of its functions', () => {
+    const state = withAddon((s) => {
+      s.http.meta.get['/console/stream'] = {
+        pikkuFuncId: 'console:streamFunctionTests',
+        route: '/console/stream',
+        method: 'GET',
+        tags: [],
+        middleware: [],
+        permissions: [],
+      } as any
+    })
+    const filtered = filterInspectorState(
+      state,
+      { names: ['console:streamFunctionTests'] },
+      mockLogger
+    )
+    assert.strictEqual(filtered.rpc.wireAddonDeclarations.size, 1)
+    assert.ok(filtered.rpc.wireAddonDeclarations.has('console'))
+  })
+
+  test('keeps an addon when a kept function body-invokes it', () => {
+    const state = withAddon((s) => {
+      s.rpc.invokedFunctionsByFile = new Map([
+        ['/test/project/src/api/users.ts', new Set(['console:getSchema'])],
+      ])
+    })
+    const filtered = filterInspectorState(
+      state,
+      { names: ['getUsers'] },
+      mockLogger
+    )
+    assert.strictEqual(filtered.rpc.wireAddonDeclarations.size, 1)
+  })
+
+  test('drops an addon body-invoked only from filtered-out files', () => {
+    const state = withAddon((s) => {
+      s.rpc.invokedFunctionsByFile = new Map([
+        [
+          '/test/project/src/admin/settings.ts',
+          new Set(['console:getSchema']),
+        ],
+      ])
+    })
+    const filtered = filterInspectorState(
+      state,
+      { names: ['getUsers'] },
+      mockLogger
+    )
+    assert.strictEqual(filtered.rpc.wireAddonDeclarations.size, 0)
+  })
+
+  test('unfiltered state keeps all addons', () => {
+    const state = withAddon()
+    const filtered = filterInspectorState(state, {}, mockLogger)
+    assert.strictEqual(filtered.rpc.wireAddonDeclarations.size, 1)
+  })
+})
+
+describe('invokedFunctionsByFile serialization', () => {
+  test('round-trips through serialize/deserialize', () => {
+    const state = getInitialInspectorState('/test/project')
+    state.rpc.invokedFunctionsByFile = new Map([
+      ['/test/project/src/api/users.ts', new Set(['console:getSchema'])],
+      [
+        '/test/project/src/api/tasks.ts',
+        new Set(['listTasks', 'console:runAgent']),
+      ],
+    ])
+    const restored = deserializeInspectorState(
+      JSON.parse(JSON.stringify(serializeInspectorState(state as any)))
+    )
+    assert.ok(restored.rpc.invokedFunctionsByFile instanceof Map)
+    assert.strictEqual(restored.rpc.invokedFunctionsByFile.size, 2)
+    assert.deepStrictEqual(
+      [
+        ...restored.rpc.invokedFunctionsByFile.get(
+          '/test/project/src/api/tasks.ts'
+        )!,
+      ].sort(),
+      ['console:runAgent', 'listTasks']
+    )
+  })
+
+  test('deserializing legacy state without the field yields an empty Map', () => {
+    const serialized = JSON.parse(
+      JSON.stringify(
+        serializeInspectorState(getInitialInspectorState('/test/project') as any)
+      )
+    )
+    delete serialized.rpc.invokedFunctionsByFile
+    const restored = deserializeInspectorState(serialized)
+    assert.ok(restored.rpc.invokedFunctionsByFile instanceof Map)
+    assert.strictEqual(restored.rpc.invokedFunctionsByFile.size, 0)
   })
 })

--- a/packages/inspector/src/utils/filter-inspector-state.test.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.test.ts
@@ -1706,6 +1706,105 @@ describe('addon bootstrap tree-shake', () => {
     assert.ok(filtered.rpc.wireAddonDeclarations.has('console'))
   })
 
+  test('keeps an addon when a kept route ref()-targets one of its functions', () => {
+    // Real inspector shape for `func: ref('console:streamFunctionTests')`:
+    // pikkuFuncId is a minted inline context id; the addon target lives in
+    // refTarget. The inline function meta has no services and no namespace —
+    // only refTarget links the route to the addon.
+    const state = withAddon((s) => {
+      s.http.meta.get['/function-tests/stream'] = {
+        pikkuFuncId: 'http:get:/function-tests/stream',
+        refTarget: 'console:streamFunctionTests',
+        route: '/function-tests/stream',
+        method: 'GET',
+        tags: [],
+        middleware: [],
+        permissions: [],
+      } as any
+      s.functions.meta['http:get:/function-tests/stream'] = {
+        services: { optimized: false, services: [] },
+      } as any
+    })
+    const filtered = filterInspectorState(
+      state,
+      // per-unit deploy codegen passes the minted inline id as the name
+      { names: ['http:get:/function-tests/stream'] },
+      mockLogger
+    )
+    assert.strictEqual(filtered.rpc.wireAddonDeclarations.size, 1)
+    assert.ok(filtered.rpc.wireAddonDeclarations.has('console'))
+    assert.ok(
+      filtered.serviceAggregation.usedFunctions.has(
+        'console:streamFunctionTests'
+      )
+    )
+  })
+
+  test('drops the addon when the ref()-wired route is filtered out', () => {
+    const state = withAddon((s) => {
+      s.http.meta.get['/function-tests/stream'] = {
+        pikkuFuncId: 'http:get:/function-tests/stream',
+        refTarget: 'console:streamFunctionTests',
+        route: '/function-tests/stream',
+        method: 'GET',
+        tags: [],
+        middleware: [],
+        permissions: [],
+      } as any
+      s.functions.meta['http:get:/function-tests/stream'] = {
+        services: { optimized: false, services: [] },
+      } as any
+    })
+    const filtered = filterInspectorState(
+      state,
+      { names: ['getUsers'] },
+      mockLogger
+    )
+    assert.strictEqual(filtered.rpc.wireAddonDeclarations.size, 0)
+    assert.ok(
+      !filtered.serviceAggregation.usedFunctions.has(
+        'console:streamFunctionTests'
+      )
+    )
+  })
+
+  test('keeps an addon when a kept MCP tool targets one of its functions', () => {
+    const state = withAddon((s) => {
+      s.mcpEndpoints.toolsMeta['console:getSchema'] = {
+        name: 'console:getSchema',
+        description: 'addon tool',
+        pikkuFuncId: 'console:getSchema',
+        tags: [],
+        middleware: [],
+        permissions: [],
+      } as any
+    })
+    const filtered = filterInspectorState(
+      state,
+      { names: ['console:getSchema'] },
+      mockLogger
+    )
+    assert.strictEqual(filtered.rpc.wireAddonDeclarations.size, 1)
+  })
+
+  test('keeps an addon when a kept agent lists one of its functions as a tool', () => {
+    const state = withAddon((s) => {
+      s.agents = s.agents ?? ({ agentsMeta: {} } as any)
+      s.agents.agentsMeta['support-agent'] = {
+        name: 'support-agent',
+        pikkuFuncId: 'supportAgent',
+        tools: ['console:getSchema'],
+        tags: [],
+      } as any
+    })
+    const filtered = filterInspectorState(
+      state,
+      { names: ['support-agent'] },
+      mockLogger
+    )
+    assert.strictEqual(filtered.rpc.wireAddonDeclarations.size, 1)
+  })
+
   test('keeps an addon when a kept function body-invokes it', () => {
     const state = withAddon((s) => {
       s.rpc.invokedFunctionsByFile = new Map([

--- a/packages/inspector/src/utils/filter-inspector-state.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.ts
@@ -1105,6 +1105,66 @@ export function filterInspectorState(
     filteredState.serviceAggregation.requiredServices.add('queueService')
   }
 
+  // Addon bootstrap tree-shake: a filtered state (e.g. per-unit deploy
+  // codegen) only needs an addon when something kept reaches into it — a
+  // kept wiring whose function id is `namespace:*`, a kept agent listing an
+  // addon tool, a kept MCP tool targeting it, or a body-level
+  // `rpc.invoke('namespace:*')` in a file that still contains a kept
+  // function. Unreferenced addons are dropped so the generated bootstrap
+  // never imports their package bootstrap — which would otherwise register
+  // the addon's ENTIRE function surface into every deploy unit (e.g.
+  // @pikku/addon-console statically imports node:fs, which Cloudflare
+  // rejects at upload). Wiring-level ref() targets are deliberately NOT
+  // consulted globally: a ref belongs to its wiring, and if the wiring was
+  // filtered out the reference goes with it.
+  if ((filteredState.rpc.wireAddonDeclarations?.size ?? 0) > 0) {
+    const referencedIds = new Set<string>(
+      filteredState.serviceAggregation.usedFunctions
+    )
+    const keptFiles = new Set<string>()
+    for (const funcId of filteredState.serviceAggregation.usedFunctions) {
+      const file = filteredState.functions.files.get(funcId)
+      if (file?.path) keptFiles.add(file.path)
+    }
+    for (const [file, invoked] of state.rpc.invokedFunctionsByFile ??
+      new Map<string, Set<string>>()) {
+      if (!keptFiles.has(file)) continue
+      for (const id of invoked) referencedIds.add(id)
+    }
+    for (const toolMeta of Object.values(
+      filteredState.mcpEndpoints?.toolsMeta ?? {}
+    ) as Array<{ pikkuFuncId?: string }>) {
+      if (toolMeta.pikkuFuncId) referencedIds.add(toolMeta.pikkuFuncId)
+    }
+    for (const agentMeta of Object.values(
+      filteredState.agents?.agentsMeta ?? {}
+    ) as Array<{ tools?: string[] }>) {
+      for (const tool of agentMeta.tools ?? []) referencedIds.add(tool)
+    }
+    const keptNamespaces = new Set<string>()
+    for (const namespace of filteredState.rpc.wireAddonDeclarations.keys()) {
+      const prefix = `${namespace}:`
+      for (const id of referencedIds) {
+        if (id.startsWith(prefix)) {
+          keptNamespaces.add(namespace)
+          break
+        }
+      }
+    }
+    // Assign fresh collections — the shallow rpc copy shares these Maps/Sets
+    // with the unfiltered (cached) state, so never mutate them in place.
+    filteredState.rpc.wireAddonDeclarations = new Map(
+      [...filteredState.rpc.wireAddonDeclarations].filter(([namespace]) =>
+        keptNamespaces.has(namespace)
+      )
+    )
+    filteredState.rpc.usedAddons = new Set(
+      [...filteredState.rpc.usedAddons].filter((namespace) =>
+        keptNamespaces.has(namespace)
+      )
+    )
+  }
+
   // Recalculate requiredServices based on filtered functions/middleware/permissions
   // Need to cast to InspectorState temporarily for aggregateRequiredServices
   const stateForAggregation = filteredState as InspectorState

--- a/packages/inspector/src/utils/filter-inspector-state.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.ts
@@ -468,6 +468,13 @@ export function filterInspectorState(
           filteredState.serviceAggregation.usedFunctions.add(
             routeMeta.pikkuFuncId
           )
+          // ref()-wired routes dispatch to an addon function at runtime —
+          // keep the target so the addon registration survives pruning
+          if (routeMeta.refTarget) {
+            filteredState.serviceAggregation.usedFunctions.add(
+              routeMeta.refTarget
+            )
+          }
           // For workflow/agent routes, also add the base name
           // so the workflow/agent definition survives pruning
           const colonIdx = routeMeta.pikkuFuncId.indexOf(':')

--- a/packages/inspector/src/utils/filter-inspector-state.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.ts
@@ -468,8 +468,6 @@ export function filterInspectorState(
           filteredState.serviceAggregation.usedFunctions.add(
             routeMeta.pikkuFuncId
           )
-          // ref()-wired routes dispatch to an addon function at runtime —
-          // keep the target so the addon registration survives pruning
           if (routeMeta.refTarget) {
             filteredState.serviceAggregation.usedFunctions.add(
               routeMeta.refTarget
@@ -1112,18 +1110,6 @@ export function filterInspectorState(
     filteredState.serviceAggregation.requiredServices.add('queueService')
   }
 
-  // Addon bootstrap tree-shake: a filtered state (e.g. per-unit deploy
-  // codegen) only needs an addon when something kept reaches into it — a
-  // kept wiring whose function id is `namespace:*`, a kept agent listing an
-  // addon tool, a kept MCP tool targeting it, or a body-level
-  // `rpc.invoke('namespace:*')` in a file that still contains a kept
-  // function. Unreferenced addons are dropped so the generated bootstrap
-  // never imports their package bootstrap — which would otherwise register
-  // the addon's ENTIRE function surface into every deploy unit (e.g.
-  // @pikku/addon-console statically imports node:fs, which Cloudflare
-  // rejects at upload). Wiring-level ref() targets are deliberately NOT
-  // consulted globally: a ref belongs to its wiring, and if the wiring was
-  // filtered out the reference goes with it.
   if ((filteredState.rpc.wireAddonDeclarations?.size ?? 0) > 0) {
     const referencedIds = new Set<string>(
       filteredState.serviceAggregation.usedFunctions
@@ -1138,8 +1124,6 @@ export function filterInspectorState(
       if (!keptFiles.has(file)) continue
       for (const id of invoked) {
         referencedIds.add(id)
-        // Namespaced body invokes have no wiring meta — feed them into
-        // usedFunctions so the target's services aggregate for this unit
         if (id.includes(':')) {
           filteredState.serviceAggregation.usedFunctions.add(id)
         }
@@ -1165,8 +1149,6 @@ export function filterInspectorState(
         }
       }
     }
-    // Assign fresh collections — the shallow rpc copy shares these Maps/Sets
-    // with the unfiltered (cached) state, so never mutate them in place.
     filteredState.rpc.wireAddonDeclarations = new Map(
       [...filteredState.rpc.wireAddonDeclarations].filter(([namespace]) =>
         keptNamespaces.has(namespace)

--- a/packages/inspector/src/utils/filter-inspector-state.ts
+++ b/packages/inspector/src/utils/filter-inspector-state.ts
@@ -1136,7 +1136,14 @@ export function filterInspectorState(
     for (const [file, invoked] of state.rpc.invokedFunctionsByFile ??
       new Map<string, Set<string>>()) {
       if (!keptFiles.has(file)) continue
-      for (const id of invoked) referencedIds.add(id)
+      for (const id of invoked) {
+        referencedIds.add(id)
+        // Namespaced body invokes have no wiring meta — feed them into
+        // usedFunctions so the target's services aggregate for this unit
+        if (id.includes(':')) {
+          filteredState.serviceAggregation.usedFunctions.add(id)
+        }
+      }
     }
     for (const toolMeta of Object.values(
       filteredState.mcpEndpoints?.toolsMeta ?? {}

--- a/packages/inspector/src/utils/load-addon-functions-meta.ts
+++ b/packages/inspector/src/utils/load-addon-functions-meta.ts
@@ -231,13 +231,8 @@ export async function loadAddonFunctionsMeta(
             `Loaded ${addonMeta.requiredParentServices.length} required parent services for '${namespace}' from addon meta`
           )
         }
-      } catch {
-        // No addon meta or no serverlessIncompatible declared — that's fine
-      }
+      } catch {}
 
-      // Fallback for addons built before requiredParentServices shipped in
-      // the addon meta json — needs the compiled pikku-services.gen.js,
-      // which only exists for dist-form addons.
       if (!loadedParentServices) {
         try {
           const servicesGenPath = require.resolve(
@@ -255,9 +250,7 @@ export async function loadAddonFunctionsMeta(
               `Loaded ${servicesModule.requiredParentServices.length} required parent services for '${namespace}' from ${decl.package}`
             )
           }
-        } catch {
-          // No services gen — addon may not have requiredParentServices
-        }
+        } catch {}
       }
 
       try {

--- a/packages/inspector/src/utils/load-addon-functions-meta.ts
+++ b/packages/inspector/src/utils/load-addon-functions-meta.ts
@@ -200,6 +200,7 @@ export async function loadAddonFunctionsMeta(
         // No variables meta — that's fine
       }
       // Load addon serverlessIncompatible service names from pikku-addon-meta.gen.json
+      let loadedParentServices = false
       try {
         const addonMetaPath = require.resolve(
           `${decl.package}/.pikku/console/pikku-addon-meta.gen.json`
@@ -218,29 +219,45 @@ export async function loadAddonFunctionsMeta(
             `Addon '${namespace}' marks [${addonMeta.serverlessIncompatible.join(', ')}] as serverless-incompatible`
           )
         }
+        if (
+          Array.isArray(addonMeta.requiredParentServices) &&
+          addonMeta.requiredParentServices.length > 0
+        ) {
+          for (const service of addonMeta.requiredParentServices) {
+            state.addonRequiredParentServices.push(service)
+          }
+          loadedParentServices = true
+          logger.debug(
+            `Loaded ${addonMeta.requiredParentServices.length} required parent services for '${namespace}' from addon meta`
+          )
+        }
       } catch {
         // No addon meta or no serverlessIncompatible declared — that's fine
       }
 
-      // Load addon required parent services from pikku-services.gen
-      try {
-        const servicesGenPath = require.resolve(
-          `${decl.package}/.pikku/pikku-services.gen.js`
-        )
-        const servicesModule = await import(servicesGenPath)
-        if (
-          servicesModule.requiredParentServices &&
-          Array.isArray(servicesModule.requiredParentServices)
-        ) {
-          for (const service of servicesModule.requiredParentServices) {
-            state.addonRequiredParentServices.push(service)
-          }
-          logger.debug(
-            `Loaded ${servicesModule.requiredParentServices.length} required parent services for '${namespace}' from ${decl.package}`
+      // Fallback for addons built before requiredParentServices shipped in
+      // the addon meta json — needs the compiled pikku-services.gen.js,
+      // which only exists for dist-form addons.
+      if (!loadedParentServices) {
+        try {
+          const servicesGenPath = require.resolve(
+            `${decl.package}/.pikku/pikku-services.gen.js`
           )
+          const servicesModule = await import(servicesGenPath)
+          if (
+            servicesModule.requiredParentServices &&
+            Array.isArray(servicesModule.requiredParentServices)
+          ) {
+            for (const service of servicesModule.requiredParentServices) {
+              state.addonRequiredParentServices.push(service)
+            }
+            logger.debug(
+              `Loaded ${servicesModule.requiredParentServices.length} required parent services for '${namespace}' from ${decl.package}`
+            )
+          }
+        } catch {
+          // No services gen — addon may not have requiredParentServices
         }
-      } catch {
-        // No services gen — addon may not have requiredParentServices
       }
 
       try {

--- a/packages/inspector/src/utils/post-process.test.ts
+++ b/packages/inspector/src/utils/post-process.test.ts
@@ -192,6 +192,34 @@ describe('aggregateRequiredServices — per-function addon services', () => {
     assert.ok(!required.has('rpc'))
   })
 
+  test('a ref()-wired route (inline id + namespaced target) aggregates the target services', () => {
+    // Shape produced by add-http-route for func: ref('console:streamFunctionTests'):
+    // usedFunctions carries both the minted inline id and the addon target.
+    const state = makeState({
+      usedFunctions: [
+        'http:get:/function-tests/stream',
+        'console:streamFunctionTests',
+      ],
+      functionsMeta: {
+        'http:get:/function-tests/stream': {
+          services: { optimized: false, services: [] },
+        },
+      },
+      addonFunctions: {
+        console: {
+          streamFunctionTests: {
+            services: { optimized: true, services: ['metaService'] },
+          },
+        },
+      },
+      addonRequiredParentServices: CONSOLE_PARENT_SERVICES,
+    })
+    aggregateRequiredServices(state)
+    const required = state.serviceAggregation.requiredServices
+    assert.ok(required.has('metaService'))
+    assert.ok(!required.has('aiAgentRunner'))
+  })
+
   test('multiple used addon functions union their parent services', () => {
     const state = makeState({
       usedFunctions: ['console:getSchema', 'console:runAgent'],

--- a/packages/inspector/src/utils/post-process.test.ts
+++ b/packages/inspector/src/utils/post-process.test.ts
@@ -3,11 +3,6 @@ import { describe, test } from 'node:test'
 import { aggregateRequiredServices } from './post-process.js'
 import type { InspectorState } from '../types.js'
 
-/**
- * Minimal state for exercising aggregateRequiredServices. No typesLookup —
- * mirrors the deserialized per-unit deploy codegen path, where service
- * extraction is skipped and only aggregation runs.
- */
 function makeState(
   overrides: {
     usedFunctions?: string[]
@@ -94,8 +89,6 @@ describe('aggregateRequiredServices — per-function addon services', () => {
       addonFunctions: {
         console: {
           editCode: {
-            // codeEditService is created by the addon services factory —
-            // constructing it needs the addon's full declared parent set
             services: {
               optimized: true,
               services: ['codeEditService', 'metaService'],
@@ -126,12 +119,12 @@ describe('aggregateRequiredServices — per-function addon services', () => {
   })
 
   test('a bare project function colliding with an addon function name adds nothing', () => {
-    // perauset regression: project fn `getAgentThreads` shares its bare name
-    // with console:getAgentThreads — the blanket must not fire
     const state = makeState({
       usedFunctions: ['getAgentThreads'],
       functionsMeta: {
-        getAgentThreads: { services: { optimized: true, services: ['kysely'] } },
+        getAgentThreads: {
+          services: { optimized: true, services: ['kysely'] },
+        },
       },
       addonFunctions: {
         console: {
@@ -211,8 +204,6 @@ describe('aggregateRequiredServices — per-function addon services', () => {
   })
 
   test('a ref()-wired route (inline id + namespaced target) aggregates the target services', () => {
-    // Shape produced by add-http-route for func: ref('console:streamFunctionTests'):
-    // usedFunctions carries both the minted inline id and the addon target.
     const state = makeState({
       usedFunctions: [
         'http:get:/function-tests/stream',

--- a/packages/inspector/src/utils/post-process.test.ts
+++ b/packages/inspector/src/utils/post-process.test.ts
@@ -192,6 +192,24 @@ describe('aggregateRequiredServices — per-function addon services', () => {
     assert.ok(!required.has('rpc'))
   })
 
+  test('default framework services in addon function meta never force the blanket', () => {
+    const state = makeState({
+      usedFunctions: ['ext:goodbye'],
+      addonFunctions: {
+        ext: {
+          goodbye: {
+            services: { optimized: true, services: ['logger', 'config'] },
+          },
+        },
+      },
+      addonRequiredParentServices: ['greetingStore', 'auditSink'],
+    })
+    aggregateRequiredServices(state)
+    const required = state.serviceAggregation.requiredServices
+    assert.ok(!required.has('greetingStore'))
+    assert.ok(!required.has('auditSink'))
+  })
+
   test('a ref()-wired route (inline id + namespaced target) aggregates the target services', () => {
     // Shape produced by add-http-route for func: ref('console:streamFunctionTests'):
     // usedFunctions carries both the minted inline id and the addon target.

--- a/packages/inspector/src/utils/post-process.test.ts
+++ b/packages/inspector/src/utils/post-process.test.ts
@@ -1,0 +1,217 @@
+import { strict as assert } from 'assert'
+import { describe, test } from 'node:test'
+import { aggregateRequiredServices } from './post-process.js'
+import type { InspectorState } from '../types.js'
+
+/**
+ * Minimal state for exercising aggregateRequiredServices. No typesLookup —
+ * mirrors the deserialized per-unit deploy codegen path, where service
+ * extraction is skipped and only aggregation runs.
+ */
+function makeState(
+  overrides: {
+    usedFunctions?: string[]
+    functionsMeta?: Record<string, any>
+    addonFunctions?: Record<string, Record<string, any>>
+    addonRequiredParentServices?: string[]
+  } = {}
+): Omit<InspectorState, 'typesLookup'> {
+  return {
+    serviceAggregation: {
+      requiredServices: new Set<string>(),
+      usedFunctions: new Set(overrides.usedFunctions ?? []),
+      usedMiddleware: new Set<string>(),
+      usedPermissions: new Set<string>(),
+      allSingletonServices: [],
+      allWireServices: [],
+    },
+    functions: { meta: overrides.functionsMeta ?? {} },
+    middleware: { definitions: {}, tagMiddleware: new Map() },
+    permissions: { definitions: {}, tagPermissions: new Map() },
+    http: {
+      meta: {
+        get: {},
+        post: {},
+        put: {},
+        patch: {},
+        delete: {},
+        head: {},
+        options: {},
+      },
+      routeMiddleware: new Map(),
+      routePermissions: new Map(),
+    },
+    channels: { meta: {} },
+    queueWorkers: { meta: {} },
+    scheduledTasks: { meta: {} },
+    mcpEndpoints: { toolsMeta: {}, promptsMeta: {}, resourcesMeta: {} },
+    agents: { agentsMeta: {} },
+    workflows: { meta: {}, graphMeta: {} },
+    wireServicesMeta: new Map(),
+    rpc: { internalMeta: {}, exposedMeta: {} },
+    addonFunctions: overrides.addonFunctions ?? {},
+    addonRequiredParentServices: overrides.addonRequiredParentServices ?? [],
+  } as unknown as Omit<InspectorState, 'typesLookup'>
+}
+
+const CONSOLE_PARENT_SERVICES = [
+  'metaService',
+  'aiAgentRunner',
+  'deploymentService',
+  'credentialService',
+]
+
+describe('aggregateRequiredServices — per-function addon services', () => {
+  test('a used addon function adds only its own parent services', () => {
+    const state = makeState({
+      usedFunctions: ['console:getSchema'],
+      addonFunctions: {
+        console: {
+          getSchema: {
+            services: { optimized: true, services: ['metaService'] },
+          },
+          runAgent: {
+            services: {
+              optimized: true,
+              services: ['aiAgentRunner', 'deploymentService'],
+            },
+          },
+        },
+      },
+      addonRequiredParentServices: CONSOLE_PARENT_SERVICES,
+    })
+    aggregateRequiredServices(state)
+    const required = state.serviceAggregation.requiredServices
+    assert.ok(required.has('metaService'))
+    assert.ok(!required.has('aiAgentRunner'))
+    assert.ok(!required.has('deploymentService'))
+    assert.ok(!required.has('credentialService'))
+  })
+
+  test('an addon-created service falls back to the full parent blanket', () => {
+    const state = makeState({
+      usedFunctions: ['console:editCode'],
+      addonFunctions: {
+        console: {
+          editCode: {
+            // codeEditService is created by the addon services factory —
+            // constructing it needs the addon's full declared parent set
+            services: {
+              optimized: true,
+              services: ['codeEditService', 'metaService'],
+            },
+          },
+        },
+      },
+      addonRequiredParentServices: CONSOLE_PARENT_SERVICES,
+    })
+    aggregateRequiredServices(state)
+    const required = state.serviceAggregation.requiredServices
+    for (const service of CONSOLE_PARENT_SERVICES) {
+      assert.ok(required.has(service), `expected blanket to add ${service}`)
+    }
+  })
+
+  test('missing services meta (old addon build) falls back to the blanket', () => {
+    const state = makeState({
+      usedFunctions: ['console:getSchema'],
+      addonFunctions: { console: { getSchema: {} } },
+      addonRequiredParentServices: CONSOLE_PARENT_SERVICES,
+    })
+    aggregateRequiredServices(state)
+    const required = state.serviceAggregation.requiredServices
+    for (const service of CONSOLE_PARENT_SERVICES) {
+      assert.ok(required.has(service), `expected blanket to add ${service}`)
+    }
+  })
+
+  test('a bare project function colliding with an addon function name adds nothing', () => {
+    // perauset regression: project fn `getAgentThreads` shares its bare name
+    // with console:getAgentThreads — the blanket must not fire
+    const state = makeState({
+      usedFunctions: ['getAgentThreads'],
+      functionsMeta: {
+        getAgentThreads: { services: { optimized: true, services: ['kysely'] } },
+      },
+      addonFunctions: {
+        console: {
+          getAgentThreads: {
+            services: { optimized: true, services: ['metaService'] },
+          },
+        },
+      },
+      addonRequiredParentServices: CONSOLE_PARENT_SERVICES,
+    })
+    aggregateRequiredServices(state)
+    const required = state.serviceAggregation.requiredServices
+    assert.ok(required.has('kysely'))
+    assert.ok(!required.has('metaService'))
+    assert.ok(!required.has('aiAgentRunner'))
+  })
+
+  test('no used addon functions adds no parent services', () => {
+    const state = makeState({
+      usedFunctions: ['listTasks'],
+      functionsMeta: {
+        listTasks: { services: { optimized: true, services: ['kysely'] } },
+      },
+      addonFunctions: {
+        console: {
+          getSchema: {
+            services: { optimized: true, services: ['metaService'] },
+          },
+        },
+      },
+      addonRequiredParentServices: CONSOLE_PARENT_SERVICES,
+    })
+    aggregateRequiredServices(state)
+    const required = state.serviceAggregation.requiredServices
+    assert.ok(!required.has('metaService'))
+    assert.ok(!required.has('aiAgentRunner'))
+  })
+
+  test('internal services in addon function meta never force the blanket', () => {
+    const state = makeState({
+      usedFunctions: ['console:getSchema'],
+      addonFunctions: {
+        console: {
+          getSchema: {
+            services: {
+              optimized: true,
+              services: ['metaService', 'rpc', 'channel'],
+            },
+          },
+        },
+      },
+      addonRequiredParentServices: CONSOLE_PARENT_SERVICES,
+    })
+    aggregateRequiredServices(state)
+    const required = state.serviceAggregation.requiredServices
+    assert.ok(required.has('metaService'))
+    assert.ok(!required.has('aiAgentRunner'))
+    assert.ok(!required.has('rpc'))
+  })
+
+  test('multiple used addon functions union their parent services', () => {
+    const state = makeState({
+      usedFunctions: ['console:getSchema', 'console:runAgent'],
+      addonFunctions: {
+        console: {
+          getSchema: {
+            services: { optimized: true, services: ['metaService'] },
+          },
+          runAgent: {
+            services: { optimized: true, services: ['aiAgentRunner'] },
+          },
+        },
+      },
+      addonRequiredParentServices: CONSOLE_PARENT_SERVICES,
+    })
+    aggregateRequiredServices(state)
+    const required = state.serviceAggregation.requiredServices
+    assert.ok(required.has('metaService'))
+    assert.ok(required.has('aiAgentRunner'))
+    assert.ok(!required.has('deploymentService'))
+    assert.ok(!required.has('credentialService'))
+  })
+})

--- a/packages/inspector/src/utils/post-process.ts
+++ b/packages/inspector/src/utils/post-process.ts
@@ -325,17 +325,6 @@ export function aggregateRequiredServices(
   }
 
   // 7. Services that consumed addons need from the parent project.
-  // Computed per used addon function: each addon function's shipped meta
-  // lists the services it destructures, so a unit deploying one addon RPC
-  // carries only that function's parent-service needs — never the union
-  // over the addon's whole surface. Addon ids in usedFunctions are always
-  // namespaced (`console:getSchema`); bare project function names that
-  // collide with addon function names must not match.
-  // The addon-level blanket (addonRequiredParentServices) is the fallback
-  // for two cases: the used function ships no services meta (addon built
-  // before per-function services shipped), or it needs an addon-created
-  // service — the addon services factory is monolithic, so constructing
-  // anything needs its full declared parent set.
   const addonFnServices = new Map<string, string[] | undefined>()
   for (const [namespace, fns] of Object.entries(state.addonFunctions ?? {})) {
     for (const [id, meta] of Object.entries(fns)) {
@@ -347,8 +336,6 @@ export function aggregateRequiredServices(
   }
   const parentDeclared = state.addonRequiredParentServices ?? []
   const parentDeclaredSet = new Set(parentDeclared)
-  // Always-present framework services — an addon function using these must
-  // not be inferred as needing the addon services factory
   const defaultServices = new Set([
     'config',
     'logger',
@@ -373,8 +360,6 @@ export function aggregateRequiredServices(
         !internalServices.has(service) &&
         !defaultServices.has(service)
       ) {
-        // Not parent-provided and not a framework default → created by the
-        // addon services factory
         addonFactoryNeeded = true
       }
     }

--- a/packages/inspector/src/utils/post-process.ts
+++ b/packages/inspector/src/utils/post-process.ts
@@ -347,6 +347,15 @@ export function aggregateRequiredServices(
   }
   const parentDeclared = state.addonRequiredParentServices ?? []
   const parentDeclaredSet = new Set(parentDeclared)
+  // Always-present framework services — an addon function using these must
+  // not be inferred as needing the addon services factory
+  const defaultServices = new Set([
+    'config',
+    'logger',
+    'variables',
+    'schema',
+    'secrets',
+  ])
   let usesAddonFn = false
   let addonFactoryNeeded = false
   for (const funcId of usedFunctions) {
@@ -360,8 +369,12 @@ export function aggregateRequiredServices(
     for (const service of services) {
       if (parentDeclaredSet.has(service)) {
         requiredServices.add(service)
-      } else if (!internalServices.has(service)) {
-        // Not parent-provided → created by the addon services factory
+      } else if (
+        !internalServices.has(service) &&
+        !defaultServices.has(service)
+      ) {
+        // Not parent-provided and not a framework default → created by the
+        // addon services factory
         addonFactoryNeeded = true
       }
     }

--- a/packages/inspector/src/utils/post-process.ts
+++ b/packages/inspector/src/utils/post-process.ts
@@ -325,20 +325,49 @@ export function aggregateRequiredServices(
   }
 
   // 7. Services that consumed addons need from the parent project.
-  // These are required ONLY by units that actually deploy an addon function;
-  // a unit that merely calls the addon over RPC (or never touches it) must not
-  // carry them, or every per-unit bundle would over-include the addon's
-  // parent-service dependencies (e.g. aiAgentRunner, deploymentService) and
-  // defeat per-unit tree-shaking.
-  const addonFuncIds = new Set<string>()
-  for (const fns of Object.values(state.addonFunctions ?? {})) {
-    for (const id of Object.keys(fns)) addonFuncIds.add(id)
+  // Computed per used addon function: each addon function's shipped meta
+  // lists the services it destructures, so a unit deploying one addon RPC
+  // carries only that function's parent-service needs — never the union
+  // over the addon's whole surface. Addon ids in usedFunctions are always
+  // namespaced (`console:getSchema`); bare project function names that
+  // collide with addon function names must not match.
+  // The addon-level blanket (addonRequiredParentServices) is the fallback
+  // for two cases: the used function ships no services meta (addon built
+  // before per-function services shipped), or it needs an addon-created
+  // service — the addon services factory is monolithic, so constructing
+  // anything needs its full declared parent set.
+  const addonFnServices = new Map<string, string[] | undefined>()
+  for (const [namespace, fns] of Object.entries(state.addonFunctions ?? {})) {
+    for (const [id, meta] of Object.entries(fns)) {
+      addonFnServices.set(
+        `${namespace}:${id}`,
+        (meta as { services?: FunctionServicesMeta })?.services?.services
+      )
+    }
   }
-  const unitDeploysAddonFn = [...usedFunctions].some((fn) =>
-    addonFuncIds.has(fn)
-  )
-  if (unitDeploysAddonFn) {
-    for (const service of state.addonRequiredParentServices ?? []) {
+  const parentDeclared = state.addonRequiredParentServices ?? []
+  const parentDeclaredSet = new Set(parentDeclared)
+  let usesAddonFn = false
+  let addonFactoryNeeded = false
+  for (const funcId of usedFunctions) {
+    if (!addonFnServices.has(funcId)) continue
+    usesAddonFn = true
+    const services = addonFnServices.get(funcId)
+    if (!services) {
+      addonFactoryNeeded = true
+      continue
+    }
+    for (const service of services) {
+      if (parentDeclaredSet.has(service)) {
+        requiredServices.add(service)
+      } else if (!internalServices.has(service)) {
+        // Not parent-provided → created by the addon services factory
+        addonFactoryNeeded = true
+      }
+    }
+  }
+  if (usesAddonFn && addonFactoryNeeded) {
+    for (const service of parentDeclared) {
       requiredServices.add(service)
     }
   }

--- a/packages/inspector/src/utils/serialize-inspector-state.ts
+++ b/packages/inspector/src/utils/serialize-inspector-state.ts
@@ -381,11 +381,10 @@ export function serializeInspectorState(
       exposedFiles: Array.from(state.rpc.exposedFiles.entries()),
       invokedFunctions: Array.from(state.rpc.invokedFunctions),
       invokedFunctionsByFile: Array.from(
-        (state.rpc.invokedFunctionsByFile ?? new Map()).entries()
-      ).map(([file, fns]): [string, string[]] => [
-        file,
-        Array.from(fns as Set<string>),
-      ]),
+        (
+          state.rpc.invokedFunctionsByFile ?? new Map<string, Set<string>>()
+        ).entries()
+      ).map(([file, fns]): [string, string[]] => [file, Array.from(fns)]),
       usedAddons: Array.from(state.rpc.usedAddons),
       wireAddonDeclarations: Array.from(
         state.rpc.wireAddonDeclarations.entries()

--- a/packages/inspector/src/utils/serialize-inspector-state.ts
+++ b/packages/inspector/src/utils/serialize-inspector-state.ts
@@ -155,6 +155,7 @@ export interface SerializableInspectorState {
     exposedMeta: InspectorState['rpc']['exposedMeta']
     exposedFiles: Array<[string, { path: string; exportedName: string }]>
     invokedFunctions: string[]
+    invokedFunctionsByFile?: Array<[string, string[]]>
     usedAddons: string[]
     wireAddonDeclarations: Array<
       [
@@ -379,6 +380,12 @@ export function serializeInspectorState(
       exposedMeta: state.rpc.exposedMeta,
       exposedFiles: Array.from(state.rpc.exposedFiles.entries()),
       invokedFunctions: Array.from(state.rpc.invokedFunctions),
+      invokedFunctionsByFile: Array.from(
+        (state.rpc.invokedFunctionsByFile ?? new Map()).entries()
+      ).map(([file, fns]): [string, string[]] => [
+        file,
+        Array.from(fns as Set<string>),
+      ]),
       usedAddons: Array.from(state.rpc.usedAddons),
       wireAddonDeclarations: Array.from(
         state.rpc.wireAddonDeclarations.entries()
@@ -565,6 +572,11 @@ export function deserializeInspectorState(
       exposedMeta: data.rpc.exposedMeta,
       exposedFiles: new Map(data.rpc.exposedFiles),
       invokedFunctions: new Set(data.rpc.invokedFunctions),
+      invokedFunctionsByFile: new Map(
+        (data.rpc.invokedFunctionsByFile || []).map(
+          ([file, fns]): [string, Set<string>] => [file, new Set(fns)]
+        )
+      ),
       usedAddons: new Set(data.rpc.usedAddons || []),
       wireAddonDeclarations: new Map(data.rpc.wireAddonDeclarations || []),
       wireAddonFiles: new Set(data.rpc.wireAddonFiles || []),

--- a/templates/function-addon/src/functions/goodbye.functions.ts
+++ b/templates/function-addon/src/functions/goodbye.functions.ts
@@ -1,0 +1,19 @@
+import { pikkuSessionlessFunc } from '../../.pikku/pikku-types.gen.js'
+
+/**
+ * Uses only default services (logger) — a consumer unit deploying just this
+ * function needs neither the addon services factory nor any of the addon's
+ * requiredParentServices.
+ */
+export const goodbye = pikkuSessionlessFunc<
+  { name: string },
+  { message: string }
+>({
+  description: 'Sends a farewell message',
+  func: async ({ logger }, data) => {
+    const message = `Goodbye, ${data.name}!`
+    logger.info(`Addon: ${message}`)
+    return { message }
+  },
+  tags: ['addon'],
+})

--- a/templates/function-addon/src/functions/goodbye.functions.ts
+++ b/templates/function-addon/src/functions/goodbye.functions.ts
@@ -1,10 +1,5 @@
 import { pikkuSessionlessFunc } from '../../.pikku/pikku-types.gen.js'
 
-/**
- * Uses only default services (logger) — a consumer unit deploying just this
- * function needs neither the addon services factory nor any of the addon's
- * requiredParentServices.
- */
 export const goodbye = pikkuSessionlessFunc<
   { name: string },
   { message: string }

--- a/templates/function-addon/src/functions/greet-from-store.functions.ts
+++ b/templates/function-addon/src/functions/greet-from-store.functions.ts
@@ -1,0 +1,17 @@
+import { pikkuSessionlessFunc } from '../../.pikku/pikku-types.gen.js'
+
+/**
+ * Uses one parent-provided service directly (greetingStore) and no
+ * addon-created services — a consumer unit deploying just this function
+ * carries greetingStore but NOT auditSink and does not need the factory.
+ */
+export const greetFromStore = pikkuSessionlessFunc<
+  { name: string },
+  { message: string }
+>({
+  description: 'Greets using the parent project greeting store',
+  func: async ({ greetingStore }, data) => {
+    return { message: greetingStore.greet(data.name) }
+  },
+  tags: ['addon'],
+})

--- a/templates/function-addon/src/functions/greet-from-store.functions.ts
+++ b/templates/function-addon/src/functions/greet-from-store.functions.ts
@@ -1,10 +1,5 @@
 import { pikkuSessionlessFunc } from '../../.pikku/pikku-types.gen.js'
 
-/**
- * Uses one parent-provided service directly (greetingStore) and no
- * addon-created services — a consumer unit deploying just this function
- * carries greetingStore but NOT auditSink and does not need the factory.
- */
 export const greetFromStore = pikkuSessionlessFunc<
   { name: string },
   { message: string }

--- a/templates/function-addon/src/services.ts
+++ b/templates/function-addon/src/services.ts
@@ -2,7 +2,11 @@ import { pikkuAddonServices } from '#pikku'
 import { NoopService } from './services/noop-service.js'
 
 export const createSingletonServices = pikkuAddonServices(
-  async (_config, _services) => {
+  async (_config, { greetingStore, auditSink }) => {
+    // Destructuring declares requiredParentServices for consumers; the noop
+    // construction here stands in for addon services that depend on them.
+    void greetingStore
+    void auditSink
     return {
       noop: new NoopService(),
     }

--- a/templates/function-addon/src/services.ts
+++ b/templates/function-addon/src/services.ts
@@ -3,8 +3,6 @@ import { NoopService } from './services/noop-service.js'
 
 export const createSingletonServices = pikkuAddonServices(
   async (_config, { greetingStore, auditSink }) => {
-    // Destructuring declares requiredParentServices for consumers; the noop
-    // construction here stands in for addon services that depend on them.
     void greetingStore
     void auditSink
     return {

--- a/templates/function-addon/types/application-types.d.ts
+++ b/templates/function-addon/types/application-types.d.ts
@@ -12,10 +12,6 @@ export interface UserSession extends CoreUserSession {}
 
 export interface SingletonServices extends CoreSingletonServices<Config> {
   noop: NoopService
-  // Parent-provided services (declared via the pikkuAddonServices factory's
-  // second parameter) — used by the treeshaking verifier to assert that a
-  // consumer unit only carries the parent services its used addon functions
-  // actually need.
   greetingStore: { greet(name: string): string }
   auditSink: { record(event: string): void }
 }

--- a/verifiers/addon-treeshake/README.md
+++ b/verifiers/addon-treeshake/README.md
@@ -1,0 +1,14 @@
+# Addon Tree-Shaking Verifier
+
+Verifies per-unit deploy codegen against `@pikku/templates-function-addon`:
+
+- a unit that never touches the addon does not import its bootstrap
+- a unit using an addon function imports the bootstrap, and its
+  `requiredSingletonServices` flags only the parent services that function's
+  meta declares — not the addon's full `requiredParentServices`
+- an addon function using an addon-created service (the monolithic services
+  factory) falls back to the full parent set
+- `ref('ns:fn')`-wired routes keep the addon and aggregate the target
+  function's services
+
+Run with `yarn test` (codegen → typecheck → filtered-unit assertions).

--- a/verifiers/addon-treeshake/package.json
+++ b/verifiers/addon-treeshake/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@pikku/verifiers-addon-treeshake",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "imports": {
+    "#pikku": "./.pikku/pikku-types.gen.ts"
+  },
+  "scripts": {
+    "tsc": "tsc --noEmit",
+    "test": "pikku && tsc --noEmit && npx tsx src/treeshake-services.assert.ts"
+  },
+  "dependencies": {
+    "@pikku/core": "workspace:*",
+    "@pikku/templates-function-addon": "workspace:*"
+  },
+  "devDependencies": {
+    "@pikku/cli": "workspace:*",
+    "@types/node": "^24",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.3",
+    "zod": "^4"
+  }
+}

--- a/verifiers/addon-treeshake/pikku.config.json
+++ b/verifiers/addon-treeshake/pikku.config.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/pikkujs/pikku/refs/heads/main/packages/cli/cli.schema.json",
+  "srcDirectories": ["./src", "./types"],
+  "outDir": "./.pikku",
+  "tsconfig": "./tsconfig.json",
+  "schema": {
+    "supportsImportAttributes": true
+  }
+}

--- a/verifiers/addon-treeshake/src/function/mixed-file.functions.ts
+++ b/verifiers/addon-treeshake/src/function/mixed-file.functions.ts
@@ -1,11 +1,5 @@
 import { pikkuSessionlessFunc } from '#pikku'
 
-/**
- * Two functions sharing one source file — invocation attribution is
- * file-granular, so a unit keeping only mixedPlain still keeps the addon
- * (conservative over-inclusion, never under-inclusion). Kept deliberately
- * as the documented mixed-file behavior; one-function-per-file avoids it.
- */
 export const mixedAddonCaller = pikkuSessionlessFunc<
   { name: string },
   { message: string }

--- a/verifiers/addon-treeshake/src/function/mixed-file.functions.ts
+++ b/verifiers/addon-treeshake/src/function/mixed-file.functions.ts
@@ -1,0 +1,23 @@
+import { pikkuSessionlessFunc } from '#pikku'
+
+/**
+ * Two functions sharing one source file — invocation attribution is
+ * file-granular, so a unit keeping only mixedPlain still keeps the addon
+ * (conservative over-inclusion, never under-inclusion). Kept deliberately
+ * as the documented mixed-file behavior; one-function-per-file avoids it.
+ */
+export const mixedAddonCaller = pikkuSessionlessFunc<
+  { name: string },
+  { message: string }
+>({
+  func: async (_, data, { rpc }) => {
+    return await rpc.invoke('ext:goodbye', data)
+  },
+})
+
+export const mixedPlain = pikkuSessionlessFunc<void, { ok: boolean }>({
+  func: async ({ logger }) => {
+    logger.debug('plain')
+    return { ok: true }
+  },
+})

--- a/verifiers/addon-treeshake/src/function/no-addon-ping.function.ts
+++ b/verifiers/addon-treeshake/src/function/no-addon-ping.function.ts
@@ -1,9 +1,5 @@
 import { pikkuSessionlessFunc } from '#pikku'
 
-/**
- * Touches nothing addon-related — the unit keeping only this must not
- * import the addon at all.
- */
 export const noAddonPing = pikkuSessionlessFunc<void, { pong: boolean }>({
   func: async ({ logger }) => {
     logger.debug('ping')

--- a/verifiers/addon-treeshake/src/function/no-addon-ping.function.ts
+++ b/verifiers/addon-treeshake/src/function/no-addon-ping.function.ts
@@ -1,0 +1,12 @@
+import { pikkuSessionlessFunc } from '#pikku'
+
+/**
+ * Touches nothing addon-related — the unit keeping only this must not
+ * import the addon at all.
+ */
+export const noAddonPing = pikkuSessionlessFunc<void, { pong: boolean }>({
+  func: async ({ logger }) => {
+    logger.debug('ping')
+    return { pong: true }
+  },
+})

--- a/verifiers/addon-treeshake/src/function/test-addon-goodbye.function.ts
+++ b/verifiers/addon-treeshake/src/function/test-addon-goodbye.function.ts
@@ -1,10 +1,5 @@
 import { pikkuSessionlessFunc } from '#pikku'
 
-/**
- * Body-invokes an addon function that needs no parent services — the unit
- * keeping this must import the addon (registration) but require none of
- * its requiredParentServices.
- */
 export const testAddonGoodbye = pikkuSessionlessFunc<
   { name: string },
   { message: string }

--- a/verifiers/addon-treeshake/src/function/test-addon-goodbye.function.ts
+++ b/verifiers/addon-treeshake/src/function/test-addon-goodbye.function.ts
@@ -1,0 +1,15 @@
+import { pikkuSessionlessFunc } from '#pikku'
+
+/**
+ * Body-invokes an addon function that needs no parent services — the unit
+ * keeping this must import the addon (registration) but require none of
+ * its requiredParentServices.
+ */
+export const testAddonGoodbye = pikkuSessionlessFunc<
+  { name: string },
+  { message: string }
+>({
+  func: async (_, data, { rpc }) => {
+    return await rpc.invoke('ext:goodbye', data)
+  },
+})

--- a/verifiers/addon-treeshake/src/function/test-addon-hello.function.ts
+++ b/verifiers/addon-treeshake/src/function/test-addon-hello.function.ts
@@ -1,0 +1,15 @@
+import { pikkuSessionlessFunc } from '#pikku'
+
+/**
+ * Body-invokes an addon function that uses an addon-created service (noop),
+ * which forces the addon services factory — the unit keeping this carries
+ * the addon's full requiredParentServices.
+ */
+export const testAddonHello = pikkuSessionlessFunc<
+  { name: string; greeting?: string },
+  { message: string; timestamp: number; noopCalls: number }
+>({
+  func: async (_, data, { rpc }) => {
+    return await rpc.invoke('ext:hello', data)
+  },
+})

--- a/verifiers/addon-treeshake/src/function/test-addon-hello.function.ts
+++ b/verifiers/addon-treeshake/src/function/test-addon-hello.function.ts
@@ -1,10 +1,5 @@
 import { pikkuSessionlessFunc } from '#pikku'
 
-/**
- * Body-invokes an addon function that uses an addon-created service (noop),
- * which forces the addon services factory — the unit keeping this carries
- * the addon's full requiredParentServices.
- */
 export const testAddonHello = pikkuSessionlessFunc<
   { name: string; greeting?: string },
   { message: string; timestamp: number; noopCalls: number }

--- a/verifiers/addon-treeshake/src/function/treeshake.wiring.ts
+++ b/verifiers/addon-treeshake/src/function/treeshake.wiring.ts
@@ -1,0 +1,58 @@
+import { wireHTTP, wireAddon, ref } from '#pikku'
+import { testAddonHello } from './test-addon-hello.function.js'
+import { testAddonGoodbye } from './test-addon-goodbye.function.js'
+import { noAddonPing } from './no-addon-ping.function.js'
+import { mixedAddonCaller, mixedPlain } from './mixed-file.functions.js'
+
+wireAddon({ name: 'ext', package: '@pikku/templates-function-addon' })
+
+wireHTTP({
+  auth: false,
+  method: 'post',
+  route: '/treeshake/hello',
+  func: testAddonHello,
+  tags: ['treeshake'],
+})
+
+wireHTTP({
+  auth: false,
+  method: 'post',
+  route: '/treeshake/goodbye',
+  func: testAddonGoodbye,
+  tags: ['treeshake'],
+})
+
+wireHTTP({
+  auth: false,
+  method: 'get',
+  route: '/treeshake/ping',
+  func: noAddonPing,
+  tags: ['treeshake'],
+})
+
+// ref()-wired addon function using exactly one parent service — the unit
+// keeping this route must import the addon and require greetingStore but
+// NOT auditSink.
+wireHTTP({
+  auth: false,
+  method: 'post',
+  route: '/treeshake/greet-from-store',
+  func: ref('ext:greetFromStore'),
+  tags: ['treeshake'],
+})
+
+wireHTTP({
+  auth: false,
+  method: 'post',
+  route: '/treeshake/mixed-caller',
+  func: mixedAddonCaller,
+  tags: ['treeshake'],
+})
+
+wireHTTP({
+  auth: false,
+  method: 'get',
+  route: '/treeshake/mixed-plain',
+  func: mixedPlain,
+  tags: ['treeshake'],
+})

--- a/verifiers/addon-treeshake/src/function/treeshake.wiring.ts
+++ b/verifiers/addon-treeshake/src/function/treeshake.wiring.ts
@@ -30,9 +30,6 @@ wireHTTP({
   tags: ['treeshake'],
 })
 
-// ref()-wired addon function using exactly one parent service — the unit
-// keeping this route must import the addon and require greetingStore but
-// NOT auditSink.
 wireHTTP({
   auth: false,
   method: 'post',

--- a/verifiers/addon-treeshake/src/services.ts
+++ b/verifiers/addon-treeshake/src/services.ts
@@ -1,0 +1,29 @@
+import { pikkuConfig, pikkuServices, pikkuWireServices } from '#pikku'
+import {
+  ConsoleLogger,
+  LocalVariablesService,
+  LocalSecretService,
+} from '@pikku/core/services'
+
+import '../.pikku/pikku-bootstrap.gen.js'
+
+export const createConfig = pikkuConfig(async () => {
+  return {}
+})
+
+export const createSingletonServices = pikkuServices(async (config) => {
+  const variables = new LocalVariablesService()
+
+  return {
+    config,
+    logger: new ConsoleLogger(),
+    variables,
+    secrets: new LocalSecretService(variables),
+    greetingStore: { greet: (name: string) => `Hello from store, ${name}!` },
+    auditSink: { record: () => {} },
+  }
+})
+
+export const createWireServices = pikkuWireServices(async () => {
+  return {} as any
+})

--- a/verifiers/addon-treeshake/src/treeshake-services.assert.ts
+++ b/verifiers/addon-treeshake/src/treeshake-services.assert.ts
@@ -1,15 +1,3 @@
-/**
- * Addon tree-shaking verifier.
- *
- * Runs filtered codegen (the per-unit deploy path) for units with different
- * relationships to the function-addon and asserts that:
- *  - the addon package bootstrap is only imported when a kept function or
- *    wiring actually reaches into the addon
- *  - requiredSingletonServices only flags the parent services the used addon
- *    functions declare (per-function services meta), falling back to the
- *    addon's full requiredParentServices only when an addon-created service
- *    forces the (monolithic) addon services factory
- */
 import { execFileSync } from 'node:child_process'
 import { readFileSync, rmSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'

--- a/verifiers/addon-treeshake/src/treeshake-services.assert.ts
+++ b/verifiers/addon-treeshake/src/treeshake-services.assert.ts
@@ -1,0 +1,140 @@
+/**
+ * Addon tree-shaking verifier.
+ *
+ * Runs filtered codegen (the per-unit deploy path) for units with different
+ * relationships to the function-addon and asserts that:
+ *  - the addon package bootstrap is only imported when a kept function or
+ *    wiring actually reaches into the addon
+ *  - requiredSingletonServices only flags the parent services the used addon
+ *    functions declare (per-function services meta), falling back to the
+ *    addon's full requiredParentServices only when an addon-created service
+ *    forces the (monolithic) addon services factory
+ */
+import { execFileSync } from 'node:child_process'
+import { readFileSync, rmSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+const ADDON_BOOTSTRAP_IMPORT =
+  '@pikku/templates-function-addon/.pikku/pikku-bootstrap.gen.js'
+
+interface Scenario {
+  name: string
+  filterNames: string
+  addonImported: boolean
+  greetingStore: boolean
+  auditSink: boolean
+  why: string
+}
+
+const scenarios: Scenario[] = [
+  {
+    name: 'no-addon',
+    filterNames: 'noAddonPing',
+    addonImported: false,
+    greetingStore: false,
+    auditSink: false,
+    why: 'unit touches nothing addon-related',
+  },
+  {
+    name: 'goodbye',
+    filterNames: 'testAddonGoodbye',
+    addonImported: true,
+    greetingStore: false,
+    auditSink: false,
+    why: 'body-invoked addon fn uses only default services',
+  },
+  {
+    name: 'hello',
+    filterNames: 'testAddonHello',
+    addonImported: true,
+    greetingStore: true,
+    auditSink: true,
+    why: 'addon fn uses addon-created noop → factory → full parent set',
+  },
+  {
+    name: 'greet-ref',
+    filterNames: 'http:post:/treeshake/greet-from-store',
+    addonImported: true,
+    greetingStore: true,
+    auditSink: false,
+    why: 'ref()-wired addon fn declares exactly greetingStore',
+  },
+  {
+    name: 'mixed-caller',
+    filterNames: 'mixedAddonCaller',
+    addonImported: true,
+    greetingStore: false,
+    auditSink: false,
+    why: 'body-invoked addon fn from a shared file uses only defaults',
+  },
+  {
+    name: 'mixed-plain',
+    filterNames: 'mixedPlain',
+    addonImported: true,
+    greetingStore: false,
+    auditSink: false,
+    why: 'file-granular attribution keeps the addon for file-mates (conservative)',
+  },
+]
+
+const flag = (servicesGen: string, service: string): boolean => {
+  const match = servicesGen.match(new RegExp(`'${service}': (true|false)`))
+  if (!match) throw new Error(`service '${service}' missing from services map`)
+  return match[1] === 'true'
+}
+
+console.log('\nAddon Tree-Shaking Verifier')
+console.log('===========================\n')
+
+let passed = true
+const check = (scenario: string, label: string, ok: boolean) => {
+  console.log(`${ok ? '✓' : '✗'} [${scenario}] ${label}`)
+  if (!ok) passed = false
+}
+
+for (const scenario of scenarios) {
+  const outDir = join(rootDir, '.pikku-shake', scenario.name)
+  rmSync(outDir, { recursive: true, force: true })
+  execFileSync(
+    'npx',
+    [
+      'pikku',
+      'all',
+      `--names=${scenario.filterNames}`,
+      `--outDir=${outDir}`,
+      '--force-relative-imports',
+      '--silent',
+    ],
+    { cwd: rootDir, stdio: 'pipe' }
+  )
+
+  const bootstrap = readFileSync(join(outDir, 'pikku-bootstrap.gen.ts'), 'utf8')
+  const servicesGen = readFileSync(
+    join(outDir, 'pikku-services.gen.ts'),
+    'utf8'
+  )
+
+  check(
+    scenario.name,
+    `addon bootstrap ${scenario.addonImported ? 'imported' : 'NOT imported'} (${scenario.why})`,
+    bootstrap.includes(ADDON_BOOTSTRAP_IMPORT) === scenario.addonImported
+  )
+  check(
+    scenario.name,
+    `greetingStore: ${scenario.greetingStore}`,
+    flag(servicesGen, 'greetingStore') === scenario.greetingStore
+  )
+  check(
+    scenario.name,
+    `auditSink: ${scenario.auditSink}`,
+    flag(servicesGen, 'auditSink') === scenario.auditSink
+  )
+}
+
+if (!passed) {
+  console.log('\n✗ Addon tree-shaking verification FAILED')
+  process.exit(1)
+}
+console.log('\n✓ Addon tree-shaking verification passed')

--- a/verifiers/addon-treeshake/tsconfig.json
+++ b/verifiers/addon-treeshake/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": false,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "types/**/*", ".pikku/**/*"]
+}

--- a/verifiers/addon-treeshake/types/application-types.d.ts
+++ b/verifiers/addon-treeshake/types/application-types.d.ts
@@ -10,9 +10,6 @@ export interface Config extends CoreConfig {}
 export interface UserSession extends CoreUserSession {}
 
 export interface SingletonServices extends CoreSingletonServices<Config> {
-  // Parent services the function-addon declares via pikkuAddonServices —
-  // the treeshake assertions check filtered units only require the ones
-  // their used addon functions actually need.
   greetingStore: { greet(name: string): string }
   auditSink: { record(event: string): void }
 }

--- a/verifiers/addon-treeshake/types/application-types.d.ts
+++ b/verifiers/addon-treeshake/types/application-types.d.ts
@@ -4,26 +4,17 @@ import type {
   CoreSingletonServices,
   CoreUserSession,
 } from '@pikku/core'
-import type { NoopService } from '../src/services/noop-service.js'
 
 export interface Config extends CoreConfig {}
 
 export interface UserSession extends CoreUserSession {}
 
 export interface SingletonServices extends CoreSingletonServices<Config> {
-  noop: NoopService
-  // Parent-provided services (declared via the pikkuAddonServices factory's
-  // second parameter) — used by the treeshaking verifier to assert that a
-  // consumer unit only carries the parent services its used addon functions
-  // actually need.
+  // Parent services the function-addon declares via pikkuAddonServices —
+  // the treeshake assertions check filtered units only require the ones
+  // their used addon functions actually need.
   greetingStore: { greet(name: string): string }
   auditSink: { record(event: string): void }
 }
 
 export interface Services extends CoreServices<SingletonServices> {}
-
-export interface CreateSingletonServices {
-  noop: NoopService
-}
-
-export interface CreateWireServices {}

--- a/verifiers/treeshaking/test-scenarios.ts
+++ b/verifiers/treeshaking/test-scenarios.ts
@@ -376,9 +376,9 @@ export const scenarios: TestScenario[] = [
     filter: '--names=sendEmail',
     expectedSingletonServices: ['email', 'logger', 'secrets'],
     expectedWireServices: ['userContext'],
-    expectedAddonBootstrap: true,
+    expectedAddonBootstrap: false,
     description:
-      'Addon bootstrap is currently always included when package is a dependency (treeshaking TODO: only include when addon RPC methods are invoked)',
+      'Addon bootstrap is excluded when no kept function or wiring invokes the addon',
   },
 
   // Versioned function filters

--- a/yarn.lock
+++ b/yarn.lock
@@ -6971,6 +6971,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@pikku/verifiers-addon-treeshake@workspace:verifiers/addon-treeshake":
+  version: 0.0.0-use.local
+  resolution: "@pikku/verifiers-addon-treeshake@workspace:verifiers/addon-treeshake"
+  dependencies:
+    "@pikku/cli": "workspace:*"
+    "@pikku/core": "workspace:*"
+    "@pikku/templates-function-addon": "workspace:*"
+    "@types/node": "npm:^24"
+    tsx: "npm:^4.21.0"
+    typescript: "npm:^6.0.3"
+    zod: "npm:^4"
+  languageName: unknown
+  linkType: soft
+
 "@pikku/verifiers-addon@workspace:verifiers/addon":
   version: 0.0.0-use.local
   resolution: "@pikku/verifiers-addon@workspace:verifiers/addon"


### PR DESCRIPTION
## Addon tree-shaking in per-unit deploy codegen

Fixes Cloudflare `CF 400: No such module "node:fs"` on customer deploys: the generated per-unit bootstrap blanket-imported every wired addon's bootstrap (registering all 55 `@pikku/addon-console` functions, some with static `node:fs`), regardless of whether the unit used the addon.

### What changed

**Filtering (`filterInspectorState`)** — an addon's `wireAddonDeclarations`/`usedAddons` entries survive per-unit filtering only when something kept actually reaches into it:
- a kept wiring targets a namespaced function (incl. `func: ref('ns:fn')` HTTP routes via the new persisted `refTarget` on `HTTPWiringMeta` — route `pikkuFuncId` stays the minted inline id)
- a kept MCP tool or agent tool targets it
- a kept function's **source file** body-invokes it (`rpc.invokedFunctionsByFile`, new serialized state field; wiring-site `ref()`s deliberately excluded — the scaffold SSE refs were pinning the addon into all 110 units)

**Per-function required services (`aggregateRequiredServices`)** — addon builds now ship per-function `services` meta (`reattachFunctionServices`) plus `requiredParentServices` in `pikku-addon-meta.gen.json` (module-import fallback kept for older dist addons; the `.js` import never worked for source-form workspace addons). A consuming unit's `requiredSingletonServices` flags only the parent services its *used* addon functions declare (namespaced-id match — bare-name matching caused project/addon name collisions to flip flags on). The full parent blanket applies only when a used addon function has no services meta (old builds) or needs an addon-created service (the monolithic factory). Default framework services (`logger`, `config`, …) never force the blanket. Body-invoked namespaced functions now join `usedFunctions` so their services aggregate (full builds + filtered units).

### Tests

- `verifiers/addon-treeshake` (new): runs filtered codegen end-to-end against `@pikku/templates-function-addon` and asserts addon-bootstrap import presence + parent-service flags across 6 scenarios (18 assertions): untouched addon dropped; body-invoke keeps it with defaults-only services; addon-created service falls back to the blanket; `ref()`-route keeps it with exactly the declared service; mixed-file conservative keep documented. The template gains `goodbye`/`greetFromStore` functions and a factory that destructures `{ greetingStore, auditSink }`.
- Unit tests: inspector filter/aggregation/invocation-attribution suites extended (~90 tests), CLI strip/reattach tests.
- `verifiers/treeshaking`'s documented "addon always included (TODO)" expectation flipped to the now-correct excluded behavior.

### Validation (perauset, exact CF-failing versions: core 0.12.49 + addon-console 0.12.20)

- **0/110** units with static `node:fs`/`node:child_process` (was 110/110); `LocalMetaService` absent everywhere; scaffold functions intact.
- Keep path: `--names=http:get:/function-tests/stream` unit imports the addon bootstrap with `metaService` as its only non-default required service.
- Bundle total 80.1MB → **73.3MB** (bun bundler).

### Known limitations (follow-ups)

- Invocation attribution is file-granular: a helper file body-invoking an addon keeps the addon for every function in that file (conservative over-inclusion; one-function-per-file avoids it). A helper in a *separate non-kept* file is the inverse hazard — documented, inspector already warns on dynamic invocations.
- The addon services factory is monolithic: any addon-created service pulls the full declared parent set. Phase 2 = per-function addon registration modules + factory gating.