### PR TITLE
fix(e2e): raise backend readiness deadline to 120s for --coverage instrumented boots

### DIFF
--- a/e2e/tests/support/hooks.ts
+++ b/e2e/tests/support/hooks.ts
@@ -44,7 +44,7 @@ BeforeAll(async function () {
   )
 
   // Wait for the backend to be ready
-  const deadline = Date.now() + 30_000
+  const deadline = Date.now() + 120_000
   while (Date.now() < deadline) {
     try {
       await fetch(config.apiUrl)
@@ -53,7 +53,9 @@ BeforeAll(async function () {
       await new Promise((r) => setTimeout(r, 500))
     }
   }
-  throw new Error(`Backend did not start within 30 seconds on ${config.apiUrl}`)
+  throw new Error(
+    `Backend did not start within 120 seconds on ${config.apiUrl}`
+  )
 })
 
 AfterAll(async function () {


### PR DESCRIPTION
## Why

E2E Standard fails on main since #871 merged: the e2e hooks now start the backend with `--coverage`, and V8 detailed precise coverage roughly triples boot time (measured locally: 4.0s → ~12.7s; CI runners are slower still). The 30s readiness deadline in `e2e/tests/support/hooks.ts` predates instrumented boots and now times out — `Backend did not start within 30 seconds on http://localhost:4077`.

Cheaper V8 modes were measured first (`callCount: false`, lazily enabling `Debugger` only at snapshot time) and bought nothing — the cost is the `detailed` block-coverage instrumentation itself, which the console's per-line coverage mapping needs. So the harness deadline moves to 120s instead.

## Verifier note

This is a timeout constant in the e2e harness itself; there is no meaningful failing-then-passing unit test for it. Verification is CI: E2E Standard red on main at `efb0406ea`, green with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the backend startup wait time to reduce false failures during end-to-end testing.
  * Updated the timeout error message to better reflect the longer wait and include the configured API address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->