### PR TITLE
fix(gateway-slack): enforce Slack request-signature verification

### DIFF
--- a/.changeset/slack-signature-verification.md
+++ b/.changeset/slack-signature-verification.md
@@ -1,0 +1,5 @@
+---
+'@pikku/gateway-slack': patch
+---
+
+SlackGatewayAdapter now enforces request-signature verification: `verifyWebhook` HMAC-verifies every inbound webhook (including url_verification) against the configured `signingSecret` using the raw request body, rejecting invalid/missing/stale signatures with UnauthorizedError. Previously `signingSecret` was accepted but never used, leaving webhook endpoints open to spoofed events.

--- a/packages/gateways/slack/package.json
+++ b/packages/gateways/slack/package.json
@@ -10,7 +10,7 @@
     "tsc": "tsc",
     "ncu": "npx npm-check-updates",
     "build": "tsc -b",
-    "test": "echo \"no tests yet\"",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "release": "npm run build && npm test",
     "prepublishOnly": "yarn build"
   },

--- a/packages/gateways/slack/src/slack-gateway-adapter.test.ts
+++ b/packages/gateways/slack/src/slack-gateway-adapter.test.ts
@@ -1,0 +1,114 @@
+import { test, describe } from 'node:test'
+import * as assert from 'assert'
+import { createHmac } from 'node:crypto'
+import { SlackGatewayAdapter } from './slack-gateway-adapter.js'
+import type { PikkuHTTPRequest } from '@pikku/core/http'
+
+const SIGNING_SECRET = 'test-signing-secret'
+
+const signedRequest = (
+  body: string,
+  overrides: { signature?: string; timestamp?: string } = {}
+): PikkuHTTPRequest => {
+  const timestamp =
+    overrides.timestamp ?? String(Math.floor(Date.now() / 1000))
+  const signature =
+    overrides.signature ??
+    'v0=' +
+      createHmac('sha256', SIGNING_SECRET)
+        .update(`v0:${timestamp}:${body}`)
+        .digest('hex')
+  const headers: Record<string, string> = {
+    'x-slack-signature': signature,
+    'x-slack-request-timestamp': timestamp,
+  }
+  return {
+    header: (name: string) => headers[name.toLowerCase()] ?? null,
+    arrayBuffer: async () => new TextEncoder().encode(body).buffer,
+  } as unknown as PikkuHTTPRequest
+}
+
+const createAdapter = () =>
+  new SlackGatewayAdapter({
+    signingSecret: SIGNING_SECRET,
+    tokenResolver: async () => 'xoxb-test-token',
+  })
+
+describe('SlackGatewayAdapter.verifyWebhook', () => {
+  test('echoes url_verification challenge when signature is valid', async () => {
+    const adapter = createAdapter()
+    const body = JSON.stringify({
+      type: 'url_verification',
+      challenge: 'challenge-123',
+    })
+    const result = await adapter.verifyWebhook(
+      JSON.parse(body),
+      signedRequest(body)
+    )
+    assert.deepEqual(result, {
+      verified: true,
+      response: { challenge: 'challenge-123' },
+    })
+  })
+
+  test('returns verified:false for signed event_callback (falls through to parse)', async () => {
+    const adapter = createAdapter()
+    const body = JSON.stringify({ type: 'event_callback', event: {} })
+    const result = await adapter.verifyWebhook(
+      JSON.parse(body),
+      signedRequest(body)
+    )
+    assert.deepEqual(result, { verified: false })
+  })
+
+  test('rejects an invalid signature', async () => {
+    const adapter = createAdapter()
+    const body = JSON.stringify({ type: 'event_callback', event: {} })
+    await assert.rejects(
+      adapter.verifyWebhook(
+        JSON.parse(body),
+        signedRequest(body, { signature: 'v0=deadbeef' })
+      ),
+      /Invalid Slack request signature/
+    )
+  })
+
+  test('rejects a stale timestamp (replay protection)', async () => {
+    const adapter = createAdapter()
+    const body = JSON.stringify({ type: 'event_callback', event: {} })
+    const stale = String(Math.floor(Date.now() / 1000) - 600)
+    // Signature is recomputed for the stale timestamp, so only age fails
+    const signature =
+      'v0=' +
+      createHmac('sha256', SIGNING_SECRET)
+        .update(`v0:${stale}:${body}`)
+        .digest('hex')
+    await assert.rejects(
+      adapter.verifyWebhook(
+        JSON.parse(body),
+        signedRequest(body, { signature, timestamp: stale })
+      ),
+      /Invalid Slack request signature/
+    )
+  })
+
+  test('rejects when signature headers are missing', async () => {
+    const adapter = createAdapter()
+    const request = {
+      header: () => null,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    } as unknown as PikkuHTTPRequest
+    await assert.rejects(
+      adapter.verifyWebhook({ type: 'event_callback' }, request),
+      /Missing Slack signature headers/
+    )
+  })
+
+  test('rejects when no HTTP request access (fail closed)', async () => {
+    const adapter = createAdapter()
+    await assert.rejects(
+      adapter.verifyWebhook({ type: 'url_verification', challenge: 'x' }),
+      /cannot be verified/
+    )
+  })
+})

