### PR TITLE
fix(cli): fail codegen on @pikku/core version skew against the CLI's peer range (PKU718)

### DIFF
--- a/.changeset/cli-core-peer-skew-check.md
+++ b/.changeset/cli-core-peer-skew-check.md
@@ -1,0 +1,10 @@
+---
+'@pikku/inspector': patch
+'@pikku/cli': patch
+---
+
+Fail codegen with a clear error when the installed `@pikku/core` violates the CLI's peer range (PKU718).
+
+Some package managers (bun, yarn) install straight past an unsatisfied `peerDependencies` range instead of failing, so `@pikku/cli` could end up next to a `@pikku/core` outside the range it declares — and the only symptom was a cryptic missing-export crash deep in codegen or at runtime (e.g. `The requested module '@pikku/core/dev' does not provide an export named 'reloadGeneratedMeta'`).
+
+The existing preflight that catches a *split* core (two installed versions, `PKU717`) now also validates the *single* installed core's version against the CLI's own `@pikku/core` peer range, and fails with the exact versions and the fix (`@pikku/cli` and `@pikku/core` move together — bump both to the same release, update any overrides/resolutions pins, reinstall). Set `PIKKU_ALLOW_CORE_SKEW=1` to downgrade the failure to a warning if you have verified the installed pair is compatible, mirroring `PIKKU_ALLOW_DUPLICATE_CORE`.

--- a/packages/cli/src/utils/assert-single-core-version.test.ts
+++ b/packages/cli/src/utils/assert-single-core-version.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, afterEach } from 'node:test'
+import assert from 'node:assert'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
+import {
+  assertSingleCoreVersion,
+  coreSatisfiesRange,
+} from './assert-single-core-version.js'
+
+describe('coreSatisfiesRange', () => {
+  test('caret ranges (0.x bumps the minor)', () => {
+    assert.strictEqual(coreSatisfiesRange('0.12.57', '^0.12.57'), true)
+    assert.strictEqual(coreSatisfiesRange('0.12.99', '^0.12.57'), true)
+    assert.strictEqual(coreSatisfiesRange('0.12.56', '^0.12.57'), false)
+    assert.strictEqual(coreSatisfiesRange('0.13.0', '^0.12.57'), false)
+    assert.strictEqual(coreSatisfiesRange('1.5.0', '^1.2.3'), true)
+    assert.strictEqual(coreSatisfiesRange('2.0.0', '^1.2.3'), false)
+    assert.strictEqual(coreSatisfiesRange('0.0.3', '^0.0.3'), true)
+    assert.strictEqual(coreSatisfiesRange('0.0.4', '^0.0.3'), false)
+  })
+
+  test('tilde, exact, and comparator ranges', () => {
+    assert.strictEqual(coreSatisfiesRange('0.12.58', '~0.12.44'), true)
+    assert.strictEqual(coreSatisfiesRange('0.13.0', '~0.12.44'), false)
+    assert.strictEqual(coreSatisfiesRange('1.2.3', '1.2.3'), true)
+    assert.strictEqual(coreSatisfiesRange('1.2.4', '1.2.3'), false)
+    assert.strictEqual(coreSatisfiesRange('0.12.5', '>=0.12.4'), true)
+    assert.strictEqual(coreSatisfiesRange('0.12.3', '>=0.12.4'), false)
+    assert.strictEqual(coreSatisfiesRange('0.12.5', '>=0.12.0 <0.12.6'), true)
+    assert.strictEqual(coreSatisfiesRange('0.12.6', '>=0.12.0 <0.12.6'), false)
+    assert.strictEqual(coreSatisfiesRange('0.12.5', '^0.11.0 || ^0.12.0'), true)
+    assert.strictEqual(
+      coreSatisfiesRange('0.13.1', '^0.11.0 || ^0.12.0'),
+      false
+    )
+  })
+
+  test('not-understood input returns null so callers skip', () => {
+    assert.strictEqual(coreSatisfiesRange('1.2.3', 'workspace:*'), null)
+    assert.strictEqual(coreSatisfiesRange('not-a-version', '^1.0.0'), null)
+    assert.strictEqual(coreSatisfiesRange('1.2.3', '*'), null)
+  })
+})
+
+describe('assertSingleCoreVersion', () => {
+  const warnings: string[] = []
+  const logger = { warn: (m: string) => warnings.push(m) }
+  const dirs: string[] = []
+
+  const projectWithCores = (...versions: string[]) => {
+    const root = mkdtempSync(path.join(tmpdir(), 'pikku-core-skew-'))
+    dirs.push(root)
+    versions.forEach((version, i) => {
+      // First copy hoisted, further copies nested one level (npm/yarn layout).
+      const base =
+        i === 0
+          ? path.join(root, 'node_modules')
+          : path.join(root, 'node_modules', `dep-${i}`, 'node_modules')
+      const coreDir = path.join(base, '@pikku', 'core')
+      mkdirSync(coreDir, { recursive: true })
+      writeFileSync(
+        path.join(coreDir, 'package.json'),
+        JSON.stringify({ name: '@pikku/core', version })
+      )
+    })
+    return root
+  }
+
+  // The CLI's real peer range moves over time — derive an in-range version from
+  // it so these tests don't rot on release.
+  const cliCorePeerRange = async () => {
+    const pkg = JSON.parse(
+      await readFile(
+        new URL('../../package.json', import.meta.url),
+        'utf-8'
+      ).catch(async () =>
+        readFile(new URL('../../../package.json', import.meta.url), 'utf-8')
+      )
+    )
+    return pkg.peerDependencies['@pikku/core'] as string
+  }
+
+  afterEach(() => {
+    warnings.length = 0
+    delete process.env.PIKKU_ALLOW_CORE_SKEW
+    delete process.env.PIKKU_ALLOW_DUPLICATE_CORE
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+  })
+
+  test('single core inside the peer range passes', async () => {
+    const range = await cliCorePeerRange()
+    const inRange = /(\d+\.\d+\.\d+)/.exec(range)![1]!
+    await assertSingleCoreVersion(projectWithCores(inRange), logger)
+    assert.strictEqual(warnings.length, 0)
+  })
+
+  test('single core outside the peer range throws PKU718', async () => {
+    await assert.rejects(
+      assertSingleCoreVersion(projectWithCores('999.999.999'), logger),
+      /PKU718.*requires @pikku\/core/s
+    )
+  })
+
+  test('PIKKU_ALLOW_CORE_SKEW downgrades skew to a warning', async () => {
+    process.env.PIKKU_ALLOW_CORE_SKEW = '1'
+    await assertSingleCoreVersion(projectWithCores('999.999.999'), logger)
+    assert.strictEqual(warnings.length, 1)
+    assert.match(warnings[0]!, /PKU718/)
+  })
+
+  test('two distinct cores still throw PKU717 (split beats skew)', async () => {
+    await assert.rejects(
+      assertSingleCoreVersion(projectWithCores('0.12.51', '0.12.56'), logger),
+      /PKU717.*Multiple @pikku\/core versions/s
+    )
+  })
+
+  test('no core installed is not an error', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'pikku-core-skew-'))
+    dirs.push(root)
+    mkdirSync(path.join(root, 'node_modules'), { recursive: true })
+    await assertSingleCoreVersion(root, logger)
+    assert.strictEqual(warnings.length, 0)
+  })
+})

