### PR TITLE
fix(console): suspended workflow run rendered as a red error

### DIFF
--- a/.changeset/console-suspended-run.md
+++ b/.changeset/console-suspended-run.md
@@ -1,0 +1,21 @@
+---
+'@pikku/console': patch
+---
+
+Stop rendering a suspended workflow run as a red error.
+
+Core stores a suspended run with a synthetic `error` row carrying the suspend reason
+(`code: 'WORKFLOW_SUSPENDED'` or `'RPC_NOT_FOUND'`). The run detail panel gated its red **Error**
+card on error truthiness alone, never on status, so a healthy run merely waiting on a human was
+presented as a failure.
+
+- The error card now excludes suspend reasons; a suspended run gets its own card instead.
+- `WORKFLOW_SUSPENDED` and `RPC_NOT_FOUND` get distinct copy — "waiting to be resumed" vs "deploy the
+  missing function, then resume" are different operator actions.
+- `statusDefs` gained a `suspended` entry (yellow, matching the canvas and timeline, which already
+  coloured it that way). Previously it fell back to an unstyled gray badge.
+- Flow cards showed no status badge at all for a suspended last run.
+- The run list gained a Suspended filter.
+
+An unrecognised `error.code` on a suspended run is still shown as a real error, so a genuine failure
+can't hide behind a reassuring card.

--- a/packages/console/src/components/flows/FlowCard.tsx
+++ b/packages/console/src/components/flows/FlowCard.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react'
 import { Box, Group, Stack, Text, Badge } from '@pikku/mantine/core'
 import { asI18n } from '@pikku/react'
-import { Route, Check, X, Loader } from 'lucide-react'
+import { Route, Check, X, Loader, Pause } from 'lucide-react'
 import { FlowCast } from './FlowCast'
 import { useWorkflowRuns } from '../../hooks/useWorkflowRuns'
 import type { FlowEntry } from './flow-types'
@@ -26,6 +26,7 @@ const STATUS_META: Record<
   failed: { tone: 'red', label: 'failed', Icon: X },
   cancelled: { tone: 'red', label: 'cancelled', Icon: X },
   running: { tone: 'blue', label: 'running', Icon: Loader },
