### PR TITLE
feat: pikkuActorFlow — actor-agents, User Flows console page, run flows in e2e (#850)

### DIFF
--- a/.changeset/actor-flow-approval-loop-cap.md
+++ b/.changeset/actor-flow-approval-loop-cap.md
@@ -1,0 +1,12 @@
+---
+'@pikku/core': patch
+---
+
+Bound the actor-flow approval loop (#850)
+
+`converseWithTarget` now caps suspend→approve rounds within a single target turn
+(default 16, override via `maxApprovalRounds`). A cooperative target completes
+after a handful of rounds; a buggy or uncooperative one — e.g. re-requesting a
+tool the persona keeps denying — previously could spin the inner loop forever
+without ever spending a `maxTurns` credit. Exceeding the cap now throws instead
+of hanging.

--- a/.changeset/console-run-user-flow-actors.md
+++ b/.changeset/console-run-user-flow-actors.md
@@ -1,0 +1,18 @@
+---
+'@pikku/core': patch
+'@pikku/console': patch
+---
+
+Run user flows from the console, actors and all (#850)
+
+Starting a `user-flow` workflow without explicit run actors (as the console's
+Run button does) now auto-builds HTTP actors from `USER_FLOW_ACTOR_SECRET` and
+`API_URL`: each actor signs in via the actor auth plugin — which mints the
+`actor: true` user row on first sign-in — and drives its steps over HTTP as
+that persona. When the secret or API base URL isn't configured the run simply
+proceeds without actors (with a warning) instead of failing.
+
+The workflow-detail view also gains the shared console header: the workflow
+selector and the "complex workflow" note now live in the header bar, the right
+details panel hides when it has nothing to show, and step nodes display their
+DSL labels (e.g. `Double ${item}`).

--- a/.changeset/console-user-flows-page.md
+++ b/.changeset/console-user-flows-page.md
@@ -1,0 +1,13 @@
+---
+'@pikku/console': patch
+---
+
+Add a dedicated **User Flows** page to the console (#850)
+
+User flows and their personas now live under Tests → User Flows
+(`/tests/userflows`) instead of the Workflows page. The page has a
+`Flows | Personas` view: flow cards show their cast (overlapping persona
+avatars) and last-run status, personas render as cards with a read-only
+detail drawer, and opening a flow shows a persona-driven timeline of its
+steps (actor, status, and per-step RPC args). The Workflows page is now
+workflows-only. Built with Mantine primitives and theme-aware colours.

--- a/.changeset/userflow-run-exit-code.md
+++ b/.changeset/userflow-run-exit-code.md
@@ -1,0 +1,12 @@
+---
+'@pikku/cli': patch
+---
+
+Fix: the Pikku CLI no longer force-exits `0`, so a command's `process.exitCode` is honoured (#850)
+
+`bin/pikku.ts` called `process.exit(0)` unconditionally once a command finished,
+overriding any exit code the command had set. `pikku userflow run` sets
+`process.exitCode = 1` when a flow fails, but the process still exited `0` — so
+CI could not gate on a failed user flow. The CLI now exits with
+`process.exitCode ?? 0`, making failures observable to CI for every command
+(throwing commands already exited non-zero via `CLIError`).

--- a/e2e/packages/functions/src/auth.ts
+++ b/e2e/packages/functions/src/auth.ts
@@ -1,6 +1,7 @@
 import { betterAuth } from 'better-auth'
 import { getMigrations } from 'better-auth/db/migration'
 import { admin, bearer } from 'better-auth/plugins'
+import { actor } from '@pikku/better-auth'
 import { pikkuBetterAuth } from '#pikku/pikku-types.gen.js'
 
 /**
@@ -40,7 +41,15 @@ export const auth = pikkuBetterAuth(async ({ secrets, variables, kysely }) => {
       github: await secrets.getSecret('GITHUB_OAUTH'),
     },
     // admin: role/banned session fields + listUsers/impersonation endpoints.
-    plugins: [bearer(), admin()],
+    // actor: `/sign-in/actor` for user-flow actors — only rows flagged
+    // `actor: true` can sign in, gated by the USER_FLOW_ACTOR_SECRET.
+    plugins: [
+      bearer(),
+      admin(),
+      actor({
+        secret: (await variables.get('USER_FLOW_ACTOR_SECRET')) ?? '',
+      }),
+    ],
   })
 
   migrated ??= getMigrations(instance.options).then(({ runMigrations }) =>

--- a/e2e/packages/functions/src/functions/workflow-steps.functions.ts
+++ b/e2e/packages/functions/src/functions/workflow-steps.functions.ts
@@ -4,6 +4,7 @@ export const doubleValue = pikkuSessionlessFunc<
   { value: number },
   { result: number }
 >({
+  expose: true,
   func: async (_services, { value }) => ({
     result: value * 2,
   }),
@@ -13,6 +14,7 @@ export const formatMessage = pikkuSessionlessFunc<
   { greeting: string; name: string },
   { message: string }
 >({
+  expose: true,
   func: async (_services, { greeting, name }) => ({
     message: `${greeting}, ${name}!`,
   }),

--- a/e2e/packages/functions/src/workflows/failing.userflow.ts
+++ b/e2e/packages/functions/src/workflows/failing.userflow.ts
@@ -1,0 +1,17 @@
+import { pikkuUserFlow } from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+/**
+ * Test fixture: a user flow that always fails. Used to verify that
+ * `pikku userflow run` surfaces a failing flow via a non-zero process exit
+ * code (so CI can gate on it), not just via stdout.
+ */
+export const failingUserFlow = pikkuUserFlow<
+  { trigger?: boolean },
+  { ok: boolean }
+>({
+  title: 'Always fails (test fixture)',
+  tags: ['user-flow', 'test-fixture'],
+  func: async () => {
+    throw new Error('failingUserFlow always fails (exit-code fixture)')
+  },
+})

--- a/e2e/packages/functions/src/workflows/order-support.userflow.ts
+++ b/e2e/packages/functions/src/workflows/order-support.userflow.ts
@@ -19,10 +19,14 @@ export const orderSupportUserFlow = pikkuUserFlow<
     }
     logger.debug('order-support user flow starting')
 
+    // `pikku userflow run` invokes flows with no input, so the story carries
+    // its own sample order value; a programmatic caller can still override it.
+    const value = data?.value ?? 21
+
     const doubled = await workflow.do(
       'shopper doubles their order',
       'doubleValue',
-      { value: data.value },
+      { value },
       { actor: actors.shopper }
     )
 

--- a/e2e/packages/functions/src/workflows/order-support.userflow.ts
+++ b/e2e/packages/functions/src/workflows/order-support.userflow.ts
@@ -6,7 +6,7 @@ import { pikkuUserFlow } from '#pikku/workflow/pikku-workflow-types.gen.js'
  * Runnable via `pikku userflow run` too — the steps are plain exposed RPCs.
  */
 export const orderSupportUserFlow = pikkuUserFlow<
-  { value: number },
+  { value?: number },
   { doubled: number; message: string }
 >({
   title: 'Order support (user flow)',

--- a/e2e/pikku.config.json
+++ b/e2e/pikku.config.json
@@ -50,7 +50,8 @@
     },
     "environments": {
       "local": {
-        "apiUrl": "http://localhost:4077"
+        "apiUrl": "http://localhost:4077",
+        "signInPath": "/api/auth/sign-in/actor"
       }
     }
   }

--- a/e2e/tests/features/userflow-run.feature
+++ b/e2e/tests/features/userflow-run.feature
@@ -1,0 +1,13 @@
+@ai @userflow
+Feature: User flow runs
+  User flows drive real signed-in actors against the running API via
+  `pikku userflow run`. Each step executes as its actor, so the actor auth
+  plugin and the shared USER_FLOW_ACTOR_SECRET must be wired end to end.
+
+  Scenario: orderSupportUserFlow passes with signed-in actors
+    When I run the "orderSupportUserFlow" user flow against the "local" environment
+    Then the user flow run reports all flows passed
+
+  Scenario: a failing user flow surfaces a non-zero exit code
+    When I run the "failingUserFlow" user flow against the "local" environment
+    Then the user flow run exits non-zero

--- a/e2e/tests/steps/userflow-run.steps.ts
+++ b/e2e/tests/steps/userflow-run.steps.ts
@@ -1,0 +1,68 @@
+import { When, Then } from '@cucumber/cucumber'
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+interface UserFlowRunResult {
+  code: number | null
+  output: string
+}
+
+let lastRun: UserFlowRunResult | undefined
+
+const runUserFlow = (
+  environment: string,
+  flow: string
+): Promise<UserFlowRunResult> =>
+  new Promise((resolvePromise) => {
+    const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+    const child = spawn(
+      'npx',
+      ['pikku', 'userflow', 'run', environment, '--flows', flow],
+      { cwd: projectDir, env: { ...process.env } }
+    )
+    let output = ''
+    child.stdout.on('data', (d: Buffer) => {
+      output += d.toString()
+    })
+    child.stderr.on('data', (d: Buffer) => {
+      output += d.toString()
+    })
+    child.on('close', (code) => resolvePromise({ code, output }))
+  })
+
+When(
+  'I run the {string} user flow against the {string} environment',
+  async function (flow: string, environment: string) {
+    lastRun = await runUserFlow(environment, flow)
+  }
+)
+
+Then('the user flow run reports all flows passed', function () {
+  assert.ok(lastRun, 'no user flow run recorded')
+  assert.equal(
+    lastRun.code,
+    0,
+    `pikku userflow run exited ${lastRun.code}:\n${lastRun.output}`
+  )
+  assert.doesNotMatch(
+    lastRun.output,
+    /^FAIL /m,
+    `a flow failed:\n${lastRun.output}`
+  )
+  assert.match(
+    lastRun.output,
+    /\b(\d+)\/\1 user flows passed\b/,
+    `expected every flow to pass:\n${lastRun.output}`
+  )
+})
+
+Then('the user flow run exits non-zero', function () {
+  assert.ok(lastRun, 'no user flow run recorded')
+  assert.notEqual(
+    lastRun.code,
+    0,
+    `expected a non-zero exit code on failure:\n${lastRun.output}`
+  )
+})

--- a/e2e/tests/support/hooks.ts
+++ b/e2e/tests/support/hooks.ts
@@ -24,6 +24,11 @@ BeforeAll(async function () {
   const backendPort = new URL(config.apiUrl).port
   const consolePort = Number(new URL(config.consoleUrl).port)
 
+  // Shared actor secret: the server's actor auth plugin and any
+  // `pikku userflow run` step both read USER_FLOW_ACTOR_SECRET from the
+  // environment, so setting it here lets both sign the same synthetic actors in.
+  process.env.USER_FLOW_ACTOR_SECRET ??= 'e2e-actor-secret'
+
   // Start the backend + console via pikku serve --console <port>
   // pikkuOnStart in src/lifecycle.ts handles mock OAuth + user seeding
   backendProcess = spawn(

--- a/packages/cli/bin/pikku.ts
+++ b/packages/cli/bin/pikku.ts
@@ -41,7 +41,9 @@ if (existsSync(pikkuCliPath)) {
     const updateCheck = checkForUpdate()
     await PikkuCLI(process.argv.slice(2))
     await updateCheck
-    process.exit(0)
+    // Respect any exit code a command set (e.g. `userflow run` on a failed
+    // flow sets process.exitCode = 1); forcing 0 here would mask failures.
+    process.exit(process.exitCode ?? 0)
   } catch (error: any) {
     console.error('Failed to run Pikku CLI:', error.message)
     process.exit(1)

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -22,6 +22,7 @@ import { AdminUsersPage } from './pages/AdminUsersPage'
 import { RenderWorkflowPage } from './pages/RenderWorkflowPage'
 import { ChangesPage } from './pages/ChangesPage'
 import { TestsPage } from './pages/TestsPage'
+import { UserFlowsPage } from './pages/UserFlowsPage'
 import { DatabasePage } from './pages/DatabasePage'
 import { AuthProvidersPage } from './pages/AuthProvidersPage'
 import { SecurityPage } from './pages/SecurityPage'
@@ -49,6 +50,7 @@ export const App: React.FC = () => {
         <Route path="/agents/playground" element={<AgentPlaygroundPage />} />
         <Route path="/changes" element={<ChangesPage />} />
         <Route path="/tests" element={<TestsPage showRunButton />} />
+        <Route path="/tests/userflows" element={<UserFlowsPage />} />
         <Route path="/database" element={<DatabasePage />} />
         <Route path="/apis" element={<ApisPage />} />
         <Route path="/jobs" element={<JobsPage />} />

--- a/packages/console/src/components/flows/FlowCard.tsx
+++ b/packages/console/src/components/flows/FlowCard.tsx
@@ -1,0 +1,121 @@
+import React, { useMemo, useState } from 'react'
+import { Box, Group, Stack, Text, Badge } from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import { Route, Check, X, Loader } from 'lucide-react'
+import { FlowCast } from './FlowCast'
+import { useWorkflowRuns } from '../../hooks/useWorkflowRuns'
+import type { FlowEntry } from './flow-types'
+
+const relativeTime = (iso?: string): string => {
+  if (!iso) return ''
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+  const min = Math.round((Date.now() - then) / 60000)
+  if (min < 1) return 'just now'
+  if (min < 60) return `${min}m ago`
+  const hr = Math.round(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  return `${Math.round(hr / 24)}d ago`
+}
+
+const STATUS_META: Record<
+  string,
+  { tone: string; label: string; Icon: typeof Check }
+> = {
+  completed: { tone: 'green', label: 'passed', Icon: Check },
+  failed: { tone: 'red', label: 'failed', Icon: X },
+  cancelled: { tone: 'red', label: 'cancelled', Icon: X },
+  running: { tone: 'blue', label: 'running', Icon: Loader },
+}
+
+type FlowCardProps = {
+  flow: FlowEntry
+  onOpen: (name: string) => void
+}
+
+export const FlowCard: React.FC<FlowCardProps> = ({ flow, onOpen }) => {
+  const [hovered, setHovered] = useState(false)
+  const { data: runs } = useWorkflowRuns(flow.name)
+
+  const { lastRun, count } = useMemo(() => {
+    const list = (runs as { status: string; startedAt?: string }[]) ?? []
+    const sorted = [...list].sort(
+      (a, b) =>
+        new Date(b.startedAt ?? 0).getTime() -
+        new Date(a.startedAt ?? 0).getTime()
+    )
+    return { lastRun: sorted[0], count: list.length }
+  }, [runs])
+
+  const status = lastRun ? STATUS_META[lastRun.status] : undefined
+
+  return (
+    <Box
+      data-testid={`flow-card-${flow.name}`}
+      onClick={() => onOpen(flow.name)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        background: hovered
+          ? 'var(--mantine-color-default-hover)'
+          : 'var(--app-surface, var(--mantine-color-body))',
+        border: '1px solid var(--mantine-color-default-border)',
+        borderRadius: 14,
+        cursor: 'pointer',
+        transition: 'background 100ms',
+        padding: '18px 22px',
+      }}
+    >
+      <Group gap={18} wrap="nowrap" align="center">
+        <Box
+          style={{
+            width: 46,
+            height: 46,
+            borderRadius: 12,
+            flexShrink: 0,
+            display: 'grid',
+            placeItems: 'center',
+            background: 'var(--mantine-color-cyan-light)',
+            color: 'var(--mantine-color-cyan-light-color)',
+          }}
+        >
+          <Route size={22} strokeWidth={1.8} />
+        </Box>
+        <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
+          <Text size="md" fw={600} style={{ lineHeight: 1.2 }}>
+            {asI18n(flow.displayName)}
+          </Text>
+          {flow.description && (
+            <Text size="sm" c="dimmed" lineClamp={2}>
+              {asI18n(flow.description)}
+            </Text>
+          )}
+        </Stack>
+        {flow.cast.length > 0 && <FlowCast cast={flow.cast} />}
+        <Stack gap={6} align="flex-end" style={{ flexShrink: 0, minWidth: 92 }}>
+          {status && (
+            <Badge
+              variant="light"
+              color={status.tone}
+              radius="xl"
+              tt="none"
+              fw={500}
+              leftSection={<status.Icon size={11} strokeWidth={2.4} />}
+            >
+              {asI18n(`${status.label} · ${relativeTime(lastRun?.startedAt)}`)}
+            </Badge>
+          )}
+          {count > 0 ? (
+            <Text size="xs" ff="monospace" c="dimmed">
+              {asI18n(`${count} ${count === 1 ? 'run' : 'runs'}`)}
+            </Text>
+          ) : (
+            <Text size="xs" ff="monospace" c="dimmed">
+              {asI18n(`${flow.stepCount} ${flow.stepCount === 1 ? 'step' : 'steps'}`)}
+            </Text>
+          )}
+        </Stack>
+      </Group>
+    </Box>
+  )
+}

--- a/packages/console/src/components/flows/FlowCast.tsx
+++ b/packages/console/src/components/flows/FlowCast.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Box, Group } from '@pikku/mantine/core'
+import { PersonaAvatar } from '../personas/PersonaAvatar'
+import type { PersonaRef } from '../personas/persona-types'
+
+type FlowCastProps = {
+  cast: PersonaRef[]
+  size?: number
+}
+
+export const FlowCast: React.FC<FlowCastProps> = ({ cast, size = 26 }) => {
+  return (
+    <Group gap={0} wrap="nowrap">
+      {cast.map((ref, i) => (
+        <Box
+          key={ref.key}
+          style={{
+            marginLeft: i === 0 ? 0 : -size * 0.32,
+            borderRadius: '50%',
+            border: '2px solid var(--app-surface, var(--mantine-color-body))',
+          }}
+        >
+          <PersonaAvatar
+            personaKey={ref.key}
+            jobTitle={ref.jobTitle}
+            name={ref.name}
+            size={size}
+          />
+        </Box>
+      ))}
+    </Group>
+  )
+}

--- a/packages/console/src/components/flows/FlowsList.tsx
+++ b/packages/console/src/components/flows/FlowsList.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Stack, Skeleton } from '@pikku/mantine/core'
+import { Route } from 'lucide-react'
+import { m } from '@/i18n/messages'
+import { useLocale } from '@/i18n/config'
+import { EmptyStatePlaceholder } from '../layout/EmptyStatePlaceholder'
+import { FlowCard } from './FlowCard'
+import type { FlowEntry } from './flow-types'
+
+type FlowsListProps = {
+  flows: FlowEntry[]
+  onOpen: (name: string) => void
+  loading?: boolean
+}
+
+export const FlowsList: React.FC<FlowsListProps> = ({
+  flows,
+  onOpen,
+  loading = false,
+}) => {
+  useLocale()
+
+  if (loading) {
+    return (
+      <Stack gap={12} p="md">
+        <Skeleton height={84} radius={14} />
+        <Skeleton height={84} radius={14} />
+      </Stack>
+    )
+  }
+
+  if (flows.length === 0) {
+    return (
+      <EmptyStatePlaceholder
+        icon={Route}
+        title={m.user_flows_empty_title()}
+        description={m.user_flows_empty_description()}
+        docsHref="https://pikku.dev/docs/wiring/workflows"
+      />
+    )
+  }
+
+  return (
+    <Stack gap={12}>
+      {flows.map((flow) => (
+        <FlowCard key={flow.name} flow={flow} onOpen={onOpen} />
+      ))}
+    </Stack>
+  )
+}

--- a/packages/console/src/components/flows/flow-types.ts
+++ b/packages/console/src/components/flows/flow-types.ts
@@ -1,0 +1,9 @@
+import type { PersonaRef } from '../personas/persona-types'
+
+export interface FlowEntry {
+  name: string
+  displayName: string
+  description?: string
+  cast: PersonaRef[]
+  stepCount: number
+}

--- a/packages/console/src/components/flows/timeline/PersonaTimeline.tsx
+++ b/packages/console/src/components/flows/timeline/PersonaTimeline.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo } from 'react'
+import { Box, ScrollArea } from '@pikku/mantine/core'
+import { usePikkuMeta } from '../../../context/PikkuMetaContext'
+import { useWorkflowRunContextSafe } from '../../../context/WorkflowRunContext'
+import { TimelineStep } from './TimelineStep'
+import { buildFlowTimeline } from './timeline-model'
+import type { PersonaRef } from '../../personas/persona-types'
+
+type PersonaTimelineProps = {
+  workflow: {
+    nodes?: Record<string, any>
+    entryNodeIds?: string[]
+  }
+}
+
+export const PersonaTimeline: React.FC<PersonaTimelineProps> = ({
+  workflow,
+}) => {
+  const { meta } = usePikkuMeta()
+  const run = useWorkflowRunContextSafe()
+
+  const timeline = useMemo(
+    () => buildFlowTimeline(workflow.nodes, workflow.entryNodeIds),
+    [workflow.nodes, workflow.entryNodeIds]
+  )
+
+  const actors = meta.userFlowActors ?? {}
+  const stepStates = run?.stepStates
+
+  return (
+    <ScrollArea h="100%" type="auto">
+      <Box p="xl" style={{ maxWidth: 760, margin: '0 auto' }}>
+        {timeline.map((node, i) => {
+          const actor: PersonaRef | undefined = node.actor
+            ? {
+                key: node.actor,
+                name: (actors as any)[node.actor]?.name,
+                jobTitle: (actors as any)[node.actor]?.jobTitle,
+              }
+            : undefined
+          return (
+            <TimelineStep
+              key={node.nodeId}
+              node={node}
+              actor={actor}
+              status={stepStates?.get(node.nodeId)?.status}
+              isLast={i === timeline.length - 1}
+            />
+          )
+        })}
+      </Box>
+    </ScrollArea>
+  )
+}

--- a/packages/console/src/components/flows/timeline/PersonaTimeline.tsx
+++ b/packages/console/src/components/flows/timeline/PersonaTimeline.tsx
@@ -1,5 +1,7 @@
 import React, { useMemo } from 'react'
-import { Box, ScrollArea } from '@pikku/mantine/core'
+import { Box, ScrollArea, Center, Stack, Text, ThemeIcon } from '@pikku/mantine/core'
+import { Route } from 'lucide-react'
+import { asI18n } from '@pikku/react'
 import { usePikkuMeta } from '../../../context/PikkuMetaContext'
 import { useWorkflowRunContextSafe } from '../../../context/WorkflowRunContext'
 import { TimelineStep } from './TimelineStep'
@@ -26,6 +28,24 @@ export const PersonaTimeline: React.FC<PersonaTimelineProps> = ({
 
   const actors = meta.userFlowActors ?? {}
   const stepStates = run?.stepStates
+
+  if (timeline.length === 0) {
+    return (
+      <Center h="100%" p="xl">
+        <Stack align="center" gap={10}>
+          <ThemeIcon variant="light" color="gray" size={44} radius="md">
+            <Route size={22} />
+          </ThemeIcon>
+          <Text fw={600}>{asI18n('No steps to show')}</Text>
+          <Text size="sm" c="dimmed" ta="center" maw={360}>
+            {asI18n(
+              'This user flow has no workflow steps — actors call the API directly, or the flow returns without any `workflow.do` calls.'
+            )}
+          </Text>
+        </Stack>
+      </Center>
+    )
+  }
 
   return (
     <ScrollArea h="100%" type="auto">

--- a/packages/console/src/components/flows/timeline/TimelineStep.tsx
+++ b/packages/console/src/components/flows/timeline/TimelineStep.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import { Box, Group, Stack, Text, Badge } from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import {
+  MousePointerClick,
+  Hourglass,
+  Flag,
+  GitFork,
+  Network,
+  Circle,
+  Check,
+  X,
+  Loader,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { PersonaAvatar } from '../../personas/PersonaAvatar'
+import type { PersonaRef } from '../../personas/persona-types'
+import { summarizeArgs } from './timeline-model'
+import type { FlowTimelineNode } from './timeline-model'
+
+const KIND_STYLE: Record<
+  FlowTimelineNode['kind'],
+  { Icon: LucideIcon; color: string; badge: string }
+> = {
+  rpc: { Icon: MousePointerClick, color: 'green', badge: 'RPC' },
+  eventual: { Icon: Hourglass, color: 'yellow', badge: 'EVENTUAL' },
+  return: { Icon: Flag, color: 'gray', badge: 'RETURN' },
+  parallel: { Icon: GitFork, color: 'blue', badge: 'PARALLEL' },
+  fanout: { Icon: Network, color: 'blue', badge: 'FANOUT' },
+  other: { Icon: Circle, color: 'gray', badge: 'STEP' },
+}
+
+const statusChip = (
+  status?: string
+): { color: string; label: string; Icon: LucideIcon } | undefined => {
+  switch (status) {
+    case 'succeeded':
+    case 'completed':
+      return { color: 'green', label: 'pass', Icon: Check }
+    case 'failed':
+    case 'cancelled':
+      return { color: 'red', label: 'fail', Icon: X }
+    case 'running':
+      return { color: 'blue', label: 'running', Icon: Loader }
+    default:
+      return undefined
+  }
+}
+
+type TimelineStepProps = {
+  node: FlowTimelineNode
+  actor?: PersonaRef
+  status?: string
+  isLast?: boolean
+}
+
+export const TimelineStep: React.FC<TimelineStepProps> = ({
+  node,
+  actor,
+  status,
+  isLast = false,
+}) => {
+  const style = KIND_STYLE[node.kind]
+  const chip = statusChip(status)
+  const args = summarizeArgs(node.args)
+
+  return (
+    <Group align="stretch" gap={16} wrap="nowrap">
+      <Box style={{ position: 'relative', width: 40, flexShrink: 0 }}>
+        {!isLast && (
+          <Box
+            style={{
+              position: 'absolute',
+              left: 19,
+              top: 22,
+              bottom: -18,
+              width: 2,
+              background: 'var(--mantine-color-default-border)',
+            }}
+          />
+        )}
+        <Box
+          style={{
+            position: 'relative',
+            zIndex: 1,
+            width: 40,
+            height: 40,
+            borderRadius: 11,
+            display: 'grid',
+            placeItems: 'center',
+            background: `var(--mantine-color-${style.color}-light)`,
+            color: `var(--mantine-color-${style.color}-light-color)`,
+            border: `1px solid var(--mantine-color-${style.color}-outline, var(--mantine-color-default-border))`,
+          }}
+        >
+          <style.Icon size={19} strokeWidth={1.8} />
+        </Box>
+      </Box>
+      <Box
+        style={{
+          flex: 1,
+          minWidth: 0,
+          marginBottom: 18,
+          background: 'var(--app-surface, var(--mantine-color-body))',
+          border: '1px solid var(--mantine-color-default-border)',
+          borderRadius: 12,
+          padding: '14px 16px',
+        }}
+      >
+        <Group gap={10} wrap="nowrap" align="center">
+          {actor ? (
+            <Group gap={8} wrap="nowrap">
+              <PersonaAvatar
+                personaKey={actor.key}
+                jobTitle={actor.jobTitle}
+                name={actor.name}
+                size={22}
+              />
+              <Text size="sm" fw={500}>
+                {asI18n(actor.name ?? actor.key)}
+              </Text>
+            </Group>
+          ) : (
+            <Badge variant="light" color={style.color} radius="sm" tt="none">
+              {asI18n(style.badge)}
+            </Badge>
+          )}
+          <Box style={{ flex: 1 }} />
+          {chip ? (
+            <Badge
+              variant="light"
+              color={chip.color}
+              radius="sm"
+              tt="none"
+              leftSection={<chip.Icon size={11} strokeWidth={2.4} />}
+            >
+              {asI18n(chip.label)}
+            </Badge>
+          ) : (
+            <Badge variant="light" color={style.color} radius="sm" tt="none">
+              {asI18n(style.badge)}
+            </Badge>
+          )}
+        </Group>
+        <Text size="sm" fw={500} mt={9} c="var(--mantine-color-text)">
+          {asI18n(node.title)}
+        </Text>
+        {node.rpcName && (
+          <Text size="xs" ff="monospace" c="dimmed" mt={4}>
+            {asI18n(`${node.rpcName}(${args})`)}
+          </Text>
+        )}
+      </Box>
+    </Group>
+  )
+}

--- a/packages/console/src/components/flows/timeline/timeline-model.test.ts
+++ b/packages/console/src/components/flows/timeline/timeline-model.test.ts
@@ -62,6 +62,19 @@ test('buildFlowTimeline appends nodes unreachable via next in insertion order', 
   )
 })
 
+test('buildFlowTimeline walks every entry root in entryNodeIds order', () => {
+  const nodes = {
+    r1: { nodeId: 'r1', rpcName: 'one' },
+    r3: { nodeId: 'r3', rpcName: 'three' },
+    r2: { nodeId: 'r2', rpcName: 'two' },
+  }
+  const timeline = buildFlowTimeline(nodes as any, ['r1', 'r2', 'r3'])
+  assert.deepEqual(
+    timeline.map((n) => n.nodeId),
+    ['r1', 'r2', 'r3']
+  )
+})
+
 test('summarizeArgs renders $ref paths and primitives', () => {
   assert.equal(
     summarizeArgs({ value: { $ref: 'trigger', path: 'value' } }),

--- a/packages/console/src/components/flows/timeline/timeline-model.test.ts
+++ b/packages/console/src/components/flows/timeline/timeline-model.test.ts
@@ -1,0 +1,75 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { buildFlowTimeline, summarizeArgs } from './timeline-model.js'
+
+const ORDER_SUPPORT_NODES = {
+  step_0: {
+    nodeId: 'step_0',
+    flow: 'branch',
+    branches: [],
+    next: 'shopper doubles their order',
+  },
+  'shopper doubles their order': {
+    nodeId: 'shopper doubles their order',
+    rpcName: 'doubleValue',
+    next: 'support sees the greeting settle',
+    actor: 'shopper',
+    input: { value: { $ref: 'trigger', path: 'value' } },
+  },
+  'support sees the greeting settle': {
+    nodeId: 'support sees the greeting settle',
+    rpcName: 'formatMessage',
+    next: 'step_3',
+    actor: 'support',
+    expectEventually: true,
+    input: { greeting: 'Hello', name: 'Support' },
+  },
+  step_3: { nodeId: 'step_3', flow: 'return', outputs: {} },
+}
+
+test('buildFlowTimeline orders by next, drops the structural branch, and maps kinds', () => {
+  const timeline = buildFlowTimeline(ORDER_SUPPORT_NODES as any, ['step_0'])
+
+  assert.deepEqual(
+    timeline.map((n) => n.nodeId),
+    [
+      'shopper doubles their order',
+      'support sees the greeting settle',
+      'step_3',
+    ]
+  )
+  assert.deepEqual(
+    timeline.map((n) => n.kind),
+    ['rpc', 'eventual', 'return']
+  )
+  assert.equal(timeline[0].actor, 'shopper')
+  assert.equal(timeline[1].actor, 'support')
+  assert.equal(timeline[1].expectEventually, true)
+  assert.equal(timeline[2].title, 'Return')
+})
+
+test('buildFlowTimeline appends nodes unreachable via next in insertion order', () => {
+  const nodes = {
+    a: { nodeId: 'a', rpcName: 'first', next: 'c' },
+    b: { nodeId: 'b', rpcName: 'orphan' },
+    c: { nodeId: 'c', flow: 'return' },
+  }
+  const timeline = buildFlowTimeline(nodes as any, ['a'])
+  assert.deepEqual(
+    timeline.map((n) => n.nodeId),
+    ['a', 'c', 'b']
+  )
+})
+
+test('summarizeArgs renders $ref paths and primitives', () => {
+  assert.equal(
+    summarizeArgs({ value: { $ref: 'trigger', path: 'value' } }),
+    'value: trigger.value'
+  )
+  assert.equal(
+    summarizeArgs({ greeting: 'Hello', name: 'Support' }),
+    'greeting: "Hello", name: "Support"'
+  )
+  assert.equal(summarizeArgs(undefined), '')
+})

--- a/packages/console/src/components/flows/timeline/timeline-model.ts
+++ b/packages/console/src/components/flows/timeline/timeline-model.ts
@@ -1,0 +1,103 @@
+export type FlowTimelineKind =
+  | 'rpc'
+  | 'eventual'
+  | 'return'
+  | 'parallel'
+  | 'fanout'
+  | 'other'
+
+export interface FlowTimelineNode {
+  nodeId: string
+  kind: FlowTimelineKind
+  title: string
+  actor?: string
+  rpcName?: string
+  args?: Record<string, unknown>
+  expectEventually?: boolean
+}
+
+interface RawNode {
+  nodeId: string
+  flow?: string
+  rpcName?: string
+  actor?: string
+  input?: Record<string, unknown>
+  expectEventually?: boolean
+  branches?: unknown[]
+  next?: string
+}
+
+const isStructuralBranch = (node: RawNode): boolean =>
+  node.flow === 'branch' &&
+  (!node.branches || node.branches.length === 0) &&
+  !node.rpcName
+
+const kindOf = (node: RawNode): FlowTimelineKind => {
+  if (node.flow === 'return') return 'return'
+  if (node.flow === 'parallel') return 'parallel'
+  if (node.flow === 'fanout') return 'fanout'
+  if (node.rpcName) return node.expectEventually ? 'eventual' : 'rpc'
+  return 'other'
+}
+
+const titleOf = (node: RawNode): string => {
+  if (node.flow === 'return') return 'Return'
+  if (/^step_\d+$/.test(node.nodeId)) return node.rpcName ?? node.nodeId
+  return node.nodeId
+}
+
+/**
+ * Flattens a workflow's runtime node map into an ordered timeline. Nodes are
+ * walked via their `next` pointers starting from the entry, with any nodes not
+ * reachable that way appended in insertion order. Purely structural branch
+ * nodes (empty branch used as a start marker) are dropped.
+ */
+export function buildFlowTimeline(
+  nodes: Record<string, RawNode> | undefined,
+  entryNodeIds?: string[]
+): FlowTimelineNode[] {
+  if (!nodes) return []
+  const ordered: RawNode[] = []
+  const visited = new Set<string>()
+
+  const walk = (startId?: string) => {
+    let current = startId
+    while (current && nodes[current] && !visited.has(current)) {
+      visited.add(current)
+      ordered.push(nodes[current])
+      current = nodes[current].next
+    }
+  }
+
+  const entry = entryNodeIds?.[0] ?? Object.keys(nodes)[0]
+  walk(entry)
+  for (const id of Object.keys(nodes)) {
+    if (!visited.has(id)) walk(id)
+  }
+
+  return ordered
+    .filter((node) => !isStructuralBranch(node))
+    .map((node) => ({
+      nodeId: node.nodeId,
+      kind: kindOf(node),
+      title: titleOf(node),
+      actor: node.actor,
+      rpcName: node.rpcName,
+      args: node.input,
+      expectEventually: node.expectEventually,
+    }))
+}
+
+/** Renders a compact one-line preview of an RPC step's input arguments. */
+export function summarizeArgs(input?: Record<string, unknown>): string {
+  if (!input) return ''
+  const parts = Object.entries(input).map(([key, value]) => {
+    if (value && typeof value === 'object' && '$ref' in value) {
+      const ref = value as { $ref?: string; path?: string }
+      const path = [ref.$ref, ref.path].filter(Boolean).join('.')
+      return `${key}: ${path}`
+    }
+    return `${key}: ${JSON.stringify(value)}`
+  })
+  return parts.join(', ')
+}

--- a/packages/console/src/components/flows/timeline/timeline-model.ts
+++ b/packages/console/src/components/flows/timeline/timeline-model.ts
@@ -69,8 +69,11 @@ export function buildFlowTimeline(
     }
   }
 
-  const entry = entryNodeIds?.[0] ?? Object.keys(nodes)[0]
-  walk(entry)
+  const roots =
+    entryNodeIds && entryNodeIds.length > 0
+      ? entryNodeIds
+      : [Object.keys(nodes)[0]]
+  for (const root of roots) walk(root)
   for (const id of Object.keys(nodes)) {
     if (!visited.has(id)) walk(id)
   }

--- a/packages/console/src/components/layout/ThreePaneLayout.tsx
+++ b/packages/console/src/components/layout/ThreePaneLayout.tsx
@@ -13,6 +13,7 @@ interface ThreePaneLayoutProps {
   emptyPanelMessage?: I18nNode
   showTabs?: boolean
   hidePanel?: boolean
+  collapseWhenEmpty?: boolean
 }
 
 export const ThreePaneLayout: React.FC<ThreePaneLayoutProps> = ({
@@ -23,12 +24,15 @@ export const ThreePaneLayout: React.FC<ThreePaneLayoutProps> = ({
   emptyPanelMessage,
   showTabs = false,
   hidePanel = false,
+  collapseWhenEmpty = false,
 }) => {
   const { panels } = usePanelContext()
   const alwaysVisible = !showTabs
 
   const showLeft = !!runsPanel && runsPanelVisible
-  const showRight = !hidePanel && (alwaysVisible || panels.size !== 0)
+  const showRight =
+    !hidePanel &&
+    (panels.size !== 0 || (alwaysVisible && !collapseWhenEmpty))
 
   return (
     <Box className={classes.flexColumn} style={{ flex: 1, minHeight: 0 }}>

--- a/packages/console/src/components/personas/PersonaAvatar.tsx
+++ b/packages/console/src/components/personas/PersonaAvatar.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { Box } from '@pikku/mantine/core'
+import { personaVisual } from './personaVisual'
+
+type PersonaAvatarProps = {
+  personaKey: string
+  jobTitle?: string
+  name?: string
+  size?: number
+}
+
+export const PersonaAvatar: React.FC<PersonaAvatarProps> = ({
+  personaKey,
+  jobTitle,
+  name,
+  size = 48,
+}) => {
+  const { color, Icon } = personaVisual(personaKey, jobTitle, name)
+  const ring = Math.max(2, Math.round(size * 0.06))
+  return (
+    <Box
+      style={{
+        padding: ring,
+        borderRadius: '50%',
+        flexShrink: 0,
+        background: `var(--mantine-color-${color}-light)`,
+      }}
+    >
+      <Box
+        style={{
+          width: size,
+          height: size,
+          borderRadius: '50%',
+          display: 'grid',
+          placeItems: 'center',
+          background: `var(--mantine-color-${color}-filled)`,
+          color: 'var(--mantine-color-white)',
+        }}
+      >
+        <Icon size={Math.round(size * 0.46)} strokeWidth={1.9} />
+      </Box>
+    </Box>
+  )
+}

--- a/packages/console/src/components/personas/PersonaCard.tsx
+++ b/packages/console/src/components/personas/PersonaCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Box, Group, Stack, Text, Badge } from '@pikku/mantine/core'
+import { Route } from 'lucide-react'
 import { asI18n } from '@pikku/react'
 import { PersonaAvatar } from './PersonaAvatar'
 import { personaVisual } from './personaVisual'
@@ -50,17 +51,35 @@ export const PersonaCard: React.FC<PersonaCardProps> = ({ persona, onOpen }) => 
             </Text>
           )}
         </Stack>
-        <Stack gap={8} align="flex-end" style={{ flexShrink: 0 }}>
+        <Stack gap={8} align="flex-end" style={{ flexShrink: 0, maxWidth: 260 }}>
           {persona.jobTitle && (
             <Badge variant="light" color={color} radius="sm" tt="none" fw={500}>
               {asI18n(persona.jobTitle)}
             </Badge>
           )}
-          {persona.flowCount > 0 && (
-            <Text size="xs" ff="monospace" c="dimmed">
-              {asI18n(
-                `in ${persona.flowCount} ${persona.flowCount === 1 ? 'flow' : 'flows'}`
+          {persona.flows.length > 0 ? (
+            <Group gap={6} justify="flex-end" wrap="wrap">
+              {persona.flows.slice(0, 3).map((flow) => (
+                <Badge
+                  key={flow.name}
+                  variant="default"
+                  radius="sm"
+                  tt="none"
+                  fw={500}
+                  leftSection={<Route size={11} />}
+                >
+                  {asI18n(flow.displayName)}
+                </Badge>
+              ))}
+              {persona.flows.length > 3 && (
+                <Text size="xs" c="dimmed">
+                  {asI18n(`+${persona.flows.length - 3}`)}
+                </Text>
               )}
+            </Group>
+          ) : (
+            <Text size="xs" c="dimmed">
+              {asI18n('in no flows')}
             </Text>
           )}
         </Stack>

--- a/packages/console/src/components/personas/PersonaCard.tsx
+++ b/packages/console/src/components/personas/PersonaCard.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import { Box, Group, Stack, Text, Badge } from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import { PersonaAvatar } from './PersonaAvatar'
+import { personaVisual } from './personaVisual'
+import type { PersonaEntry } from './persona-types'
+
+type PersonaCardProps = {
+  persona: PersonaEntry
+  onOpen?: (key: string) => void
+}
+
+export const PersonaCard: React.FC<PersonaCardProps> = ({ persona, onOpen }) => {
+  const [hovered, setHovered] = useState(false)
+  const { color } = personaVisual(persona.key, persona.jobTitle, persona.name)
+  return (
+    <Box
+      data-testid={`persona-card-${persona.key}`}
+      onClick={() => onOpen?.(persona.key)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        background: hovered
+          ? 'var(--mantine-color-default-hover)'
+          : 'var(--app-surface, var(--mantine-color-body))',
+        border: '1px solid var(--mantine-color-default-border)',
+        borderRadius: 14,
+        cursor: onOpen ? 'pointer' : 'default',
+        transition: 'background 100ms',
+        padding: '18px 22px',
+      }}
+    >
+      <Group gap={18} wrap="nowrap" align="center">
+        <PersonaAvatar
+          personaKey={persona.key}
+          jobTitle={persona.jobTitle}
+          name={persona.name}
+          size={48}
+        />
+        <Stack gap={2} style={{ flex: 1, minWidth: 0 }}>
+          <Text size="md" fw={600} style={{ lineHeight: 1.2 }}>
+            {asI18n(persona.name)}
+          </Text>
+          <Text size="xs" ff="monospace" c="dimmed">
+            {asI18n(persona.email)}
+          </Text>
+          {persona.personality && (
+            <Text size="sm" c="dimmed" fs="italic" lineClamp={2} mt={4}>
+              {asI18n(`“${persona.personality}”`)}
+            </Text>
+          )}
+        </Stack>
+        <Stack gap={8} align="flex-end" style={{ flexShrink: 0 }}>
+          {persona.jobTitle && (
+            <Badge variant="light" color={color} radius="sm" tt="none" fw={500}>
+              {asI18n(persona.jobTitle)}
+            </Badge>
+          )}
+          {persona.flowCount > 0 && (
+            <Text size="xs" ff="monospace" c="dimmed">
+              {asI18n(
+                `in ${persona.flowCount} ${persona.flowCount === 1 ? 'flow' : 'flows'}`
+              )}
+            </Text>
+          )}
+        </Stack>
+      </Group>
+    </Box>
+  )
+}

--- a/packages/console/src/components/personas/PersonaCard.tsx
+++ b/packages/console/src/components/personas/PersonaCard.tsx
@@ -17,7 +17,15 @@ export const PersonaCard: React.FC<PersonaCardProps> = ({ persona, onOpen }) => 
   return (
     <Box
       data-testid={`persona-card-${persona.key}`}
+      role={onOpen ? 'button' : undefined}
+      tabIndex={onOpen ? 0 : undefined}
       onClick={() => onOpen?.(persona.key)}
+      onKeyDown={(e) => {
+        if (onOpen && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault()
+          onOpen(persona.key)
+        }
+      }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{

--- a/packages/console/src/components/personas/PersonaDrawer.tsx
+++ b/packages/console/src/components/personas/PersonaDrawer.tsx
@@ -7,7 +7,10 @@ import {
   TextInput,
   Textarea,
   Divider,
+  UnstyledButton,
+  ThemeIcon,
 } from '@pikku/mantine/core'
+import { Route, ChevronRight } from 'lucide-react'
 import { asI18n } from '@pikku/react'
 import { PersonaAvatar } from './PersonaAvatar'
 import type { PersonaEntry } from './persona-types'
@@ -16,12 +19,14 @@ type PersonaDrawerProps = {
   persona: PersonaEntry | null
   opened: boolean
   onClose: () => void
+  onOpenFlow?: (name: string) => void
 }
 
 export const PersonaDrawer: React.FC<PersonaDrawerProps> = ({
   persona,
   opened,
   onClose,
+  onOpenFlow,
 }) => {
   return (
     <Drawer
@@ -80,6 +85,45 @@ export const PersonaDrawer: React.FC<PersonaDrawerProps> = ({
             autosize
             minRows={3}
           />
+
+          <Stack gap={6}>
+            <Text size="sm" fw={600}>
+              {asI18n(
+                `Appears in ${persona.flows.length} ${persona.flows.length === 1 ? 'flow' : 'flows'}`
+              )}
+            </Text>
+            {persona.flows.length === 0 ? (
+              <Text size="xs" c="dimmed">
+                {asI18n('Not cast in any user flow yet.')}
+              </Text>
+            ) : (
+              persona.flows.map((flow) => (
+                <UnstyledButton
+                  key={flow.name}
+                  onClick={() => onOpenFlow?.(flow.name)}
+                  style={{
+                    borderRadius: 8,
+                    border: '1px solid var(--mantine-color-default-border)',
+                    padding: '8px 12px',
+                  }}
+                >
+                  <Group gap={10} wrap="nowrap">
+                    <ThemeIcon variant="light" color="cyan" size="sm" radius="sm">
+                      <Route size={13} />
+                    </ThemeIcon>
+                    <Text size="sm" style={{ flex: 1, minWidth: 0 }}>
+                      {asI18n(flow.displayName)}
+                    </Text>
+                    <ChevronRight
+                      size={15}
+                      color="var(--mantine-color-dimmed)"
+                    />
+                  </Group>
+                </UnstyledButton>
+              ))
+            )}
+          </Stack>
+
           <Text size="xs" c="dimmed">
             {asI18n(
               'Personas are defined in pikku.config.json under userFlows.actors.'

--- a/packages/console/src/components/personas/PersonaDrawer.tsx
+++ b/packages/console/src/components/personas/PersonaDrawer.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import {
+  Drawer,
+  Group,
+  Stack,
+  Text,
+  TextInput,
+  Textarea,
+  Divider,
+} from '@pikku/mantine/core'
+import { asI18n } from '@pikku/react'
+import { PersonaAvatar } from './PersonaAvatar'
+import type { PersonaEntry } from './persona-types'
+
+type PersonaDrawerProps = {
+  persona: PersonaEntry | null
+  opened: boolean
+  onClose: () => void
+}
+
+export const PersonaDrawer: React.FC<PersonaDrawerProps> = ({
+  persona,
+  opened,
+  onClose,
+}) => {
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      position="right"
+      size={440}
+      title={
+        persona ? (
+          <Group gap={12} wrap="nowrap">
+            <PersonaAvatar
+              personaKey={persona.key}
+              jobTitle={persona.jobTitle}
+              name={persona.name}
+              size={40}
+            />
+            <Stack gap={0}>
+              <Text fw={600} size="md">
+                {asI18n(persona.name)}
+              </Text>
+              <Text ff="monospace" size="xs" c="dimmed">
+                {asI18n(`actors.${persona.key}`)}
+              </Text>
+            </Stack>
+          </Group>
+        ) : null
+      }
+    >
+      {persona && (
+        <Stack gap="md" pt="xs">
+          <Divider />
+          <TextInput
+            label={asI18n('Name')}
+            value={persona.name}
+            readOnly
+            variant="filled"
+          />
+          <TextInput
+            label={asI18n('Email')}
+            value={persona.email}
+            readOnly
+            variant="filled"
+            styles={{ input: { fontFamily: 'var(--mantine-font-family-monospace)' } }}
+          />
+          <TextInput
+            label={asI18n('Role label')}
+            value={persona.jobTitle ?? '—'}
+            readOnly
+            variant="filled"
+          />
+          <Textarea
+            label={asI18n('Personality — drives converse')}
+            value={persona.personality ?? '—'}
+            readOnly
+            variant="filled"
+            autosize
+            minRows={3}
+          />
+          <Text size="xs" c="dimmed">
+            {asI18n(
+              'Personas are defined in pikku.config.json under userFlows.actors.'
+            )}
+          </Text>
+        </Stack>
+      )}
+    </Drawer>
+  )
+}

--- a/packages/console/src/components/personas/PersonasView.tsx
+++ b/packages/console/src/components/personas/PersonasView.tsx
@@ -11,11 +11,13 @@ import type { PersonaEntry } from './persona-types'
 type PersonasViewProps = {
   personas: PersonaEntry[]
   loading?: boolean
+  onOpenFlow?: (name: string) => void
 }
 
 export const PersonasView: React.FC<PersonasViewProps> = ({
   personas,
   loading = false,
+  onOpenFlow,
 }) => {
   useLocale()
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
@@ -52,6 +54,7 @@ export const PersonasView: React.FC<PersonasViewProps> = ({
         persona={selected}
         opened={selected !== null}
         onClose={() => setSelectedKey(null)}
+        onOpenFlow={onOpenFlow}
       />
     </>
   )

--- a/packages/console/src/components/personas/PersonasView.tsx
+++ b/packages/console/src/components/personas/PersonasView.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react'
+import { Stack, Skeleton } from '@pikku/mantine/core'
+import { UserRound } from 'lucide-react'
+import { m } from '@/i18n/messages'
+import { useLocale } from '@/i18n/config'
+import { EmptyStatePlaceholder } from '../layout/EmptyStatePlaceholder'
+import { PersonaCard } from './PersonaCard'
+import { PersonaDrawer } from './PersonaDrawer'
+import type { PersonaEntry } from './persona-types'
+
+type PersonasViewProps = {
+  personas: PersonaEntry[]
+  loading?: boolean
+}
+
+export const PersonasView: React.FC<PersonasViewProps> = ({
+  personas,
+  loading = false,
+}) => {
+  useLocale()
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const selected = personas.find((p) => p.key === selectedKey) ?? null
+
+  if (loading) {
+    return (
+      <Stack gap={12} p="md">
+        <Skeleton height={92} radius={14} />
+        <Skeleton height={92} radius={14} />
+      </Stack>
+    )
+  }
+
+  if (personas.length === 0) {
+    return (
+      <EmptyStatePlaceholder
+        icon={UserRound}
+        title={m.personas_empty_title()}
+        description={m.personas_empty_description()}
+        docsHref="https://pikku.dev/docs/wiring/workflows"
+      />
+    )
+  }
+
+  return (
+    <>
+      <Stack gap={12}>
+        {personas.map((p) => (
+          <PersonaCard key={p.key} persona={p} onOpen={setSelectedKey} />
+        ))}
+      </Stack>
+      <PersonaDrawer
+        persona={selected}
+        opened={selected !== null}
+        onClose={() => setSelectedKey(null)}
+      />
+    </>
+  )
+}

--- a/packages/console/src/components/personas/persona-types.ts
+++ b/packages/console/src/components/personas/persona-types.ts
@@ -1,0 +1,14 @@
+export interface PersonaEntry {
+  key: string
+  name: string
+  email: string
+  jobTitle?: string
+  personality?: string
+  flowCount: number
+}
+
+export interface PersonaRef {
+  key: string
+  name?: string
+  jobTitle?: string
+}

--- a/packages/console/src/components/personas/persona-types.ts
+++ b/packages/console/src/components/personas/persona-types.ts
@@ -1,10 +1,15 @@
+export interface PersonaFlowRef {
+  name: string
+  displayName: string
+}
+
 export interface PersonaEntry {
   key: string
   name: string
   email: string
   jobTitle?: string
   personality?: string
-  flowCount: number
+  flows: PersonaFlowRef[]
 }
 
 export interface PersonaRef {

--- a/packages/console/src/components/personas/personaVisual.ts
+++ b/packages/console/src/components/personas/personaVisual.ts
@@ -1,0 +1,70 @@
+import type { LucideIcon } from 'lucide-react'
+import {
+  ShoppingCart,
+  Headset,
+  Briefcase,
+  Wrench,
+  CreditCard,
+  Stethoscope,
+  GraduationCap,
+  Truck,
+  Building2,
+  UserRound,
+  Smile,
+  Package,
+} from 'lucide-react'
+
+const PALETTE = [
+  'yellow',
+  'violet',
+  'blue',
+  'teal',
+  'grape',
+  'cyan',
+  'pink',
+  'orange',
+  'lime',
+  'indigo',
+] as const
+
+export type PersonaColor = (typeof PALETTE)[number]
+
+const stableHash = (value: string): number => {
+  let h = 0
+  for (let i = 0; i < value.length; i++) {
+    h = (Math.imul(h, 31) + value.charCodeAt(i)) | 0
+  }
+  return Math.abs(h)
+}
+
+const ICON_KEYWORDS: Array<[RegExp, LucideIcon]> = [
+  [/shop|buy|cart|checkout|customer|order/, ShoppingCart],
+  [/support|agent|help|service|desk/, Headset],
+  [/admin|manager|owner|exec|lead|boss/, Briefcase],
+  [/dev|engineer|tech|build/, Wrench],
+  [/pay|bill|finance|account/, CreditCard],
+  [/doctor|nurse|clinic|patient|health/, Stethoscope],
+  [/teach|student|tutor|learn/, GraduationCap],
+  [/ship|deliver|courier|logistics|driver/, Truck],
+  [/company|org|business|enterprise/, Building2],
+]
+
+const FALLBACK_ICONS: LucideIcon[] = [UserRound, Smile, Package, Building2]
+
+export interface PersonaVisual {
+  color: PersonaColor
+  Icon: LucideIcon
+}
+
+export const personaVisual = (
+  key: string,
+  jobTitle?: string,
+  name?: string
+): PersonaVisual => {
+  const color = PALETTE[stableHash(key) % PALETTE.length]
+  const haystack = `${key} ${jobTitle ?? ''} ${name ?? ''}`.toLowerCase()
+  const matched = ICON_KEYWORDS.find(([re]) => re.test(haystack))?.[1]
+  const Icon =
+    matched ?? FALLBACK_ICONS[stableHash(key) % FALLBACK_ICONS.length]
+  return { color, Icon }
+}

--- a/packages/console/src/components/project/Sidebar.tsx
+++ b/packages/console/src/components/project/Sidebar.tsx
@@ -33,6 +33,7 @@ import {
   GitCompare,
   Mail,
   FlaskConical,
+  Route,
   Database,
   Users,
   Sun,
@@ -71,6 +72,7 @@ export function useDefaultNavSections(): NavSection[] {
         { label: m.nav_workflows(), href: '/workflow', icon: GitBranch, matchPrefix: '/workflow' },
         { label: m.nav_agents(), href: '/agents', icon: Bot, matchPrefix: '/agents' },
         { label: m.nav_tests(), href: '/tests', icon: FlaskConical, matchPrefix: '/tests' },
+        { label: asI18n('User Flows'), href: '/tests/userflows', icon: Route, matchPrefix: '/tests/userflows' },
       ],
     },
     {

--- a/packages/console/src/components/project/WorkflowCanvas.tsx
+++ b/packages/console/src/components/project/WorkflowCanvas.tsx
@@ -44,6 +44,7 @@ import { usePanelContext } from '../../context/PanelContext'
 import { usePikkuRPC } from '../../context/PikkuRpcProvider'
 import { createCanvasDrawerContent } from '../canvas-drawer/CanvasDrawerFactory'
 import { WorkflowTimelineDrawer } from './WorkflowTimelineDrawer'
+import { PersonaTimeline } from '../flows/timeline/PersonaTimeline'
 import { useWorkflowRuns } from '../../hooks/useWorkflowRuns'
 import { RunsPanel, type RunItem } from '../layout/RunsPanel'
 import { WiringNode } from './nodes/WiringNode'
@@ -431,6 +432,7 @@ const WorkflowCanvasContent: React.FC<WorkflowCanvasProps> = ({
 
   const workflowSource = workflow.source || 'graph'
   const isComplex = workflowSource === 'complex'
+  const isUserFlow = workflowSource === 'user-flow'
 
   const runContext = useWorkflowRunContextSafe()
 
@@ -502,10 +504,14 @@ const WorkflowCanvasContent: React.FC<WorkflowCanvasProps> = ({
             </Alert>
           )}
           <Box style={{ flex: 1, minHeight: 0 }}>
-            <WorkflowCanvasInner
-              workflow={canvasWorkflow}
-              onPaneClick={handlePaneClick}
-            />
+            {isUserFlow ? (
+              <PersonaTimeline workflow={canvasWorkflow} />
+            ) : (
+              <WorkflowCanvasInner
+                workflow={canvasWorkflow}
+                onPaneClick={handlePaneClick}
+              />
+            )}
           </Box>
           <WorkflowTimelineDrawer />
         </Box>

--- a/packages/console/src/components/project/WorkflowCanvas.tsx
+++ b/packages/console/src/components/project/WorkflowCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useCallback, useState } from 'react'
+import React, { useMemo, useEffect, useCallback } from 'react'
 import type { NodeTypes, EdgeTypes } from 'reactflow'
 import ReactFlow, {
   useNodesState,
@@ -14,20 +14,13 @@ import {
   Drawer,
   Text,
   Alert,
-  Popover,
-  TextInput,
-  UnstyledButton,
-  ScrollArea,
-  Stack,
+  Badge,
+  Tooltip,
 } from '@pikku/mantine/core'
 import { asI18n } from '@pikku/react'
-import {
-  AlertTriangle,
-  History,
-  ChevronDown,
-  Search,
-  Check,
-} from 'lucide-react'
+import { AlertTriangle, History } from 'lucide-react'
+import { ListPageHeader } from '../layout/PageLayout'
+import { WorkflowSelector } from './WorkflowSelector'
 import {
   CanvasDrawerProvider,
   useCanvasDrawerContext,
@@ -226,33 +219,13 @@ const WorkflowCanvasInner: React.FC<{
 
 const WorkflowRunsPanel: React.FC<{
   workflowName: string
-  items: { name: string; description?: string }[]
-  onItemSelect: (name: string) => void
-}> = ({ workflowName, items, onItemSelect }) => {
+}> = ({ workflowName }) => {
   const { selectedRunId, setSelectedRunId, setIsCreatingRun } =
     useWorkflowRunContext()
   const { setActivePanel } = usePanelContext()
   const editable = useConsoleEditable()
   const rpc = usePikkuRPC()
   const { data: runs, isLoading, refetch } = useWorkflowRuns(workflowName)
-  const [selectorOpen, setSelectorOpen] = useState(false)
-  const [search, setSearch] = useState('')
-
-  const filteredItems = useMemo(() => {
-    if (!search) return items
-    const q = search.toLowerCase()
-    return items.filter(
-      (i) =>
-        i.name.toLowerCase().includes(q) ||
-        i.description?.toLowerCase().includes(q)
-    )
-  }, [items, search])
-
-  const handleSelect = (name: string) => {
-    setSelectorOpen(false)
-    setSearch('')
-    onItemSelect(name)
-  }
 
   const runItems: RunItem[] = useMemo(() => {
     if (!runs || !Array.isArray(runs)) return []
@@ -276,103 +249,6 @@ const WorkflowRunsPanel: React.FC<{
     setActivePanel(`workflow-${workflowName}`)
   }, [setSelectedRunId, setIsCreatingRun, setActivePanel, workflowName])
 
-  const selector = (
-    <Popover
-      opened={selectorOpen}
-      onChange={setSelectorOpen}
-      width={280}
-      position="bottom-start"
-      shadow="md"
-      zIndex={10000}
-    >
-      <Popover.Target>
-        <UnstyledButton
-          px="sm"
-          py="xs"
-          style={{
-            width: '100%',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 4,
-            borderBottom: '1px solid var(--mantine-color-default-border)',
-          }}
-          onClick={() => setSelectorOpen((o) => !o)}
-        >
-          <Text
-            size="sm"
-            fw={600}
-            style={{
-              flex: 1,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {asI18n(workflowName)}
-          </Text>
-          <ChevronDown size={14} style={{ flexShrink: 0 }} />
-        </UnstyledButton>
-      </Popover.Target>
-      <Popover.Dropdown p={0}>
-        <TextInput
-          placeholder={asI18n('Search workflows...')}
-          leftSection={<Search size={14} />}
-          value={search}
-          onChange={(e) => setSearch(e.currentTarget.value)}
-          styles={{
-            input: {
-              border: 'none',
-              borderBottom: '1px solid var(--mantine-color-default-border)',
-              borderRadius: 0,
-            },
-          }}
-        />
-        <ScrollArea.Autosize mah={300}>
-          <Stack gap={0}>
-            {filteredItems.map((item) => (
-              <UnstyledButton
-                key={item.name}
-                onClick={() => handleSelect(item.name)}
-                py="xs"
-                px="sm"
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 8,
-                  backgroundColor:
-                    item.name === workflowName
-                      ? 'var(--mantine-color-green-light)'
-                      : undefined,
-                }}
-              >
-                {item.name === workflowName ? (
-                  <Check size={14} color="var(--mantine-color-green-6)" />
-                ) : (
-                  <Box w={14} />
-                )}
-                <div>
-                  <Text size="sm" fw={item.name === workflowName ? 500 : 400}>
-                    {asI18n(item.name)}
-                  </Text>
-                  {item.description && (
-                    <Text size="sm" c="dimmed">
-                      {asI18n(item.description)}
-                    </Text>
-                  )}
-                </div>
-              </UnstyledButton>
-            ))}
-            {filteredItems.length === 0 && (
-              <Text size="sm" c="dimmed" ta="center" py="md">
-                {asI18n('No results')}
-              </Text>
-            )}
-          </Stack>
-        </ScrollArea.Autosize>
-      </Popover.Dropdown>
-    </Popover>
-  )
-
   return (
     <RunsPanel
       title="Runs"
@@ -383,7 +259,6 @@ const WorkflowRunsPanel: React.FC<{
       loading={isLoading}
       emptyMessage={asI18n('No runs found')}
       statusFilters={[]}
-      header={selector}
       onNewClick={editable ? handleNewClick : undefined}
       newButtonLabel={editable ? asI18n('New workflow run') : undefined}
       onDelete={editable ? handleDelete : undefined}
@@ -451,17 +326,48 @@ const WorkflowCanvasContent: React.FC<WorkflowCanvasProps> = ({
   }, [baseWorkflow, runContext?.runData?.wire])
 
   const runsPanel = runContext ? (
-    <WorkflowRunsPanel
-      workflowName={workflowName}
-      items={items}
-      onItemSelect={onItemSelect}
-    />
+    <WorkflowRunsPanel workflowName={workflowName} />
   ) : undefined
+
+  const complexNote = isComplex ? (
+    <Tooltip
+      label={asI18n(
+        'This is a complex workflow. The visual representation may not be accurate.'
+      )}
+      multiline
+      w={260}
+    >
+      <Badge
+        color="yellow"
+        variant="light"
+        leftSection={<AlertTriangle size={12} />}
+        style={{ textTransform: 'none' }}
+      >
+        {asI18n('Complex')}
+      </Badge>
+    </Tooltip>
+  ) : undefined
+
+  const header = immersiveDetail ? undefined : (
+    <ListPageHeader
+      title={asI18n('Workflow')}
+      filters={complexNote}
+      lead={
+        <WorkflowSelector
+          workflowName={workflowName}
+          items={items}
+          onItemSelect={onItemSelect}
+        />
+      }
+    />
+  )
 
   return (
     <>
       <ThreePaneLayout
+        header={header}
         showTabs={immersiveDetail}
+        collapseWhenEmpty
         emptyPanelMessage={asI18n('Select a node to view its details')}
         runsPanel={runsPanel}
       >
@@ -473,21 +379,6 @@ const WorkflowCanvasContent: React.FC<WorkflowCanvasProps> = ({
             flexDirection: 'column',
           }}
         >
-          {isComplex && (
-            <Alert
-              icon={<AlertTriangle size={16} />}
-              color="yellow"
-              radius={0}
-              py="xs"
-              style={{ flexShrink: 0 }}
-            >
-              <Text size="sm">
-                {asI18n(
-                  'This is a complex workflow. The visual representation may not be accurate.'
-                )}
-              </Text>
-            </Alert>
-          )}
           {runContext?.isVersionMismatch && (
             <Alert
               icon={<History size={16} />}

--- a/packages/console/src/components/project/WorkflowSelector.tsx
+++ b/packages/console/src/components/project/WorkflowSelector.tsx
@@ -1,0 +1,147 @@
+import React, { useMemo, useState } from 'react'
+import {
+  Box,
+  Popover,
+  TextInput,
+  UnstyledButton,
+  ScrollArea,
+  Stack,
+  Text,
+} from '@pikku/mantine/core'
+import { ChevronDown, Search, Check } from 'lucide-react'
+import { asI18n } from '@pikku/react'
+
+export interface WorkflowSelectorItem {
+  name: string
+  description?: string
+}
+
+type WorkflowSelectorProps = {
+  workflowName: string
+  items: WorkflowSelectorItem[]
+  onItemSelect: (name: string) => void
+}
+
+export const WorkflowSelector: React.FC<WorkflowSelectorProps> = ({
+  workflowName,
+  items,
+  onItemSelect,
+}) => {
+  const [opened, setOpened] = useState(false)
+  const [search, setSearch] = useState('')
+
+  const filteredItems = useMemo(() => {
+    if (!search) return items
+    const q = search.toLowerCase()
+    return items.filter(
+      (i) =>
+        i.name.toLowerCase().includes(q) ||
+        i.description?.toLowerCase().includes(q)
+    )
+  }, [items, search])
+
+  const handleSelect = (name: string) => {
+    setOpened(false)
+    setSearch('')
+    onItemSelect(name)
+  }
+
+  return (
+    <Popover
+      opened={opened}
+      onChange={setOpened}
+      width={280}
+      position="bottom-start"
+      shadow="md"
+      zIndex={10000}
+    >
+      <Popover.Target>
+        <UnstyledButton
+          px="sm"
+          py={6}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            maxWidth: 320,
+            border: '1px solid var(--mantine-color-default-border)',
+            borderRadius: 'var(--mantine-radius-sm)',
+            background: 'var(--mantine-color-default)',
+          }}
+          onClick={() => setOpened((o) => !o)}
+        >
+          <Text
+            size="sm"
+            fw={600}
+            style={{
+              flex: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {asI18n(workflowName)}
+          </Text>
+          <ChevronDown size={14} style={{ flexShrink: 0 }} />
+        </UnstyledButton>
+      </Popover.Target>
+      <Popover.Dropdown p={0}>
+        <TextInput
+          placeholder={asI18n('Search workflows...')}
+          leftSection={<Search size={14} />}
+          value={search}
+          onChange={(e) => setSearch(e.currentTarget.value)}
+          styles={{
+            input: {
+              border: 'none',
+              borderBottom: '1px solid var(--mantine-color-default-border)',
+              borderRadius: 0,
+            },
+          }}
+        />
+        <ScrollArea.Autosize mah={300}>
+          <Stack gap={0}>
+            {filteredItems.map((item) => (
+              <UnstyledButton
+                key={item.name}
+                onClick={() => handleSelect(item.name)}
+                py="xs"
+                px="sm"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  backgroundColor:
+                    item.name === workflowName
+                      ? 'var(--mantine-color-green-light)'
+                      : undefined,
+                }}
+              >
+                {item.name === workflowName ? (
+                  <Check size={14} color="var(--mantine-color-green-6)" />
+                ) : (
+                  <Box w={14} />
+                )}
+                <div>
+                  <Text size="sm" fw={item.name === workflowName ? 500 : 400}>
+                    {asI18n(item.name)}
+                  </Text>
+                  {item.description && (
+                    <Text size="sm" c="dimmed">
+                      {asI18n(item.description)}
+                    </Text>
+                  )}
+                </div>
+              </UnstyledButton>
+            ))}
+            {filteredItems.length === 0 && (
+              <Text size="sm" c="dimmed" ta="center" py="md">
+                {asI18n('No results')}
+              </Text>
+            )}
+          </Stack>
+        </ScrollArea.Autosize>
+      </Popover.Dropdown>
+    </Popover>
+  )
+}

--- a/packages/console/src/context/ConsoleNavigatorContext.tsx
+++ b/packages/console/src/context/ConsoleNavigatorContext.tsx
@@ -21,14 +21,11 @@ export function useConsoleNavigator(): ConsoleNavigator {
 
 export { Ctx as ConsoleNavigatorCtx }
 
-const SECTION_PATHS: Record<ConsoleSection, string> = {
-  workflows: '/workflow',
-}
-
 /** OSS default — IDs live in the `?id=` query param. */
-export const OSSConsoleNavigator: React.FC<{ children: ReactNode }> = ({
-  children,
-}) => {
+export const OSSConsoleNavigator: React.FC<{
+  children: ReactNode
+  basePath?: string
+}> = ({ children, basePath = '/workflow' }) => {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
 
@@ -36,9 +33,8 @@ export const OSSConsoleNavigator: React.FC<{ children: ReactNode }> = ({
     <Ctx.Provider
       value={{
         workflowId: searchParams.get('id'),
-        navigateTo: (section, id) => {
-          const base = SECTION_PATHS[section]
-          navigate(id ? `${base}?id=${encodeURIComponent(id)}` : base)
+        navigateTo: (_section, id) => {
+          navigate(id ? `${basePath}?id=${encodeURIComponent(id)}` : basePath)
         },
       }}
     >

--- a/packages/console/src/hooks/useWiringFlow.ts
+++ b/packages/console/src/hooks/useWiringFlow.ts
@@ -67,6 +67,16 @@ function getStepType(step: any): string {
   return 'unknown'
 }
 
+// The DSL step label (first arg to `workflow.do`) is stored as the nodeId when
+// it is a real label; synthetic `step_N` ids carry no label, so fall back to
+// the rpc/function name in that case.
+function deriveStepName(step: any, stepNodeId: string): string | undefined {
+  if (step.stepName) {
+    return step.stepName
+  }
+  return /^step_\d+$/.test(stepNodeId) ? undefined : stepNodeId
+}
+
 function processStep(
   step: any,
   stepNodeId: string,
@@ -84,7 +94,7 @@ function processStep(
         stepNodeId,
         step.rpcName,
         position,
-        step.stepName,
+        deriveStepName(step, stepNodeId),
         index,
         undefined,
         step
@@ -102,7 +112,7 @@ function processStep(
         stepNodeId,
         'inline',
         position,
-        step.stepName,
+        deriveStepName(step, stepNodeId),
         index,
         undefined,
         step

--- a/packages/console/src/pages/UserFlowsPage.tsx
+++ b/packages/console/src/pages/UserFlowsPage.tsx
@@ -1,0 +1,164 @@
+import React, { Suspense, useMemo, useState } from 'react'
+import {
+  Group,
+  TextInput,
+  Center,
+  Loader,
+  SegmentedControl,
+} from '@pikku/mantine/core'
+import { Search } from 'lucide-react'
+import { asI18n } from '@pikku/react'
+import { useLocale } from '@/i18n/config'
+import { usePikkuMeta } from '../context/PikkuMetaContext'
+import { WorkflowTabContent } from '../components/tabs/WorkflowTabContent'
+import { PanelProvider } from '../context/PanelContext'
+import { ResizablePanelLayout } from '../components/layout/ResizablePanelLayout'
+import { ListPageHeader } from '../components/layout/PageLayout'
+import { FlowsList } from '../components/flows/FlowsList'
+import type { FlowEntry } from '../components/flows/flow-types'
+import { PersonasView } from '../components/personas/PersonasView'
+import type { PersonaEntry } from '../components/personas/persona-types'
+import { OSSConsoleNavigator, useConsoleNavigator } from '../context/ConsoleNavigatorContext'
+import { toEnglishName } from '../lib/strings'
+
+const USER_FLOWS_BASE_PATH = '/tests/userflows'
+
+const UserFlowsPageInner: React.FC = () => {
+  useLocale()
+  const { workflowId, navigateTo } = useConsoleNavigator()
+  const { meta, loading } = usePikkuMeta()
+  const [view, setView] = useState<'user-flows' | 'personas'>('user-flows')
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const flowEntries = useMemo((): FlowEntry[] => {
+    const actors = meta.userFlowActors ?? {}
+    return (Object.values(meta.workflows ?? {}) as any[])
+      .filter((w) => w.source === 'user-flow' || w.userFlow === true)
+      .map((w): FlowEntry => ({
+        name: w.name,
+        displayName: toEnglishName(w.name),
+        description: w.description ?? w.summary,
+        stepCount: w.nodes
+          ? Object.keys(w.nodes).length
+          : (w.steps?.length ?? 0),
+        cast: (w.actors ?? []).map((key: string) => ({
+          key,
+          name: (actors as any)[key]?.name,
+          jobTitle: (actors as any)[key]?.jobTitle,
+        })),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [meta.workflows, meta.userFlowActors])
+
+  const personaEntries = useMemo((): PersonaEntry[] => {
+    const actors = meta.userFlowActors ?? {}
+    const flowsByActor = new Map<string, number>()
+    for (const w of Object.values(meta.workflows ?? {}) as any[]) {
+      for (const actor of w.actors ?? []) {
+        flowsByActor.set(actor, (flowsByActor.get(actor) ?? 0) + 1)
+      }
+    }
+    return Object.entries(actors)
+      .map(([key, cfg]: [string, any]): PersonaEntry => ({
+        key,
+        name: cfg.name ?? key,
+        email: cfg.email,
+        jobTitle: cfg.jobTitle,
+        personality: cfg.personality,
+        flowCount: flowsByActor.get(key) ?? 0,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [meta.userFlowActors, meta.workflows])
+
+  const filteredFlows = useMemo(() => {
+    const q = searchQuery.toLowerCase()
+    if (!q) return flowEntries
+    return flowEntries.filter(
+      (f) =>
+        f.name.toLowerCase().includes(q) ||
+        f.description?.toLowerCase().includes(q)
+    )
+  }, [flowEntries, searchQuery])
+
+  const filteredPersonas = useMemo(() => {
+    const q = searchQuery.toLowerCase()
+    if (!q) return personaEntries
+    return personaEntries.filter(
+      (p) =>
+        p.key.toLowerCase().includes(q) ||
+        p.name.toLowerCase().includes(q) ||
+        p.email.toLowerCase().includes(q) ||
+        p.personality?.toLowerCase().includes(q)
+    )
+  }, [personaEntries, searchQuery])
+
+  if (workflowId) {
+    return <WorkflowTabContent immersiveDetail />
+  }
+
+  return (
+    <PanelProvider>
+      <ResizablePanelLayout
+        hidePanel
+        header={
+          <ListPageHeader
+            title={asI18n('User Flows')}
+            description={asI18n(
+              'End-to-end user-flow tests and the personas that run them'
+            )}
+            docsHref="https://pikku.dev/docs/wiring/workflows"
+            filters={
+              <Group gap="sm" wrap="nowrap">
+                <SegmentedControl
+                  size="xs"
+                  value={view}
+                  onChange={(value) => setView(value as typeof view)}
+                  data={[
+                    { label: asI18n('Flows'), value: 'user-flows' },
+                    { label: asI18n('Personas'), value: 'personas' },
+                  ]}
+                />
+                <TextInput
+                  placeholder={
+                    view === 'personas'
+                      ? asI18n('Search personas…')
+                      : asI18n('Search flows…')
+                  }
+                  leftSection={<Search size={14} />}
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  size="xs"
+                  style={{ width: 240 }}
+                />
+              </Group>
+            }
+          />
+        }
+      >
+        {view === 'personas' ? (
+          <PersonasView personas={filteredPersonas} loading={loading} />
+        ) : (
+          <FlowsList
+            flows={filteredFlows}
+            onOpen={(name) => navigateTo('workflows', name)}
+            loading={loading}
+          />
+        )}
+      </ResizablePanelLayout>
+    </PanelProvider>
+  )
+}
+
+export const UserFlowsPage: React.FC = () => (
+  <OSSConsoleNavigator basePath={USER_FLOWS_BASE_PATH}>
+    <Suspense
+      fallback={
+        <Center h="100vh">
+          <Loader />
+        </Center>
+      }
+    >
+      <UserFlowsPageInner />
+    </Suspense>
+  </OSSConsoleNavigator>
+)

--- a/packages/console/src/pages/UserFlowsPage.tsx
+++ b/packages/console/src/pages/UserFlowsPage.tsx
@@ -17,7 +17,10 @@ import { ListPageHeader } from '../components/layout/PageLayout'
 import { FlowsList } from '../components/flows/FlowsList'
 import type { FlowEntry } from '../components/flows/flow-types'
 import { PersonasView } from '../components/personas/PersonasView'
-import type { PersonaEntry } from '../components/personas/persona-types'
+import type {
+  PersonaEntry,
+  PersonaFlowRef,
+} from '../components/personas/persona-types'
 import { OSSConsoleNavigator, useConsoleNavigator } from '../context/ConsoleNavigatorContext'
 import { toEnglishName } from '../lib/strings'
 
@@ -34,6 +37,7 @@ const UserFlowsPageInner: React.FC = () => {
     const actors = meta.userFlowActors ?? {}
     return (Object.values(meta.workflows ?? {}) as any[])
       .filter((w) => w.source === 'user-flow' || w.userFlow === true)
+      .filter((w) => !(w.tags ?? []).includes('test-fixture'))
       .map((w): FlowEntry => ({
         name: w.name,
         displayName: toEnglishName(w.name),
@@ -52,10 +56,14 @@ const UserFlowsPageInner: React.FC = () => {
 
   const personaEntries = useMemo((): PersonaEntry[] => {
     const actors = meta.userFlowActors ?? {}
-    const flowsByActor = new Map<string, number>()
+    const flowsByActor = new Map<string, PersonaFlowRef[]>()
     for (const w of Object.values(meta.workflows ?? {}) as any[]) {
+      if (!(w.source === 'user-flow' || w.userFlow === true)) continue
+      if ((w.tags ?? []).includes('test-fixture')) continue
       for (const actor of w.actors ?? []) {
-        flowsByActor.set(actor, (flowsByActor.get(actor) ?? 0) + 1)
+        const list = flowsByActor.get(actor) ?? []
+        list.push({ name: w.name, displayName: toEnglishName(w.name) })
+        flowsByActor.set(actor, list)
       }
     }
     return Object.entries(actors)
@@ -65,7 +73,7 @@ const UserFlowsPageInner: React.FC = () => {
         email: cfg.email,
         jobTitle: cfg.jobTitle,
         personality: cfg.personality,
-        flowCount: flowsByActor.get(key) ?? 0,
+        flows: flowsByActor.get(key) ?? [],
       }))
       .sort((a, b) => a.name.localeCompare(b.name))
   }, [meta.userFlowActors, meta.workflows])
@@ -136,7 +144,11 @@ const UserFlowsPageInner: React.FC = () => {
         }
       >
         {view === 'personas' ? (
-          <PersonasView personas={filteredPersonas} loading={loading} />
+          <PersonasView
+            personas={filteredPersonas}
+            loading={loading}
+            onOpenFlow={(name) => navigateTo('workflows', name)}
+          />
         ) : (
           <FlowsList
             flows={filteredFlows}

--- a/packages/console/src/pages/WorkflowPage.tsx
+++ b/packages/console/src/pages/WorkflowPage.tsx
@@ -1,13 +1,7 @@
 import React, { Suspense, useContext, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
-import {
-  Group,
-  TextInput,
-  Center,
-  Loader,
-  SegmentedControl,
-} from '@pikku/mantine/core'
-import { GitBranch, Search, UserRound } from 'lucide-react'
+import { Group, TextInput, Center, Loader } from '@pikku/mantine/core'
+import { GitBranch, Search } from 'lucide-react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { usePikkuMeta } from '../context/PikkuMetaContext'
@@ -46,9 +40,6 @@ const WorkflowPageInner: React.FC<{
   const { meta, loading } = usePikkuMeta()
   const { data: aiWorkflows } = useAIWorkflows()
   const [searchQuery, setSearchQuery] = useState('')
-  const [view, setView] = useState<'workflows' | 'user-flows' | 'personas'>(
-    'workflows'
-  )
 
   const userFlowNames = useMemo(() => {
     const names = new Set<string>()
@@ -96,47 +87,8 @@ const WorkflowPageInner: React.FC<{
       .sort((a, b) => a.name.localeCompare(b.name))
   }, [meta.workflows, aiWorkflows])
 
-  const personaItems = useMemo((): EntityCardItem[] => {
-    const actors = meta.userFlowActors ?? {}
-    const flowsByActor = new Map<string, number>()
-    for (const w of Object.values(meta.workflows ?? {}) as any[]) {
-      for (const actor of w.actors ?? []) {
-        flowsByActor.set(actor, (flowsByActor.get(actor) ?? 0) + 1)
-      }
-    }
-    return Object.entries(actors)
-      .map(([key, cfg]: [string, any]): EntityCardItem => {
-        const metaTags: string[] = [cfg.email]
-        if (cfg.jobTitle) metaTags.push(cfg.jobTitle)
-        const flowCount = flowsByActor.get(key) ?? 0
-        return {
-          name: key,
-          displayName: cfg.name ?? key,
-          badges:
-            flowCount > 0
-              ? [
-                  {
-                    label: `${flowCount} ${flowCount === 1 ? 'flow' : 'flows'}`,
-                    tone: 'accent' as const,
-                  },
-                ]
-              : [],
-          meta: metaTags,
-          description: cfg.personality,
-        }
-      })
-      .sort((a, b) => a.name.localeCompare(b.name))
-  }, [meta.userFlowActors, meta.workflows])
-
-  const hasPersonas = personaItems.length > 0
-
   const items = useMemo(() => {
-    const base =
-      view === 'personas'
-        ? personaItems
-        : allItems.filter(
-            (item) => userFlowNames.has(item.name) === (view === 'user-flows')
-          )
+    const base = allItems.filter((item) => !userFlowNames.has(item.name))
     const q = searchQuery.toLowerCase()
     if (!q) return base
     return base.filter(
@@ -144,41 +96,19 @@ const WorkflowPageInner: React.FC<{
         item.name.toLowerCase().includes(q) ||
         item.description?.toLowerCase().includes(q)
     )
-  }, [allItems, personaItems, userFlowNames, view, searchQuery])
+  }, [allItems, userFlowNames, searchQuery])
 
   if (!onOpen && workflowId) {
     return <WorkflowTabContent immersiveDetail={immersiveDetail} />
   }
 
   const handleOpen = (name: string) => {
-    if (view === 'personas') return
     if (onOpen) {
       onOpen(name)
     } else {
       navigateTo('workflows', name)
     }
   }
-
-  const viewOptions = [
-    { label: m.workflows_view_workflows(), value: 'workflows' },
-    { label: m.workflows_view_user_flows(), value: 'user-flows' },
-    ...(hasPersonas
-      ? [{ label: m.workflows_view_personas(), value: 'personas' }]
-      : []),
-  ]
-
-  const emptyTitle =
-    view === 'user-flows'
-      ? m.user_flows_empty_title()
-      : view === 'personas'
-        ? m.personas_empty_title()
-        : m.workflows_empty_title()
-  const emptyDescription =
-    view === 'user-flows'
-      ? m.user_flows_empty_description()
-      : view === 'personas'
-        ? m.personas_empty_description()
-        : m.workflows_empty_description()
 
   return (
     <PanelProvider>
@@ -191,12 +121,6 @@ const WorkflowPageInner: React.FC<{
             docsHref="https://pikku.dev/docs/wiring/workflows"
             filters={
               <Group gap="sm" wrap="nowrap">
-                <SegmentedControl
-                  size="xs"
-                  value={view}
-                  onChange={(value) => setView(value as typeof view)}
-                  data={viewOptions}
-                />
                 <TextInput
                   placeholder={m.workflows_search_placeholder()}
                   leftSection={<Search size={14} />}
@@ -215,12 +139,12 @@ const WorkflowPageInner: React.FC<{
           items={items}
           onOpen={handleOpen}
           loading={loading}
-          icon={view === 'personas' ? UserRound : icon}
-          emptyHero={view === 'workflows' ? emptyHero : undefined}
-          emptyTitle={emptyTitle}
-          emptyDescription={emptyDescription}
+          icon={icon}
+          emptyHero={emptyHero}
+          emptyTitle={m.workflows_empty_title()}
+          emptyDescription={m.workflows_empty_description()}
           docsHref="https://pikku.dev/docs/wiring/workflows"
-          metricSlot={view === 'personas' ? undefined : metricSlot}
+          metricSlot={metricSlot}
         />
       </ResizablePanelLayout>
     </PanelProvider>

--- a/packages/core/src/wirings/actor-flow/run-conversation.test.ts
+++ b/packages/core/src/wirings/actor-flow/run-conversation.test.ts
@@ -84,6 +84,30 @@ const suspendingTarget = (): {
   return { target, approvedWith }
 }
 
+/** A target that never completes — always re-suspends for the same approval. */
+const alwaysSuspendingTarget = (): {
+  target: TargetAgentDriver
+  approveCalls: () => number
+} => {
+  let approveCalls = 0
+  const suspended: TargetAgentReply = {
+    text: 'working on it',
+    runId: 'run-stuck',
+    status: 'suspended',
+    pendingApprovals: [
+      { toolCallId: 'tc1', toolName: 'createTodo', args: { title: 'x' } },
+    ],
+  }
+  const target: TargetAgentDriver = {
+    run: async () => suspended,
+    approve: async () => {
+      approveCalls++
+      return suspended
+    },
+  }
+  return { target, approveCalls: () => approveCalls }
+}
+
 const base = {
   persona: { email: 'pm@example.com', name: 'Priya', personality: 'concise' },
   personaName: 'Priya',
@@ -133,5 +157,20 @@ describe('runConversation', () => {
     assert.deepEqual(approvedWith, [[{ toolCallId: 'tc1', approved: false }]])
     assert.ok(!calls.includes('approval'))
     assert.equal(verdict.passed, false)
+  })
+
+  test('caps the approval loop when the target never stops suspending', async () => {
+    const { llm } = scriptedLLM({
+      turns: [{ message: 'please make a todo', done: false }],
+      decisions: [{ toolCallId: 'tc1', approved: true }],
+      evaluation: { passed: false, reasoning: 'never got there' },
+    })
+    const { target, approveCalls } = alwaysSuspendingTarget()
+
+    await assert.rejects(
+      runConversation({ ...base, approvals: 'always', maxApprovalRounds: 3, llm, target }),
+      /approval rounds/
+    )
+    assert.equal(approveCalls(), 3)
   })
 })

--- a/packages/core/src/wirings/actor-flow/run-conversation.ts
+++ b/packages/core/src/wirings/actor-flow/run-conversation.ts
@@ -53,6 +53,15 @@ const EVALUATION_SCHEMA = {
 
 const DEFAULT_MAX_TURNS = 12
 
+/**
+ * Hard cap on suspend→approve rounds within a single target turn. A cooperative
+ * target completes after a handful of tool-approval rounds; a buggy or
+ * uncooperative one (e.g. re-requesting a tool the persona keeps denying) could
+ * otherwise keep the loop spinning forever inside one turn, never spending a
+ * `maxTurns` credit.
+ */
+const DEFAULT_MAX_APPROVAL_ROUNDS = 16
+
 /** The LLM call the persona uses for its own turns/decisions/evaluation. */
 export type PersonaLLM = (
   params: AIAgentRunnerParams
@@ -73,6 +82,8 @@ export interface RunConversationParams {
   model: string
   /** Hard cap on conversation turns. Default 12. */
   maxTurns?: number
+  /** Hard cap on tool-approval rounds within a single target turn. Default 16. */
+  maxApprovalRounds?: number
   /** Transport that drives the target agent (HTTP in production). */
   target: TargetAgentDriver
   /** The persona's own LLM. */
@@ -180,12 +191,20 @@ async function converseWithTarget(
   instructions: string,
   message: string
 ) {
+  const maxRounds = params.maxApprovalRounds ?? DEFAULT_MAX_APPROVAL_ROUNDS
   let reply = await params.target.run(message)
+  let rounds = 0
   while (
     reply.status === 'suspended' &&
     reply.pendingApprovals &&
     reply.pendingApprovals.length > 0
   ) {
+    if (rounds >= maxRounds) {
+      throw new Error(
+        `Target agent "${params.agentName}" stayed suspended after ${maxRounds} approval rounds (runId ${reply.runId}); aborting to avoid an unbounded approve loop.`
+      )
+    }
+    rounds++
     const decisions = await decideApprovals(
       params,
       instructions,

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -11,6 +11,7 @@ import {
   pikkuState,
 } from '../../pikku-state.js'
 import { getDurationInMilliseconds } from '../../time-utils.js'
+import { createHttpUserFlowActors } from '../../services/http-user-flow-actors.js'
 
 const resolveWorkflowMeta = (
   name: string
@@ -1071,6 +1072,46 @@ export abstract class PikkuWorkflowService implements WorkflowService {
    * @param options.inline - If true, execute workflow directly without queue service
    * @param options.startNode - Starting node ID for graph workflows (from wire config)
    */
+  /**
+   * Build HTTP user-flow actors for a run started without them (e.g. from the
+   * console). The actors sign in via the actor auth plugin using
+   * USER_FLOW_ACTOR_SECRET — which creates the `actor: true` user rows on first
+   * sign-in — and drive each step over HTTP as that persona. Returns undefined
+   * (so the run proceeds actor-less) when the secret or API base URL is not
+   * configured.
+   */
+  private async resolveUserFlowActors(): Promise<UserFlowActors | undefined> {
+    const services = getSingletonServices()
+    const variables = services?.variables
+    const metaService = services?.metaService
+    if (!variables || !metaService) {
+      return undefined
+    }
+    const secret = await variables.get('USER_FLOW_ACTOR_SECRET')
+    const apiUrl = await variables.get('API_URL')
+    if (!secret || !apiUrl) {
+      services?.logger?.warn(
+        'A user flow was started without actors but USER_FLOW_ACTOR_SECRET / API_URL is not configured — running without actors.'
+      )
+      return undefined
+    }
+    const actorsConfig = await metaService.getUserFlowActorsMeta()
+    if (!actorsConfig || Object.keys(actorsConfig).length === 0) {
+      return undefined
+    }
+    const signInPath =
+      (await variables.get('USER_FLOW_SIGN_IN_PATH')) ??
+      '/api/auth/sign-in/actor'
+    const rpcPath = (await variables.get('USER_FLOW_RPC_PATH')) ?? '/rpc'
+    return createHttpUserFlowActors({
+      apiUrl,
+      secret,
+      actors: actorsConfig,
+      signInPath,
+      rpcPath,
+    })
+  }
+
   public async startWorkflow<I>(
     name: string,
     input: I,
@@ -1140,8 +1181,13 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       }
     )
 
-    if (options?.actors) {
-      this.runActors.set(runId, options.actors)
+    const actors =
+      options?.actors ??
+      (workflowMeta.source === 'user-flow'
+        ? await this.resolveUserFlowActors()
+        : undefined)
+    if (actors) {
+      this.runActors.set(runId, actors)
     }
 
     if (shouldInline) {


### PR DESCRIPTION
Closes #850.

Implements **pikkuActorFlow** end to end: LLM actor-agents that converse with, approve tools for, and evaluate a target Pikku agent — plus the console surface and tooling to author, run, and observe user flows.

## What's in here

**Core / runtime (converse)**
- `pikkuActorFlow` core types + inspector recognition; `expectEventually` as a user-flow-only primitive.
- `runActorFlow` runtime built on `runAIAgent`; `actor.converse({ agent, task, evaluate })` drives a target agent over the real transport, signs in lazily (on 401, works with no-auth agents), plays the persona from `pikku.config.json`, and returns a verdict. `agent` is typed against the generated agent-name union.

**Console — User Flows page** (`@pikku/console`)
- Dedicated **User Flows** page under Tests (`/tests/userflows`) with a `Flows | Personas` view: flow cards with cast avatars + last-run status, persona cards with a read-only detail drawer, and a persona-driven **step timeline** (actor, status, per-step RPC args). Workflows page is now workflows-only. Built with Mantine primitives, theme-aware.

**e2e — run user flows in the `@ai` suite**
- Wire the better-auth **actor sign-in plugin**, expose the flow's step RPCs, self-contained flow input, and a `@userflow` cucumber verifier (a passing flow + a failing-flow fixture that must exit non-zero).

**CLI fix** (`@pikku/cli`)
- The CLI no longer force-exits `0` after a command: it honours `process.exitCode`, so `pikku userflow run` failures are observable to CI (previously masked).

## Verification
- `@userflow` cucumber: 2 scenarios / 4 steps pass; failing flow exits non-zero (RED→GREEN demonstrated), passing flow exits 0.
- Console + e2e `tsc` clean for all touched files.

## Publish
Changesets included for `@pikku/core`, `@pikku/inspector`, `@pikku/cli`, `@pikku/console`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added actor-to-agent conversation support (`actor.converse(...)`) and new actor-flow types.
  * Introduced a dedicated **User Flows** console experience (flows/personas views, search, cards, drawers, and run timeline).
  * Automatically wires HTTP user-flow actors for runs started without explicit actors.
* **Bug Fixes**
  * Fixed CLI exit behavior to preserve non-zero codes for failed user flows.
* **Documentation**
  * Expanded guidance for running the OSS console on the e2e project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->