### PR TITLE
fix(cli): frontend skills taught a localhost fallback that only fails once deployed

### DIFF
--- a/.changeset/olive-lions-repeat.md
+++ b/.changeset/olive-lions-repeat.md
@@ -1,0 +1,30 @@
+---
+'@pikku/cli': patch
+---
+
+Stop the frontend skills teaching a localhost server URL, and cover TanStack Start
+
+`pikku-react`, `pikku-react-query` and `pikku-realtime` all showed
+`serverUrl: import.meta.env.VITE_API_URL ?? 'http://localhost:3000'`.
+`import.meta.env` is a *build-time* substitution, so any deploy that supplies the
+API URL as a runtime env var or platform binding leaves it `undefined` in the
+shipped bundle — the fallback is then the only branch that ever runs in the
+browser, and every request from the deployed app goes to the developer's own
+machine. It works locally and fails the moment it is deployed.
+
+The three skills now resolve through one shared `apiUrl()` helper that falls back
+to same-origin `${window.location.origin}/api`, which needs no build-time
+knowledge of the domain and is correct wherever the app is served from.
+`pikku-react` documents the helper and why the localhost fallback is banned.
+
+`pikku-react-query` also gains a TanStack Start section: the `import.meta.env.SSR`
+branch, building auth clients lazily (Better Auth validates its baseURL with
+`new URL()` at construction, so a module-scope client crashes SSR), the `/auth`
+suffix that Better Auth needs when the base already carries a path, and the
+`pikku tanstack-start` shim.
+
+Finally, `pikku-better-auth`, `pikku-emails`, `pikku-addon`, `pikku-ai-vercel`,
+`pikku-ai-agent` and `pikku-template-clone` are tagged `installGroups: [core]`.
+They were in no group at all, so `pikku skills install --core` left an agent with
+no guidance on auth, email, addons or the post-clone cleanup — all of which the
+starter template ships with.

--- a/packages/cli/skills/pikku-addon/SKILL.md
+++ b/packages/cli/skills/pikku-addon/SKILL.md
@@ -7,6 +7,7 @@ description: >-
   addons, reusable function packages, cross-project sharing, or addon package structure. DO NOT
   TRIGGER when: user asks about internal function composition (use pikku-rpc) or general function
   definitions (use pikku-concepts).
+installGroups: [core]
 ---
 
 # Pikku Addons

--- a/packages/cli/skills/pikku-ai-agent/SKILL.md
+++ b/packages/cli/skills/pikku-ai-agent/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   uses pikkuAIAgent/runAIAgent/streamAIAgent, user asks about AI agents, chatbots, LLM assistants,
   tool-calling agents, or agent memory/streaming. DO NOT TRIGGER when: user asks about MCP tool
   exposure (use pikku-mcp) or general function definitions (use pikku-concepts).
+installGroups: [core]
 ---
 
 # Pikku AI Agent Wiring

--- a/packages/cli/skills/pikku-ai-vercel/SKILL.md
+++ b/packages/cli/skills/pikku-ai-vercel/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   VercelAIAgentRunner, user asks about Vercel AI SDK integration, AI agent runners, or
   @pikku/ai-vercel. DO NOT TRIGGER when: user asks about AI agent wiring (use pikku-ai-agent) or
   voice I/O (use pikku-ai-voice).
+installGroups: [core]
 ---
 
 # Pikku AI Vercel (Agent Runner)

--- a/packages/cli/skills/pikku-better-auth/SKILL.md
+++ b/packages/cli/skills/pikku-better-auth/SKILL.md
@@ -9,6 +9,7 @@ description: >-
   user asks about ANY form of authentication, login, logout, sessions, or user identity — always
   answer with this skill. DO NOT TRIGGER when: user asks about JWT middleware (use pikku-security)
   or custom session services (use pikku-services).
+installGroups: [core]
 ---
 
 # Pikku Better Auth Integration

--- a/packages/cli/skills/pikku-emails/SKILL.md
+++ b/packages/cli/skills/pikku-emails/SKILL.md
@@ -10,6 +10,7 @@ description: >-
   email (verification, password reset, invitation, receipt), wire email sending, or translate an
   email. DO NOT TRIGGER when: user asks about i18n for the app UI (use pikku-i18n) or auth flows
   in general (use pikku-better-auth).
+installGroups: [core]
 ---
 
 # Pikku Emails

--- a/packages/cli/skills/pikku-react-query/SKILL.md
+++ b/packages/cli/skills/pikku-react-query/SKILL.md
@@ -59,9 +59,11 @@ import { PikkuProvider, createPikku } from '@pikku/react'
 import { PikkuFetch } from './pikku/pikku-fetch.gen'
 import { PikkuRPC } from './pikku/pikku-rpc.gen'
 
