### PR TITLE
feat(core): AIEmbeddingService interface for vector-store addons

### DIFF
--- a/.changeset/ai-embedding-service.md
+++ b/.changeset/ai-embedding-service.md
@@ -1,0 +1,9 @@
+---
+'@pikku/core': patch
+---
+
+Add a narrow, model-baked `AIEmbeddingService` interface and an optional
+`aiEmbedding` slot on `CoreSingletonServices`. Vector-store addons depend on it
+to embed text at both index and query time; pinning the model to the service
+guarantees the two share the same vector space. Provider addons (e.g.
+`@pikku/addon-openai`) implement it and the app wires a single instance.

--- a/.changeset/ai-embedding-service.md
+++ b/.changeset/ai-embedding-service.md
@@ -5,5 +5,8 @@
 Add a narrow, model-baked `AIEmbeddingService` interface and an optional
 `aiEmbedding` slot on `CoreSingletonServices`. Vector-store addons depend on it
 to embed text at both index and query time; pinning the model to the service
-guarantees the two share the same vector space. Provider addons (e.g.
-`@pikku/addon-openai`) implement it and the app wires a single instance.
+keeps the two on the same vector space. Documents and queries embed through
+separate `embedDocuments`/`embedQuery` methods so asymmetric providers (Cohere
+`input_type`, E5 prefixes, BGE query instruction) can produce comparable
+vectors. Provider addons (e.g. `@pikku/addon-openai`) implement it and the app
+wires a single instance.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -169,6 +169,7 @@ export type {
   AITranscriptionParams,
   AITranscriptionResult,
 } from './services/ai-agent-runner-service.js'
+export type { AIEmbeddingService } from './services/ai-embedding-service.js'
 export type { AIRunStateService } from './services/ai-run-state-service.js'
 export type { AIStorageService } from './services/ai-storage-service.js'
 export type {

--- a/packages/core/src/services/ai-embedding-service.ts
+++ b/packages/core/src/services/ai-embedding-service.ts
@@ -1,0 +1,25 @@
+/**
+ * A narrow, dedicated embedding service.
+ *
+ * Vector stores (Qdrant, Pinecone, Supabase/pgvector, …) depend on this to turn
+ * text into vectors, at BOTH index time (ingest) and query time (search). The
+ * embedding model is fixed at construction so those two moments cannot drift
+ * into different vector spaces — a mismatch would silently break similarity
+ * search. Provider addons (e.g. `@pikku/addon-openai`) implement it; the app
+ * wires a single instance into `singletonServices.aiEmbedding`.
+ *
+ * This is deliberately smaller than {@link AIAgentRunnerService} (whose optional
+ * `embed`/`embedMany` take a per-call model): a vector store should not have to
+ * pull in the whole agent-runner tool loop just to embed, and pinning the model
+ * to the service is what guarantees index/query consistency.
+ */
+export interface AIEmbeddingService {
+  /** The embedding model backing this service. Index and query share it. */
+  readonly model: string
+  /** The vector dimensionality this model produces, when known. */
+  readonly dimensions?: number
+  /** Embed a single value into a vector. */
+  embed(value: string): Promise<number[]>
+  /** Embed many values into vectors, preserving input order. */
+  embedMany(values: string[]): Promise<number[][]>
+}

--- a/packages/core/src/services/ai-embedding-service.ts
+++ b/packages/core/src/services/ai-embedding-service.ts
@@ -12,14 +12,20 @@
  * `embed`/`embedMany` take a per-call model): a vector store should not have to
  * pull in the whole agent-runner tool loop just to embed, and pinning the model
  * to the service is what guarantees index/query consistency.
+ *
+ * Documents (ingested corpus) and queries (search text) are embedded through
+ * separate methods because some models are asymmetric — Cohere's `input_type`,
+ * E5's `query:`/`passage:` prefixes, BGE's query instruction — and must know
+ * which side they are embedding to produce comparable vectors. Symmetric
+ * providers (e.g. OpenAI) point both methods at the same call.
  */
 export interface AIEmbeddingService {
   /** The embedding model backing this service. Index and query share it. */
   readonly model: string
   /** The vector dimensionality this model produces, when known. */
   readonly dimensions?: number
-  /** Embed a single value into a vector. */
-  embed(value: string): Promise<number[]>
-  /** Embed many values into vectors, preserving input order. */
-  embedMany(values: string[]): Promise<number[][]>
+  /** Embed corpus documents (index time), preserving input order. */
+  embedDocuments(values: string[]): Promise<number[][]>
+  /** Embed a search query (query time) into a vector. */
+  embedQuery(value: string): Promise<number[]>
 }

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -95,6 +95,7 @@ export type {
   AITranscriptionResult,
   AIAgentRunnerService,
 } from './ai-agent-runner-service.js'
