### PR TITLE
fix(cli): pin core and inspector in the bootstrap install

### DIFF
--- a/.changeset/pin-cli-bootstrap-deps.md
+++ b/.changeset/pin-cli-bootstrap-deps.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': patch
+---
+
+Pin the CLI bootstrap's `@pikku/core` and `@pikku/inspector` alongside the pinned `@pikku/cli`, so a fresh release of core can no longer break the build on every branch at once.

--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -16,6 +16,14 @@ echo "Bootstrapping with published @pikku/cli..."
 : "${PIKKU_CLI_VERSION:=0.12.35}"
 : "${PIKKU_AUTH_JS_VERSION:=0.12.5}"
 : "${PIKKU_BETTER_AUTH_VERSION:=0.12.12}"
+# Pinning the CLI alone is not enough: it declares caret ranges on its own
+# @pikku/* deps, so npm pairs a months-old CLI with today's core/inspector. The
+# moment the inspector-state shape moves, bootstrap dies on every branch at once
+# (`Cannot read properties of undefined (reading 'size')`) with no commit to
+# blame. These are the versions that shipped alongside @pikku/cli 0.12.35 — bump
+# them together with PIKKU_CLI_VERSION, never independently.
+: "${PIKKU_CORE_VERSION:=0.12.31}"
+: "${PIKKU_INSPECTOR_VERSION:=0.12.19}"
 _bootstrap_dir=$(mktemp -d)
 trap 'rm -rf "$_bootstrap_dir"' EXIT
 # The published bootstrap CLI's own auth codegen imports the auth package at
@@ -37,7 +45,9 @@ cat > "$_bootstrap_dir/package.json" <<JSON
     "@pikku/auth-js": "${PIKKU_AUTH_JS_VERSION}"
   },
   "overrides": {
-    "@pikku/better-auth": "${PIKKU_BETTER_AUTH_VERSION}"
+    "@pikku/better-auth": "${PIKKU_BETTER_AUTH_VERSION}",
+    "@pikku/core": "${PIKKU_CORE_VERSION}",
+    "@pikku/inspector": "${PIKKU_INSPECTOR_VERSION}"
   }
 }
 JSON


### PR DESCRIPTION
## The failure

Every branch — including `main` itself at `31980d5e4` — currently fails the Build job with:

```
Error: TypeError: Cannot read properties of undefined (reading 'size')
    at .../@pikku/cli/dist/src/functions/wirings/permissions/pikku-command-permissions.js:11
```

No commit introduced it. I reproduced it on a clean checkout of `origin/main`, which was green in CI 14 hours earlier with no source change in between.

## Why

`packages/cli/build.sh` bootstraps codegen with a **pinned** published CLI (`0.12.35`), but pins only the CLI. That CLI declares its own siblings as caret ranges:

```
"@pikku/core": "^0.12.31",
"@pikku/inspector": "^0.12.19",
```

so npm resolves them to `latest`. The `Version Packages` release at 2026-07-19T20:25Z published core `0.12.83`, and from that moment the bootstrap has been running a June CLI against a July core. The inspector-state shape has moved since; the old CLI reads a field that no longer exists.

The pinned-CLI comment already warns about bootstrapping off `latest` self-deadlocking the build. This is the same hazard one level down — the pin was only half applied.

## Fix

Pin `@pikku/core` and `@pikku/inspector` to the versions that shipped alongside CLI `0.12.35`, via the existing `overrides` block.

Pinning core alone isn't sufficient: a floating `@pikku/inspector` then fails with `Package subpath './scope' is not defined by "exports"`, since today's inspector needs a core subpath the old core doesn't export. All three have to move together, which the comment now says explicitly.

## Verification

On a clean `origin/main` worktree, before the change: the `.size` crash. After: bootstrap completes and codegen proceeds past schema generation. The build then stops on unbuilt workspace deps (`@pikku/node-http-server/dist`), which is an artifact of building one workspace in isolation — CI runs `yarn build:packages` in dependency order.

## Follow-up

The real fix is for the bootstrap not to float at all. Worth considering whether the pin set should be derived from a single `PIKKU_BOOTSTRAP_VERSION` — or whether the CLI can bootstrap from the previous release's full lockfile — so this can't silently drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)