+import { apiUrl } from './lib/env'
+
 const queryClient = new QueryClient()
 const pikku = createPikku(PikkuFetch, PikkuRPC, {
-  serverUrl: import.meta.env.VITE_API_URL ?? 'http://localhost:3000',
+  serverUrl: apiUrl(),
 })
 
 <QueryClientProvider client={queryClient}>
@@ -74,6 +76,41 @@ const pikku = createPikku(PikkuFetch, PikkuRPC, {
 The two generated files come from `pikku.config.json`'s
 `clientFiles.fetchFile` and `clientFiles.rpcWiringsFile`. Hooks live in
 the file at `clientFiles.reactQueryFile` (typically `api.gen.ts`).
+
+`apiUrl()` is the shared server-URL helper — see **pikku-react**. Never
+inline `?? 'http://localhost:3000'`: a deploy that supplies the URL as a
+runtime binding leaves `import.meta.env.VITE_API_URL` undefined in the
+bundle, so the fallback is the branch that actually runs.
+
+## TanStack Start (SSR)
+
+Under Start the provider mounts in `routes/__root.tsx` rather than
+`main.tsx`, and the same module is evaluated on the server. Three things
+differ:
+
+1. **`apiUrl()` must have an SSR branch.** `window` is undefined during
+   render; return the build-time var or a placeholder (the client hooks
+   only fire in the browser).
+2. **Build auth clients lazily.** Better Auth validates its baseURL with
+   `new URL(...)` at construction, so a module-scope `createAuthClient`
+   crashes SSR on the placeholder. Memoize it behind a getter:
+
+   ```ts
+   let _authClient: ReturnType<typeof createAuthClient> | undefined
+   export const authClient = () =>
+     (_authClient ??= createAuthClient({ baseURL: `${apiUrl()}/auth` }))
+   ```
+
+3. **The auth baseURL needs the `/auth` suffix.** Better Auth only
+   appends its default `/api/auth` when the baseURL carries no path.
+   `apiUrl()` already ends in `/api`, so a bare `apiUrl()` leaves the
+   client calling `/api/get-session` and 404ing.
+
+Server functions that need typed RPC access use the generated shim:
+
+```bash
+pikku tanstack-start   # emits the makeApi server-function shim
+```
 
 ## The hooks
 

--- a/packages/cli/skills/pikku-react/SKILL.md
+++ b/packages/cli/skills/pikku-react/SKILL.md
@@ -36,15 +36,44 @@ import {
 Five exports. `usePikkuRealtime` is only valid when you wired a
 `PikkuRealtime` class via `createPikku` — see step 3 below.
 
+## Resolving the server URL
+
+Every client (`createPikku`, realtime, the auth client) resolves its base
+through one shared helper in `src/lib/env.ts`. Write this once:
+
+```ts
+// Endpoints come from env, never hardcoded.
+export function apiUrl(): string {
+  // SSR: the client hooks only run in the browser, so a placeholder is fine.
+  if (import.meta.env.SSR) {
+    return import.meta.env.VITE_API_URL ?? '/__api'
+  }
+  return import.meta.env.VITE_API_URL ?? `${window.location.origin}/api`
+}
+```
+
+**Never fall back to `http://localhost:3000`.** `import.meta.env.VITE_API_URL`
+is substituted by Vite at *build* time, so any deploy that supplies the URL as
+a *runtime* env var or platform binding leaves it `undefined` in the shipped
+bundle — the fallback is then the only branch that ever runs in the browser. A
+localhost fallback means every request from a deployed app goes to the user's
+own machine. `origin + '/api'` is same-origin, needs no build-time knowledge of
+the domain, and is correct wherever the app is served from.
+
+For local dev, set `VITE_API_URL`, or proxy `/api` → your backend in
+`vite.config.ts` under `server.proxy`. One `/api` entry also covers
+`/api/auth/*`; only add more entries for root-level routes outside `/api`.
+
 ## Setup at the app root
 
 ```tsx
 import { createPikku, PikkuProvider } from '@pikku/react'
 import { PikkuFetch } from './pikku/pikku-fetch.gen'
 import { PikkuRPC } from './pikku/pikku-rpc.gen'
+import { apiUrl } from './lib/env'
 
 const pikku = createPikku(PikkuFetch, PikkuRPC, {
-  serverUrl: import.meta.env.VITE_API_URL ?? 'http://localhost:3000',
+  serverUrl: apiUrl(),
 })
 
 createRoot(document.getElementById('root')!).render(
@@ -62,7 +91,7 @@ the `PikkuRealtime` class as the third argument and the instance gets a
 import { PikkuRealtime } from './pikku/realtime.gen'
 
 const pikku = createPikku(PikkuFetch, PikkuRPC, PikkuRealtime, {
-  serverUrl: import.meta.env.VITE_API_URL ?? 'http://localhost:3000',
+  serverUrl: apiUrl(),
 })
 // pikku.fetch / pikku.rpc / pikku.realtime — all share the same fetch
 // (server URL + auth configured once).
@@ -159,7 +188,7 @@ or set headers on the fetch instance after creation. Common pattern:
 
 ```tsx
 const pikku = createPikku(PikkuFetch, PikkuRPC, {
-  serverUrl: '...',
+  serverUrl: apiUrl(),
   fetchOptions: {
     onRequest: (req) => {
       const token = localStorage.getItem('token')

--- a/packages/cli/skills/pikku-realtime/SKILL.md
+++ b/packages/cli/skills/pikku-realtime/SKILL.md
@@ -160,7 +160,7 @@ const pikku = createPikku(
   PikkuFetch,
   PikkuRPC,
   PikkuRealtime, // pass the realtime class as the third arg
-  { serverUrl: import.meta.env.VITE_API_URL ?? 'http://localhost:3000' }
+  { serverUrl: apiUrl() } // shared env helper — see pikku-react
 )
 // pikku.fetch / pikku.rpc / pikku.realtime — all share the same fetch.
 

--- a/packages/cli/skills/pikku-template-clone/SKILL.md
+++ b/packages/cli/skills/pikku-template-clone/SKILL.md
@@ -2,6 +2,7 @@
 name: pikku-template-clone
 description: 'Standard cleanup to run right after a Pikku template is cloned or scaffolded into a new project. TRIGGER when: a Pikku template was just cloned/scaffolded (via `npm create pikku`, `git clone <template>`, or the user says "I cloned the kanban template / starter / template"), or the working tree still looks like an untouched template (template README, placeholder `@project/*` name in package.json). DO NOT TRIGGER when: working in an established project mid-feature, or editing the template repo itself.'
 allowed-tools: Bash(git status *), Bash(git add *), Bash(git commit *), Bash(git rm *), Bash(git mv *), Bash(git log *)
+installGroups: [core]
 ---
 
 # Pikku Template Post-Clone Cleanup


### PR DESCRIPTION
## The bug

`pikku-react`, `pikku-react-query` and `pikku-realtime` all documented the client setup as:

```ts
serverUrl: import.meta.env.VITE_API_URL ?? 'http://localhost:3000'
```

`import.meta.env` is a **build-time** substitution. Any deploy that supplies the API URL as a *runtime* env var or platform binding (e.g. a Cloudflare Worker `plain_text` binding) leaves the identifier `undefined` in the already-built bundle — so the fallback is not an edge case, it is **the only branch the browser ever takes**. Every request from the deployed app goes to the developer's own machine.

It works locally and dies the moment it ships, which is the worst possible failure shape for a skill an agent follows verbatim.

## The fix

All three now resolve through one shared `apiUrl()` helper that falls back to same-origin `${window.location.origin}/api` — no build-time knowledge of the domain required, correct wherever the app is served from. `pikku-react` owns the canonical definition and explains why localhost is never valid; the other two reference it.

## TanStack Start

`pikku-react-query` gains an SSR section. Nothing in the skill corpus mentioned `tanstack-start`, `makeApi` or `routeTree`, despite `pikku tanstack-start` being a shipped command. Three things bite immediately under Start:

- `apiUrl()` needs an `import.meta.env.SSR` branch — `window` is undefined during render.
- Auth clients must be built lazily. Better Auth validates its baseURL with `new URL()` at construction, so a module-scope `createAuthClient` crashes SSR on the placeholder.
- The auth base needs the `/auth` suffix. Better Auth only appends its default `/api/auth` when the baseURL carries no path; `apiUrl()` already ends in `/api`, so a bare `apiUrl()` leaves the client calling `/api/get-session` and 404ing.

## installGroups

`pikku-better-auth`, `pikku-emails`, `pikku-addon`, `pikku-ai-vercel`, `pikku-ai-agent` and `pikku-template-clone` were in no install group, so `pikku skills install --core` left an agent with no guidance on auth, email, addons or post-clone cleanup — all of which the starter template ships with. Tagged `[core]`. The `fabric` group is unchanged.

## Testing

`src/functions/commands/skills.test.ts` — 19/19 pass, including `installGroups only reference known groups` and `the fabric group holds exactly the intended skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TanStack Start support, including SSR-safe authentication setup and a CLI command for generating the required server-function shim.
  - Core skill installations now include additional authentication, email, AI, addon, and template guidance.

- **Bug Fixes**
  - Improved API URL resolution to support runtime environments and same-origin `/api` requests.
  - Removed reliance on build-time environment values and unsuitable localhost fallbacks.

- **Documentation**
  - Updated React, realtime, and React Query setup guidance with the new API URL configuration and SSR considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->