### PR TITLE
feat(console): extract presentation-only UsersTable from AdminUsersPage

### DIFF
--- a/.changeset/console-users-table-extract.md
+++ b/.changeset/console-users-table-extract.md
@@ -1,0 +1,5 @@
+---
+'@pikku/console': patch
+---
+
+Extract a presentation-only `UsersTable` component from `AdminUsersPage` and export it. It takes `users`, translated `labels`, and an optional `renderActions` slot — no data fetching, router, or auth client — so external hosts (e.g. Fabric's server-brokered stage Users tab) can render the same table fed from their own source instead of duplicating the UI.

--- a/packages/console/src/components/users/UsersTable.tsx
+++ b/packages/console/src/components/users/UsersTable.tsx
@@ -1,0 +1,99 @@
+import { Table, Group, Avatar, Box, Text, Badge } from '@pikku/mantine/core'
+import { asI18n, type I18nString } from '@pikku/react'
+
+/**
+ * A user row as rendered by {@link UsersTable}. A structural superset of both
+ * the Better Auth admin user (image/banned) and a brokered listing that only
+ * carries id/email/name/role/createdAt — the extra fields are optional so a
+ * host that lacks them (e.g. Fabric's server-brokered stage users) can omit
+ * them.
+ */
+export interface UsersTableUser {
+  id: string
+  email: string
+  name?: string | null
+  image?: string | null
+  role?: string | null
+  banned?: boolean | null
+  createdAt?: string | Date | null
+}
+
+/** Translated column headers and badge labels — passed in so the component
+ * carries no i18n bundle of its own and both consoles supply their own copy. */
+export interface UsersTableLabels {
+  columnUser: I18nString
+  columnRole: I18nString
+  columnCreated: I18nString
+  roleAdmin: I18nString
+  roleUser: I18nString
+  banned: I18nString
+}
+
+export interface UsersTableProps {
+  users: UsersTableUser[]
+  labels: UsersTableLabels
+  /** Trailing action cell per row (e.g. an impersonate button). The host owns
+   * the behaviour; this component stays presentation-only. Omit for no column. */
+  renderActions?: (user: UsersTableUser) => React.ReactNode
+}
+
+/**
+ * Presentation-only user list: avatar + name/email, role/banned badges, joined
+ * date, and an optional host-supplied action cell. No data fetching, router,
+ * or auth client — feed it `users` and translated `labels`. Shared by the OSS
+ * AdminUsersPage (fed by the Better Auth admin client) and Fabric's stage Users
+ * tab (fed by a server-brokered RPC).
+ */
+export const UsersTable: React.FC<UsersTableProps> = ({ users, labels, renderActions }) => (
+  <Table verticalSpacing="sm" highlightOnHover>
+    <Table.Thead>
+      <Table.Tr>
+        <Table.Th>{labels.columnUser}</Table.Th>
+        <Table.Th>{labels.columnRole}</Table.Th>
+        <Table.Th>{labels.columnCreated}</Table.Th>
+        {renderActions && <Table.Th />}
+      </Table.Tr>
+    </Table.Thead>
+    <Table.Tbody>
+      {users.map((u) => (
+        <Table.Tr key={u.id}>
+          <Table.Td>
+            <Group gap="sm" wrap="nowrap">
+              <Avatar src={u.image ?? undefined} radius="xl" size="sm">
+                {(u.name ?? u.email).slice(0, 1).toUpperCase()}
+              </Avatar>
+              <Box style={{ minWidth: 0 }}>
+                {u.name && (
+                  <Text size="sm" fw={500} truncate>
+                    {asI18n(u.name)}
+                  </Text>
+                )}
+                <Text size="xs" c="dimmed" truncate>
+                  {asI18n(u.email)}
+                </Text>
+              </Box>
+            </Group>
+          </Table.Td>
+          <Table.Td>
+            <Group gap={6}>
+              <Badge size="sm" variant="light" color={u.role === 'admin' ? 'blue' : 'gray'}>
+                {u.role === 'admin' ? labels.roleAdmin : labels.roleUser}
+              </Badge>
+              {u.banned && (
+                <Badge size="sm" variant="light" color="red">
+                  {labels.banned}
+                </Badge>
+              )}
+            </Group>
+          </Table.Td>
+          <Table.Td>
+            <Text size="sm" c="dimmed">
+              {u.createdAt ? asI18n(new Date(u.createdAt).toLocaleDateString()) : asI18n('—')}
+            </Text>
+          </Table.Td>
+          {renderActions && <Table.Td>{renderActions(u)}</Table.Td>}
+        </Table.Tr>
+      ))}
+    </Table.Tbody>
+  </Table>
+)

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -15,6 +15,15 @@ export { reactRouterAdapter } from './adapters/react-router'
 // Page gate context (host apps use this to inject a body override while keeping headers visible)
 export { PageGateContext } from './context/PageGateContext'
 
+// Users — presentation-only table shared by AdminUsersPage and external hosts
+// (e.g. Fabric's server-brokered stage Users tab).
+export { UsersTable } from './components/users/UsersTable'
+export type {
+  UsersTableUser,
+  UsersTableLabels,
+  UsersTableProps,
+} from './components/users/UsersTable'
+
 // Layout
 export { AppLayout } from './components/layout/AppLayout'
 export type { AppLayoutProps } from './components/layout/AppLayout'

--- a/packages/console/src/pages/AdminUsersPage.tsx
+++ b/packages/console/src/pages/AdminUsersPage.tsx
@@ -1,20 +1,10 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import {
-  Table,
-  Group,
-  Avatar,
-  Box,
-  Text,
-  Badge,
-  Button,
-  Center,
-  Loader,
-  Alert,
-} from '@pikku/mantine/core'
+import { Text, Button, Center, Loader, Alert } from '@pikku/mantine/core'
 import { useDebouncedValue } from '@mantine/hooks'
 import { AlertTriangle, UserCog } from 'lucide-react'
 import { PageContainer, ListPageHeader } from '../components/layout/PageLayout'
+import { UsersTable } from '../components/users/UsersTable'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
 import { asI18n } from '@pikku/react'
@@ -63,85 +53,41 @@ export const AdminUsersPage: React.FC = () => {
           {m.users_empty()}
         </Text>
       ) : (
-        <Table verticalSpacing="sm" highlightOnHover>
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th>{m.users_col_user()}</Table.Th>
-              <Table.Th>{m.users_col_role()}</Table.Th>
-              <Table.Th>{m.users_col_created()}</Table.Th>
-              <Table.Th />
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
-            {users.map((u) => (
-              <Table.Tr key={u.id}>
-                <Table.Td>
-                  <Group gap="sm" wrap="nowrap">
-                    <Avatar src={u.image ?? undefined} radius="xl" size="sm">
-                      {(u.name ?? u.email).slice(0, 1).toUpperCase()}
-                    </Avatar>
-                    <Box style={{ minWidth: 0 }}>
-                      {u.name && (
-                        <Text size="sm" fw={500} truncate>
-                          {asI18n(u.name)}
-                        </Text>
-                      )}
-                      <Text size="xs" c="dimmed" truncate>
-                        {asI18n(u.email)}
-                      </Text>
-                    </Box>
-                  </Group>
-                </Table.Td>
-                <Table.Td>
-                  <Group gap={6}>
-                    <Badge
-                      size="sm"
-                      variant="light"
-                      color={u.role === 'admin' ? 'blue' : 'gray'}
-                    >
-                      {u.role === 'admin' ? m.users_role_admin() : m.users_role_user()}
-                    </Badge>
-                    {u.banned && (
-                      <Badge size="sm" variant="light" color="red">
-                        {m.users_banned()}
-                      </Badge>
-                    )}
-                  </Group>
-                </Table.Td>
-                <Table.Td>
-                  <Text size="sm" c="dimmed">
-                    {u.createdAt
-                      ? asI18n(new Date(u.createdAt).toLocaleDateString())
-                      : asI18n('—')}
-                  </Text>
-                </Table.Td>
-                <Table.Td>
-                  {u.id !== currentUser?.id &&
-                    (target?.id === u.id ? (
-                      <Button
-                        size="compact-sm"
-                        variant="light"
-                        color="yellow"
-                        leftSection={<UserCog size={14} />}
-                        onClick={() => setTarget(null)}
-                      >
-                        {m.impersonate_stop()}
-                      </Button>
-                    ) : (
-                      <Button
-                        size="compact-sm"
-                        variant="subtle"
-                        leftSection={<UserCog size={14} />}
-                        onClick={() => setTarget(u)}
-                      >
-                        {m.impersonate_button()}
-                      </Button>
-                    ))}
-                </Table.Td>
-              </Table.Tr>
-            ))}
-          </Table.Tbody>
-        </Table>
+        <UsersTable
+          users={users}
+          labels={{
+            columnUser: m.users_col_user(),
+            columnRole: m.users_col_role(),
+            columnCreated: m.users_col_created(),
+            roleAdmin: m.users_role_admin(),
+            roleUser: m.users_role_user(),
+            banned: m.users_banned(),
+          }}
+          renderActions={(u) => {
+            if (u.id === currentUser?.id) return null
+            const full = users.find((x) => x.id === u.id) ?? null
+            return target?.id === u.id ? (
+              <Button
+                size="compact-sm"
+                variant="light"
+                color="yellow"
+                leftSection={<UserCog size={14} />}
+                onClick={() => setTarget(null)}
+              >
+                {m.impersonate_stop()}
+              </Button>
+            ) : (
+              <Button
+                size="compact-sm"
+                variant="subtle"
+                leftSection={<UserCog size={14} />}
+                onClick={() => setTarget(full)}
+              >
+                {m.impersonate_button()}
+              </Button>
+            )
+          }}
+        />
       )}
     </PageContainer>
   )


### PR DESCRIPTION
## What

Extracts the user list out of `AdminUsersPage` into a **props-only** `UsersTable` component and exports it from `@pikku/console`.

`UsersTable` takes `users`, translated `labels` (as `I18nString`), and an optional `renderActions(user)` slot for the trailing action cell. No data fetching, router, or auth client inside it.

`AdminUsersPage` now renders `<UsersTable>` fed from the Better Auth admin client (`useAuth().listUsers`), passing an impersonate button via `renderActions` — behaviour unchanged.

## Why

Pikku Fabric's control-plane console can't reuse `AdminUsersPage` directly: its browser is on a different origin and the operator isn't a user of the deployed app, so it lists users via a **server-brokered RPC** instead of `client.admin.listUsers`. Today it hand-rolls a near-identical table. Exposing a presentation-only `UsersTable` lets Fabric render the same UI from its own source — sharing the component, keeping only the (necessarily different) data-access layer separate.

## Notes

- Patch changeset included.
- Pure refactor + new export; no behaviour change to `AdminUsersPage`.
- Labels passed in as `I18nString` so the component ships no i18n bundle of its own.