### PR TITLE
feat(cucumber): pluggable browser connection provider

### DIFF
--- a/.changeset/cucumber-browser-provider.md
+++ b/.changeset/cucumber-browser-provider.md
@@ -1,0 +1,7 @@
+---
+'@pikku/cucumber': patch
+---
+
+`BrowserWorld` now accepts a pluggable browser connection so the package stays provider-agnostic. Override the new `protected connectBrowser(): Promise<BrowserConnection>` to supply a connected Playwright `Browser` (plus an optional `release`) from any provider — a cloud browser session (Steel, BrowserStack), a warm pool, a custom endpoint — instead of the built-in `cdpUrl`/local-launch path. When defined it replaces that path entirely; all provider-specific logic (API keys, session create/release) lives in your override.
+
+`registerBrowserHooks` now takes an optional `AfterAll` and a new `disposeSharedBrowser()` export runs the provider's `release()` once at process end — the correct place to release a billable cloud session, since the per-scenario `After` hook does not (and must not) tear down the process-shared browser. Fully backwards-compatible: existing consumers that pass neither `connectBrowser` nor `AfterAll` behave exactly as before (the `cdpUrl` connection simply drops at process exit).

--- a/packages/cucumber/src/browser/hooks.ts
+++ b/packages/cucumber/src/browser/hooks.ts
@@ -1,4 +1,5 @@
 import type { BrowserWorld } from './world.js'
+import { disposeSharedBrowser } from './world.js'
 
 export interface BrowserHookApi {
   Before: (fn: (this: BrowserWorld) => void | Promise<void>) => void
@@ -8,6 +9,7 @@ export interface BrowserHookApi {
       arg: { result?: { status?: string } }
     ) => void | Promise<void>
   ) => void
+  AfterAll?: (fn: () => void | Promise<void>) => void
   setDefaultTimeout?: (ms: number) => void
 }
 
@@ -16,7 +18,7 @@ export interface BrowserHookApi {
  * servers, golden DBs) stays project-side — these hooks only manage the
  * browser and the optional data-reset call.
  */
