### PR TITLE
feat(cucumber): connect browser world to a remote CDP (Steel) browser

### DIFF
--- a/.changeset/cucumber-steel-cdp.md
+++ b/.changeset/cucumber-steel-cdp.md
@@ -1,0 +1,8 @@
+---
+'@pikku/cucumber': patch
+---
+
+browser world: connect to a remote CDP browser (e.g. Steel) via `cdpUrl` /
+`XBROWSER_CDP_URL` instead of launching a local chromium. On this path the app is
+reached at its public edge, so the loopback host-resolver mapping is skipped. Lets
+CPU/RAM-capped sandboxes run smoke/scenario suites against a shared remote browser.

--- a/packages/cucumber/src/browser/config.ts
+++ b/packages/cucumber/src/browser/config.ts
@@ -26,6 +26,14 @@ export interface BrowserConfig {
   locale?: string
   /** Explicit chromium binary (e.g. the sandbox-image system chromium). */
   chromiumPath?: string
+  /**
+   * Remote CDP endpoint (e.g. a Steel browser). When set, connect over CDP to
+   * this shared/remote browser instead of launching a local chromium — so a
+   * CPU/RAM-capped sandbox never runs a browser. The remote browser reaches the
+   * app at its PUBLIC edge, so `appUrl` must be publicly resolvable (no
+   * hostnameOnly loopback mapping is applied on this path).
+   */
+  cdpUrl?: string
   /** Bare hostname mapped to 127.0.0.1 via a chromium host-resolver rule. */
   hostnameOnly?: string
   /** Accept self-signed edge certs (in-container Caddy CA). */
@@ -70,6 +78,7 @@ export function browserConfigFromEnv(
     slowMo: overrides.slowMo ?? (env.HEADED ? 120 : 0),
     locale: overrides.locale ?? env.E2E_LOCALE,
     chromiumPath: overrides.chromiumPath ?? (env.PLAYWRIGHT_CHROMIUM_PATH || undefined),
+    cdpUrl: overrides.cdpUrl ?? (env.XBROWSER_CDP_URL || undefined),
     hostnameOnly: overrides.hostnameOnly ?? (host ? host.split(':')[0] : undefined),
     ignoreHTTPSErrors: overrides.ignoreHTTPSErrors ?? true,
     defaultPersona: overrides.defaultPersona ?? defaultPersona,

--- a/packages/cucumber/src/browser/world.ts
+++ b/packages/cucumber/src/browser/world.ts
@@ -112,6 +112,16 @@ export class BrowserWorld<Clients = unknown> {
 
   private async launchBrowser(): Promise<Browser> {
     if (this.browser) return this.browser
+    // Remote/Steel browser: connect over CDP instead of launching a local
+    // chromium in a CPU/RAM-capped sandbox. The remote browser reaches the app at
+    // its PUBLIC edge via real DNS, so we do NOT add the host-resolver 127.0.0.1
+    // mapping (that's only for a local browser hitting the in-container loopback
+    // edge). browser.close() on a connected browser only clears the contexts this
+    // connection created and disconnects — it never kills the shared browser.
+    if (this.config.cdpUrl) {
+      this.browser = await chromium.connectOverCDP(await resolveCdpWsUrl(this.config.cdpUrl))
+      return this.browser
+    }
     this.browser = await chromium.launch({
       headless: !this.config.headed,
       executablePath: this.config.chromiumPath,
@@ -128,4 +138,25 @@ export class BrowserWorld<Clients = unknown> {
     })
     return this.browser
   }
+}
+
+/**
+ * Resolve a dialable ws:// endpoint for a remote CDP base URL. Passing the http
+ * base straight to connectOverCDP makes Playwright fetch /json/version and trust
+ * its `webSocketDebuggerUrl` — but proxies (e.g. Steel's nginx) echo the request
+ * Host and DROP the port, yielding an undialable URL. Fetch it ourselves, then
+ * force host:port back from the base URL.
+ */
+async function resolveCdpWsUrl(cdpBaseUrl: string): Promise<string> {
+  const res = await fetch(new URL('/json/version', cdpBaseUrl))
+  if (!res.ok) throw new Error(`[e2e] remote CDP /json/version returned ${res.status}`)
+  const { webSocketDebuggerUrl } = (await res.json()) as { webSocketDebuggerUrl?: string }
+  if (!webSocketDebuggerUrl) {
+    throw new Error('[e2e] remote CDP /json/version had no webSocketDebuggerUrl')
+  }
+  const base = new URL(cdpBaseUrl)
+  const ws = new URL(webSocketDebuggerUrl)
+  ws.protocol = 'ws:'
+  ws.host = base.host
+  return ws.toString()
 }


### PR DESCRIPTION
## What
Adds `BrowserConfig.cdpUrl` (from `XBROWSER_CDP_URL`) to the `@pikku/cucumber` browser world. When set, the world **connects over CDP to a shared/remote browser (e.g. Steel)** instead of launching a local chromium — so a CPU/RAM-capped sandbox never runs a browser.

## Why
Smoke/scenario suites in Fabric build-sandboxes currently `chromium.launch()` a local headless browser inside the sandbox, which competes for the sandbox's RAM and intermittently stalls page loads. Moving the browser onto a shared remote Steel box removes that.

## Details
- On the CDP path we **do not** add the `--host-resolver-rules=MAP … 127.0.0.1` mapping — a remote browser reaches the app at its **public** edge via real DNS, so `appUrl` must be publicly resolvable (it already is for hosted sandboxes: `https://${SANDBOX_HOSTNAME}`).
- `resolveCdpWsUrl` fetches `/json/version` and forces `host:port` back from the base URL — a workaround for proxies (Steel's nginx) that echo the request Host but drop the port, yielding an undialable `webSocketDebuggerUrl`.
- `browser.close()` on a *connected* browser only clears the contexts this connection created and disconnects — it never kills the shared remote browser, so teardown (`closeAll`) is safe unchanged.

Patch changeset included. No behaviour change when `cdpUrl`/`XBROWSER_CDP_URL` is unset (local chromium path is untouched).