### PR TITLE
feat(cli): open the sign-in page automatically, and stop on a cancelled login

### DIFF
--- a/.changeset/tidy-falcons-greet.md
+++ b/.changeset/tidy-falcons-greet.md
@@ -1,0 +1,16 @@
+---
+'@pikku/cli': patch
+---
+
+Put the login code in the sign-in link, and open it automatically
+
+`pikku fabric login` printed a bare `/cli-auth` URL plus a separate code for the
+user to retype. The console page has always read `?code=` from the URL and
+prefilled the field — the CLI just never used it. The code now rides in the
+link, so following it is the whole flow. It is still printed for a hand-typed
+fallback and so it survives a copied terminal line.
+
+The link also opens in the default browser automatically. It is skipped when
+`SSH_TTY` or `CI` is set, where opening a browser on the wrong machine is worse
+than not opening one, and `--no-browser` disables it. A launch failure warns and
+leaves the printed URL as the fallback rather than failing the login.

--- a/.changeset/tidy-falcons-greet.md
+++ b/.changeset/tidy-falcons-greet.md
@@ -2,15 +2,19 @@
 '@pikku/cli': patch
 ---
 
-Put the login code in the sign-in link, and open it automatically
+Open the sign-in page automatically, and stop on a cancelled login
 
-`pikku fabric login` printed a bare `/cli-auth` URL plus a separate code for the
-user to retype. The console page has always read `?code=` from the URL and
-prefilled the field — the CLI just never used it. The code now rides in the
-link, so following it is the whole flow. It is still printed for a hand-typed
-fallback and so it survives a copied terminal line.
-
-The link also opens in the default browser automatically. It is skipped when
+`pikku fabric login` printed a `/cli-auth` URL and left the user to find it. The
+link now opens in the default browser automatically. It is skipped when
 `SSH_TTY` or `CI` is set, where opening a browser on the wrong machine is worse
 than not opening one, and `--no-browser` disables it. A launch failure warns and
 leaves the printed URL as the fallback rather than failing the login.
