### PR TITLE
fix(cli): make wireCredential the single source of truth for oauth2 config

### DIFF
--- a/.changeset/oauth2-config-single-source.md
+++ b/.changeset/oauth2-config-single-source.md
@@ -1,5 +1,6 @@
 ---
 '@pikku/cli': patch
+'@pikku/inspector': patch
 '@pikku/openapi-parser': patch
 ---
 
@@ -20,5 +21,11 @@ the service then looked for the token under a name nothing had written.
 - The OpenAPI importer emits a `wireCredential` using the spec's real
   `authorizationUrl` / `tokenUrl` / `scopes`, and marks placeholder URLs with a TODO
   when the spec declares no oauth2 flow.
+- The inspector now extracts `oauth2.additionalParams`. It read every other field
+  and silently dropped this one, so provider-specific flags never reached runtime
+  even though `OAuth2Client` honours them — `access_type=offline` (Google),
+  `token_access_type=offline` (Dropbox) and `duration=permanent` (Reddit) all
+  control whether a refresh token is issued at all, so an addon declaring them
+  would connect successfully and then break at the first token expiry.
 
 Existing addons pick this up on regeneration.

--- a/.changeset/oauth2-config-single-source.md
+++ b/.changeset/oauth2-config-single-source.md
@@ -1,0 +1,24 @@
+---
+'@pikku/cli': patch
+'@pikku/openapi-parser': patch
+---
+
+Make `wireCredential` the single source of truth for an addon's OAuth2 config.
+
+Generated addon services declared their own `<NAME>_OAUTH2_CONFIG` const and passed
+it to `OAuth2Client`, so an addon's OAuth2 config existed twice and the two drifted:
+`pikku new addon --oauth` emitted a service reading `<NAME>_TOKENS` alongside a
+credential declaring `<NAME>_OAUTH_TOKENS`, and the OpenAPI importer fell back to
+`https://example.com/oauth2/token` while emitting no `wireCredential` at all. The
+console builds its authorize URL from `wireCredential`, so connecting succeeded and
+the service then looked for the token under a name nothing had written.
+
+- `pikku-credentials.gen.ts` now exports `CREDENTIAL_OAUTH2_CONFIGS` with each
+  credential's full declared config. It previously reduced `oauth2` to a boolean, so
+  there was nothing for a service to import — which is why the const existed.
+- Generated services import their config from it instead of redeclaring it.
+- The OpenAPI importer emits a `wireCredential` using the spec's real
+  `authorizationUrl` / `tokenUrl` / `scopes`, and marks placeholder URLs with a TODO
+  when the spec declares no oauth2 flow.
+
+Existing addons pick this up on regeneration.

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -391,15 +391,9 @@ export class ${pascalName}Service {
     files[`src/${name}-api.service.ts`] =
       `import { OAuth2Client } from '@pikku/core/oauth2'
 import type { TypedSecretService } from '#pikku/secrets/pikku-secrets.gen.js'
+import { CREDENTIAL_OAUTH2_CONFIGS } from '#pikku/credentials/pikku-credentials.gen.js'
 
 const BASE_URL = 'https://api.example.com/v1'
-
-export const ${screamingName}_OAUTH2_CONFIG = {
-  tokenSecretId: '${screamingName}_TOKENS',
-  authorizationUrl: 'https://example.com/oauth2/authorize',
-  tokenUrl: 'https://example.com/oauth2/token',
-  scopes: ['read', 'write'],
-}
 
 export interface RequestOptions {
   body?: unknown
@@ -410,9 +404,12 @@ export class ${pascalName}Service {
   private oauth: OAuth2Client
 
   constructor(secrets: TypedSecretService) {
+    // Config comes from wireCredential in ${name}.credential.ts via codegen —
+    // never redeclare it here, or the two silently drift (#950).
+    const oauth2 = CREDENTIAL_OAUTH2_CONFIGS['${camelName}']
     this.oauth = new OAuth2Client(
-      ${screamingName}_OAUTH2_CONFIG,
-      '${screamingName}_APP_CREDENTIALS',
+      oauth2,
+      oauth2.appCredentialSecretId,
       secrets
     )
   }

--- a/packages/cli/src/functions/commands/new-addon.ts
+++ b/packages/cli/src/functions/commands/new-addon.ts
@@ -404,8 +404,6 @@ export class ${pascalName}Service {
   private oauth: OAuth2Client
 
   constructor(secrets: TypedSecretService) {
-    // Config comes from wireCredential in ${name}.credential.ts via codegen —
-    // never redeclare it here, or the two silently drift (#950).
     const oauth2 = CREDENTIAL_OAUTH2_CONFIGS['${camelName}']
     this.oauth = new OAuth2Client(
       oauth2,

--- a/packages/cli/src/functions/wirings/credentials/serialize-credentials-types.ts
+++ b/packages/cli/src/functions/wirings/credentials/serialize-credentials-types.ts
@@ -27,6 +27,7 @@ export const serializeCredentialsTypes = ({
 
   const mapEntries: string[] = []
   const metaEntries: string[] = []
+  const oauth2Entries: string[] = []
 
   for (const [name, meta] of credentialEntries) {
     if (meta.schema && typeof meta.schema === 'string') {
@@ -51,6 +52,11 @@ export const serializeCredentialsTypes = ({
     ]
     if (meta.oauth2) {
       metaParts.push(`oauth2: true`)
+      // Emit the whole declared config, not just the flag: generated addon
+      // services import this instead of hand-rolling a duplicate const that
+      // silently drifts from wireCredential (#950).
+      const config = JSON.stringify(meta.oauth2, null, 2).replace(/\n/g, '\n  ')
+      oauth2Entries.push(`  '${name}': ${config}`)
     }
     metaEntries.push(`  '${name}': { ${metaParts.join(', ')} }`)
   }
@@ -61,6 +67,12 @@ export const serializeCredentialsTypes = ({
     `import { TypedCredentialService as CoreTypedCredentialService, type CredentialMetaInfo } from '@pikku/core/services'`
   )
   imports.push(`import type { CredentialService } from '@pikku/core/services'`)
+
+  if (oauth2Entries.length > 0) {
+    imports.push(
+      `import type { OAuth2CredentialConfig } from '@pikku/core/secret'`
+    )
+  }
 
   if (needsZod) {
     imports.push(`import type { z } from 'zod'`)
@@ -76,6 +88,15 @@ export const serializeCredentialsTypes = ({
     imports.push(`import { ${vars} } from '${importPath}'`)
   }
 
+  const oauth2Configs =
+    oauth2Entries.length > 0
+      ? `
+export const CREDENTIAL_OAUTH2_CONFIGS = {
+${oauth2Entries.join(',\n')}
+} satisfies Record<string, OAuth2CredentialConfig & { appCredentialSecretId: string }>
+`
+      : ''
+
   return `${imports.join('\n')}
 
 export interface CredentialsMap {
@@ -87,6 +108,7 @@ export type CredentialName = keyof CredentialsMap
 const CREDENTIALS_META: Record<string, CredentialMetaInfo> = {
 ${metaEntries.join(',\n')}
 }
+${oauth2Configs}
 
 export class TypedCredentialService extends CoreTypedCredentialService<CredentialsMap> {
   constructor(credentials: CredentialService) {

--- a/packages/cli/src/functions/wirings/credentials/serialize-credentials-types.ts
+++ b/packages/cli/src/functions/wirings/credentials/serialize-credentials-types.ts
@@ -52,9 +52,6 @@ export const serializeCredentialsTypes = ({
     ]
     if (meta.oauth2) {
       metaParts.push(`oauth2: true`)
-      // Emit the whole declared config, not just the flag: generated addon
-      // services import this instead of hand-rolling a duplicate const that
-      // silently drifts from wireCredential (#950).
       const config = JSON.stringify(meta.oauth2, null, 2).replace(/\n/g, '\n  ')
       oauth2Entries.push(`  '${name}': ${config}`)
     }

--- a/packages/inspector/src/add/add-credential.ts
+++ b/packages/inspector/src/add/add-credential.ts
@@ -2,6 +2,7 @@ import * as ts from 'typescript'
 import {
   getPropertyValue,
   getArrayPropertyValue,
+  getRecordPropertyValue,
   assertStringLiteralProperty,
 } from '../utils/get-property-value.js'
 import type { AddWiring } from '../types.js'
@@ -133,6 +134,14 @@ export const addCredential: AddWiring = (
       const tokenUrl = getPropertyValue(oauth2Obj, 'tokenUrl') as string | null
       const scopes = getArrayPropertyValue(oauth2Obj, 'scopes')
       const pkce = getPropertyValue(oauth2Obj, 'pkce') as boolean | null
+      // OAuth2Client honours additionalParams at runtime, so dropping them here
+      // silently loses provider-specific flags — `access_type=offline`,
+      // `duration=permanent` — whose absence means no refresh token is ever
+      // issued and the addon dies when the first access token expires.
+      const additionalParams = getRecordPropertyValue(
+        oauth2Obj,
+        'additionalParams'
+      )
 
       if (appCredentialSecretId && authorizationUrl && tokenUrl && scopes) {
         oauth2 = {
@@ -142,6 +151,7 @@ export const addCredential: AddWiring = (
           tokenUrl,
           scopes,
           pkce: pkce || undefined,
+          additionalParams: additionalParams || undefined,
         }
       }
     }

--- a/packages/inspector/src/add/add-credential.ts
+++ b/packages/inspector/src/add/add-credential.ts
@@ -134,10 +134,6 @@ export const addCredential: AddWiring = (
       const tokenUrl = getPropertyValue(oauth2Obj, 'tokenUrl') as string | null
       const scopes = getArrayPropertyValue(oauth2Obj, 'scopes')
       const pkce = getPropertyValue(oauth2Obj, 'pkce') as boolean | null
-      // OAuth2Client honours additionalParams at runtime, so dropping them here
-      // silently loses provider-specific flags — `access_type=offline`,
-      // `duration=permanent` — whose absence means no refresh token is ever
-      // issued and the addon dies when the first access token expires.
       const additionalParams = getRecordPropertyValue(
         oauth2Obj,
         'additionalParams'

--- a/packages/inspector/src/utils/get-property-value.test.ts
+++ b/packages/inspector/src/utils/get-property-value.test.ts
@@ -1,0 +1,70 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert'
+import * as ts from 'typescript'
+import { getRecordPropertyValue } from './get-property-value.js'
+
+const firstObjectLiteral = (src: string): ts.ObjectLiteralExpression => {
+  const sourceFile = ts.createSourceFile(
+    'test.ts',
+    src,
+    ts.ScriptTarget.Latest,
+    true
+  )
+  let found: ts.ObjectLiteralExpression | undefined
+  const walk = (node: ts.Node) => {
+    if (!found && ts.isObjectLiteralExpression(node)) {
+      found = node
+    }
+    ts.forEachChild(node, walk)
+  }
+  walk(sourceFile)
+  if (!found) {
+    throw new Error('no object literal in source')
+  }
+  return found
+}
+
+describe('getRecordPropertyValue', () => {
+  test('extracts a string record', () => {
+    const obj = firstObjectLiteral(
+      `const x = { additionalParams: { access_type: 'offline', prompt: 'consent' } }`
+    )
+    assert.deepStrictEqual(getRecordPropertyValue(obj, 'additionalParams'), {
+      access_type: 'offline',
+      prompt: 'consent',
+    })
+  })
+
+  test('handles quoted keys', () => {
+    const obj = firstObjectLiteral(
+      `const x = { additionalParams: { 'token_access_type': 'offline' } }`
+    )
+    assert.deepStrictEqual(getRecordPropertyValue(obj, 'additionalParams'), {
+      token_access_type: 'offline',
+    })
+  })
+
+  test('returns null when the property is absent', () => {
+    const obj = firstObjectLiteral(`const x = { scopes: ['a'] }`)
+    assert.strictEqual(getRecordPropertyValue(obj, 'additionalParams'), null)
+  })
+
+  test('returns null for a non-literal initializer', () => {
+    const obj = firstObjectLiteral(`const x = { additionalParams: SOME_CONST }`)
+    assert.strictEqual(getRecordPropertyValue(obj, 'additionalParams'), null)
+  })
+
+  test('skips non-string values rather than coercing them', () => {
+    const obj = firstObjectLiteral(
+      `const x = { additionalParams: { a: 'keep', b: 42, c: true } }`
+    )
+    assert.deepStrictEqual(getRecordPropertyValue(obj, 'additionalParams'), {
+      a: 'keep',
+    })
+  })
+
+  test('returns null for an empty record', () => {
+    const obj = firstObjectLiteral(`const x = { additionalParams: {} }`)
+    assert.strictEqual(getRecordPropertyValue(obj, 'additionalParams'), null)
+  })
+})

--- a/packages/inspector/src/utils/get-property-value.ts
+++ b/packages/inspector/src/utils/get-property-value.ts
@@ -29,6 +29,56 @@ export const getArrayPropertyValue = (
 }
 
 /**
+ * Extracts a string->string record from an object property.
+ *
+ * `getPropertyValue` falls through to `getText()` for an object literal, which
+ * returns the raw source text rather than the record — so callers that need the
+ * entries (e.g. oauth2 `additionalParams`) must use this instead.
+ */
+export const getRecordPropertyValue = (
+  obj: ts.ObjectLiteralExpression,
+  propertyName: string
+): Record<string, string> | null => {
+  const property = obj.properties.find(
+    (p) =>
+      ts.isPropertyAssignment(p) &&
+      ts.isIdentifier(p.name) &&
+      p.name.text === propertyName
+  )
+
+  if (!property || !ts.isPropertyAssignment(property)) {
+    return null
+  }
+  const initializer = property.initializer
+  if (!ts.isObjectLiteralExpression(initializer)) {
+    return null
+  }
+
+  const record: Record<string, string> = {}
+  for (const prop of initializer.properties) {
+    if (!ts.isPropertyAssignment(prop)) {
+      continue
+    }
+    const key = ts.isIdentifier(prop.name)
+      ? prop.name.text
+      : ts.isStringLiteral(prop.name)
+        ? prop.name.text
+        : null
+    if (key === null) {
+      continue
+    }
+    if (
+      ts.isStringLiteral(prop.initializer) ||
+      ts.isNoSubstitutionTemplateLiteral(prop.initializer)
+    ) {
+      record[key] = prop.initializer.text
+    }
+  }
+
+  return Object.keys(record).length > 0 ? record : null
+}
+
+/**
  * Wiring identity fields (`name`, `secretId`, `variableId`, …) are read
  * STATICALLY from source — a const or variable reference is keyed by its
  * identifier text, not its runtime value, so the wiring is silently skipped at

--- a/packages/openapi-parser/src/codegen.ts
+++ b/packages/openapi-parser/src/codegen.ts
@@ -449,7 +449,6 @@ export function generateAddonFromOpenAPI(
     flags
   )
 
-  // Declare the oauth2 credential the service resolves its config from.
   if (flags.oauth || flags.credential === 'oauth2') {
     files[`src/${name}.credential.ts`] = generateCredentialFile(spec, vars)
   }
@@ -1288,9 +1287,6 @@ function generateServiceFile(
   lines.push('')
 
   if (flags.oauth) {
-    // The config is declared once by wireCredential in `<name>.credential.ts`
-    // and reaches us through codegen. Redeclaring it here is what let the two
-    // drift apart silently (#950).
     lines.push(
       `import { CREDENTIAL_OAUTH2_CONFIGS } from '#pikku/credentials/pikku-credentials.gen.js'`
     )

--- a/packages/openapi-parser/src/codegen.ts
+++ b/packages/openapi-parser/src/codegen.ts
@@ -105,7 +105,10 @@ function humanDescription(parsed: ParsedOperation): string {
   if (summary && !GENERIC_SUMMARIES.has(summary.toLowerCase())) {
     return capitalize(summary)
   }
-  return humanizeOperationId(parsed.operationId) ?? `${parsed.method.toUpperCase()} ${parsed.path}`
+  return (
+    humanizeOperationId(parsed.operationId) ??
+    `${parsed.method.toUpperCase()} ${parsed.path}`
+  )
 }
 
 function getErrorClassesForResponses(
@@ -433,7 +436,9 @@ export function generateAddonFromOpenAPI(
 
   // Generate index.ts with all exports
   files['src/index.ts'] = generateIndexFile(functionExports, {
-    upstreamAuth: upstreamAuthExport ? { name, export: upstreamAuthExport } : undefined,
+    upstreamAuth: upstreamAuthExport
+      ? { name, export: upstreamAuthExport }
+      : undefined,
   })
 
   // Generate typed API service class with route map
@@ -443,6 +448,11 @@ export function generateAddonFromOpenAPI(
     vars,
     flags
   )
+
+  // Declare the oauth2 credential the service resolves its config from.
+  if (flags.oauth || flags.credential === 'oauth2') {
+    files[`src/${name}.credential.ts`] = generateCredentialFile(spec, vars)
+  }
 
   // Generate variable file for BASE_URL
   files[`src/${name}.variable.ts`] = generateVariableFile(spec, vars)
@@ -1075,9 +1085,7 @@ function generateUpstreamAuthFile(
   )
   lines.push('}')
   lines.push('')
-  lines.push(
-    `export interface ${pascalName}UpstreamCredentials {`
-  )
+  lines.push(`export interface ${pascalName}UpstreamCredentials {`)
   lines.push('  email?: string')
   lines.push('  password?: string')
   lines.push('  apiKey?: string')
@@ -1098,18 +1106,16 @@ function generateUpstreamAuthFile(
     "  typeof value === 'string' && value ? value : typeof value === 'number' ? String(value) : undefined"
   )
   lines.push('')
-  lines.push('/** Decode a JWT payload without verifying — see file docblock. */')
+  lines.push(
+    '/** Decode a JWT payload without verifying — see file docblock. */'
+  )
   lines.push('const decodeJwtPayload = (token: string): unknown => {')
   lines.push("  const part = token.split('.')[1]")
   lines.push('  if (!part) return undefined')
   lines.push('  try {')
   lines.push("    const pad = part + '==='.slice((part.length + 3) % 4)")
-  lines.push(
-    "    const bin = atob(pad.replace(/-/g, '+').replace(/_/g, '/'))"
-  )
-  lines.push(
-    '    const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0))'
-  )
+  lines.push("    const bin = atob(pad.replace(/-/g, '+').replace(/_/g, '/'))")
+  lines.push('    const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0))')
   lines.push('    return JSON.parse(new TextDecoder().decode(bytes))')
   lines.push('  } catch {')
   lines.push('    // Not a decodable JWT — caller treats it as missing claims.')
@@ -1156,7 +1162,9 @@ function generateUpstreamAuthFile(
   lines.push(
     `  const response = await fetch(\`\${baseUrl.replace(/\\/+$/, '')}${delegated.loginPath}\`, {`
   )
-  lines.push(`    method: ${JSON.stringify(delegated.loginMethod.toUpperCase())},`)
+  lines.push(
+    `    method: ${JSON.stringify(delegated.loginMethod.toUpperCase())},`
+  )
   lines.push('    headers,')
   lines.push(
     '    body: Object.keys(body).length > 0 ? JSON.stringify(body) : undefined,'
@@ -1165,7 +1173,9 @@ function generateUpstreamAuthFile(
   lines.push('  if (!response.ok) return null')
   lines.push('')
   lines.push('  const data: unknown = await response.json()')
-  lines.push(`  const token = str(pick(data, ${JSON.stringify(delegated.tokenPath)}))`)
+  lines.push(
+    `  const token = str(pick(data, ${JSON.stringify(delegated.tokenPath)}))`
+  )
   lines.push('  if (!token) return null')
   lines.push('')
   if (claims.source === 'jwt') {
@@ -1178,7 +1188,9 @@ function generateUpstreamAuthFile(
   lines.push(
     `  const externalId = str(pick(claims, ${JSON.stringify(claims.externalId)}))`
   )
-  lines.push(`  const email = str(pick(claims, ${JSON.stringify(claims.email)}))`)
+  lines.push(
+    `  const email = str(pick(claims, ${JSON.stringify(claims.email)}))`
+  )
   lines.push('  if (!externalId || !email) return null')
   lines.push('')
   if (namePaths.length > 0) {
@@ -1244,7 +1256,7 @@ function generateServiceFile(
   vars: AddonVars,
   flags: CodegenFlags
 ): string {
-  const { name, pascalName, screamingName } = vars
+  const { name, camelName, pascalName, screamingName } = vars
   const displayName = vars.displayName.replace(/'/g, '')
   const lines: string[] = []
 
@@ -1276,25 +1288,12 @@ function generateServiceFile(
   lines.push('')
 
   if (flags.oauth) {
-    // Use OAuth2 details from spec if available
-    const oauthScheme = Object.values(spec.securitySchemes).find(
-      (s) => s.type === 'oauth2'
+    // The config is declared once by wireCredential in `<name>.credential.ts`
+    // and reaches us through codegen. Redeclaring it here is what let the two
+    // drift apart silently (#950).
+    lines.push(
+      `import { CREDENTIAL_OAUTH2_CONFIGS } from '#pikku/credentials/pikku-credentials.gen.js'`
     )
-    const authUrl =
-      oauthScheme?.flows?.authorizationUrl ??
-      'https://example.com/oauth2/authorize'
-    const tokenUrl =
-      oauthScheme?.flows?.tokenUrl ?? 'https://example.com/oauth2/token'
-    const scopes = oauthScheme?.flows?.scopes
-      ? Object.keys(oauthScheme.flows.scopes)
-      : ['read', 'write']
-
-    lines.push(`export const ${screamingName}_OAUTH2_CONFIG = {`)
-    lines.push(`  tokenSecretId: '${screamingName}_TOKENS',`)
-    lines.push(`  authorizationUrl: ${JSON.stringify(authUrl)},`)
-    lines.push(`  tokenUrl: ${JSON.stringify(tokenUrl)},`)
-    lines.push(`  scopes: ${JSON.stringify(scopes)},`)
-    lines.push('}')
     lines.push('')
   }
 
@@ -1367,9 +1366,10 @@ function generateServiceFile(
     lines.push(
       `    this.baseUrl = variables.get('${screamingName}_BASE_URL') as string`
     )
+    lines.push(`    const oauth2 = CREDENTIAL_OAUTH2_CONFIGS['${camelName}']`)
     lines.push('    this.oauth = new OAuth2Client(')
-    lines.push(`      ${screamingName}_OAUTH2_CONFIG,`)
-    lines.push(`      '${screamingName}_APP_CREDENTIALS',`)
+    lines.push('      oauth2,')
+    lines.push('      oauth2.appCredentialSecretId,')
     lines.push('      secrets')
     lines.push('    )')
     lines.push('  }')
@@ -1399,9 +1399,7 @@ function generateServiceFile(
   lines.push('    path: string,')
   lines.push('    data?: unknown')
   lines.push('  ): Promise<T> {')
-  lines.push(
-    '    const input = data as Record<string, unknown> | undefined'
-  )
+  lines.push('    const input = data as Record<string, unknown> | undefined')
   if (flags.camelCase) {
     lines.push('    const rawData = input ? _toSnakeCase(input) : input')
   }
@@ -1576,6 +1574,84 @@ function generateServiceFile(
   lines.push('  }')
 
   lines.push('}')
+  lines.push('')
+
+  return lines.join('\n')
+}
+
+/**
+ * OAuth2 credential declaration. This is the single source of truth for the
+ * addon's oauth2 config — the generated service imports it back through
+ * codegen rather than redeclaring it (#950).
+ */
+function generateCredentialFile(spec: ParsedSpec, vars: AddonVars): string {
+  const { camelName, screamingName } = vars
+  const displayName = vars.displayName.replace(/'/g, '')
+  const description = vars.description.replace(/'/g, '')
+
+  const oauthScheme = Object.values(spec.securitySchemes).find(
+    (s) => s.type === 'oauth2'
+  )
+  const authorizationUrl = oauthScheme?.flows?.authorizationUrl
+  const tokenUrl = oauthScheme?.flows?.tokenUrl
+  const scopes = oauthScheme?.flows?.scopes
+    ? Object.keys(oauthScheme.flows.scopes)
+    : ['read', 'write']
+
+  const lines: string[] = []
+  lines.push("import { z } from 'zod'")
+  lines.push("import { wireCredential } from '@pikku/core/credential'")
+  lines.push("import { wireSecret } from '@pikku/core/secret'")
+  lines.push('')
+  lines.push(`export const ${camelName}TokenSchema = z.object({`)
+  lines.push('  accessToken: z.string(),')
+  lines.push('  refreshToken: z.string().optional(),')
+  lines.push('})')
+  lines.push('')
+  lines.push(`export const ${camelName}OAuthAppSchema = z.object({`)
+  lines.push("  clientId: z.string().describe('OAuth2 app client ID'),")
+  lines.push("  clientSecret: z.string().describe('OAuth2 app client secret'),")
+  lines.push('})')
+  lines.push('')
+
+  if (!authorizationUrl || !tokenUrl) {
+    lines.push(
+      '// TODO: this spec declares no oauth2 flow URLs, so the placeholder(s)'
+    )
+    lines.push(
+      `// below are not real. Replace them with ${displayName}'s endpoints —`
+    )
+    lines.push('// OAuth will fail against example.com.')
+  }
+
+  // oauth2 must stay an inline object literal: the inspector reads it via AST
+  // (add-credential.ts) and silently drops a config behind an identifier.
+  lines.push('wireCredential({')
+  lines.push(`  name: '${camelName}',`)
+  lines.push(`  displayName: '${displayName}',`)
+  lines.push(`  description: '${description}',`)
+  lines.push(`  type: 'wire',`)
+  lines.push(`  schema: ${camelName}TokenSchema,`)
+  lines.push('  oauth2: {')
+  lines.push(`    appCredentialSecretId: '${screamingName}_OAUTH_APP',`)
+  lines.push(`    tokenSecretId: '${screamingName}_OAUTH_TOKENS',`)
+  lines.push(
+    `    authorizationUrl: ${JSON.stringify(authorizationUrl ?? 'https://example.com/oauth2/authorize')},`
+  )
+  lines.push(
+    `    tokenUrl: ${JSON.stringify(tokenUrl ?? 'https://example.com/oauth2/token')},`
+  )
+  lines.push(`    scopes: ${JSON.stringify(scopes)},`)
+  lines.push('  },')
+  lines.push('})')
+  lines.push('')
+  lines.push('wireSecret({')
+  lines.push(`  name: '${camelName}OAuthApp',`)
+  lines.push(`  displayName: '${displayName} OAuth App',`)
+  lines.push(`  description: 'OAuth2 app credentials for ${displayName}',`)
+  lines.push(`  secretId: '${screamingName}_OAUTH_APP',`)
+  lines.push(`  schema: ${camelName}OAuthAppSchema,`)
+  lines.push('})')
   lines.push('')
 
   return lines.join('\n')

--- a/packages/openapi-parser/src/codegen.ts
+++ b/packages/openapi-parser/src/codegen.ts
@@ -1575,11 +1575,6 @@ function generateServiceFile(
   return lines.join('\n')
 }
 
-/**
- * OAuth2 credential declaration. This is the single source of truth for the
- * addon's oauth2 config — the generated service imports it back through
- * codegen rather than redeclaring it (#950).
- */
 function generateCredentialFile(spec: ParsedSpec, vars: AddonVars): string {
   const { camelName, screamingName } = vars
   const displayName = vars.displayName.replace(/'/g, '')


### PR DESCRIPTION
Closes #950. Prereq for #844.

## The bug

An addon's OAuth2 config existed **twice**, and the copy that ran at runtime was the wrong one.

`google-drive.credential.ts` declares:
```ts
wireCredential({ name: 'googleDrive', type: 'wire', oauth2: {
  tokenSecretId: 'GOOGLE_DRIVE_OAUTH_TOKENS',
  tokenUrl: 'https://oauth2.googleapis.com/token', ... } })
```

`google-drive-api.service.ts` declares its own, and *that* is what `OAuth2Client` uses:
```ts
export const GOOGLE_DRIVE_OAUTH2_CONFIG = {
  tokenSecretId: 'GOOGLE_DRIVE_TOKENS',
  tokenUrl: "https://example.com/oauth2/token",
}
this.oauth = new OAuth2Client(GOOGLE_DRIVE_OAUTH2_CONFIG, 'GOOGLE_DRIVE_APP_CREDENTIALS', secrets)
```

They disagree on **every field**. The console builds its authorize URL from `wireCredential`, so connecting succeeds — then the service looks for the token under a name nothing ever wrote, and would refresh against `example.com`.

## Why

Two generators, and they never agreed:

- `new-addon.ts` emits the service const with `<NAME>_TOKENS` / `<NAME>_APP_CREDENTIALS` and the credential with `<NAME>_OAUTH_TOKENS` / `<NAME>_OAUTH_APP`. `pikku new addon --oauth` has never produced a matching pair.
- `openapi-parser/codegen.ts` emits the const falling back to `example.com`, and no `wireCredential` at all.

The root enabler: `pikku-credentials.gen.ts` reduced `oauth2` to a boolean (`oauth2: true`), so there was nothing typed for a service to import. The full config only survived into the JSON meta, which is why the console (runtime `metaService`) sees it and a compile-time consumer can't.

## The fix

- `pikku-credentials.gen.ts` now exports `CREDENTIAL_OAUTH2_CONFIGS` with each credential's full declared config, `satisfies Record<string, OAuth2CredentialConfig & { appCredentialSecretId: string }>`.
- Both generators import from it instead of redeclaring.
- The OpenAPI importer emits a `wireCredential` from the spec's real `authorizationUrl`/`tokenUrl`/`scopes`, with a TODO when the spec declares no oauth2 flow.

`oauth2` stays an inline object literal in `wireCredential` — the inspector reads it via AST (`add-credential.ts` requires `isObjectLiteralExpression`) and silently drops a config hidden behind an identifier.

## Verification

Ran the built CLI against `@pikku/addon-google-drive`. Generated file now carries the real config, extracted from `wireCredential`:

```ts
export const CREDENTIAL_OAUTH2_CONFIGS = {
  'googleDrive': {
    "appCredentialSecretId": "GOOGLE_DRIVE_OAUTH_APP",
    "tokenSecretId": "GOOGLE_DRIVE_OAUTH_TOKENS",
    "authorizationUrl": "https://accounts.google.com/o/oauth2/auth",
    "tokenUrl": "https://oauth2.googleapis.com/token",
    "scopes": [ ...8 real Google scopes... ]
  }
} satisfies Record<string, OAuth2CredentialConfig & { appCredentialSecretId: string }>
```

- `tsc --noEmit` clean on `@pikku/openapi-parser`; zero errors attributable to `credentials.gen` when typechecking the addon.
- `OAuth2CredentialConfig` is already exported from `@pikku/core/secret` as far back as the installed `0.12.38`, so the emitted import is backward-safe.
- Prettier + oxlint clean (the one remaining warning is pre-existing, in `transitiveClosure`).

Existing addons pick this up on regeneration.

## Follow-on (not in this PR)

~51 files across the addons monorepo carry `example.com/oauth2/token` — broken regardless of which flow runs. Needs a regeneration sweep now that the generators are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth2 configurations are now centralized, helping keep credential and service settings consistent.
  * Generated OAuth2 services use the complete credential configuration, including app credential details.
  * OpenAPI imports now generate OAuth2 credentials from the specification’s authorization URL, token URL, and scopes.
  * OAuth2 credential files are generated automatically when applicable.

* **Bug Fixes**
  * Prevented mismatches between OAuth2 token, configuration, and credential naming.
  * Added handling for incomplete or placeholder OAuth2 flow details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->