### PR TITLE
fix(console): hide Publish CTA on a read-only console

### DIFF
--- a/.changeset/publish-cta-editable-only.md
+++ b/.changeset/publish-cta-editable-only.md
@@ -1,0 +1,7 @@
+---
+'@pikku/console': patch
+---
+
+Hide the "Publish an integration" CTA on a read-only console (e.g. a deployed
+stage). Publishing is an authoring action, so it now only shows when the console
+is editable.

--- a/packages/console/src/components/packages/CommunityGallery.tsx
+++ b/packages/console/src/components/packages/CommunityGallery.tsx
@@ -193,7 +193,9 @@ export const CommunityGallery: React.FC<CommunityGalleryProps> = ({
             )}
           </Box>
 
-          {kind === 'addon' && <PublishCta />}
+          {/* Publishing is an authoring action — hide it on a read-only console
+              (e.g. a deployed stage) where you can't install or edit anyway. */}
+          {kind === 'addon' && editable && <PublishCta />}
         </Stack>
       </Box>
 


### PR DESCRIPTION
The "Built something reusable? / Publish an integration" CTA in the addons
community gallery shows on every addons view — including read-only consoles
like a deployed stage, where you can neither install nor edit, so publishing
makes no sense there.

Gate the CTA on the existing `editable` flag so it only appears on an editable
console. This removes it from Fabric's deployed-stage addons page (always
read-only) while keeping it in editable contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hid the “Publish an integration” call-to-action in read-only console views.
  * Publishing is now available only when the console is editable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->