### PR TITLE
fix(addon-console): route OpenAPI catalogue funcs through the fabric registry

### DIFF
--- a/.changeset/addon-console-openapis-registry.md
+++ b/.changeset/addon-console-openapis-registry.md
@@ -1,0 +1,5 @@
+---
+'@pikku/addon-console': patch
+---
+
+Route `getOpenapis`/`getOpenapiDetail` through `AddonService` and the fabric registry's `/registry/openapis` endpoints (unifying with the package funcs on `FABRIC_API_URL`), instead of the divergent `REGISTRY_URL`/`/api/openapis` path.

--- a/packages/addon/pikku-console/src/functions/get-openapi-detail.function.ts
+++ b/packages/addon/pikku-console/src/functions/get-openapi-detail.function.ts
@@ -21,17 +21,9 @@ export const getOpenapiDetail = pikkuFunc<
 >({
   title: 'Get OpenAPI Detail',
   description:
-    'Fetches a single OpenAPI spec detail from the registry by name.',
+    'Fetches a single OpenAPI spec detail from the fabric registry by name.',
   expose: true,
-  func: async ({ variables }, { name }) => {
-    const registryUrl =
-      (await variables.get('REGISTRY_URL')) ?? 'https://pikku-registry.fly.dev'
-    const response = await fetch(
-      `${registryUrl}/api/openapis?limit=1&offset=0&search=${encodeURIComponent(name)}`
-    )
-    if (!response.ok) return null
-    const data = await response.json()
-    const api = data.apis?.find((a: any) => a.name === name)
-    return api ?? null
+  func: async ({ addonService }, { name }) => {
+    return addonService.readOpenapiDetail(name)
   },
 })

--- a/packages/addon/pikku-console/src/functions/get-openapis.function.ts
+++ b/packages/addon/pikku-console/src/functions/get-openapis.function.ts
@@ -15,23 +15,13 @@ export const getOpenapis = pikkuFunc<
       logo?: string
     }>
     total: number
