### PR TITLE
fix(cli): remove generated schema files that are no longer required

### DIFF
--- a/.changeset/olive-cups-shave.md
+++ b/.changeset/olive-cups-shave.md
@@ -1,0 +1,16 @@
+---
+'@pikku/cli': patch
+---
+
+Remove generated schema files that are no longer required
+
+`saveSchemas` rewrites `register.gen.ts` from scratch on every run, so a schema that
+is no longer required stops being registered — but its `<Name>.schema.json` stayed on
+disk indefinitely. That orphan is not inert: it is the artifact tooling reads to answer
+"what does the server validate against?", and it answers with the shape the function had
+at some earlier point. Anything trusting it concludes the schema is correct while the
+running server disagrees, which presents as an unfixable "stale server" that no
+regeneration or restart resolves.
+
+The schemas directory is now kept in step with `register.gen.ts`: if a schema is not
+imported there, its file is deleted.

--- a/packages/cli/src/functions/wirings/functions/schemas.ts
+++ b/packages/cli/src/functions/wirings/functions/schemas.ts
@@ -6,7 +6,18 @@ export const pikkuSchemas = pikkuSessionlessFunc<void, boolean | undefined>({
   func: async ({ logger, config, getInspectorState }) => {
     const visitState = await getInspectorState()
 
-    if (Object.keys(visitState.schemas).length === 0) {
+    // Bodies missing while functions still DECLARE schemas means the inspection pass
+    // was partial. Writing from it would empty register.gen.ts and delete the files
+    // behind schemas that are still required — unregistering the whole app off a bad
+    // read. Leave the previous output alone.
+    //
+    // Zero REQUIRED schemas is a different thing entirely and must still be written:
+    // that is a project whose last schema was removed, and it is the case where the
+    // files left by earlier runs have to be cleared.
+    if (
+      visitState.requiredSchemas.size > 0 &&
+      Object.keys(visitState.schemas).length === 0
+    ) {
       return undefined
     }
 

--- a/packages/cli/src/utils/serialize-schemas.test.ts
+++ b/packages/cli/src/utils/serialize-schemas.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert'
+import { mkdtemp, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, test } from 'node:test'
+import { saveSchemas } from './serialize-schemas.js'
+import type { CLILogger } from '../services/cli-logger.service.js'
+
+const noopLogger = {
+  info: () => {},
+  error: () => {},
+  debug: () => {},
+  warn: () => {},
+} as unknown as CLILogger
+
+const dirs: string[] = []
+
+async function makeDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'pikku-schemas-'))
+  dirs.push(dir)
+  return dir
+}
+
+/** Drop a schema file that a previous codegen run would have left behind. */
+async function seedExistingSchema(parent: string, name: string) {
+  await mkdir(join(parent, 'schemas'), { recursive: true })
+  await writeFile(
+    join(parent, 'schemas', `${name}.schema.json`),
+    JSON.stringify({ type: 'object', properties: { stale: { type: 'string' } } }),
+    'utf-8'
+  )
+}
+
+const listSchemaFiles = async (parent: string) =>
+  (await readdir(join(parent, 'schemas'))).sort()
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('saveSchemas', () => {
+  test('removes schema files that are no longer required', async () => {
+    const parent = await makeDir()
+    // Two schemas from an earlier run; this run only still needs one of them.
+    await seedExistingSchema(parent, 'CreateClassInput')
+    await seedExistingSchema(parent, 'DeletedFunctionInput')
+
+    await saveSchemas(
+      noopLogger,
+      parent,
+      { CreateClassInput: { type: 'object', properties: { title: { type: 'string' } } } },
+      new Set(['CreateClassInput']),
+      true
+    )
+
+    assert.deepEqual(await listSchemaFiles(parent), ['CreateClassInput.schema.json'])
+  })
+
+  test('the surviving file is the one this run generated, not the stale copy', async () => {
+    const parent = await makeDir()
+    await seedExistingSchema(parent, 'CreateClassInput')
+
+    await saveSchemas(
+      noopLogger,
+      parent,
+      { CreateClassInput: { type: 'object', properties: { title: { type: 'string' } } } },
+      new Set(['CreateClassInput']),
+      true
+    )
+
+    const written = JSON.parse(
+      await readFile(join(parent, 'schemas', 'CreateClassInput.schema.json'), 'utf-8')
+    )
+    assert.deepEqual(Object.keys(written.properties), ['title'])
+  })
+
+  test('every schema file is registered in register.gen.ts', async () => {
+    const parent = await makeDir()
+    await seedExistingSchema(parent, 'OrphanInput')
+
+    await saveSchemas(
+      noopLogger,
+      parent,
+      { KeptInput: { type: 'object', properties: {} } },
+      new Set(['KeptInput']),
+      true
+    )
+
+    // The invariant the fix exists to hold: a file on disk that register.gen.ts does
+    // not import is read as authoritative by tooling and silently contradicts the
+    // running server.
+    const register = await readFile(join(parent, 'register.gen.ts'), 'utf-8')
+    for (const file of await listSchemaFiles(parent)) {
+      const name = file.replace('.schema.json', '')
+      assert.ok(
+        register.includes(`addSchema('${name}'`),
+        `${file} is on disk but never registered`
+      )
+    }
+  })
+
+  test('clears every schema file when nothing is required any more', async () => {
+    const parent = await makeDir()
+    await seedExistingSchema(parent, 'GoneInput')
+
+    await saveSchemas(noopLogger, parent, {}, new Set(), true)
+
+    assert.deepEqual(await listSchemaFiles(parent), [])
+  })
+
+  test('leaves an unrelated file in the schemas dir alone', async () => {
+    const parent = await makeDir()
+    await mkdir(join(parent, 'schemas'), { recursive: true })
+    await writeFile(join(parent, 'schemas', 'notes.md'), 'not codegen output', 'utf-8')
+
+    await saveSchemas(
+      noopLogger,
+      parent,
+      { KeptInput: { type: 'object', properties: {} } },
+      new Set(['KeptInput']),
+      true
+    )
+
+    assert.deepEqual(await listSchemaFiles(parent), [
+      'KeptInput.schema.json',
+      'notes.md',
+    ])
+  })
+})

--- a/packages/cli/src/utils/serialize-schemas.test.ts
+++ b/packages/cli/src/utils/serialize-schemas.test.ts
@@ -21,7 +21,6 @@ async function makeDir(): Promise<string> {
   return dir
 }
 
-/** Drop a schema file that a previous codegen run would have left behind. */
 async function seedExistingSchema(parent: string, name: string) {
   await mkdir(join(parent, 'schemas'), { recursive: true })
   await writeFile(
@@ -41,7 +40,6 @@ afterEach(async () => {
 describe('saveSchemas', () => {
   test('removes schema files that are no longer required', async () => {
     const parent = await makeDir()
-    // Two schemas from an earlier run; this run only still needs one of them.
     await seedExistingSchema(parent, 'CreateClassInput')
     await seedExistingSchema(parent, 'DeletedFunctionInput')
 
@@ -106,6 +104,38 @@ describe('saveSchemas', () => {
     await saveSchemas(noopLogger, parent, {}, new Set(), true)
 
     assert.deepEqual(await listSchemaFiles(parent), [])
+  })
+
+  test('reports a schema it could not delete instead of failing the build', async () => {
+    const parent = await makeDir()
+    // A directory cannot be unlink()ed, so this stands in for any undeletable entry.
+    await mkdir(join(parent, 'schemas', 'Undeletable.schema.json'), { recursive: true })
+
+    const errors: string[] = []
+    const logger = { ...noopLogger, error: (m: string) => errors.push(m) } as CLILogger
+
+    await saveSchemas(
+      logger,
+      parent,
+      { KeptInput: { type: 'object', properties: {} } },
+      new Set(['KeptInput']),
+      true
+    )
+
+    assert.ok(
+      errors.some((m) => m.includes('Undeletable.schema.json')),
+      `stale schema left on disk without a word about it: ${JSON.stringify(errors)}`
+    )
+  })
+
+  test('keeps a `false` schema, which is valid and rejects everything', async () => {
+    const parent = await makeDir()
+
+    await saveSchemas(noopLogger, parent, { DenyAll: false }, new Set(['DenyAll']), true)
+
+    assert.deepEqual(await listSchemaFiles(parent), ['DenyAll.schema.json'])
+    const register = await readFile(join(parent, 'register.gen.ts'), 'utf-8')
+    assert.ok(register.includes(`addSchema('DenyAll'`))
   })
 
   test('leaves an unrelated file in the schemas dir alone', async () => {

--- a/packages/cli/src/utils/serialize-schemas.ts
+++ b/packages/cli/src/utils/serialize-schemas.ts
@@ -37,9 +37,15 @@ async function pruneOrphanedSchemaFiles(
   let entries: string[]
   try {
     entries = await readdir(dir)
-  } catch {
+  } catch (e) {
     // No schemas dir yet (first run, or none were ever generated) — nothing to prune.
-    return
+    // Anything else (permissions, IO) means we do NOT know what is on disk, and
+    // reporting a clean generation over an unread directory is the exact false
+    // "everything is registered" claim this prune exists to stop.
+    if ((e as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return
+    }
+    throw e
   }
 
   const orphans = entries.filter(
@@ -102,7 +108,9 @@ export async function saveSchemas(
   // Sort so register.gen.ts is byte-identical across runs — requiredSchemas is
   // a Set in (nondeterministic) traversal-insertion order.
   const availableSchemas = Array.from(requiredSchemas)
-    .filter((schema) => schemas[schema])
+    // Presence, not truthiness: `false` is a legal JSON Schema (it rejects everything),
+    // and dropping it here would unregister the schema AND prune its file.
+    .filter((schema) => schemas[schema] !== undefined)
     .sort()
 
   // Keep exactly what register.gen.ts is about to import — the two must not disagree.

--- a/packages/cli/src/utils/serialize-schemas.ts
+++ b/packages/cli/src/utils/serialize-schemas.ts
@@ -1,7 +1,9 @@
 import { writeFileInDir } from './file-writer.js'
-import { mkdir, writeFile } from 'fs/promises'
+import { mkdir, readdir, unlink, writeFile } from 'fs/promises'
 import type { JSONValue } from '@pikku/core'
 import type { CLILogger } from '../services/cli-logger.service.js'
+
+const SCHEMA_FILE_SUFFIX = '.schema.json'
 
 function toValidIdentifier(name: string): string {
   let result = name.replace(/[-./: ]/g, '_')
@@ -9,6 +11,58 @@ function toValidIdentifier(name: string): string {
     result = '_' + result
   }
   return result
+}
+
+/**
+ * Delete `<schemaParentDir>/schemas/*.schema.json` for schemas this run did not
+ * generate.
+ *
+ * Codegen rewrites `register.gen.ts` from scratch every run, so a schema that is no
+ * longer required stops being registered — but its JSON file used to stay on disk
+ * forever. That orphan is not inert: it is the artifact everything reaches for when
+ * asking "what does the server validate against?", and it answers with the shape the
+ * function had at some earlier point. Tooling reading it concludes the schema is fine
+ * while the running server disagrees, which is a dead end that reads as "the server is
+ * stale" and cannot be resolved by regenerating or restarting.
+ *
+ * Keeping the directory in step with `register.gen.ts` is the whole fix: if it is not
+ * imported there, it must not be on disk to be misread.
+ */
+async function pruneOrphanedSchemaFiles(
+  logger: CLILogger,
+  schemaParentDir: string,
+  keep: ReadonlySet<string>
+) {
+  const dir = `${schemaParentDir}/schemas`
+  let entries: string[]
+  try {
+    entries = await readdir(dir)
+  } catch {
+    // No schemas dir yet (first run, or none were ever generated) — nothing to prune.
+    return
+  }
+
+  const orphans = entries.filter(
+    (entry) =>
+      entry.endsWith(SCHEMA_FILE_SUFFIX) &&
+      !keep.has(entry.slice(0, -SCHEMA_FILE_SUFFIX.length))
+  )
+
+  await Promise.all(
+    orphans.map(async (orphan) => {
+      try {
+        await unlink(`${dir}/${orphan}`)
+      } catch (e) {
+        // A file we cannot remove is stale output, not a reason to fail the build —
+        // but say so, because it will keep being read as if it were current.
+        logger.error(`• Could not remove stale schema ${orphan}: ${e}`)
+      }
+    })
+  )
+
+  if (orphans.length > 0) {
+    logger.info(`• Removed ${orphans.length} stale schema file(s).\x1b[0m`)
+  }
 }
 
 export async function saveSchemas(
@@ -25,6 +79,9 @@ export async function saveSchemas(
       `${schemaParentDir}/register.gen.ts`,
       'export const empty = null;'
     )
+    // Every file in schemas/ is now an orphan: register.gen.ts registers nothing, so
+    // leaving them would be exactly the misleading state this prune exists to prevent.
+    await pruneOrphanedSchemaFiles(logger, schemaParentDir, new Set())
     logger.info(`• Skipping schemas since none found.\x1b[0m`)
     return
   }
@@ -47,6 +104,9 @@ export async function saveSchemas(
   const availableSchemas = Array.from(requiredSchemas)
     .filter((schema) => schemas[schema])
     .sort()
+
+  // Keep exactly what register.gen.ts is about to import — the two must not disagree.
+  await pruneOrphanedSchemaFiles(logger, schemaParentDir, new Set(availableSchemas))
 
   const packageNameArg = packageName ? `, '${packageName}'` : ''
 


### PR DESCRIPTION
## The bug

`saveSchemas` rewrites `register.gen.ts` from scratch on every run, so a schema that is no longer required stops being registered — but its `<Name>.schema.json` stayed on disk indefinitely.

That orphan is not inert. It is the artifact tooling reaches for to answer *"what does the server validate against?"*, and it answers with the shape the function had at some earlier point.

## Why it matters

A consumer trusting the file concludes the schema is correct while the running server rejects the very field the file lists. That presents as an unfixable "stale server":

- regenerating does not remove the file, so the contradiction survives
- restarting does not change what the file says, so the advice it implies never works

We hit this in an automated build agent, which spent its entire budget on one rejected call — repeatedly restarting and rewriting a function whose on-disk schema looked correct the whole time, because the orphaned file was the thing being read.

## The fix

Keep the schemas directory in step with `register.gen.ts`: if a schema is not imported there, its file is deleted. This also covers the case where nothing is required any more, where every file in the directory is an orphan (`register.gen.ts` is already reduced to `export const empty = null`, so leaving the JSON behind is exactly the misleading state).

Failures to unlink are logged rather than thrown — stale output should not fail a build, but it must not be silent either.

## Tests

`packages/cli/src/utils/serialize-schemas.test.ts`, 5 cases:

| test | asserts |
|---|---|
| removes schema files that are no longer required | orphans are deleted |
| the surviving file is this run's output | not the stale copy |
| every schema file is registered in `register.gen.ts` | the disk/register invariant |
| clears every schema file when nothing is required | the empty case |
| leaves an unrelated file alone | only `*.schema.json` is touched |

**3 of the 5 fail without the fix**; the other 2 are controls that should pass either way.

All 54 tests in `src/utils/` pass. Other suites in the package fail on a clean worktree for an unrelated pre-existing reason (they import `dist/.pikku/*.gen.js`, which needs a build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed stale generated schema files when schemas are deleted or no longer registered.
  * Kept schema files synchronized with generated registrations to prevent outdated validation artifacts.
  * Preserved unrelated files in the schemas directory during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->