### PR TITLE
fix(core): forward parent context into delegated sub-agent runs

### DIFF
--- a/.changeset/forward-context-to-subagents.md
+++ b/.changeset/forward-context-to-subagents.md
@@ -1,0 +1,20 @@
+---
+'@pikku/core': patch
+---
+
+Forward the parent run's `context` into delegated sub-agent invocations.
+
+A supervisor agent's injected `context` (the "Current context" block holding the
+authoritative identifiers — organizationId, project/stage ids) was appended only
+to the supervisor's own instructions. When it delegated, the sub-agent tool's
+input schema carries just `{ message, session }`, and `buildToolDefs` invoked the
+sub-agent with `{ message, threadId, resourceId }` — dropping the context. The
+sub-agent therefore never saw the real ids and depended on the model re-typing
+them into the free-text `message`, which weaker models routinely botch, producing
+schema-validation and permission rejections that the agent then retries — burning
+steps and ballooning the transcript.
+
+`buildToolDefs` now takes the parent `context` and forwards it (via the new
+`buildSubAgentRunInput` helper) into both the streaming and non-streaming
+sub-agent invocations, so a specialist inherits the same identifier block in its
+instructions.

--- a/packages/core/src/wirings/ai-agent/ai-agent-prepare.test.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-prepare.test.ts
@@ -7,6 +7,7 @@ import {
   assertResourceOwner,
   canAccessThread,
   buildInstructions,
+  buildSubAgentRunInput,
   buildToolDefs,
   createScopedChannel,
   getAddonCredentialRequirements,
@@ -773,5 +774,33 @@ describe('C2 sessionScope + resume ownership', () => {
         ),
       (e: unknown) => e instanceof ForbiddenError
     )
+  })
+})
+
+describe('buildSubAgentRunInput (parent context forwarding)', () => {
+  // A delegated sub-agent's tool-call schema only carries { message, session }.
+  // If its run input does not inherit the parent's `context` (the identifier
+  // block with organizationId / project ids), the sub-agent never sees the
+  // authoritative ids and depends on the model re-typing them into `message` —
+  // which weak models botch, causing schema/permission rejections and retry
+  // loops. These pin that the parent context is always forwarded.
+  test('forwards the parent context onto the sub-agent run input', () => {
+    const input = buildSubAgentRunInput(
+      'find failing functions',
+      'thread-1',
+      'org-uuid',
+      'organizationId: 11111111-1111-1111-1111-111111111111'
+    )
+    assert.deepEqual(input, {
+      message: 'find failing functions',
+      threadId: 'thread-1',
+      resourceId: 'org-uuid',
+      context: 'organizationId: 11111111-1111-1111-1111-111111111111',
+    })
+  })
+
+  test('context is undefined when the parent run had none (root agent)', () => {
+    const input = buildSubAgentRunInput('hi', 'thread-1', 'res-1')
+    assert.equal(input.context, undefined)
   })
 })

--- a/packages/core/src/wirings/ai-agent/ai-agent-prepare.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-prepare.ts
@@ -476,6 +476,26 @@ export function createScopedChannel(
   }
 }
 
+/**
+ * Build the run input for a delegated sub-agent.
+ *
+ * `context` is the PARENT run's identifier block (the "Current context" text
+ * with organizationId, project/stage ids). A sub-agent's tool-call schema only
+ * carries { message, session }, so unless the sub-agent inherits the parent's
+ * context it never sees the authoritative ids — it depends on the model
+ * re-typing them into `message`, which weak models botch, causing
+ * schema/permission rejections and retry loops. Forwarding it here is the
+ * regression this seam guards.
+ */
+export function buildSubAgentRunInput(
+  message: string,
+  threadId: string,
+  resourceId: string,
+  parentContext?: string
+): { message: string; threadId: string; resourceId: string; context?: string } {
+  return { message, threadId, resourceId, context: parentContext }
+}
+
 export async function buildToolDefs(
   params: RunAIAgentParams,
   agentSessionMap: Map<string, string>,
@@ -484,7 +504,15 @@ export async function buildToolDefs(
   packageName: string | null,
   streamContext?: StreamContext,
   aiMiddlewares?: PikkuAIMiddlewareHooks[],
-  agentMode?: 'delegate' | 'supervise'
+  agentMode?: 'delegate' | 'supervise',
+  // The parent run's `context` (the "Current context" identifier block). A
+  // delegated sub-agent's tool-call input schema only carries { message,
+  // session }, so without inheriting this the sub-agent never sees the
+  // authoritative ids (organizationId, project/stage ids) — it depends on the
+  // model re-typing them into `message`, which weak models botch, causing
+  // schema/permission rejections and retry loops. Forward it so the sub-agent
+  // gets the same context block in its instructions.
+  parentContext?: string
 ): Promise<{ tools: AIAgentToolDef[]; missingRpcs: string[] }> {
   const singletonServices = getSingletonServices()
   const tools: AIAgentToolDef[] = []
@@ -716,7 +744,12 @@ export async function buildToolDefs(
                 }
             const resultText = await streamAIAgent(
               subAgentName,
-              { message, threadId, resourceId },
+              buildSubAgentRunInput(
+                message,
+                threadId,
+                resourceId,
+                parentContext
+              ),
               effectiveChannel,
               params,
               agentSessionMap,
@@ -744,7 +777,7 @@ export async function buildToolDefs(
           // No stream context: sub-agent runs non-streaming
           const result = await runAIAgent(
             subAgentName,
-            { message, threadId, resourceId },
+            buildSubAgentRunInput(message, threadId, resourceId, parentContext),
             params,
             agentSessionMap
           )
@@ -1017,7 +1050,8 @@ export async function prepareAgentRun(
     packageName,
     streamContext,
     aiMiddlewares,
-    agent.agentMode
+    agent.agentMode,
+    input.context
   )
 
   let instructions = await buildInstructions(resolvedName, packageName)


### PR DESCRIPTION
## Problem

A supervisor agent's injected `context` — the "Current context (use these identifiers directly…)" block holding the authoritative ids (organizationId, project/stage ids) — is appended only to the **supervisor's** instructions (`ai-agent-prepare.ts`, `prepareAgentRun`).

When the supervisor delegates, the sub-agent tool's input schema carries only `{ message, session }`, and `buildToolDefs` invoked the sub-agent with `{ message, threadId, resourceId }` — **the context is dropped**. The specialist therefore never sees the real ids and depends entirely on the model re-typing them into the free-text `message`. Weaker models (e.g. `gpt-5-mini`) routinely botch that — passing a slug or a hallucinated id — which produces:

- schema-validation rejections (`organizationId does not match schema` on `.uuid()` inputs), and
- permission rejections (`ForbiddenError` when the id resolves to no org),

each a wasted model round-trip. The agent retries across its step budget, the transcript balloons, and long runs can blow the model context window. In a production Fabric org this made the assistant slow and occasionally hang.

## Fix

Thread the parent `context` through `buildToolDefs` and forward it into **both** the streaming and non-streaming sub-agent invocations, via a small `buildSubAgentRunInput` seam. A delegated specialist now inherits the same identifier block in its own instructions, so its tool calls carry correct ids without relying on the model to re-serialize them.

## Tests

`buildSubAgentRunInput` is unit-tested (forwards context; leaves it `undefined` for a root agent with none). Full `ai-agent-prepare` suite passes (39 tests), `tsc -b` clean.

Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)