### PR TITLE
fix(core): log AI agent tool execute() failures unconditionally

### DIFF
--- a/.changeset/ai-agent-tool-error-logging.md
+++ b/.changeset/ai-agent-tool-error-logging.md
@@ -1,0 +1,5 @@
+---
+'@pikku/core': patch
+---
+
+AI agent tool `execute()` failures are now logged through the structured logger (`logger.error`) unconditionally, even when no `aiMiddleware` `afterToolCall` hook is registered. Previously an exception thrown inside a tool's `execute()` was caught only at the AI SDK's tool-call boundary (surfacing as a generic conversational "tool error" reply) and never reached pikku's logging — making the actual failure undiagnosable server-side unless the app happened to register tool-call middleware. The error is still rethrown after logging, so runtime behavior is unchanged.

--- a/packages/core/src/wirings/ai-agent/ai-agent-prepare.test.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-prepare.test.ts
@@ -237,6 +237,51 @@ describe('ai-agent-prepare', () => {
     assert.equal(afterCalls.length, 1)
   })
 
+  test('buildToolDefs logs a tool execute() failure even without aiMiddleware hooks, then rethrows', async () => {
+    addAgent('ops-agent')
+    pikkuState(null, 'agent', 'agentsMeta')['ops-agent'] = {
+      ...pikkuState(null, 'agent', 'agentsMeta')['ops-agent'],
+      tools: ['searchInventory'],
+    } as any
+    pikkuState(null, 'rpc', 'meta').searchInventory = 'searchInventory'
+    pikkuState(null, 'function', 'meta').searchInventory = {
+      description: 'Search inventory',
+      inputSchemaName: 'SearchInput',
+      sessionless: true,
+    }
+    pikkuState(null, 'misc', 'schemas').set('SearchInput', { type: 'object' })
+    pikkuState(null, 'function', 'functions').set('searchInventory', {
+      func: async () => {
+        throw new Error('db unreachable')
+      },
+    })
+
+    const errorCalls: unknown[][] = []
+    const singletonServices = {
+      logger: {
+        warn: () => {},
+        error: (...args: unknown[]) => errorCalls.push(args),
+      },
+    } as any
+    pikkuState(null, 'package', 'singletonServices', singletonServices)
+
+    const { tools } = await buildToolDefs(
+      {},
+      new Map<string, string>(),
+      'resource-1',
+      'ops-agent',
+      null
+    )
+
+    assert.equal(tools.length, 1)
+    await assert.rejects(
+      () => tools[0].execute({}),
+      /db unreachable/
+    )
+    assert.equal(errorCalls.length, 1)
+    assert.match(String(errorCalls[0][0]), /searchInventory.*execute/)
+  })
+
   test('buildToolDefs skips permissioned tools without a session and adds sub-agent tools', async () => {
     addAgent('manager', {
       agents: ['assistant'],

--- a/packages/core/src/wirings/ai-agent/ai-agent-prepare.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-prepare.ts
@@ -606,6 +606,26 @@ export async function buildToolDefs(
     }
   }
 
+  // A tool's execute() can throw (bad input, RPC failure, DB error, ...). The AI
+  // SDK catches that at the tool-call boundary and turns it into a conversational
+  // "tool error" reply — without this, the exception never reaches pikku's own
+  // logger, so a failing tool is undiagnosable server-side. Log unconditionally,
+  // even when no aiMiddleware afterToolCall hook is registered to see it.
+  for (const tool of tools) {
+    const originalExecute = tool.execute
+    tool.execute = async (toolInput: unknown) => {
+      try {
+        return await originalExecute(toolInput)
+      } catch (err) {
+        singletonServices.logger.error(
+          `AI agent tool '${tool.name}' threw during execute()`,
+          err
+        )
+        throw err
+      }
+    }
+  }
+
   const hasToolHooks = aiMiddlewares?.some(
     (mw) => mw.beforeToolCall || mw.afterToolCall
   )


### PR DESCRIPTION
## Summary

- `buildToolDefs` wraps every AI-agent tool's `execute()` in a try/catch that logs any thrown error via the injected `logger.error(...)` before rethrowing — previously this only happened when the agent had an `aiMiddleware` `afterToolCall` hook registered, which most agents don't.
- Without this, an exception thrown inside a tool's `execute()` (bad input, RPC failure, DB error, etc.) is caught only at the AI SDK's tool-call boundary and surfaces as a generic conversational "tool error" reply — with zero server-side trace to diagnose why.
- Runtime behavior for callers is unchanged: the error still propagates the same way after being logged.

## Context

Found via a Fabric build-eval harness run: a generated warehouse-CRM app's `searchInventory` tool threw at runtime with no error-level log anywhere, despite the same sandbox reliably logging other unrelated errors (a workflow RPC-not-found, a DB constraint violation). Traced it to `buildToolDefs` in `ai-agent-prepare.ts` only logging tool failures inside the `hasToolHooks` branch.

## Test plan

- [x] Added a new test (`buildToolDefs logs a tool execute() failure even without aiMiddleware hooks, then rethrows`) asserting `logger.error` is called and the original error still rejects the `execute()` promise.
- [x] Full `packages/core` test suite green (1093 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)