### PR TITLE
fix(console): forward credentials so cross-origin cookie auth works (#852)

### DIFF
--- a/.changeset/console-cross-origin-credentials.md
+++ b/.changeset/console-cross-origin-credentials.md
@@ -1,0 +1,5 @@
+---
+'@pikku/console': patch
+---
+
+Fix cross-origin cookie auth in the console: `pikku()` now forwards the `credentials` option to `PikkuFetch`, so RPCs (e.g. `console:getAllMeta`) send the session cookie when the console is served on a different origin than the API (`pikku serve --console <port>`). Previously the option was accepted but dropped, causing a 403 and "Failed to load metadata" after sign-in.

--- a/packages/console/src/pikku/http.test.ts
+++ b/packages/console/src/pikku/http.test.ts
@@ -25,3 +25,26 @@ test('console RPCs invoke via HTTP /rpc/ path', async () => {
     globalThis.fetch = originalFetch
   }
 })
+
+test('console RPCs forward the credentials mode for cross-origin cookie auth', async () => {
+  const seen: (RequestCredentials | undefined)[] = []
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    seen.push(init?.credentials)
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { 'content-type': 'application/json' },
+    })
+  }) as typeof fetch
+
+  try {
+    const client = pikku({
+      serverUrl: 'https://example.com/api',
+      credentials: 'include',
+    })
+    await client.rpc.invoke('console:getAllMeta')
+
+    assert.equal(seen[0], 'include')
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})

--- a/packages/console/src/pikku/http.ts
+++ b/packages/console/src/pikku/http.ts
@@ -5,7 +5,7 @@ export const pikku = (options: {
   serverUrl: string
   credentials?: RequestCredentials
 }) => {
-  const fetch = new PikkuFetch()
+  const fetch = new PikkuFetch({ credentials: options.credentials })
   fetch.setServerUrl(options.serverUrl)
   const rpc = new PikkuRPC()
   rpc.setPikkuFetch(fetch)


### PR DESCRIPTION
Fixes #852.

## Problem

Serving the OSS console on a different port than the API (`pikku serve --port 4077 --console 7071`) puts them on different origins. After sign-in, the console's `POST /rpc/console:getAllMeta` returned **403** and the UI showed *"Connection failed — Failed to load metadata"* (`Cannot read properties of undefined (reading 'gatewayMeta')`).

## Root cause

`packages/console/src/pikku/http.ts` accepted a `credentials` option (defaulted to `'include'` by `PikkuHTTPProvider`) but never passed it to `PikkuFetch`:

```ts
const fetch = new PikkuFetch()   // credentials dropped
fetch.setServerUrl(options.serverUrl)
```

So every RPC used the default credentials mode. Cross-origin, that omits the cookie; the backend (which correctly returns `Access-Control-Allow-Credentials: true` + a specific `Access-Control-Allow-Origin`) then sees no session → 403. Verified: `getAllMeta` **with** the session cookie → 200, **without** → 403; the captured browser request carried no `Cookie` header.

## Fix

Pass `credentials` through to the `PikkuFetch` constructor (`CorePikkuFetch` already reads `this.options.credentials` when fetching). One line.

## Tests

`http.test.ts` gains a case asserting the credentials mode reaches `fetch` — fails before the fix, passes after. Also verified end-to-end in a real browser: the console goes from the 403 metadata failure to fully loading `/overview` with zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)