### PR TITLE
fix(cli): validate fixtures construct a Kysely so the db-adapter check fires

### DIFF
--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -683,7 +683,8 @@ describe('pikku fabric validate', () => {
         await makeValidProject(tmp)
         await writeFile(
           join(tmp, 'packages', 'functions', 'src', 'services.ts'),
-          "import { Kysely } from 'kysely'\nimport { PostgresDialect } from 'kysely'\n",
+          "import { Kysely, PostgresDialect } from 'kysely'\n" +
+            'export const db = new Kysely({ dialect: new PostgresDialect({}) })\n',
           'utf8'
         )
         const result = await runValidate(tmp)
@@ -710,7 +711,9 @@ describe('pikku fabric validate', () => {
         })
         await writeFile(
           join(tmp, 'packages', 'functions', 'src', 'services.ts'),
-          "import { Kysely } from 'kysely'\nimport { LibsqlWebDialect } from '@pikku/kysely-sqlite'\n",
+          "import { Kysely } from 'kysely'\n" +
+            "import { LibsqlWebDialect } from '@pikku/kysely-sqlite'\n" +
+            'export const db = new Kysely({ dialect: new LibsqlWebDialect({}) })\n',
           'utf8'
         )
         const result = await runValidate(tmp)


### PR DESCRIPTION
## What

`c42d7ec3` narrowed the `services-wrong-db-adapter` validator so it only flags a `services.ts` that actually **constructs** its own client (`new Kysely(`) — the starter scaffold takes kysely from injection and constructs nothing, and flagging it told every fresh project to import a dialect it must not use. Correct change.

But the two db-adapter test fixtures only *imported* `Kysely`, so after that narrowing the check no longer fired against them:

- `uses Kysely without LibsqlWebDialect → error` started **failing** (finding no longer emitted)
- `uses LibsqlWebDialect → no adapter error` started passing **vacuously** (it would pass whether or not the guard worked)

This is what turns `main` red on the CLI test suite right now.

## Fix

Give both fixtures a real `new Kysely({ dialect: ... })` so they exercise the guard as written — the postgres one trips the finding, the libsql one constructs the correct dialect and stays clean.

## Verification

`node --import tsx --test src/fabric/functions/validate.function.test.ts` → **66/66 pass** (both db-adapter cases green).

Test-fixture-only change; no changeset, consistent with the sibling `fix(cli): validate fixtures …` commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)