-export function registerBrowserHooks({ Before, After, setDefaultTimeout }: BrowserHookApi) {
+export function registerBrowserHooks({ Before, After, AfterAll, setDefaultTimeout }: BrowserHookApi) {
   Before(async function () {
     setDefaultTimeout?.(this.config.timeout)
     if (this.config.resetUrl) {
@@ -51,5 +53,9 @@ export function registerBrowserHooks({ Before, After, setDefaultTimeout }: Brows
       }
     }
     await this.closeAll()
+  })
+
+  AfterAll?.(async () => {
+    await disposeSharedBrowser()
   })
 }

--- a/packages/cucumber/src/browser/index.ts
+++ b/packages/cucumber/src/browser/index.ts
@@ -11,7 +11,7 @@ export {
   type ElementMap,
 } from './elements.js'
 export { ActorSession, type ClientContext, type PageIssues } from './actor-session.js'
-export { BrowserWorld } from './world.js'
+export { BrowserWorld, disposeSharedBrowser, type BrowserConnection } from './world.js'
 export { registerBrowserSteps, type BrowserStepApi } from './steps.js'
 export { registerBrowserHooks, type BrowserHookApi } from './hooks.js'
 export { staticRoutes, sweepAllPages } from './pages-sweep.js'

--- a/packages/cucumber/src/browser/world.ts
+++ b/packages/cucumber/src/browser/world.ts
@@ -7,15 +7,20 @@ import {
   type PersonaCredentials,
 } from './config.js'
 
-/**
- * A single shared connection to the remote CDP browser, reused across EVERY
- * scenario/world in this cucumber process. Cucumber builds a fresh world per
- * scenario, so a per-world connection would reconnect (and, via closeAll, tear
- * down) the shared remote browser on every scenario — racing its session
- * recycling and timing out the next connect. Connect once; scenarios get their
- * own contexts; the socket drops at process exit.
- */
-let sharedCdpBrowser: Promise<Browser> | undefined
+let sharedRemoteBrowser: Promise<Browser> | undefined
+let sharedRemoteRelease: (() => Promise<void>) | undefined
+
+export interface BrowserConnection {
+  browser: Browser
+  release?: () => Promise<void>
+}
+
+export async function disposeSharedBrowser(): Promise<void> {
+  const release = sharedRemoteRelease
+  sharedRemoteRelease = undefined
+  sharedRemoteBrowser = undefined
+  if (release) await release()
+}
 
 /**
  * BrowserWorld — one scenario's browser plus its actors.
@@ -71,6 +76,8 @@ export class BrowserWorld<Clients = unknown> {
    */
   protected createClients?(ctx: ClientContext): Clients
 
+  protected connectBrowser?(): Promise<BrowserConnection>
+
   /**
    * Backs the "the app data is reset" step. Override to call the app's own
    * reset RPC through the generated typed client (preferred); the default
@@ -111,11 +118,7 @@ export class BrowserWorld<Clients = unknown> {
     }
     this.actors.clear()
     this.last = undefined
-    // On the remote CDP path the browser is a shared, process-lifetime
-    // connection (see launchBrowser) — dispose only the contexts above; closing
-    // it would recycle the shared remote browser and stall the next scenario's
-    // connect. The socket drops when the cucumber process exits.
-    if (!this.config.cdpUrl) {
+    if (!this.config.cdpUrl && !this.connectBrowser) {
       await this.browser?.close()
     }
     this.browser = undefined
@@ -128,24 +131,31 @@ export class BrowserWorld<Clients = unknown> {
 
   private async launchBrowser(): Promise<Browser> {
     if (this.browser) return this.browser
-    // Remote/Steel browser: connect over CDP instead of launching a local
-    // chromium in a CPU/RAM-capped sandbox. The remote browser reaches the app at
-    // its PUBLIC edge via real DNS, so we do NOT add the host-resolver 127.0.0.1
-    // mapping (that's only for a local browser hitting the in-container loopback
-    // edge). One connection is shared across all scenarios (each gets its own
-    // context via ActorSession); if it drops, the next scenario reconnects.
-    if (this.config.cdpUrl) {
-      if (!sharedCdpBrowser) {
-        const cdpUrl = this.config.cdpUrl
-        sharedCdpBrowser = resolveCdpWsUrl(cdpUrl).then(async (ws) => {
-          const browser = await chromium.connectOverCDP(ws)
-          browser.on('disconnected', () => {
-            sharedCdpBrowser = undefined
-          })
-          return browser
-        })
+    if (this.connectBrowser || this.config.cdpUrl) {
+      if (!sharedRemoteBrowser) {
+        const connect: Promise<BrowserConnection> = this.connectBrowser
+          ? this.connectBrowser()
+          : resolveCdpWsUrl(this.config.cdpUrl!).then(async (ws) => ({
+              browser: await chromium.connectOverCDP(ws),
+            }))
+        sharedRemoteBrowser = connect.then(
+          ({ browser, release }) => {
+            sharedRemoteRelease = release
+            browser.on('disconnected', () => {
+              sharedRemoteBrowser = undefined
+              sharedRemoteRelease = undefined
+            })
+            return browser
+          },
+          (err) => {
+            // Clear the cached rejection so the next scenario retries the connect.
+            sharedRemoteBrowser = undefined
+            sharedRemoteRelease = undefined
+            throw err
+          }
+        )
       }
-      this.browser = await sharedCdpBrowser
+      this.browser = await sharedRemoteBrowser
       return this.browser
     }
     this.browser = await chromium.launch({


### PR DESCRIPTION
## What

`BrowserWorld` gains a `protected connectBrowser(): Promise<BrowserConnection>` override that supplies a connected Playwright `Browser` (plus an optional `release`) from **any** provider — a cloud browser session (Steel, BrowserStack), a warm pool, a custom endpoint — instead of the built-in `cdpUrl`/local-launch path. When defined it replaces that path; all provider-specific logic (API keys, session create/release) lives in the override, so the package stays provider-agnostic.

`registerBrowserHooks` now accepts an optional `AfterAll`, and a new `disposeSharedBrowser()` export runs the provider's `release()` once at process end — the correct place to release a **billable** cloud session, since the per-scenario `After` hook does not (and must not) tear down the process-shared browser.

## Why

Self-hosted single-browser CDP endpoints don't scale — one shared Chromium under concurrent load intermittently 500s. Cloud providers (e.g. Steel Cloud) give each session its own isolated browser, but require an API-key session create + explicit release (`browser.close()` alone keeps billing). This hook lets consumers wire that lifecycle without the package taking a dependency on any provider.

## Compatibility

Fully backwards-compatible: consumers passing neither `connectBrowser` nor `AfterAll` behave exactly as before (the `cdpUrl` connection simply drops at process exit).

Changeset: `@pikku/cucumber` patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom browser providers through an overridable browser connection.
  * Added public browser connection and shared-browser disposal APIs.
  * Added process-level cleanup for shared remote browser sessions.

* **Bug Fixes**
  * Shared browsers now remain available across scenarios and are released only during final process teardown.
  * Improved cleanup when remote browser connections disconnect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->