-    nextCursor: number
+    nextCursor: number | null
   }
 >({
   title: 'Get OpenAPI Specs',
-  description: 'Fetches available OpenAPI specs from the registry.',
+  description: 'Fetches available OpenAPI specs from the fabric registry.',
   expose: true,
-  func: async ({ variables }, { limit, offset, search }) => {
-    const registryUrl =
-      (await variables.get('REGISTRY_URL')) ?? 'https://pikku-registry.fly.dev'
-    let url = `${registryUrl}/api/openapis?limit=${limit}&offset=${offset}`
-    if (search) {
-      url += `&search=${encodeURIComponent(search)}`
-    }
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Registry returned ${response.status}`)
-    }
-    return response.json()
+  func: async ({ addonService }, { limit, offset, search }) => {
+    return addonService.readOpenapis({ limit, offset, search })
   },
 })

--- a/packages/addon/pikku-console/src/services/addon.service.test.ts
+++ b/packages/addon/pikku-console/src/services/addon.service.test.ts
@@ -52,4 +52,32 @@ describe('AddonService', () => {
     )
     assert.deepEqual(result, { id: 'pkg-1', name: '@x/y' })
   })
+
+  test('readOpenapis queries the fabric registry openapis endpoint', async () => {
+    mockFetch({ apis: [{ name: 'stripe' }], total: 1, nextCursor: null })
+    const service = new AddonService(FABRIC)
+    const result = await service.readOpenapis({ limit: 50, offset: 0, search: 'stripe' })
+    assert.equal(calls.length, 1)
+    assert.ok(
+      calls[0].startsWith(`${FABRIC}/registry/openapis`),
+      `expected fabric /registry/openapis, got ${calls[0]}`
+    )
+    assert.ok(
+      calls[0].includes('query=stripe'),
+      `expected query param, got ${calls[0]}`
+    )
+    assert.deepEqual(result, { apis: [{ name: 'stripe' }], total: 1, nextCursor: null })
+  })
+
+  test('readOpenapiDetail queries the fabric registry openapi-by-name endpoint', async () => {
+    mockFetch({ name: 'stripe', title: 'Stripe' })
+    const service = new AddonService(FABRIC)
+    const result = await service.readOpenapiDetail('stripe')
+    assert.equal(calls.length, 1)
+    assert.ok(
+      calls[0].startsWith(`${FABRIC}/registry/openapis/stripe`),
+      `expected fabric /registry/openapis/:name, got ${calls[0]}`
+    )
+    assert.deepEqual(result, { name: 'stripe', title: 'Stripe' })
+  })
 })

--- a/packages/addon/pikku-console/src/services/addon.service.ts
+++ b/packages/addon/pikku-console/src/services/addon.service.ts
@@ -43,6 +43,32 @@ export interface AddonPackageInfo {
 export type AddonMeta = AddonPackageInfo
 export type AddonDetail = AddonPackageInfo
 
+export interface OpenApiSummary {
+  name: string
+  version: string
+  provider: string
+  service: string | null
+  title: string
+  description: string
+  openapiVer: string
+  swaggerUrl: string
+  logo?: string
+}
+
+export interface OpenApiListResult {
+  apis: OpenApiSummary[]
+  total: number
+  nextCursor: number | null
+}
+
+export interface OpenApiDetail extends OpenApiSummary {
+  swaggerYamlUrl?: string
+  categories: string[]
+  tags: string[]
+  added?: string
+  updated?: string
+}
+
 export class AddonService {
   constructor(private fabricApiUrl: string) {}
 
@@ -60,6 +86,37 @@ export class AddonService {
   async readAddon(id: string): Promise<AddonDetail | null> {
     const response = await fetch(
       `${this.fabricApiUrl}/registry/packages/${encodeURIComponent(id)}`
+    )
+    if (!response.ok) return null
+    const text = await response.text()
+    if (!text) return null
+    return JSON.parse(text)
+  }
+
+  /** Browse the fabric registry's OpenAPI catalogue (apis.guru + published). */
+  async readOpenapis(opts: {
+    limit: number
+    offset: number
+    search?: string
+  }): Promise<OpenApiListResult> {
+    const params = new URLSearchParams({
+      limit: String(opts.limit),
+      offset: String(opts.offset),
+    })
+    if (opts.search) params.set('query', opts.search)
+    const response = await fetch(
+      `${this.fabricApiUrl}/registry/openapis?${params.toString()}`
+    )
+    if (!response.ok) {
+      throw new Error(`Registry returned ${response.status}`)
+    }
+    return response.json()
+  }
+
+  /** Fetch one OpenAPI catalogue entry by name (returns null when absent). */
+  async readOpenapiDetail(name: string): Promise<OpenApiDetail | null> {
+    const response = await fetch(
+      `${this.fabricApiUrl}/registry/openapis/${encodeURIComponent(name)}`
     )
     if (!response.ok) return null
     const text = await response.text()


### PR DESCRIPTION
## What

`@pikku/addon-console`'s `getOpenapis` / `getOpenapiDetail` fetched a **separate** registry — the `REGISTRY_URL` variable, defaulting to the legacy `pikku-registry.fly.dev` (`/api/openapis`) — while the package/addon funcs already go through `AddonService` against `${FABRIC_API_URL}/registry/*`. That split meant the OpenAPI catalogue and the package catalogue pointed at different registries.

This unifies them on the one layer:

- Add `AddonService.readOpenapis({ limit, offset, search })` → `GET ${fabricApiUrl}/registry/openapis?limit&offset&query=…` → `{ apis, total, nextCursor }`.
- Add `AddonService.readOpenapiDetail(name)` → `GET ${fabricApiUrl}/registry/openapis/:name` → entry | null (direct route, no more search-then-find hack).
- `get-openapis` / `get-openapi-detail` become thin wrappers over `AddonService` (mirroring `getAddonCommunityPackage` → `addonService.readAddon`).

## Compatibility

- Function **input** signatures unchanged (`{ limit, offset, search? }` / `{ name }`).
- **Output** shapes unchanged except `getOpenapis.nextCursor` widened to `number | null`. The console consumers (`PackagesPage`, `PackageDetailPage`, `AddonDetailDrawer`) read `apis`/`total` only, so they're unaffected.
- The divergent `REGISTRY_URL` variable is no longer read.

## Tests

- `AddonService` unit tests extended to cover `readOpenapis` (asserts `/registry/openapis` + `query=` param) and `readOpenapiDetail` (asserts `/registry/openapis/:name`).
- `pikku all` codegen + `tsc --noEmit` clean; `node --test` green (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)