### PR TITLE
docs(skills): update permission skills for function-only authz (#972)

### DIFF
--- a/packages/cli/skills/pikku-concepts/references/concept-mapping.md
+++ b/packages/cli/skills/pikku-concepts/references/concept-mapping.md
@@ -197,19 +197,21 @@ const isAdmin = pikkuPermission(async (services, data, wire) => {
   return session?.role === 'admin'
 })
 
-// Apply to route pattern
-addHTTPPermission('/admin/*', { admin: [isAdmin] })
-
-// Or inline on specific wiring
-wireHTTP({
-  route: '/users/:id',
-  method: 'delete',
-  func: deleteUser,
+// Declare on the function definition (the only place permissions live)
+export const deleteUser = pikkuFunc({
+  func: async (services, data) => {
+    /* ... */
+  },
   permissions: { admin: [isAdmin] },
 })
+
+// App-wide baseline every function must also pass (AND gate, narrow-only)
+addGlobalPermission([signedInUser])
 ```
 
 **Permission groups:** `{ groupA: [perm1, perm2], groupB: [perm3] }` means `(perm1 AND perm2) OR perm3`.
+
+> Route-pattern (`addHTTPPermission`) and wire-level `permissions` were removed in #972 — permissions live on the function, plus the optional global gate.
 
 ---
 

--- a/packages/cli/skills/pikku-http/SKILL.md
+++ b/packages/cli/skills/pikku-http/SKILL.md
@@ -2,7 +2,7 @@
 name: pikku-http
 description: >-
   Use when adding HTTP routes, REST APIs, web endpoints, or SSE streams to a Pikku app. Covers
-  wireHTTP, defineHTTPRoutes, route groups, auth, middleware, permissions, SSE, and generated
+  wireHTTP, defineHTTPRoutes, route groups, auth, middleware, SSE, and generated
   fetch client. TRIGGER when: code uses wireHTTP/defineHTTPRoutes/wireHTTPRoutes, user asks about
   REST endpoints, API routes, SSE, or the generated fetch client. DO NOT TRIGGER when: user asks
   about WebSocket (use pikku-websocket), queue workers (use pikku-queue), or deployment (use
@@ -22,7 +22,7 @@ Use this skill as an execution checklist, not reference material.
 4. Validate with the narrowest relevant command first, then run `pikku-verify` or `pikku all` when functions, wirings, schemas, or generated clients may have changed.
 5. If validation fails, fix the source cause and rerun validation. Do not paper over generated errors by editing generated files.
 
-Wire Pikku functions to HTTP endpoints. Supports single routes, composable route groups, auth, middleware, permissions, SSE, and auto-generated type-safe clients.
+Wire Pikku functions to HTTP endpoints. Supports single routes, composable route groups, auth, middleware, SSE, and auto-generated type-safe clients. (Authorization lives on the function, not the wiring — see `pikku-permissions`.)
 
 ## Before You Start
 
@@ -54,11 +54,7 @@ addHTTPMiddleware('*', [authBearer()]) // All routes
 addHTTPMiddleware('/api/*', [rateLimit()]) // Pattern match
 ```
 
-### `addHTTPPermission(pattern, permissions)`
-
-```typescript
-addHTTPPermission('/admin/*', { admin: [isAdmin] })
-```
+> HTTP-route-level permissions (`addHTTPPermission`, a `permissions` field on the wiring) were removed in #972. Declare authorization on the function definition (`pikkuFunc({ permissions })`, see `pikku-permissions`), or app-wide via `addGlobalPermission`. Tags/patterns are for *middleware* only now.
 
 ## Data Flow
 
@@ -111,23 +107,17 @@ wireHTTPRoutes({
 // Results in: GET /api/v1/books, POST /api/v1/books, GET /api/v1/todos, etc.
 ```
 
-### Auth & Permissions
+### Auth
 
 ```typescript
 // Public route (no auth)
 wireHTTP({ method: 'get', route: '/books', func: listBooks, auth: false })
 
-// Route with permission check
-wireHTTP({
-  method: 'delete',
-  route: '/books/:bookId',
-  func: deleteBook,
-  permissions: { admin: isAdmin },
-})
-
-// Pattern-based permissions
-addHTTPPermission('/admin/*', { admin: isAdmin })
+// Authenticated route (default when a global auth middleware is set)
+wireHTTP({ method: 'delete', route: '/books/:bookId', func: deleteBook })
 ```
+
+Authorization is not a wiring concern — declare it on the function via `permissions` (see `pikku-permissions`), or app-wide via `addGlobalPermission`.
 
 ### Middleware
 

--- a/packages/cli/skills/pikku-http/references/http-options.md
+++ b/packages/cli/skills/pikku-http/references/http-options.md
@@ -11,7 +11,6 @@ Wire a single function to an HTTP endpoint. Import from `@pikku/core/http`.
 | `func` | `PikkuFunc` | The function to call |
 | `auth?` | `boolean` | Override default auth (`true` = require session) |
 | `tags?` | `string[]` | For grouping, middleware targeting |
-| `permissions?` | `Record<string, PikkuPermission \| PikkuPermission[]>` | Permission checks |
 | `middleware?` | `PikkuMiddleware[]` | Per-route middleware |
 | `sse?` | `boolean` | Enable Server-Sent Events |
 | `contentType?` | `'xml' \| 'json'` | Response content type |
@@ -35,7 +34,6 @@ const routes = defineHTTPRoutes({
       route: string,
       func: PikkuFunc,
       auth?: boolean,      // Override group auth
-      permissions?: Record<string, PikkuPermission | PikkuPermission[]>,
       middleware?: PikkuMiddleware[],
     }
   }

--- a/packages/cli/skills/pikku-info/SKILL.md
+++ b/packages/cli/skills/pikku-info/SKILL.md
@@ -47,7 +47,7 @@ yarn pikku info functions --verbose --silent
 
 ### Tags
 
-List all tags with counts of associated functions, middleware, and permissions:
+List all tags with counts of associated functions and middleware:
 
 ```bash
 yarn pikku info tags --silent

--- a/packages/cli/skills/pikku-permissions/SKILL.md
+++ b/packages/cli/skills/pikku-permissions/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: pikku-permissions
 description: >-
-  Use when adding authorization checks to Pikku functions or routes — pikkuPermission, pikkuAuth,
-  per-function permissions, pattern-based permissions, or understanding OR/AND permission logic.
+  Use when adding authorization checks to Pikku functions — pikkuPermission, pikkuAuth,
+  per-function permissions, global permissions, or understanding OR/AND permission logic.
   TRIGGER when: user wants to restrict who can call a function, check resource ownership, add
   role-based access, or understand where permission checks belong. DO NOT TRIGGER when: user asks
   about middleware or request interception (use pikku-middleware), authentication strategies (use
@@ -42,7 +42,7 @@ export const deleteBook = pikkuFunc({
 
 1. Discover before editing. Run `pikku info permissions --verbose` and `pikku info functions --verbose` to understand what permissions are already defined and applied.
 2. Define permission checkers in a `src/permissions.ts` or domain-specific `src/lib/*-permissions.ts` file.
-3. Apply them via the `permissions` field on the function, or via `addHTTPPermission` / `addPermission` for pattern/tag-based application.
+3. Apply them via the `permissions` field on the function. For an app-wide baseline that every function must additionally satisfy, use `addGlobalPermission`.
 4. Validate: run `pikku all --tsc` to confirm permission checker signatures are correct.
 
 ## Permission Factories
@@ -113,21 +113,28 @@ export const deleteBook = pikkuFunc({
 })
 ```
 
-### Pattern-Based (`addHTTPPermission`)
+### Global (`addGlobalPermission`) — App-Wide AND Gate
+
+A global permission is an app-wide baseline that **every** function must additionally pass. It is an independent AND gate: it can only ever *narrow* access — it never grants access a function's own `permissions` would deny.
 
 ```typescript
-import { addHTTPPermission } from '@pikku/core/http'
+import { addGlobalPermission } from '.pikku/pikku-types.gen.js'
 
-addHTTPPermission('/admin/*', { admin: isAdmin })
+addGlobalPermission([signedInUser]) // every function now also requires a session
 ```
 
-### Tag-Based (`addPermission`)
+Multiple `addGlobalPermission` calls accumulate and are AND'd together.
 
-```typescript
-import { addPermission } from '.pikku/pikku-types.gen.js'
+> Wire-, tag-, and HTTP-route-level permissions (`addHTTPPermission`, `addTagPermission`, and a `permissions` field on HTTP/channel/MCP wirings) were **removed in #972**. Permissions now live only on the function definition, plus the optional global gate. Tags are organizational only — use tag/HTTP *middleware* (`addTagMiddleware`, `addHTTPMiddleware`) for cross-cutting request handling, not authorization.
 
-addPermission('internal', { machine: isMachineAgent })
-```
+## The Two Gates
+
+Authorization is two independent gates, both of which must pass:
+
+1. **Global permissions** (`addGlobalPermission`) — AND'd together. A broad baseline that can only narrow access.
+2. **The function's own `permissions`** — OR'd groups (OR-of-ANDs), as above.
+
+The gates are independent: a broad global (e.g. `signedInUser`) can **never** satisfy an admin-only function's own requirement. Each function still enforces its own `permissions` in full.
 
 ## Complete Example
 


### PR DESCRIPTION
Follow-up to #974 (merged). Updates the CLI skills to match the #972 API surface so the skills stay the source of truth.

## Changes
- **pikku-permissions** — replaced the `addHTTPPermission`/`addTagPermission` (pattern/tag) sections with an `addGlobalPermission` section; added a "Two Gates" section (global AND gate + function-scoped OR groups, independent).
- **pikku-http** — removed `addHTTPPermission` and wire-level `permissions`; authorization now points to `pikku-permissions`.
- **pikku-http/references/http-options.md** — dropped the `permissions?` option from the `wireHTTP` / `defineHTTPRoutes` tables.
- **pikku-concepts/references/concept-mapping.md** — n8n/OpenAPI mapping now shows function-level permissions + `addGlobalPermission`.
- **pikku-info** — `pikku info tags` no longer lists per-tag permission counts.

Docs only — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authorization guidance to use function-level permission declarations.
  * Documented app-wide baseline authorization through `addGlobalPermission`.
  * Removed documentation for route-level and wiring-level permission configuration.
  * Clarified that public HTTP routes can disable authentication explicitly, while other routes follow global authentication behavior.
  * Updated HTTP option references to remove permission settings.
  * Revised tag information guidance to count functions and middleware only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->