--- a/packages/gateways/slack/src/slack-gateway-adapter.ts
+++ b/packages/gateways/slack/src/slack-gateway-adapter.ts
@@ -4,7 +4,10 @@ import type {
   GatewayOutboundMessage,
   WebhookVerificationResult,
 } from '@pikku/core/gateway'
+import type { PikkuHTTPRequest } from '@pikku/core/http'
+import { UnauthorizedError } from '@pikku/core/errors'
 import { WebClient } from '@slack/web-api'
+import { verifySlackSignature } from './slack-signature.js'
 
 /**
  * Slack event payload types
@@ -101,10 +104,18 @@ export class SlackGatewayAdapter implements GatewayAdapter {
   }
 
   /**
-   * Handle Slack's url_verification challenge.
-   * Slack POSTs { type: 'url_verification', challenge: '...' } and expects the challenge back.
+   * Verify the request signature, then handle Slack's url_verification challenge.
+   *
+   * Every Slack webhook (including url_verification) is HMAC-signed with the
+   * app's signing secret; any request that fails verification is rejected
+   * with UnauthorizedError before it can reach parse/handler.
    */
-  verifyWebhook(data: unknown): WebhookVerificationResult {
+  async verifyWebhook(
+    data: unknown,
+    request?: PikkuHTTPRequest
+  ): Promise<WebhookVerificationResult> {
+    await this.assertValidSignature(request)
+
     const payload = data as Record<string, unknown>
     if (payload?.type === 'url_verification') {
       return {
@@ -115,6 +126,36 @@ export class SlackGatewayAdapter implements GatewayAdapter {
       }
     }
     return { verified: false }
+  }
+
+  /**
+   * Fail-closed signature check: no request access, missing headers, stale
+   * timestamp, or HMAC mismatch all reject the request.
+   */
+  private async assertValidSignature(
+    request?: PikkuHTTPRequest
+  ): Promise<void> {
+    if (!request) {
+      throw new UnauthorizedError(
+        'Slack signature cannot be verified without HTTP request access'
+      )
+    }
+    const signature = request.header('x-slack-signature')
+    const timestamp = request.header('x-slack-request-timestamp')
+    if (!signature || !timestamp) {
+      throw new UnauthorizedError('Missing Slack signature headers')
+    }
+    const rawBody = new TextDecoder().decode(await request.arrayBuffer())
+    if (
+      !verifySlackSignature(
+        this.options.signingSecret,
+        signature,
+        timestamp,
+        rawBody
+      )
+    ) {
+      throw new UnauthorizedError('Invalid Slack request signature')
+    }
   }
 
   /**


### PR DESCRIPTION
`SlackGatewayAdapter` accepted a `signingSecret` option but never used it — any POST to the webhook route was processed as a genuine Slack event.

`verifyWebhook` now verifies the HMAC signature over the raw request body (`PikkuHTTPRequest.arrayBuffer()` is cached in core, so reading it after JSON parsing is safe) before the url_verification/parse path runs. Fail closed: no request access, missing `x-slack-signature`/`x-slack-request-timestamp`, stale timestamp (>5 min replay window, already in `verifySlackSignature`), or mismatch → `UnauthorizedError`.

6 new unit tests; package test script now actually runs them. Patch changeset.

Part of wiring business-tier WhatsApp/Slack gateways into Fabric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)