### PR TITLE
fix(cli): scaffold new addons into addon-<name> directory

### DIFF
--- a/.changeset/addon-dir-prefix.md
+++ b/.changeset/addon-dir-prefix.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+`pikku new addon <name>` now scaffolds into `addon-<name>/` (e.g. `packages/addon-stripe`), mirroring the `@pikku/addon-<name>` package name so addon workspaces are visually distinct from app packages.

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -940,7 +940,9 @@ export const pikkuNewAddon = pikkuSessionlessFunc<
 
     // Resolve target directory
     const baseDir = dir || config.scaffold?.addonDir || process.cwd()
-    const addonDir = join(baseDir, name)
+    // Folder mirrors the package name (@pikku/addon-<name>) so a packages/
+    // listing reads as packages/addon-<name>, distinct from app workspaces.
+    const addonDir = join(baseDir, `addon-${name}`)
 
     if (existsSync(addonDir)) {
       logger.error(`Directory already exists: ${addonDir}`)


### PR DESCRIPTION
`pikku new addon stripe --dir packages` currently scaffolds into `packages/stripe`, while the package it creates is named `@pikku/addon-stripe`. This makes addon workspaces indistinguishable from app packages in a `packages/` listing (and downstream tooling that wants to treat addons specially has to read every package.json).

Now the folder mirrors the package name: `packages/addon-stripe`.

One-line change in `new-addon.ts` (`join(baseDir, name)` → `join(baseDir, \`addon-${name}\`)`); the existing "directory already exists" guard and all writes key off `addonDir`, so nothing else moves. Consumers that locate addons by package name (not folder) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated addon scaffolding so projects are generated inside an `addon-<name>/` directory to align with the corresponding package naming convention.
  * Adjusted generated file locations, existence checks, and console messaging to reflect the new output path.

* **Documentation**
  * Added/updated release notes describing the revised addon generation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->