+export type { AIEmbeddingService } from './ai-embedding-service.js'
 export type {
   CreateRunInput,
   AIRunStateService,

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -32,6 +32,7 @@ import type { AIStorageService } from '../services/ai-storage-service.js'
 import type { ContentService } from '../services/content-service.js'
 import type { ScenarioActors } from '../services/scenario-actors-service.js'
 import type { AIAgentRunnerService } from '../services/ai-agent-runner-service.js'
+import type { AIEmbeddingService } from '../services/ai-embedding-service.js'
 import type { AIRunStateService } from '../services/ai-run-state-service.js'
 import type { AgentRunService } from '../wirings/ai-agent/ai-agent.types.js'
 import type { PikkuAIMiddlewareHooks } from '../wirings/ai-agent/ai-agent.types.js'
@@ -289,6 +290,8 @@ export interface CoreSingletonServices<Config extends CoreConfig = CoreConfig> {
   content?: ContentService
   /** AI agent runner service (model calls + tool loop) */
   aiAgentRunner?: AIAgentRunnerService
+  /** Dedicated embedding service (vector stores use it at index & query time) */
+  aiEmbedding?: AIEmbeddingService
   /** AI run state service (run lifecycle + approval persistence) */
   aiRunState?: AIRunStateService
   /** Agent run service (listing threads, runs, steps) */


### PR DESCRIPTION
## What

Adds a narrow, **model-baked** `AIEmbeddingService` interface to `@pikku/core` plus an optional `aiEmbedding?` slot on `CoreSingletonServices`.

```ts
export interface AIEmbeddingService {
  readonly model: string
  readonly dimensions?: number
  embedDocuments(values: string[]): Promise<number[][]>
  embedQuery(value: string): Promise<number[]>
}
```

## Why a dedicated interface

Vector-store addons (Qdrant, Pinecone, Supabase/pgvector, future Turso) and n8n-import RAG all need to turn text into vectors — and **embedding providers are a different population from LLM providers.** Local ONNX/sentence-transformers, fastembed, Cohere's embed endpoint, and hosted embedding-only APIs are all common (usually for cost), and none of them can implement `AIAgentRunnerService`: its `stream()`/`run()` are required, so an embedding-only backend would have to stub the whole tool loop to throw. A store depending on the runner also can't be wired with a pure embedder while an unrelated model runs the agent.

So this is deliberately smaller than `AIAgentRunnerService` (whose optional `embed`/`embedMany` take a per-call model): a vector store shouldn't pull in the agent-runner surface just to embed. The model is fixed at construction, so a given index's ingest and query paths stay on the same vector space by construction (different models produce non-comparable spaces — you can't mix them, and swapping a populated index's model means a full re-embed).

## Why two methods

Documents (ingested corpus) and queries (search text) embed through **separate** methods because some models are asymmetric and must know which side they're on to produce comparable vectors — Cohere's `input_type`, E5's `query:`/`passage:` prefixes, BGE's query instruction. Getting it wrong doesn't error, it silently degrades retrieval. A single `embed(value: string)` had nowhere to express this and would mis-embed on exactly the non-OpenAI providers a dedicated service exists to support. Symmetric providers (OpenAI) point both methods at the same call. This mirrors LangChain's `embedDocuments`/`embedQuery` split (the shape, not the dependency).

Because addon `SingletonServices extends CoreSingletonServices`, every addon sees `services.aiEmbedding` for free once this lands.

## Scope

Core only — interface + slot + changeset (`@pikku/core` patch). Types-only; `tsc` and `build` green.

## Follow-up (separate PR, after a `@pikku/core` release)

- `@pikku/addon-openai` exports an `OpenAIEmbeddingService` implementation (symmetric — both methods alias one call).
- Qdrant / Pinecone / Supabase vector addons consume `services.aiEmbedding` and drop the interim `rpc.exposed('openai:textEmbedding')` / `expose:true` path.
- n8n-import RAG ingestion + retrieval emit against the embedding service instead of wiring the OpenAI addon.

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a shared AI embedding service.
  * Introduced separate document and query embedding capabilities for vector-based search.
  * Exposed embedding model and optional dimension settings for compatibility across indexing and querying.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->