### PR TITLE
fix(cli): collapse Postgres db introspection into set-based queries

### DIFF
--- a/.changeset/db-introspection-batch-queries.md
+++ b/.changeset/db-introspection-batch-queries.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Fix pathologically slow `pikku db migrate` schema introspection on Postgres. Column and foreign-key introspection previously fanned out one query per table via `Promise.all` on a single `pg.Client`, which serialized every round-trip (emitting the `client.query() while already executing` deprecation warning) and scaled O(tables). It now issues a single set-based `information_schema` sweep for all columns and all foreign keys, turning introspection into a constant number of round-trips regardless of schema size. SQLite is unaffected (its introspection is synchronous and in-process).

--- a/packages/cli/src/functions/db/db-codegen.test.ts
+++ b/packages/cli/src/functions/db/db-codegen.test.ts
@@ -24,6 +24,12 @@ function fakeIntrospector(columns: ColumnInfo[]): DbIntrospector {
     async getForeignKeys() {
       return []
     },
+    async getAllColumns() {
+      return new Map([['app.widget', columns]])
+    },
+    async getAllForeignKeys() {
+      return new Map()
+    },
     async listEnums() {
       return []
     },

--- a/packages/cli/src/functions/db/db-codegen.ts
+++ b/packages/cli/src/functions/db/db-codegen.ts
@@ -526,12 +526,11 @@ export async function generateSchemaTypes(
   const dialect: Dialect = options.dialect ?? 'sqlite'
 
   const tableNames = await introspector.listTables()
-  const tables: TableSchema[] = await Promise.all(
-    tableNames.map(async (name) => ({
-      name,
-      columns: await introspector.getColumns(name),
-    }))
-  )
+  const columnsByTable = await introspector.getAllColumns()
+  const tables: TableSchema[] = tableNames.map((name) => ({
+    name,
+    columns: columnsByTable.get(name) ?? [],
+  }))
 
   const explicitAnnotations = options.rootDir
     ? loadAnnotations(options.rootDir)
@@ -652,10 +651,7 @@ export async function generateSchemaTypes(
   // ── pikku-db-schema.gen.json ─────────────────────────────────────────────────
   let schemaJsonBody: string | null = null
   if (options.schemaJsonFile) {
-    const fkResults = await Promise.all(
-      tableNames.map((name) => introspector.getForeignKeys(name))
-    )
-    const fkMap = new Map(tableNames.map((name, i) => [name, fkResults[i]!]))
+    const fkMap = await introspector.getAllForeignKeys()
     const jsonTables = tables.map((t) => ({
       name: t.name,
       columns: t.columns.map((c) => {

--- a/packages/cli/src/functions/db/db-introspector.ts
+++ b/packages/cli/src/functions/db/db-introspector.ts
@@ -37,6 +37,19 @@ export interface DbIntrospector {
   listTables(): Promise<string[]>
   getColumns(table: string): Promise<ColumnInfo[]>
   getForeignKeys(table: string): Promise<ForeignKeyInfo[]>
+  /**
+   * Columns for every table in one sweep, keyed by the same table name that
+   * {@link listTables} returns (schema-qualified for non-`public` tables). On
+   * Postgres this is a single set-based query — introspecting a large schema
+   * must not fan out one round-trip per table, which both scales O(tables) and
+   * overlaps queries on a single connection.
+   */
+  getAllColumns(): Promise<Map<string, ColumnInfo[]>>
+  /**
+   * Foreign keys for every table in one sweep, keyed like {@link getAllColumns}.
+   * Tables with no foreign keys may be omitted from the map.
+   */
+  getAllForeignKeys(): Promise<Map<string, ForeignKeyInfo[]>>
   listEnums(): Promise<EnumInfo[]>
   close(): Promise<void>
 }

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -594,8 +594,7 @@ type SchemaMap = Map<string, Set<string>>
 
 async function introspectorToMap(intro: DbIntrospector): Promise<SchemaMap> {
   const map: SchemaMap = new Map()
-  for (const table of await intro.listTables()) {
-    const cols = await intro.getColumns(table)
+  for (const [table, cols] of await intro.getAllColumns()) {
     map.set(table, new Set(cols.map((c) => c.name)))
   }
   return map

--- a/packages/cli/src/functions/db/postgres/postgres-introspector.test.ts
+++ b/packages/cli/src/functions/db/postgres/postgres-introspector.test.ts
@@ -1,6 +1,13 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { PostgresIntrospector } from './postgres-introspector.js'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  PostgresIntrospector,
+  type QueryClient,
+} from './postgres-introspector.js'
+import { generateSchemaTypes } from '../db-codegen.js'
 
 interface PgColumnRow {
   column_name: string
@@ -12,7 +19,9 @@ interface PgColumnRow {
   is_pk: boolean
 }
 
-function row(partial: Partial<PgColumnRow> & { column_name: string }): PgColumnRow {
+function row(
+  partial: Partial<PgColumnRow> & { column_name: string }
+): PgColumnRow {
   return {
     data_type: 'text',
     udt_name: 'text',
@@ -55,4 +64,127 @@ test('getColumns leaves scalar column types unchanged', async () => {
   ])
   const cols = await new PostgresIntrospector(client).getColumns('widget')
   assert.equal(cols[0]!.type, 'text')
+})
+
+interface TrackingClient extends QueryClient {
+  stats: { maxConcurrent: number; total: number }
+}
+
+/**
+ * A fake node-postgres `Client` that mimics a single physical connection: it
+ * records how many queries are in flight at once (`maxConcurrent`) and the total
+ * number of round-trips. Overlapping `query()` calls — the bug this guards
+ * against — push `maxConcurrent` above 1.
+ */
+function makeTrackingClient(tableCount: number): TrackingClient {
+  const tables = Array.from({ length: tableCount }, (_, i) => `table_${i}`)
+  let active = 0
+  const stats = { maxConcurrent: 0, total: 0 }
+
+  const columnRow = (table: string) => [
+    {
+      table_schema: 'public',
+      table_name: table,
+      column_name: 'id',
+      data_type: 'integer',
+      udt_name: 'int4',
+      is_nullable: 'NO',
+      column_default: `nextval('${table}_id_seq'::regclass)`,
+      is_generated: 'NEVER',
+      is_pk: true,
+    },
+    {
+      table_schema: 'public',
+      table_name: table,
+      column_name: 'name',
+      data_type: 'text',
+      udt_name: 'text',
+      is_nullable: 'YES',
+      column_default: null,
+      is_generated: 'NEVER',
+      is_pk: false,
+    },
+    {
+      table_schema: 'public',
+      table_name: table,
+      column_name: 'created_at',
+      data_type: 'timestamp without time zone',
+      udt_name: 'timestamp',
+      is_nullable: 'NO',
+      column_default: 'now()',
+      is_generated: 'NEVER',
+      is_pk: false,
+    },
+  ]
+
+  const rowsFor = (sql: string, params?: unknown[]): unknown[] => {
+    const s = sql.replace(/\s+/g, ' ')
+    if (s.includes('referential_constraints')) return []
+    if (s.includes('information_schema.columns')) {
+      if (params && params.length) {
+        const table = params[0] as string
+        return columnRow(table)
+      }
+      return tables.flatMap((t) => columnRow(t))
+    }
+    if (s.includes('pg_enum')) return []
+    if (s.includes('information_schema.tables')) {
+      return tables.map((t) => ({ table_schema: 'public', table_name: t }))
+    }
+    return []
+  }
+
+  async function query<T = unknown>(
+    sql: string,
+    params?: unknown[]
+  ): Promise<{ rows: T[] }> {
+    stats.total++
+    active++
+    stats.maxConcurrent = Math.max(stats.maxConcurrent, active)
+    await new Promise((resolve) => setImmediate(resolve))
+    active--
+    return { rows: rowsFor(sql, params) as T[] }
+  }
+
+  return { query, end: async () => {}, stats }
+}
+
+async function introspect(client: QueryClient) {
+  const dir = mkdtempSync(join(tmpdir(), 'pg-introspect-'))
+  const introspector = new PostgresIntrospector(client)
+  await introspector.connect()
+  try {
+    return await generateSchemaTypes(introspector, {
+      outFile: join(dir, 'schema.gen.ts'),
+      coercionFile: join(dir, 'coercion.gen.ts'),
+      schemaJsonFile: join(dir, 'schema.gen.json'),
+      dialect: 'postgres',
+    })
+  } finally {
+    await introspector.close()
+  }
+}
+
+test('introspection never overlaps queries on a single connection', async () => {
+  const client = makeTrackingClient(30)
+  const result = await introspect(client)
+  assert.equal(result.tables.length, 30)
+  assert.equal(
+    client.stats.maxConcurrent,
+    1,
+    `expected no overlapping queries on the single Client, saw ${client.stats.maxConcurrent} concurrent`
+  )
+})
+
+test('introspection query count is independent of table count', async () => {
+  const small = makeTrackingClient(3)
+  const large = makeTrackingClient(40)
+  await introspect(small)
+  await introspect(large)
+  assert.equal(
+    small.stats.total,
+    large.stats.total,
+    `expected a constant number of round-trips regardless of schema size, ` +
+      `got ${small.stats.total} for 3 tables vs ${large.stats.total} for 40`
+  )
 })

--- a/packages/cli/src/functions/db/postgres/postgres-introspector.ts
+++ b/packages/cli/src/functions/db/postgres/postgres-introspector.ts
@@ -16,7 +16,26 @@ interface PgColumnRow {
   is_pk: boolean
 }
 
-interface QueryClient {
+interface PgAllColumnRow extends PgColumnRow {
+  table_schema: string
+  table_name: string
+}
+
+interface PgAllForeignKeyRow {
+  owner_schema: string
+  owner_table: string
+  column_name: string
+  foreign_table_schema: string
+  foreign_table_name: string
+  foreign_column_name: string
+}
+
+/** Table display name matching `listTables` (schema-qualified unless `public`). */
+function tableKey(schema: string, table: string): string {
+  return schema === 'public' ? table : `${schema}.${table}`
+}
+
+export interface QueryClient {
   query<T = unknown>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>
   end(): Promise<void>
 }
@@ -69,11 +88,7 @@ export class PostgresIntrospector implements DbIntrospector {
          AND table_type = 'BASE TABLE'
        ORDER BY table_schema, table_name`
     )
-    return result.rows.map((r) =>
-      r.table_schema === 'public'
-        ? r.table_name
-        : `${r.table_schema}.${r.table_name}`
-    )
+    return result.rows.map((r) => tableKey(r.table_schema, r.table_name))
   }
 
   async getColumns(table: string): Promise<ColumnInfo[]> {
@@ -150,12 +165,105 @@ export class PostgresIntrospector implements DbIntrospector {
 
     return result.rows.map((r) => ({
       column: r.column_name,
-      foreignTable:
-        r.foreign_table_schema === 'public'
-          ? r.foreign_table_name
-          : `${r.foreign_table_schema}.${r.foreign_table_name}`,
+      foreignTable: tableKey(r.foreign_table_schema, r.foreign_table_name),
       foreignColumn: r.foreign_column_name,
     }))
+  }
+
+  async getAllColumns(): Promise<Map<string, ColumnInfo[]>> {
+    const result = await this.client.query<PgAllColumnRow>(
+      `WITH pk_cols AS (
+         SELECT tc.table_schema, tc.table_name, kcu.column_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu
+           ON tc.constraint_name = kcu.constraint_name
+          AND tc.table_schema = kcu.table_schema
+          AND tc.table_name = kcu.table_name
+         WHERE tc.constraint_type = 'PRIMARY KEY'
+       )
+       SELECT
+         c.table_schema,
+         c.table_name,
+         c.column_name,
+         c.data_type,
+         c.udt_name,
+         c.is_nullable,
+         c.column_default,
+         c.is_generated,
+         (pk.column_name IS NOT NULL) AS is_pk
+       FROM information_schema.columns c
+       JOIN information_schema.tables t
+         ON t.table_schema = c.table_schema
+        AND t.table_name = c.table_name
+        AND t.table_type = 'BASE TABLE'
+       LEFT JOIN pk_cols pk
+         ON pk.table_schema = c.table_schema
+        AND pk.table_name = c.table_name
+        AND pk.column_name = c.column_name
+       WHERE c.table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+         AND c.table_schema NOT LIKE 'pg_temp_%'
+       ORDER BY c.table_schema, c.table_name, c.ordinal_position`
+    )
+
+    const byTable = new Map<string, ColumnInfo[]>()
+    for (const r of result.rows) {
+      const key = tableKey(r.table_schema, r.table_name)
+      let cols = byTable.get(key)
+      if (!cols) {
+        cols = []
+        byTable.set(key, cols)
+      }
+      cols.push({
+        name: r.column_name,
+        type: resolveColumnType(r.data_type, r.udt_name),
+        udtName: r.udt_name,
+        notNull: r.is_nullable === 'NO',
+        pk: Boolean(r.is_pk),
+        defaultValue: r.column_default,
+        generated: r.is_generated === 'ALWAYS',
+      })
+    }
+    return byTable
+  }
+
+  async getAllForeignKeys(): Promise<Map<string, ForeignKeyInfo[]>> {
+    const result = await this.client.query<PgAllForeignKeyRow>(
+      `SELECT kcu.table_schema  AS owner_schema,
+              kcu.table_name    AS owner_table,
+              kcu.column_name,
+              kcu2.table_schema AS foreign_table_schema,
+              kcu2.table_name   AS foreign_table_name,
+              kcu2.column_name  AS foreign_column_name
+       FROM information_schema.referential_constraints rc
+       JOIN information_schema.key_column_usage kcu
+         ON kcu.constraint_catalog = rc.constraint_catalog
+        AND kcu.constraint_schema  = rc.constraint_schema
+        AND kcu.constraint_name    = rc.constraint_name
+       JOIN information_schema.key_column_usage kcu2
+         ON kcu2.constraint_catalog = rc.unique_constraint_catalog
+        AND kcu2.constraint_schema  = rc.unique_constraint_schema
+        AND kcu2.constraint_name    = rc.unique_constraint_name
+        AND kcu2.ordinal_position   = kcu.ordinal_position
+       WHERE kcu.table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+         AND kcu.table_schema NOT LIKE 'pg_temp_%'
+       ORDER BY kcu.table_schema, kcu.table_name, kcu.ordinal_position`
+    )
+
+    const byTable = new Map<string, ForeignKeyInfo[]>()
+    for (const r of result.rows) {
+      const key = tableKey(r.owner_schema, r.owner_table)
+      let fks = byTable.get(key)
+      if (!fks) {
+        fks = []
+        byTable.set(key, fks)
+      }
+      fks.push({
+        column: r.column_name,
+        foreignTable: tableKey(r.foreign_table_schema, r.foreign_table_name),
+        foreignColumn: r.foreign_column_name,
+      })
+    }
+    return byTable
   }
 
   async listEnums(): Promise<EnumInfo[]> {

--- a/packages/cli/src/functions/db/sqlite/sqlite-introspector.ts
+++ b/packages/cli/src/functions/db/sqlite/sqlite-introspector.ts
@@ -1,4 +1,9 @@
-import type { DbIntrospector, ColumnInfo, ForeignKeyInfo, EnumInfo } from '../db-introspector.js'
+import type {
+  DbIntrospector,
+  ColumnInfo,
+  ForeignKeyInfo,
+  EnumInfo,
+} from '../db-introspector.js'
 import type { SyncSqliteDatabase } from './sqlite-runtime.js'
 
 const SKIP_TABLES = new Set(['sqlite_sequence', 'sql_migrations'])
@@ -57,7 +62,9 @@ export class SqliteIntrospector implements DbIntrospector {
   private parseCheckEnums(table: string): Map<string, string[]> {
     const out = new Map<string, string[]>()
     const row = this.db
-      .prepare(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`)
+      .prepare(
+        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`
+      )
       .get(table) as { sql: string | null } | undefined
     const ddl = row?.sql
     if (!ddl) return out
@@ -83,6 +90,23 @@ export class SqliteIntrospector implements DbIntrospector {
       foreignTable: r.table,
       foreignColumn: r.to,
     }))
+  }
+
+  async getAllColumns(): Promise<Map<string, ColumnInfo[]>> {
+    const byTable = new Map<string, ColumnInfo[]>()
+    for (const table of await this.listTables()) {
+      byTable.set(table, await this.getColumns(table))
+    }
+    return byTable
+  }
+
+  async getAllForeignKeys(): Promise<Map<string, ForeignKeyInfo[]>> {
+    const byTable = new Map<string, ForeignKeyInfo[]>()
+    for (const table of await this.listTables()) {
+      const fks = await this.getForeignKeys(table)
+      if (fks.length > 0) byTable.set(table, fks)
+    }
+    return byTable
   }
 
   async listEnums(): Promise<EnumInfo[]> {


### PR DESCRIPTION
## Problem

`pikku db migrate` was pathologically slow on Postgres — a ~32-table schema took **>2 minutes** and never reached the schema-write phase. It scales with column count, so larger schemas are worse, effectively making `db migrate` unusable on non-trivial databases.

The tell was a single warning at the start of introspection:

```
DeprecationWarning: Calling client.query() when the client is already
executing a query is deprecated and will be removed in pg@9.0.
```

## Root cause

`generateSchemaTypes` fanned out introspection **per table** via two `Promise.all` blocks — `getColumns` for every table, then `getForeignKeys` for every table. The introspector on the `db migrate` path wraps a **single `pg.Client`** (one physical connection), so those N concurrent `client.query()` calls were serialized internally, each paying a full round-trip in sequence. Combined with the per-table N+1 shape, total cost was O(tables) sequential round-trips — minutes even for a small schema, and a hard break under pg@9.

## Fix

Replace the per-table probing with a single **set-based `information_schema` sweep**:

- New `getAllColumns()` / `getAllForeignKeys()` on the introspector. On Postgres each is **one query** over `information_schema` (columns joined with a PK CTE; FKs via `referential_constraints`), grouped in memory. Round-trips are now O(1) regardless of schema size, and there is no query overlap on the single connection.
- `generateSchemaTypes` and `introspectorToMap` call the batch methods sequentially — both `Promise.all` fan-outs are gone.
- **SQLite is unaffected** (synchronous, in-process, no network round-trips; it has no `information_schema` equivalent) and keeps a sequential loop.

## Tests (TDD)

Added a verifier that drives `generateSchemaTypes` through a mock `Client` tracking in-flight query count. It asserts (a) **no overlapping queries** on the single connection and (b) **round-trip count independent of table count**.

- Before: **30 concurrent queries**; 8 round-trips for 3 tables vs 82 for 40 — both fail.
- After: max concurrency 1, constant round-trips — both pass.

The existing PGlite end-to-end migrate test still passes (validates the new SQL against a real Postgres engine). Full db suite: 41/41 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)