### PR TITLE
perf(inspector): cut the schema program's memory and time cost (#982)

### DIFF
--- a/.changeset/perf-982-schema-program.md
+++ b/.changeset/perf-982-schema-program.md
@@ -1,0 +1,11 @@
+---
+'@pikku/inspector': patch
+---
+
+Cut the schema generator's ts.Program cost — the dominant contributor to `pikku all` memory and time.
+
+Two independent fixes: the program is now scoped to the virtual file's import
+closure (870 source files instead of the whole tsconfig's 2572), and it is
+released once schemas are generated instead of being pinned at module scope for
+the life of the process. On a 279-function tree this cuts cold codegen ~20% and
+in-pass live heap ~21%, with byte-identical schema output.

--- a/benchmarks/analyze-heapsnapshot.ts
+++ b/benchmarks/analyze-heapsnapshot.ts
@@ -1,0 +1,207 @@
+/**
+ * Aggregate a V8 .heapsnapshot by retained size, so we can name the top
+ * retainers in a `pikku all` run rather than guessing from code reading.
+ *
+ * Usage:
+ *   npx tsx benchmarks/analyze-heapsnapshot.ts <file.heapsnapshot> [topN]
+ *
+ * Retained size needs the dominator tree, not just self_size — a Map with a
+ * tiny shallow size can dominate hundreds of MB of ts.Type/AST objects, which
+ * is exactly the case we're trying to distinguish here.
+ *
+ * LIMITATION: reads the snapshot with JSON.parse, so it caps out at Node's
+ * ~512MB max string length. A snapshot captured near a 2GB heap limit will not
+ * load — capture at a lower --max-old-space-size, or replace the read with a
+ * streaming/byte-scanning parser (the nodes/edges arrays are flat numerics).
+ */
+import { readFileSync } from 'fs'
+
+const file = process.argv[2]
+const TOP = parseInt(process.argv[3] ?? '30', 10)
+if (!file) {
+  console.error('usage: analyze-heapsnapshot.ts <file.heapsnapshot> [topN]')
+  process.exit(1)
+}
+
+type Snapshot = {
+  snapshot: {
+    meta: {
+      node_fields: string[]
+      node_types: any[]
+      edge_fields: string[]
+      edge_types: any[]
+    }
+    node_count: number
+    edge_count: number
+  }
+  nodes: number[]
+  edges: number[]
+  strings: string[]
+}
+
+const snap: Snapshot = JSON.parse(readFileSync(file, 'utf8'))
+const { node_fields, edge_fields, node_types, edge_types } = snap.snapshot.meta
+
+const NF = node_fields.length
+const EF = edge_fields.length
+const nodeCount = snap.snapshot.node_count
+const nodes = snap.nodes
+const edges = snap.edges
+
+const nfType = node_fields.indexOf('type')
+const nfName = node_fields.indexOf('name')
+const nfSelf = node_fields.indexOf('self_size')
+const nfEdgeCount = node_fields.indexOf('edge_count')
+
+const efType = edge_fields.indexOf('type')
+const efName = edge_fields.indexOf('name_or_index')
+const efTo = edge_fields.indexOf('to_node')
+
+const nodeTypeNames: string[] = node_types[0]
+const edgeTypeNames: string[] = edge_types[0]
+
+// firstEdge[i] = index into `edges` (in edge units) where node i's edges start
+const firstEdge = new Uint32Array(nodeCount + 1)
+{
+  let acc = 0
+  for (let i = 0; i < nodeCount; i++) {
+    firstEdge[i] = acc
+    acc += nodes[i * NF + nfEdgeCount]!
+  }
+  firstEdge[nodeCount] = acc
+}
+
+const selfSize = new Float64Array(nodeCount)
+for (let i = 0; i < nodeCount; i++) selfSize[i] = nodes[i * NF + nfSelf]!
+
+function nodeLabel(i: number): string {
+  const t = nodeTypeNames[nodes[i * NF + nfType]!]!
+  const n = snap.strings[nodes[i * NF + nfName]!] ?? ''
+  if (t === 'object' || t === 'closure' || t === 'native') return n || `(${t})`
+  return `(${t})`
+}
+
+// ── BFS from root to get traversal order + parents ───────────────────────────
+// Weak/shortcut edges don't retain, so they're excluded from the dominator calc.
+function retains(edgeTypeName: string): boolean {
+  return edgeTypeName !== 'weak' && edgeTypeName !== 'shortcut'
+}
+
+const ROOT = 0
+const order: number[] = []
+const visited = new Uint8Array(nodeCount)
+const queue = new Int32Array(nodeCount)
+let qh = 0
+let qt = 0
+queue[qt++] = ROOT
+visited[ROOT] = 1
+while (qh < qt) {
+  const u = queue[qh++]!
+  order.push(u)
+  for (let e = firstEdge[u]!; e < firstEdge[u + 1]!; e++) {
+    if (!retains(edgeTypeNames[edges[e * EF + efType]!]!)) continue
+    const v = edges[e * EF + efTo]! / NF
+    if (!visited[v]) {
+      visited[v] = 1
+      queue[qt++] = v
+    }
+  }
+}
+
+// Predecessors, restricted to reachable nodes
+const predHead = new Int32Array(nodeCount).fill(-1)
+const predNext: number[] = []
+const predNode: number[] = []
+for (let u = 0; u < nodeCount; u++) {
+  if (!visited[u]) continue
+  for (let e = firstEdge[u]!; e < firstEdge[u + 1]!; e++) {
+    if (!retains(edgeTypeNames[edges[e * EF + efType]!]!)) continue
+    const v = edges[e * EF + efTo]! / NF
+    if (!visited[v]) continue
+    predNode.push(u)
+    predNext.push(predHead[v]!)
+    predHead[v] = predNode.length - 1
+  }
+}
+
+// ── Iterative dominator tree (Cooper-Harvey-Kennedy) ─────────────────────────
+const rpoIndex = new Int32Array(nodeCount).fill(-1)
+for (let i = 0; i < order.length; i++) rpoIndex[order[i]!] = i
+
+const idom = new Int32Array(nodeCount).fill(-1)
+idom[ROOT] = ROOT
+
+function intersect(a: number, b: number): number {
+  while (a !== b) {
+    while (rpoIndex[a]! > rpoIndex[b]!) a = idom[a]!
+    while (rpoIndex[b]! > rpoIndex[a]!) b = idom[b]!
+  }
+  return a
+}
+
+let changed = true
+while (changed) {
+  changed = false
+  for (let i = 1; i < order.length; i++) {
+    const u = order[i]!
+    let newIdom = -1
+    for (let p = predHead[u]!; p !== -1; p = predNext[p]!) {
+      const pred = predNode[p]!
+      if (idom[pred] === -1) continue
+      newIdom = newIdom === -1 ? pred : intersect(newIdom, pred)
+    }
+    if (newIdom !== -1 && idom[u] !== newIdom) {
+      idom[u] = newIdom
+      changed = true
+    }
+  }
+}
+
+// ── Retained size: accumulate up the dominator tree, deepest-first ───────────
+const retained = new Float64Array(nodeCount)
+for (const u of order) retained[u] = selfSize[u]!
+for (let i = order.length - 1; i >= 1; i--) {
+  const u = order[i]!
+  const d = idom[u]!
+  if (d !== -1 && d !== u) retained[d]! += retained[u]!
+}
+
+// ── Report ───────────────────────────────────────────────────────────────────
+const MB = (b: number) => (b / 1024 / 1024).toFixed(1)
+const totalHeap = order.reduce((a, u) => a + selfSize[u]!, 0)
+
+console.log(`snapshot:   ${file}`)
+console.log(`nodes:      ${nodeCount} (${order.length} reachable)`)
+console.log(`total heap: ${MB(totalHeap)} MB\n`)
+
+// By constructor/label — where the bytes actually live
+const byLabel = new Map<string, { count: number; self: number }>()
+for (const u of order) {
+  const k = nodeLabel(u)
+  const cur = byLabel.get(k) ?? { count: 0, self: 0 }
+  cur.count++
+  cur.self += selfSize[u]!
+  byLabel.set(k, cur)
+}
+console.log(`── Top ${TOP} by TOTAL SHALLOW size (where bytes live) ──`)
+console.log('        MB    count  constructor')
+for (const [k, v] of [...byLabel.entries()]
+  .sort((a, b) => b[1].self - a[1].self)
+  .slice(0, TOP)) {
+  console.log(
+    `  ${MB(v.self).padStart(8)}  ${String(v.count).padStart(7)}  ${k}`
+  )
+}
+
+// Individual dominators — which single objects hold the graph up
+console.log(
+  `\n── Top ${TOP} individual objects by RETAINED size (who holds it) ──`
+)
+console.log('        MB  constructor')
+const topRetainers = [...order]
+  .sort((a, b) => retained[b]! - retained[a]!)
+  .filter((u) => u !== ROOT)
+  .slice(0, TOP)
+for (const u of topRetainers) {
+  console.log(`  ${MB(retained[u]!).padStart(8)}  ${nodeLabel(u)}`)
+}

--- a/benchmarks/bench-cli.ts
+++ b/benchmarks/bench-cli.ts
@@ -12,10 +12,36 @@ const SIBLING_PIKKU = resolve(__dirname, '..', '..', 'pikku')
 const PIKKU_BIN = resolve(SIBLING_PIKKU, 'node_modules/.bin/pikku')
 const PIKKU_NODE_MODULES = resolve(SIBLING_PIKKU, 'node_modules')
 
-const PROJECT_DIR = resolve(os.tmpdir(), 'pikku-cli-bench')
+// ── CLI args ──────────────────────────────────────────────────────────────────
+//   --weight=light|heavy   fixture type closure (default: light)
+//   --sizes=25,50,100      function counts to sweep
+//   --runs=3               runs per size
+//   --heap=6144            --max-old-space-size for the child; omit for Node's
+//                          default, which is the whole point when hunting an OOM
+function argOf(name: string): string | undefined {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`))
+  return hit?.slice(name.length + 3)
+}
 
-const SIZES = [10, 50, 100, 250, 500, 1000]
-const RUNS_PER_SIZE = 3
+type Weight = 'light' | 'heavy'
+const WEIGHT = (argOf('weight') ?? 'light') as Weight
+if (WEIGHT !== 'light' && WEIGHT !== 'heavy') {
+  console.error(`--weight must be light or heavy, got "${WEIGHT}"`)
+  process.exit(1)
+}
+
+// Separate project dir per weight so the two fixtures never share a .pikku/ or
+// a schema cache — a warm cache from the other weight would skew the numbers.
+const PROJECT_DIR = resolve(os.tmpdir(), `pikku-cli-bench-${WEIGHT}`)
+
+const SIZES = (argOf('sizes') ?? '10,50,100,250,500,1000')
+  .split(',')
+  .map((s) => parseInt(s.trim(), 10))
+const RUNS_PER_SIZE = parseInt(argOf('runs') ?? '3', 10)
+// Undefined => let Node pick its default old-space. bench-cli previously pinned
+// 8192 here, which made the OOM this benchmark is meant to catch unobservable.
+const HEAP_MB = argOf('heap') ? parseInt(argOf('heap')!, 10) : undefined
+const KEEP = process.argv.includes('--keep')
 
 function setupProject() {
   mkdirSync(resolve(PROJECT_DIR, 'src/functions'), { recursive: true })
@@ -84,6 +110,14 @@ function setupProject() {
     ].join('\n')
   )
 
+  if (WEIGHT === 'heavy') {
+    writeFileSync(resolve(PROJECT_DIR, 'types/db-schema.ts'), dbSchemaFile())
+    writeFileSync(
+      resolve(PROJECT_DIR, 'types/deep-generic.ts'),
+      deepGenericFile()
+    )
+  }
+
   // Factory stubs — defined inline to avoid .pikku/ chicken-and-egg at bootstrap
   writeFileSync(
     resolve(PROJECT_DIR, 'src/services.ts'),
@@ -99,7 +133,152 @@ function setupProject() {
   )
 }
 
+// ── heavy fixture: external type closure ─────────────────────────────────────
+// The light fixture's zod schemas are self-contained — nothing forces the
+// typechecker to pull in a large .d.ts closure, which is why the light sweep
+// never reproduces the >2GB peak seen on real backends. These two files give
+// the heavy fixture a genuinely expensive closure to resolve.
+
+const DB_TABLES = 40
+const DB_COLUMNS = 15
+
+/** Kysely-generated-style schema: 40 tables x 15 branded columns. */
+function dbSchemaFile(): string {
+  const tables = Array.from({ length: DB_TABLES }, (_, t) => {
+    const cols = Array.from({ length: DB_COLUMNS }, (_, c) => {
+      // Rotate through Kysely's branded column types so each column forces a
+      // distinct ColumnType instantiation rather than a cached identical one.
+      const variants = [
+        `Generated<number>`,
+        `ColumnType<Date, string | Date, string | Date>`,
+        `string | null`,
+        `ColumnType<string, string, never>`,
+        `Generated<boolean>`,
+      ]
+      return `  col${c}: ${variants[c % variants.length]}`
+    }).join('\n')
+    return `export interface Table${t} {\n${cols}\n}`
+  }).join('\n\n')
+
+  const dbFields = Array.from(
+    { length: DB_TABLES },
+    (_, t) => `  table${t}: Table${t}`
+  ).join('\n')
+
+  return `import type { Generated, ColumnType, Selectable, Insertable, Updateable } from 'kysely'
+
+${tables}
+
+export interface DB {
+${dbFields}
+}
+
+export type Row<T extends keyof DB> = Selectable<DB[T]>
+export type New<T extends keyof DB> = Insertable<DB[T]>
+export type Patch<T extends keyof DB> = Updateable<DB[T]>
+`
+}
+
+/** @octokit-style deeply nested conditional + mapped generic. */
+function deepGenericFile(): string {
+  return `export type DeepPartial<T> = { [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K] }
+
+export type Paths<T, D extends number = 4> = D extends 0
+  ? never
+  : T extends object
+    ? { [K in keyof T]-?: K extends string ? K | \`\${K}.\${Paths<T[K], Prev[D]>}\` : never }[keyof T]
+    : never
+
+type Prev = [never, 0, 1, 2, 3, 4]
+
+export type Endpoints<T> = {
+  [K in keyof T as \`GET /\${string & K}\`]: {
+    parameters: DeepPartial<T[K]>
+    response: { data: T[K][]; meta: { total: number; cursor: string | null } }
+  }
+}
+
+export type Unwrap<T> = T extends { response: { data: (infer U)[] } } ? U : never
+
+export type Resolved<T, K extends keyof Endpoints<T>> = Unwrap<Endpoints<T>[K]>
+`
+}
+
+/** Heavy function: generic-based (never generics + input/output together). */
+function heavyFunctionFile(n: number): string {
+  const name = `testFunc${String(n).padStart(4, '0')}`
+  const table = `table${n % DB_TABLES}`
+
+  // Alternate the two expensive codepaths: even n exercises the
+  // ts-json-schema-generator path via TS generics over the Kysely + deep-generic
+  // closure; odd n exercises the zod path with a 30+ field inferred object.
+  if (n % 2 === 0) {
+    return `import { pikkuSessionlessFunc } from '../../.pikku/pikku-types.gen.js'
+import type { Row, New, DB } from '../../types/db-schema.js'
+import type { Endpoints, Resolved, DeepPartial, Paths } from '../../types/deep-generic.js'
+
+export type ${name}In = {
+  row: New<'${table}'>
+  filter: DeepPartial<Row<'${table}'>>
+  sort: Paths<Row<'${table}'>>
+  page: { limit: number; cursor: string | null }
+}
+
+export type ${name}Out = {
+  item: Row<'${table}'>
+  related: Resolved<Pick<DB, '${table}'>, 'GET /${table}'>
+  endpoints: keyof Endpoints<Pick<DB, '${table}'>>
+  meta: { total: number; cursor: string | null; durationMs: number }
+}
+
+export const ${name} = pikkuSessionlessFunc<${name}In, ${name}Out>({
+  func: async (_services, data) => ({
+    item: data.row as unknown as Row<'${table}'>,
+    related: null as unknown as Resolved<Pick<DB, '${table}'>, 'GET /${table}'>,
+    endpoints: 'GET /${table}' as keyof Endpoints<Pick<DB, '${table}'>>,
+    meta: { total: 0, cursor: data.page.cursor, durationMs: 0 },
+  }),
+})`
+  }
+
+  const wideFields = Array.from({ length: 35 }, (_, i) => {
+    const variants = [
+      `z.string()`,
+      `z.number()`,
+      `z.boolean()`,
+      `z.array(z.string())`,
+      `z.object({ a: z.string(), b: z.number() })`,
+    ]
+    return `  f${i}: ${variants[i % variants.length]},`
+  }).join('\n')
+
+  const wideReturn = Array.from({ length: 35 }, (_, i) => {
+    const vals = [`''`, `0`, `false`, `[]`, `{ a: '', b: 0 }`]
+    return `    f${i}: ${vals[i % vals.length]},`
+  }).join('\n')
+
+  return `import { pikkuSessionlessFunc } from '../../.pikku/pikku-types.gen.js'
+import { z } from 'zod'
+
+export const ${name}Input = z.object({
+${wideFields}
+})
+
+export const ${name}Output = z.object({
+${wideFields}
+})
+
+export const ${name} = pikkuSessionlessFunc({
+  input: ${name}Input,
+  output: ${name}Output,
+  func: async (_services, _data) => ({
+${wideReturn}
+  }),
+})`
+}
+
 function functionFile(n: number): string {
+  if (WEIGHT === 'heavy') return heavyFunctionFile(n)
   const name = `testFunc${String(n).padStart(4, '0')}`
   return `import { pikkuSessionlessFunc } from '../../.pikku/pikku-types.gen.js'
 import { z } from 'zod'
@@ -384,24 +563,34 @@ function cleanSrc() {
   // services.ts is kept (not in functions/ or wirings/)
 }
 
-function runAll(): { ms: number; peakMB: number } {
+function runAll(): { ms: number; peakMB: number; oom: boolean } {
   const start = performance.now()
   const result = spawnSync('/usr/bin/time', ['-l', PIKKU_BIN, 'all'], {
     cwd: PROJECT_DIR,
     timeout: 600_000,
-    env: { ...process.env, NODE_OPTIONS: '--max-old-space-size=8192' },
+    env: {
+      ...process.env,
+      ...(HEAP_MB
+        ? { NODE_OPTIONS: `--max-old-space-size=${HEAP_MB}` }
+        : // Strip any inherited NODE_OPTIONS so the child really does run on
+          // Node's default old-space — that ceiling is what we're measuring.
+          { NODE_OPTIONS: '' }),
+    },
   })
   const ms = performance.now() - start
-  if (result.status !== 0) {
-    throw new Error(
-      result.stderr?.toString() ?? result.error?.message ?? 'pikku all failed'
-    )
-  }
   // /usr/bin/time -l writes "NNN  maximum resident set size" to stderr (bytes on macOS)
   const stderr = result.stderr?.toString() ?? ''
   const match = stderr.match(/(\d+)\s+maximum resident set size/)
   const peakMB = match ? Math.round(parseInt(match[1]) / 1024 / 1024) : 0
-  return { ms, peakMB }
+
+  // An OOM is a data point here, not a benchmark failure — record it and keep
+  // sweeping so we can see exactly which N crosses the ceiling.
+  const oom =
+    /JavaScript heap out of memory|FATAL ERROR:.*Allocation failed/.test(stderr)
+  if (result.status !== 0 && !oom) {
+    throw new Error(stderr || result.error?.message || 'pikku all failed')
+  }
+  return { ms, peakMB, oom }
 }
 
 function median(vals: number[]): number {
@@ -438,6 +627,7 @@ async function main() {
     medianMs: number
     maxMs: number
     peakMB: number
+    oomCount: number
   }> = []
 
   for (const size of SIZES) {
@@ -446,23 +636,29 @@ async function main() {
 
     const times: number[] = []
     const heaps: number[] = []
+    let oomCount = 0
     for (let r = 0; r < RUNS_PER_SIZE; r++) {
-      const { ms, peakMB } = runAll()
+      const { ms, peakMB, oom } = runAll()
       times.push(ms)
       heaps.push(peakMB)
-      process.stdout.write('.')
+      if (oom) oomCount++
+      process.stdout.write(oom ? 'X' : '.')
     }
     console.log(
-      `  min=${Math.round(Math.min(...times))}ms  median=${Math.round(median(times))}ms  max=${Math.round(Math.max(...times))}ms  peak=${Math.max(...heaps)}MB`
+      `  min=${Math.round(Math.min(...times))}ms  median=${Math.round(median(times))}ms  max=${Math.round(Math.max(...times))}ms  peak=${Math.max(...heaps)}MB` +
+        (oomCount ? `  OOM=${oomCount}/${RUNS_PER_SIZE}` : '')
     )
 
-    cleanSrc()
+    // --keep leaves the last size's fixture on disk so it can be re-run by
+    // hand under a profiler (node --heap-prof / --inspect).
+    if (!KEEP) cleanSrc()
     results.push({
       functions: size,
       minMs: Math.min(...times),
       medianMs: median(times),
       maxMs: Math.max(...times),
       peakMB: Math.max(...heaps),
+      oomCount,
     })
   }
 
@@ -473,9 +669,29 @@ async function main() {
       'min (ms)': Math.round(r.minMs),
       'median (ms)': Math.round(r.medianMs),
       'max (ms)': Math.round(r.maxMs),
-      'peak heap (MB)': r.peakMB,
+      'peak RSS (MB)': r.peakMB,
+      OOM: r.oomCount ? `${r.oomCount}/${RUNS_PER_SIZE}` : '',
     }))
   )
+
+  // Slope between the smallest and largest completed size tells us which
+  // hypothesis holds: a steep constant slope means genuine linear per-function
+  // cost; a high intercept with a shallow slope means the fixed cost is the
+  // program/typechecker, not the functions.
+  const ok = results.filter((r) => r.oomCount === 0)
+  if (ok.length >= 2) {
+    const lo = ok[0]!
+    const hi = ok[ok.length - 1]!
+    const slope = (hi.peakMB - lo.peakMB) / (hi.functions - lo.functions)
+    const intercept = lo.peakMB - slope * lo.functions
+    console.log(
+      `\nweight=${WEIGHT}  heap=${HEAP_MB ? `${HEAP_MB}MB` : 'node default'}`
+    )
+    console.log(
+      `peak RSS ~= ${intercept.toFixed(0)}MB fixed + ${slope.toFixed(2)}MB/function ` +
+        `(fit over N=${lo.functions}..${hi.functions})`
+    )
+  }
 }
 
 main().catch((err) => {

--- a/packages/inspector/run-tests.sh
+++ b/packages/inspector/run-tests.sh
@@ -38,7 +38,7 @@ if [ ${#files[@]} -eq 0 ]; then
 fi
 
 # Construct the node command
-node_cmd=(node --import tsx --test)
+node_cmd=(node --import tsx --expose-gc --test)
 
 # Append options based on flags
 if [ "$watch_mode" = true ]; then

--- a/packages/inspector/src/utils/schema-generator.test.ts
+++ b/packages/inspector/src/utils/schema-generator.test.ts
@@ -1,0 +1,164 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { getInitialInspectorState } from '../inspector.js'
+import { generateAllSchemas } from './schema-generator.js'
+
+const debugLines: string[] = []
+const logger = {
+  debug(message: string) {
+    debugLines.push(message)
+  },
+  info() {},
+  warn() {},
+  error() {},
+} as any
+
+const UNRELATED_FILE_COUNT = 300
+
+let projectDir: string
+
+before(() => {
+  projectDir = mkdtempSync(join(tmpdir(), 'pikku-schema-gen-'))
+  mkdirSync(join(projectDir, 'src'))
+  writeFileSync(
+    join(projectDir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        target: 'ESNext',
+        module: 'NodeNext',
+        moduleResolution: 'NodeNext',
+        strict: true,
+        skipLibCheck: true,
+      },
+      include: ['src/**/*.ts'],
+    })
+  )
+  writeFileSync(
+    join(projectDir, 'src', 'types.ts'),
+    'export type Thing = { id: string; count: number }\n'
+  )
+  // Files the tsconfig picks up but no generated custom type references. They
+  // stand in for the bulk of a real project, which the schema program has no
+  // reason to load.
+  for (let i = 0; i < UNRELATED_FILE_COUNT; i += 1) {
+    writeFileSync(
+      join(projectDir, 'src', `unrelated-${i}.ts`),
+      `export type Unrelated${i} = { a: string; b: number; c: boolean }\n`
+    )
+  }
+})
+
+after(() => {
+  rmSync(projectDir, { recursive: true, force: true })
+})
+
+describe('generateAllSchemas', () => {
+  // NOTE: this must be the first test in the file. The module-level caches are
+  // per-process, so only the first call actually builds a program — a later call
+  // reuses it and would measure a few MB no matter what.
+  //
+  // The schema generator builds a second ts.Program over the whole tsconfig —
+  // on a real tree that is ~2.5k files and ~600MB, and it used to be pinned at
+  // module scope for the life of the process. Combined with the main inspector
+  // program it pushed peak heap past 2GB and OOM'd `pikku all` (#982).
+  //
+  // Only the program is released; cachedTSSchemas (the small result cache that
+  // powers the same-process fast path) is deliberately kept.
+  test('does not retain the schema ts.Program after returning', async (t) => {
+    if (typeof global.gc !== 'function') {
+      t.skip('requires --expose-gc')
+      return
+    }
+
+    const state = getInitialInspectorState(projectDir) as any
+    // A distinct type keeps this off the cachedTSSchemas fast path, so the
+    // program is genuinely rebuilt (and therefore genuinely retainable) here.
+    state.functions.typesMap.addCustomType(
+      'RetentionProbeInput',
+      '{ probe: string; n: number }',
+      []
+    )
+
+    global.gc!()
+    const before = process.memoryUsage().heapUsed
+
+    await generateAllSchemas(
+      logger,
+      { tsconfig: join(projectDir, 'tsconfig.json') },
+      state
+    )
+
+    global.gc!()
+    const retainedMB = (process.memoryUsage().heapUsed - before) / 1024 / 1024
+
+    // A retained program (with its SourceFiles and TypeChecker) measures tens of
+    // MB even for this one-file fixture; the schemas themselves are a few KB.
+    assert.ok(
+      retainedMB < 10,
+      `expected the schema program to be released, but ${retainedMB.toFixed(1)}MB is still retained after GC`
+    )
+  })
+
+  // The virtual file explicitly imports every type it needs, so it is a complete
+  // root on its own. Rooting the program at the whole tsconfig instead made it
+  // load the entire project (2572 files on a real tree vs 870), for no gain in
+  // what could be resolved (#982).
+  test('scopes the schema program to the virtual file import closure', async () => {
+    debugLines.length = 0
+
+    const state = getInitialInspectorState(projectDir) as any
+    state.functions.typesMap.addCustomType(
+      'ScopingProbeInput',
+      '{ scope: string }',
+      []
+    )
+
+    await generateAllSchemas(
+      logger,
+      { tsconfig: join(projectDir, 'tsconfig.json') },
+      state
+    )
+
+    const line = debugLines.find((l) => l.includes('Created schema program'))
+    assert.ok(
+      line,
+      `expected a "Created schema program" debug line, got: ${debugLines.join(' | ')}`
+    )
+
+    const fileCount = Number(line!.match(/(\d+) files/)?.[1])
+    assert.ok(
+      Number.isFinite(fileCount),
+      `could not parse a file count out of: ${line}`
+    )
+    // The virtual file plus types.ts plus the default lib. Rooting at the whole
+    // tsconfig would pull in all UNRELATED_FILE_COUNT files on top of that.
+    assert.ok(
+      fileCount < UNRELATED_FILE_COUNT,
+      `expected the schema program to skip the ${UNRELATED_FILE_COUNT} unreferenced files, but it loaded ${fileCount}`
+    )
+  })
+
+  test('produces a schema for a custom type', async () => {
+    const state = getInitialInspectorState(projectDir) as any
+    state.functions.typesMap.addCustomType(
+      'ThingInput',
+      '{ id: string; count: number }',
+      []
+    )
+
+    const schemas = await generateAllSchemas(
+      logger,
+      { tsconfig: join(projectDir, 'tsconfig.json') },
+      state
+    )
+
+    assert.ok(
+      Object.keys(schemas).length > 0,
+      'expected at least one generated schema'
+    )
+  })
+})

--- a/packages/inspector/src/utils/schema-generator.ts
+++ b/packages/inspector/src/utils/schema-generator.ts
@@ -87,7 +87,9 @@ const inspectorVersion: string = (() => {
   try {
     const pkgUrl = new URL('../../package.json', import.meta.url)
     const pkg = JSON.parse(readFileSync(pkgUrl, 'utf-8'))
-    return typeof pkg.version === 'string' ? pkg.version : `v${SCHEMA_CACHE_VERSION}`
+    return typeof pkg.version === 'string'
+      ? pkg.version
+      : `v${SCHEMA_CACHE_VERSION}`
   } catch {
     return `v${SCHEMA_CACHE_VERSION}`
   }
@@ -98,7 +100,10 @@ const inspectorVersion: string = (() => {
 // inspector version (schema-format changes ship with a version bump).
 function tsSchemaCacheKey(
   customTypesContent: string,
-  config: { schemasFromTypes?: string[]; schema?: { additionalProperties?: boolean } }
+  config: {
+    schemasFromTypes?: string[]
+    schema?: { additionalProperties?: boolean }
+  }
 ): string {
   return createHash('sha1')
     .update(`v${SCHEMA_CACHE_VERSION}\0`)
@@ -145,6 +150,7 @@ function writeDiskTSSchemas(
 }
 
 function createProgramWithVirtualFile(
+  logger: InspectorLogger,
   tsconfig: string,
   virtualFilePath: string,
   virtualFileContent: string
@@ -165,7 +171,11 @@ function createProgramWithVirtualFile(
   }
 
   const resolvedVirtualPath = resolve(virtualFilePath)
-  const fileNames = [...cachedParsedConfig.fileNames, resolvedVirtualPath]
+  // The virtual file imports every type it references, so it is a complete root
+  // on its own and TypeScript pulls in exactly the transitive closure it needs.
+  // Rooting at cachedParsedConfig.fileNames instead loaded the whole project
+  // (2572 files vs 870 on a real tree) without widening what could be resolved.
+  const fileNames = [resolvedVirtualPath]
 
   const defaultHost = ts.createCompilerHost(cachedParsedConfig.options)
   const customHost: ts.CompilerHost = {
@@ -200,6 +210,7 @@ function createProgramWithVirtualFile(
     },
   }
 
+  const startProgram = performance.now()
   const program = ts.createProgram(
     fileNames,
     cachedParsedConfig.options,
@@ -207,6 +218,9 @@ function createProgramWithVirtualFile(
     cachedSchemaProgram // reuse previous program for incremental compilation
   )
   cachedSchemaProgram = program
+  logger.debug(
+    `Created schema program in ${(performance.now() - startProgram).toFixed(0)}ms (${program.getSourceFiles().length} files)`
+  )
   return program
 }
 
@@ -274,6 +288,7 @@ function generateTSSchemas(
     '__pikku_virtual_types__.ts'
   )
   const program = createProgramWithVirtualFile(
+    logger,
     tsconfig,
     virtualFilePath,
     customTypesContent
@@ -613,6 +628,14 @@ export async function generateAllSchemas(
     config.schema?.additionalProperties,
     zodSchemas
   )
+
+  // Release the program once the schemas are out of it. It spans the whole
+  // tsconfig (~2.5k files, ~600MB on a large tree) and was previously pinned at
+  // module scope for the life of the process, so it stacked on top of the main
+  // inspector program and pushed `pikku all` past a 2GB heap (#982). The result
+  // cache below is what the same-process fast path actually needs; the program
+  // only bought incremental reuse on a rebuild, at a cost that dwarfs it.
+  cachedSchemaProgram = undefined
 
   cachedCustomTypesContent = customTypesContent
   cachedTSSchemas = tsSchemas


### PR DESCRIPTION
Closes #982.

## What was wrong

`pikku all` needed >2GB on a 279-function tree. Profiling pointed at the **second `ts.Program`** the schema generator builds — not the main inspector program, and not `oldProgram` reuse (both falsified by measurement).

It was paying for that program twice over:

1. **Rooted at the entire tsconfig.** The virtual file already imports every type it references, so it is a complete root on its own and TypeScript resolves exactly the closure it needs. The extra roots widened nothing.
2. **Pinned at module scope for the life of the process**, stacking on top of the main inspector program. It only ever bought incremental reuse on a rebuild, and that path is already short-circuited by `cachedTSSchemas` — the small result cache, which is kept.

## Numbers

Measured on a real 279-function tree, interleaved and repeated. Heap figures are **post-GC live heap**, not peak allocated — peak allocated is GC-timing noise (it ranged 2347–2648MB across variants with no signal).

| | baseline | scope only | release only | both |
|---|---|---|---|---|
| cold codegen | 12.2s | 9.7s | 11.8s | **9.7s** |
| in-pass live heap | 2090MB | 1774MB | 1697MB | **1646MB** |
| between-pass live heap | 1782MB | 1516MB | 1389MB | **1388MB** |
| schema program files | 2572 / 2616 | 870 / 2110 | 2572 / 2616 | **870 / 2110** |

The two fixes are independent and complementary.

**Generated schema output is byte-identical** — 803 schemas, zero diff against baseline.

## Tests

TDD, both fail before and pass after:

- `scopes the schema program to the virtual file import closure` — fixture with 300 tsconfig-included but unreferenced files; asserts the program doesn't load them.
- `does not retain the schema ts.Program after returning` — forces GC and asserts <10MB retained.

432/432 inspector tests pass, `tsc` clean. Adds `--expose-gc` to the inspector test runner so the retention test can force a collection, and a `Created schema program in Xms (N files)` debug line mirroring the one the main inspector program already emits.

## Follow-up

A shared `CompilerHost` between the two programs was considered and **not** done here: it needs the two differing `compilerOptions` aligned first, and sharing bound `SourceFile`s across programs built under different options is a correctness hazard. Scoping the roots got the same ~20% without that risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)