+
+The code is not carried in the link. Typing it is what proves the person
+authorizing the token is the person who ran the command — a URL that carries its
+own code is a one-click grant for anyone who can put it in front of a signed-in
+user. The output leads with the code and treats the URL as the destination.
+
+`pollCliAuth` can now return `rejected`, which the CLI reports as a cancelled
+sign-in and exits on, instead of polling until the code expires and then
+blaming the timeout.

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -105,6 +105,11 @@ export const fabricCommands = defineCLICommands({
       },
       apiUrl: { description: 'Override the fabric-api URL for this login' },
       consoleUrl: { description: 'Override the console URL the browser opens' },
+      browser: {
+        description:
+          'Open the sign-in link automatically (--no-browser to just print it)',
+        default: true,
+      },
     },
   }),
   init: pikkuCLICommand({

--- a/packages/cli/src/fabric/functions/login.function.ts
+++ b/packages/cli/src/fabric/functions/login.function.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { spawn } from 'node:child_process'
 import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
 import {
   readAuthFile,
@@ -13,6 +14,7 @@ export const FabricLoginInput = z.object({
   token: z.string().optional(),
   apiUrl: z.string().optional(),
   consoleUrl: z.string().optional(),
+  browser: z.boolean().optional(),
 })
 
 export const FabricLoginOutput = z.object({
@@ -22,6 +24,37 @@ export const FabricLoginOutput = z.object({
 
 const POLL_INTERVAL_MS = 2000
 const POLL_TIMEOUT_MS = 5 * 60 * 1000
+
+/**
+ * Best-effort browser launch. The URL is always printed first, so a failure
+ * here costs the user a click, not the login — hence a warning rather than a
+ * throw. Skipped over SSH and in CI, where opening a browser on the wrong
+ * machine is worse than not opening one.
+ */
+function openBrowser(url: string): void {
+  if (process.env.SSH_TTY || process.env.CI) return
+  const cmd =
+    process.platform === 'darwin'
+      ? 'open'
+      : process.platform === 'win32'
+        ? 'start'
+        : 'xdg-open'
+  try {
+    const child = spawn(cmd, [url], {
+      stdio: 'ignore',
+      detached: true,
+      shell: process.platform === 'win32',
+    })
+    child.on('error', (err) =>
+      console.warn(`[fabric] could not open a browser (${err.message}) — open the URL above.`)
+    )
+    child.unref()
+  } catch (err) {
+    console.warn(
+      `[fabric] could not open a browser (${(err as Error).message}) — open the URL above.`
+    )
+  }
+}
 
 /**
  * Device-authorization-style CLI login. Server mints a short code, user types
@@ -35,7 +68,13 @@ export const FabricLogin = pikkuSessionlessFunc({
   output: FabricLoginOutput,
   func: async (
     _services,
-    { apiKey, token, apiUrl: apiUrlOverride, consoleUrl: consoleUrlOverride }
+    {
+      apiKey,
+      token,
+      apiUrl: apiUrlOverride,
+      consoleUrl: consoleUrlOverride,
+      browser,
+    }
   ) => {
     const ctx = await resolveApiContext({ apiUrlOverride })
     const apiUrl = ctx.apiUrl
@@ -58,14 +97,21 @@ export const FabricLogin = pikkuSessionlessFunc({
 
     const { code, expiresAt } = await rpc.invoke('requestCliAuth')
 
+    // The code rides in the URL — /cli-auth prefills the field from ?code=, so
+    // following the link is the whole flow. The code is printed too, for a
+    // hand-typed fallback and so it survives a copied terminal line.
+    const authUrl = `${consoleUrl}/cli-auth?code=${encodeURIComponent(code)}`
+
     console.log('')
-    console.log('  Enter this code at:')
-    console.log(`    ${consoleUrl}/cli-auth`)
+    console.log('  Open this link to finish signing in:')
+    console.log(`    ${authUrl}`)
     console.log('')
     console.log(`  Code: ${code}`)
     console.log(`  (expires ${new Date(expiresAt).toLocaleTimeString()})`)
     console.log('')
     console.log('  Waiting for confirmation…')
+
+    if (browser !== false) openBrowser(authUrl)
 
     const deadline = Date.now() + POLL_TIMEOUT_MS
     while (Date.now() < deadline) {

--- a/packages/cli/src/fabric/functions/login.function.ts
+++ b/packages/cli/src/fabric/functions/login.function.ts
@@ -97,16 +97,17 @@ export const FabricLogin = pikkuSessionlessFunc({
 
     const { code, expiresAt } = await rpc.invoke('requestCliAuth')
 
-    // The code rides in the URL — /cli-auth prefills the field from ?code=, so
-    // following the link is the whole flow. The code is printed too, for a
-    // hand-typed fallback and so it survives a copied terminal line.
-    const authUrl = `${consoleUrl}/cli-auth?code=${encodeURIComponent(code)}`
+    // Deliberately no ?code= — the browser opens the page, but the code is
+    // typed. That hand-off is what proves the person authorizing the token is
+    // the person who ran this command; a link carrying its own code is a
+    // one-click grant for anyone who can put it in front of a signed-in user.
+    const authUrl = `${consoleUrl}/cli-auth`
 
     console.log('')
-    console.log('  Open this link to finish signing in:')
-    console.log(`    ${authUrl}`)
+    console.log('  Enter this code to finish signing in:')
+    console.log(`    ${code}`)
     console.log('')
-    console.log(`  Code: ${code}`)
+    console.log(`  at ${authUrl}`)
     console.log(`  (expires ${new Date(expiresAt).toLocaleTimeString()})`)
     console.log('')
     console.log('  Waiting for confirmation…')
@@ -120,6 +121,13 @@ export const FabricLogin = pikkuSessionlessFunc({
       if (result.status === 'expired') {
         throw new Error(
           'Code expired before confirmation. Run `pikku fabric login` again.'
+        )
+      }
+      // Distinct from expired: the user pressed Cancel, so stop immediately
+      // rather than sitting here until the TTL runs out.
+      if (result.status === 'rejected') {
+        throw new Error(
+          'Sign-in was cancelled in the browser. Run `pikku fabric login` again to retry.'
         )
       }
       if (result.status === 'confirmed' && result.token) {

--- a/packages/cli/src/fabric/sdk/rpc-map.gen.d.ts
+++ b/packages/cli/src/fabric/sdk/rpc-map.gen.d.ts
@@ -867,7 +867,7 @@ export type PollCliAuthInput = {
   code: string
 }
 export type PollCliAuthOutput = {
-  status: 'pending' | 'confirmed' | 'expired'
+  status: 'pending' | 'confirmed' | 'expired' | 'rejected'
   token?: string | undefined
 }
 export type PublishCloudflareDeploymentInput = {


### PR DESCRIPTION
`pikku fabric login` printed a `/cli-auth` URL and a code, then left the user to
find the page themselves and wait out the clock if anything went wrong.

**The link now opens in the default browser automatically.** Skipped when
`SSH_TTY` or `CI` is set — opening a browser on the wrong machine is worse than
not opening one — and `--no-browser` disables it. A launch failure warns and
leaves the printed URL as the fallback rather than failing the login.

**The code is deliberately not carried in the link.** An earlier revision of
this PR put it in `?code=` and had the console prefill the field. That was
wrong: typing the code is the security property of a device flow — it proves the
person authorizing the token is the person who ran the command. A URL that
carries its own code is a one-click grant for anyone who can put it in front of
a signed-in user, and the token here is org-scoped and non-expiring. The output
now leads with the code and treats the URL as the destination.

**`pollCliAuth` can return `rejected`.** The console page gained a Cancel
button, so a declined sign-in is reported as cancelled and exits immediately,
instead of polling until the code expires and then blaming the timeout.

`yarn build:packages` and `yarn tsc --noEmit` in `packages/cli` are both clean.