### PR TITLE
feat(openapi-parser): auth-config extraHeaders for static per-request headers

### DIFF
--- a/.changeset/auth-config-extra-headers.md
+++ b/.changeset/auth-config-extra-headers.md
@@ -1,0 +1,5 @@
+---
+'@pikku/openapi-parser': patch
+---
+
+auth-config: new `extraHeaders` field — static headers baked into every generated request (the delegated login call and all proxied service calls), for upstreams that route on a header such as multi-tenant APIs resolving the tenant from `Origin`.

--- a/packages/openapi-parser/src/auth-config.ts
+++ b/packages/openapi-parser/src/auth-config.ts
@@ -41,6 +41,13 @@ export const AuthConfigSchema = z.object({
   headerName: z.string().optional(),
   /** 'raw' sends the bare token; 'bearer' prefixes it. Default: bearer for Authorization, raw for custom headers. */
   headerFormat: z.enum(['raw', 'bearer']).optional(),
+  /**
+   * Static headers sent on EVERY request — the delegated login call and all
+   * proxied API calls. Needed for upstreams that route on a header, e.g. a
+   * multi-tenant API that resolves the tenant from an `Origin` header and
+   * rejects requests without it.
+   */
+  extraHeaders: z.record(z.string(), z.string()).optional(),
   /** Present when end-users sign in with their existing upstream credentials (delegated login). */
   delegated: DelegatedLoginSchema.optional(),
 })

--- a/packages/openapi-parser/src/codegen.test.ts
+++ b/packages/openapi-parser/src/codegen.test.ts
@@ -932,6 +932,29 @@ describe('auth config', () => {
     )
   })
 
+  test('extraHeaders are baked into the service and the upstream-auth login', () => {
+    const spec = makeSpec({ operations: [makeOp()] })
+    const files = generateAddonFromOpenAPI(spec, makeVars(), {
+      oauth: false,
+      secret: false,
+      credential: 'bearer',
+      authConfig: {
+        ...delegatedConfig,
+        extraHeaders: { Origin: 'https://tenant.example.com' },
+      },
+    })
+    const service = files['src/test-api-api.service.ts']
+    assert.ok(
+      service.includes('"Origin": "https://tenant.example.com",'),
+      'service headers init should carry the static header'
+    )
+    const authFile = files['src/test-api-upstream-auth.ts']
+    assert.ok(
+      authFile.includes('"Origin": "https://tenant.example.com",'),
+      'login fetch should carry the static header'
+    )
+  })
+
   test('no delegated config → no upstream-auth file', () => {
     const spec = makeSpec({ operations: [makeOp()] })
     const files = generateAddonFromOpenAPI(spec, makeVars(), {

--- a/packages/openapi-parser/src/codegen.ts
+++ b/packages/openapi-parser/src/codegen.ts
@@ -1132,9 +1132,12 @@ function generateUpstreamAuthFile(
   lines.push(`  credentials: ${pascalName}UpstreamCredentials,`)
   lines.push('  baseUrl: string')
   lines.push(`): Promise<${pascalName}UpstreamIdentity | null> => {`)
-  lines.push(
-    "  const headers: Record<string, string> = { 'Content-Type': 'application/json' }"
-  )
+  lines.push('  const headers: Record<string, string> = {')
+  lines.push("    'Content-Type': 'application/json',")
+  for (const [header, value] of Object.entries(authConfig.extraHeaders ?? {})) {
+    lines.push(`    ${JSON.stringify(header)}: ${JSON.stringify(value)},`)
+  }
+  lines.push('  }')
   lines.push('  const body: Record<string, string> = {}')
   if (delegated.credentials.includes('email')) {
     lines.push('  if (credentials.email) body.email = credentials.email')
@@ -1405,6 +1408,11 @@ function generateServiceFile(
   lines.push('    const query: Record<string, string> = {}')
   lines.push('    const headers: Record<string, string> = {')
   lines.push("      'Content-Type': 'application/json',")
+  for (const [header, value] of Object.entries(
+    flags.authConfig?.extraHeaders ?? {}
+  )) {
+    lines.push(`      ${JSON.stringify(header)}: ${JSON.stringify(value)},`)
+  }
   lines.push('    }')
   lines.push('')
   // When camelCase flag is on, use rawData (snake_case converted) for route matching


### PR DESCRIPTION
Adds an optional `extraHeaders` record to the addon auth-config. Entries are baked into the generated upstream-auth login fetch and every generated API service call.

Why: multi-tenant upstreams can resolve the tenant from a static header (e.g. `Origin`) and reject requests without it — even a valid delegated login 503s. The header is deployment config, so it belongs in `specs/auth-config.json` next to the login descriptor.

Covered by a codegen test asserting the header lands in both the service headers init and the login fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional static extra headers to authentication configuration.
  - Configured headers are now included in delegated login requests and proxied service requests.
  - Supports upstream services that use headers such as `Origin` to determine tenant context.

- **Bug Fixes**
  - Improved handling and validation of configured authentication headers.

- **Documentation**
  - Added a patch release note for the authentication configuration enhancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->