--- a/packages/cli/src/utils/assert-single-core-version.ts
+++ b/packages/cli/src/utils/assert-single-core-version.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { realpathSync } from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { glob } from 'tinyglobby'
 import { ErrorCode } from '@pikku/inspector'
 
@@ -16,15 +17,100 @@ const PATTERNS = [
 ]
 
 /**
- * Fail the build when more than one @pikku/core version is installed.
+ * Minimal semver range check for the shapes @pikku/cli publishes in its own
+ * peerDependencies (exact, ^, ~, >=/>/<=/< comparators, space-joined ANDs,
+ * || unions). Returns null when the range is not understood so the caller
+ * skips the check instead of false-blocking a build. No prerelease handling —
+ * a prerelease compares as its base version.
+ */
+export function coreSatisfiesRange(
+  version: string,
+  range: string
+): boolean | null {
+  const parse = (v: string): [number, number, number] | null => {
+    const m = /^(\d+)\.(\d+)\.(\d+)/.exec(v)
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null
+  }
+  const cmp = (a: number[], b: number[]) => {
+    for (let i = 0; i < 3; i++) if (a[i] !== b[i]) return a[i]! - b[i]!
+    return 0
+  }
+  const ver = parse(version)
+  if (!ver) return null
+  const comparator = (c: string): boolean | null => {
+    const m = /^(\^|~|>=|<=|>|<|=)?\s*(\d+\.\d+\.\d+)$/.exec(c.trim())
+    if (!m) return null
+    const op = m[1] ?? '='
+    const bound = parse(m[2]!)!
+    if (op === '>=') return cmp(ver, bound) >= 0
+    if (op === '>') return cmp(ver, bound) > 0
+    if (op === '<=') return cmp(ver, bound) <= 0
+    if (op === '<') return cmp(ver, bound) < 0
+    if (op === '=') return cmp(ver, bound) === 0
+    if (cmp(ver, bound) < 0) return false
+    // upper bound: ^ bumps the leftmost non-zero part; ~ bumps the minor
+    let upper: [number, number, number]
+    if (op === '~') upper = [bound[0], bound[1] + 1, 0]
+    else if (bound[0] > 0) upper = [bound[0] + 1, 0, 0]
+    else if (bound[1] > 0) upper = [0, bound[1] + 1, 0]
+    else upper = [0, 0, bound[2] + 1]
+    return cmp(ver, upper) < 0
+  }
+  for (const clause of range.split('||')) {
+    const comparators = clause.trim().split(/\s+/).filter(Boolean)
+    if (comparators.length === 0) continue
+    const results = comparators.map(comparator)
+    if (results.includes(null)) return null
+    if (results.every(Boolean)) return true
+  }
+  return false
+}
+
+// The CLI's own package.json — version + declared @pikku/core peer range.
+// Dual path like get-cli-version.ts: ../../ from src/, ../../../ from dist/src/.
+async function getCliManifest(): Promise<{
+  version: string
+  corePeerRange: string
+} | null> {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  for (const rel of ['../..', '../../..']) {
+    const raw = await readFile(
+      path.join(here, rel, 'package.json'),
+      'utf-8'
+    ).catch(() => '')
+    if (!raw) continue
+    try {
+      const pkg = JSON.parse(raw)
+      if (pkg.name !== '@pikku/cli') continue
+      const corePeerRange = pkg.peerDependencies?.['@pikku/core']
+      if (typeof pkg.version === 'string' && typeof corePeerRange === 'string')
+        return { version: pkg.version, corePeerRange }
+    } catch {
+      // Unparseable manifest — try the other layout.
+    }
+  }
+  return null
+}
+
+/**
+ * Fail the build when the installed @pikku/core cannot work with this CLI.
  *
- * A split @pikku/core means two separate module instances — and therefore two
- * separate pikkuState registries — at runtime. Wirings (workflows, RPCs, queue
- * workers, middleware) register into whichever copy the wiring files import,
- * while the runner may read the other, so they silently fail to resolve (the
- * classic symptom being `WorkflowNotFoundError` for a workflow that is plainly
- * registered). Distinct versions are the reliable signal: package managers dedupe
- * identical versions to one physical copy, so >1 version guarantees a split.
+ * Two distinct failure classes, checked in order:
+ *
+ * 1. SPLIT (PKU717): more than one @pikku/core version installed. Two module
+ *    instances means two separate pikkuState registries at runtime — wirings
+ *    (workflows, RPCs, queue workers, middleware) register into whichever copy
+ *    the wiring files import, while the runner may read the other, so they
+ *    silently fail to resolve (the classic symptom being `WorkflowNotFoundError`
+ *    for a workflow that is plainly registered). Distinct versions are the
+ *    reliable signal: package managers dedupe identical versions to one physical
+ *    copy, so >1 version guarantees a split.
+ *
+ * 2. SKEW (PKU718): exactly one @pikku/core, but its version violates the CLI's
+ *    own @pikku/core peer range. Some package managers (bun, yarn) install past
+ *    an unsatisfied peer range instead of failing, and the resulting pair breaks
+ *    codegen/runtime with cryptic missing-export errors. Fail here with the
+ *    exact versions instead.
  */
 export async function assertSingleCoreVersion(
   rootDir: string,
@@ -59,7 +145,10 @@ export async function assertSingleCoreVersion(
   }
 
   const versions = new Set(byRealPath.values())
-  if (versions.size <= 1) return
+  if (versions.size <= 1) {
+    await assertCoreVersionInPeerRange([...versions][0], logger)
+    return
+  }
 
   const found_ = [...byRealPath.entries()]
     .sort((a, b) => a[1].localeCompare(b[1]))
@@ -78,6 +167,34 @@ export async function assertSingleCoreVersion(
     `single copy is deduped. Set PIKKU_ALLOW_DUPLICATE_CORE=1 to downgrade this to a warning.`
 
   if (process.env?.PIKKU_ALLOW_DUPLICATE_CORE) {
+    logger.warn(message)
+    return
+  }
+  throw new Error(message)
+}
+
+// SKEW (PKU718): a single installed core that violates the CLI's own peer range.
+async function assertCoreVersionInPeerRange(
+  coreVersion: string | undefined,
+  logger: { warn: (message: string) => void }
+): Promise<void> {
+  if (!coreVersion) return // no core found — nothing to validate against
+  const cli = await getCliManifest()
+  if (!cli) return // manifest not found/parseable — never false-block a build
+  const ok = coreSatisfiesRange(coreVersion, cli.corePeerRange)
+  if (ok !== false) return // satisfied, or range not understood — skip
+
+  const message =
+    `[${ErrorCode.CORE_VERSION_SKEW}] @pikku/cli@${cli.version} requires @pikku/core@${cli.corePeerRange} ` +
+    `(peerDependencies), but ${coreVersion} is installed.\n` +
+    `Some package managers (bun, yarn) install past an unsatisfied peer range instead of\n` +
+    `failing, and a cli/core version skew breaks codegen and runtime with cryptic\n` +
+    `missing-export errors.\n\n` +
+    `Fix: @pikku/cli and @pikku/core move together — bump both to the same release (update\n` +
+    `any overrides/resolutions pins too), then reinstall. Set PIKKU_ALLOW_CORE_SKEW=1 to\n` +
+    `downgrade this to a warning if you have verified the installed pair is compatible.`
+
+  if (process.env?.PIKKU_ALLOW_CORE_SKEW) {
     logger.warn(message)
     return
   }

--- a/packages/inspector/src/error-codes.ts
+++ b/packages/inspector/src/error-codes.ts
@@ -72,6 +72,7 @@ export enum ErrorCode {
 
   // Dependency integrity errors
   DUPLICATE_CORE_VERSION = 'PKU717',
+  CORE_VERSION_SKEW = 'PKU718',
 
   // Data classification errors
   PII_IN_OUTPUT = 'PKU910',


### PR DESCRIPTION
## Problem

bun and yarn install straight past an unsatisfied `peerDependencies` range (npm refuses with `ERESOLVE`). So `@pikku/cli@0.12.77` (peer `@pikku/core: ^0.12.58`) can land next to a pinned `@pikku/core@0.12.56`, and the only symptom is a cryptic crash deep in codegen or at runtime:

```
The requested module '@pikku/core/dev' does not provide an export named 'reloadGeneratedMeta'
```

This happened in production twice in one day (fabric deploy VM + sandbox image build). bun does print `warn: incorrect peer dependency "@pikku/core@0.12.56"` on the one install that creates the skew — without naming which package wants which range — and prints nothing on every subsequent lockfile-stable install, so it goes unseen until the crash.

## Fix

`assertSingleCoreVersion` already globs every installed `@pikku/core` to catch a **split** core (PKU717). When exactly one core is installed, it now also validates that version against the CLI's own `@pikku/core` peer range and fails preflight with:

```
[PKU718] @pikku/cli@0.12.77 requires @pikku/core@^0.12.58 (peerDependencies), but 0.12.56 is installed.
...
Fix: @pikku/cli and @pikku/core move together — bump both to the same release (update
any overrides/resolutions pins too), then reinstall. Set PIKKU_ALLOW_CORE_SKEW=1 to
downgrade this to a warning if you have verified the installed pair is compatible.
```

- `PIKKU_ALLOW_CORE_SKEW=1` downgrades to a warning (mirrors `PIKKU_ALLOW_DUPLICATE_CORE`) — the escape hatch for ranges widened by a changesets group release where the installed pair is hand-verified compatible.
- The range matcher is a minimal local semver (`^`, `~`, comparators, space-ANDs, `||` unions) that returns `null` on unrecognised input so an odd range can never false-block a build. No new dependency.
- Same call site as PKU717 (codegen preflight in the `all` workflow) — no new wiring.

## Tests

- 8 new tests: matcher edge cases (0.x caret semantics, tilde, comparator chains, unions, unparseable input), in-range pass (derived from the CLI's real peer range so it doesn't rot on release), PKU718 throw, escape-hatch warn, PKU717 precedence, no-core no-op.
- Full CLI suite 319/319 green, inspector suite 316/316 green, both packages `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)