+  suspended: { tone: 'yellow', label: 'suspended', Icon: Pause },
 }
 
 type FlowCardProps = {

--- a/packages/console/src/components/project/WorkflowRunSelector.tsx
+++ b/packages/console/src/components/project/WorkflowRunSelector.tsx
@@ -135,6 +135,7 @@ export const WorkflowRunSelector: React.FC<WorkflowRunSelectorProps> = ({
               data={[
                 { value: 'all', label: asI18n('All') },
                 { value: 'running', label: asI18n('Running') },
+                { value: 'suspended', label: asI18n('Suspended') },
                 { value: 'completed', label: asI18n('Completed') },
                 { value: 'failed', label: asI18n('Failed') },
               ]}

--- a/packages/console/src/components/project/panels/WorkflowPanels.tsx
+++ b/packages/console/src/components/project/panels/WorkflowPanels.tsx
@@ -10,6 +10,11 @@ import { PikkuBadge } from '../../ui/PikkuBadge'
 import { wiringTypeColor } from '../../ui/badge-defs'
 import { SectionLabel } from '../../ui/SectionLabel'
 import { DataViewer } from '../../ui/DataViewer'
+import {
+  isSuspendReason,
+  suspendReasonCopy,
+  suspendReasonText,
+} from '../../../lib/workflow-suspend'
 import { CommonDetails } from './shared/CommonDetails'
 import { EmptyState } from './shared/EmptyState'
 import classes from '../../ui/console.module.css'
@@ -549,7 +554,29 @@ export const WorkflowRunOverview: React.FC<WorkflowPanelProps> = ({
         </Stack>
       )}
 
-      {runData.error && (
+      {isSuspendReason(runData.status, runData.error) && (
+        <Stack gap={6}>
+          <SectionLabel>
+            {asI18n(suspendReasonCopy(runData.error).title)}
+          </SectionLabel>
+          <Card withBorder radius="md" padding={0}>
+            <Card.Section p="md">
+              <Stack gap={6}>
+                <Text size="sm" ff="monospace">
+                  {asI18n(suspendReasonText(runData.error))}
+                </Text>
+                {suspendReasonCopy(runData.error).hint && (
+                  <Text size="xs" c="dimmed">
+                    {asI18n(suspendReasonCopy(runData.error).hint!)}
+                  </Text>
+                )}
+              </Stack>
+            </Card.Section>
+          </Card>
+        </Stack>
+      )}
+
+      {runData.error && !isSuspendReason(runData.status, runData.error) && (
         <Stack gap={6}>
           <SectionLabel>{asI18n('Error')}</SectionLabel>
           <Card withBorder radius="md" padding={0}>

--- a/packages/console/src/components/ui/badge-defs.test.ts
+++ b/packages/console/src/components/ui/badge-defs.test.ts
@@ -5,9 +5,6 @@ import { statusDefs } from './badge-defs.js'
 
 describe('statusDefs', () => {
   test('covers every WorkflowStatus core can persist', () => {
-    // Mirrors WorkflowStatus in @pikku/core (workflow.types.ts). A status with no
-    // entry silently falls back to a gray badge labelled by humanize(), which is
-    // how 'suspended' went unnoticed.
     for (const status of [
       'running',
       'suspended',
@@ -31,8 +28,10 @@ describe('statusDefs', () => {
   })
 
   test('suspended matches the yellow used by the canvas and timeline', () => {
-    // FlowNode.tsx and WorkflowTimelineDrawer.tsx already colour suspended
-    // yellow; the badge should agree rather than invent a third convention.
-    assert.equal(statusDefs.suspended?.color, 'yellow')
+    assert.equal(
+      statusDefs.suspended?.color,
+      'yellow',
+      'FlowNode and WorkflowTimelineDrawer already colour suspended yellow — the badge should agree rather than invent a third convention'
+    )
   })
 })

--- a/packages/console/src/components/ui/badge-defs.test.ts
+++ b/packages/console/src/components/ui/badge-defs.test.ts
@@ -1,0 +1,38 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { statusDefs } from './badge-defs.js'
+
+describe('statusDefs', () => {
+  test('covers every WorkflowStatus core can persist', () => {
+    // Mirrors WorkflowStatus in @pikku/core (workflow.types.ts). A status with no
+    // entry silently falls back to a gray badge labelled by humanize(), which is
+    // how 'suspended' went unnoticed.
+    for (const status of [
+      'running',
+      'suspended',
+      'completed',
+      'failed',
+      'cancelled',
+    ]) {
+      assert.ok(
+        statusDefs[status],
+        `statusDefs is missing '${status}' — it will render as an unstyled gray badge`
+      )
+    }
+  })
+
+  test('suspended is not styled as a failure', () => {
+    assert.notEqual(
+      statusDefs.suspended?.color,
+      'red',
+      'a run waiting on a human has not failed'
+    )
+  })
+
+  test('suspended matches the yellow used by the canvas and timeline', () => {
+    // FlowNode.tsx and WorkflowTimelineDrawer.tsx already colour suspended
+    // yellow; the badge should agree rather than invent a third convention.
+    assert.equal(statusDefs.suspended?.color, 'yellow')
+  })
+})

--- a/packages/console/src/components/ui/badge-defs.ts
+++ b/packages/console/src/components/ui/badge-defs.ts
@@ -108,6 +108,9 @@ export const flagDefs: Record<string, FlagBadgeDef> = {
 
 export const statusDefs: Record<string, EnumBadgeDef> = {
   running: { color: 'blue', label: 'running' },
+  // Yellow to match the canvas (FlowNode) and timeline (WorkflowTimelineDrawer),
+  // which already treat suspended as its own state rather than a failure.
+  suspended: { color: 'yellow', label: 'suspended' },
   completed: { color: 'green', label: 'completed' },
   succeeded: { color: 'green', label: 'succeeded' },
   failed: { color: 'red', label: 'failed' },

--- a/packages/console/src/components/ui/badge-defs.ts
+++ b/packages/console/src/components/ui/badge-defs.ts
@@ -108,8 +108,6 @@ export const flagDefs: Record<string, FlagBadgeDef> = {
 
 export const statusDefs: Record<string, EnumBadgeDef> = {
   running: { color: 'blue', label: 'running' },
-  // Yellow to match the canvas (FlowNode) and timeline (WorkflowTimelineDrawer),
-  // which already treat suspended as its own state rather than a failure.
   suspended: { color: 'yellow', label: 'suspended' },
   completed: { color: 'green', label: 'completed' },
   succeeded: { color: 'green', label: 'succeeded' },

--- a/packages/console/src/hooks/useWorkflowRuns.ts
+++ b/packages/console/src/hooks/useWorkflowRuns.ts
@@ -8,7 +8,12 @@ export interface WorkflowRunData {
   status: string
   input?: unknown
   output?: Record<string, unknown>
-  error?: { message: string }
+  /**
+   * A suspended run also carries an `error` — core stores the suspend reason in
+   * this field with `code: 'WORKFLOW_SUSPENDED'` or `'RPC_NOT_FOUND'`. Read
+   * `code` before presenting this as a failure; see {@link isSuspendReason}.
+   */
+  error?: { message: string; code?: string }
   startedAt?: string
   completedAt?: string
   graphHash?: string

--- a/packages/console/src/lib/workflow-suspend.test.ts
+++ b/packages/console/src/lib/workflow-suspend.test.ts
@@ -38,11 +38,10 @@ describe('isSuspendReason', () => {
   })
 
   test('a suspended run with an unrecognised code is treated as a real error', () => {
-    // Better to over-report an error than to hide a genuine one behind a
-    // reassuring "waiting" card.
     assert.equal(
       isSuspendReason('suspended', { message: 'boom', code: 'SOMETHING_ELSE' }),
-      false
+      false,
+      'better to over-report an error than to hide a genuine one behind a reassuring "waiting" card'
     )
   })
 

--- a/packages/console/src/lib/workflow-suspend.test.ts
+++ b/packages/console/src/lib/workflow-suspend.test.ts
@@ -1,0 +1,87 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  isSuspendReason,
+  suspendReasonCopy,
+  suspendReasonText,
+} from './workflow-suspend.js'
+
+describe('isSuspendReason', () => {
+  test('a suspended run’s error row is a reason, not a failure', () => {
+    assert.equal(
+      isSuspendReason('suspended', {
+        message: 'Needs approval',
+        code: 'WORKFLOW_SUSPENDED',
+      }),
+      true
+    )
+    assert.equal(
+      isSuspendReason('suspended', {
+        message: "RPC 'x' not found. Deploy the missing function and resume.",
+        code: 'RPC_NOT_FOUND',
+      }),
+      true
+    )
+  })
+
+  test('a failed run is still a failure', () => {
+    assert.equal(
+      isSuspendReason('failed', {
+        message: 'boom',
+        code: 'WORKFLOW_SUSPENDED',
+      }),
+      false,
+      'status must win — a failed run is never merely suspended'
+    )
+    assert.equal(isSuspendReason('failed', { message: 'boom' }), false)
+  })
+
+  test('a suspended run with an unrecognised code is treated as a real error', () => {
+    // Better to over-report an error than to hide a genuine one behind a
+    // reassuring "waiting" card.
+    assert.equal(
+      isSuspendReason('suspended', { message: 'boom', code: 'SOMETHING_ELSE' }),
+      false
+    )
+  })
+
+  test('no error means nothing to present either way', () => {
+    assert.equal(isSuspendReason('suspended', undefined), false)
+    assert.equal(isSuspendReason('completed', undefined), false)
+  })
+})
+
+describe('suspendReasonCopy', () => {
+  test('a missing RPC tells the operator to deploy, not to approve', () => {
+    const copy = suspendReasonCopy({ code: 'RPC_NOT_FOUND' })
+    assert.match(copy.title, /missing function/i)
+    assert.match(copy.hint ?? '', /deploy/i)
+  })
+
+  test('an ordinary suspend tells the operator it is waiting to resume', () => {
+    const copy = suspendReasonCopy({ code: 'WORKFLOW_SUSPENDED' })
+    assert.match(copy.title, /resume/i)
+    assert.doesNotMatch(copy.title, /error|fail/i)
+  })
+})
+
+describe('suspendReasonText', () => {
+  test('passes a string message through', () => {
+    assert.equal(
+      suspendReasonText({ message: 'Needs approval' }),
+      'Needs approval'
+    )
+  })
+
+  test('survives a non-string message', () => {
+    assert.equal(
+      suspendReasonText({ message: { nested: true } }),
+      JSON.stringify({ nested: true }, null, 2)
+    )
+  })
+
+  test('is empty with no error', () => {
+    assert.equal(suspendReasonText(undefined), '')
+  })
+})

--- a/packages/console/src/lib/workflow-suspend.ts
+++ b/packages/console/src/lib/workflow-suspend.ts
@@ -1,0 +1,54 @@
+/**
+ * A suspended workflow run is stored with an `error` row even though nothing has
+ * gone wrong: core puts the suspend reason in `error.message` and tags it with a
+ * code (see PikkuWorkflowService.updateRunStatus call sites). Presenting that as
+ * a failure is wrong — the run is healthy and waiting.
+ */
+
+export type WorkflowRunErrorLike = { message?: unknown; code?: string }
+
+/** `error.code` values core attaches to a run it suspended rather than failed. */
+export const SUSPEND_ERROR_CODES = ['WORKFLOW_SUSPENDED', 'RPC_NOT_FOUND']
+
+/**
+ * True when a run's `error` is really a suspend reason. Checks the status too,
+ * so a genuinely failed run that happens to carry one of these codes is still
+ * reported as a failure.
+ */
+export const isSuspendReason = (
+  status: string | undefined,
+  error: WorkflowRunErrorLike | undefined
+): boolean =>
+  status === 'suspended' &&
+  !!error &&
+  (error.code === undefined || SUSPEND_ERROR_CODES.includes(error.code))
+
+/**
+ * What to tell the operator about a suspended run. The two codes need different
+ * copy because they need different actions: one is waiting on a person, the
+ * other is waiting on a deploy.
+ */
+export const suspendReasonCopy = (
+  error: WorkflowRunErrorLike | undefined
+): { title: string; hint?: string } => {
+  if (error?.code === 'RPC_NOT_FOUND') {
+    return {
+      title: 'Waiting on a missing function',
+      hint: 'Deploy the function below, then resume the run.',
+    }
+  }
+  return {
+    title: 'Waiting to be resumed',
+    hint: 'This run is paused and will continue once it is resumed.',
+  }
+}
+
+/** The suspend reason text, tolerating a non-string message. */
+export const suspendReasonText = (
+  error: WorkflowRunErrorLike | undefined
+): string => {
+  if (!error) return ''
+  return typeof error.message === 'string'
+    ? error.message
+    : JSON.stringify(error.message ?? error, null, 2)
+}


### PR DESCRIPTION
Closes #955

## The bug

Core stores a suspended run with a synthetic `error` row carrying the suspend reason (`code: 'WORKFLOW_SUSPENDED'` or `'RPC_NOT_FOUND'`). The run detail panel gated its red **Error** card on error truthiness alone, never on status — so a healthy run merely waiting on a human was presented as a failure.

This pre-dates the approval work in #952; it's branched off `main` rather than stacked on it.

## The fix

- The error card now excludes suspend reasons, and a suspended run gets its own card instead.
- `WORKFLOW_SUSPENDED` and `RPC_NOT_FOUND` get distinct copy — "waiting to be resumed" vs "deploy the missing function, then resume" are different operator actions.
- `statusDefs` gained a `suspended` entry (yellow, matching the canvas and timeline, which already coloured it that way). It previously fell back to an unstyled gray badge.
- Flow cards showed no status badge at all for a suspended last run.
- The run list gained a Suspended filter.

An unrecognised `error.code` on a suspended run is still shown as a real error, so a genuine failure can't hide behind a reassuring card.

## Verification

12 new tests, written TDD — `badge-defs.test.ts` was red before the `suspended` entry existed. The decision logic is extracted into a pure `isSuspendReason`/`suspendReasonCopy` in `lib/workflow-suspend.ts` so it's testable without rendering.

Worth flagging: **CI does not build, typecheck, or test the console** — it's excluded from `build:packages` and `yarn test`, and the package has no `test` script, so its existing test files are orphaned. I ran the console build (`✓ built in 1.96s`, exit 0) and the new tests locally instead. That gap is arguably its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Suspended** workflow status with yellow badges and pause indicators.
  * Added a **Suspended** filter to workflow run lists.
  * Suspended runs now display clear guidance, including whether to resume the run or deploy a missing function first.
* **Bug Fixes**
  * Suspended runs are no longer incorrectly shown as errors.
  * Unrecognized suspension codes continue to display as genuine errors.
* **Tests**
  * Added coverage for suspended status styling, filtering, messaging, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->