### PR TITLE
fix(queue-pg-boss): eliminate head-of-line blocking (localConcurrency, not batchSize)

### DIFF
--- a/.changeset/pgboss-worker-hol-blocking.md
+++ b/.changeset/pgboss-worker-hol-blocking.md
@@ -1,0 +1,18 @@
+---
+'@pikku/queue-pg-boss': patch
+---
+
+Stop one slow job from holding an entire queue (head-of-line blocking).
+
+The worker mapped pikku's parallelism to pg-boss `batchSize`, whose handler
+receives the whole fetched batch and only fetches again once that handler
+resolves. Because the handler `Promise.all`s the batch, a single long-running
+job blocked every sibling in its batch *and* stalled the next fetch — so on a
+shared queue one slow job could freeze the worker and starve everything behind
+it (observed with workflow-orchestrator jobs, where a long step pinned all 10
+slots for tens of minutes).
+
+Parallelism now maps to pg-boss `localConcurrency` with `batchSize: 1`: N
+independent workers each fetch and process a single job and refill the instant
+they finish, so a slow job never holds up the others. Same effective
+concurrency, no head-of-line blocking.

--- a/packages/services/queue-pg-boss/src/pg-boss-queue-worker.test.ts
+++ b/packages/services/queue-pg-boss/src/pg-boss-queue-worker.test.ts
@@ -1,7 +1,10 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { PgBossQueueWorkers } from './pg-boss-queue-worker.js'
+import {
+  PgBossQueueWorkers,
+  mapPikkuWorkerToPgBoss,
+} from './pg-boss-queue-worker.js'
 
 describe('PgBossQueueWorkers', () => {
   test('requires a logger (explicit or from singleton services)', async () => {
@@ -10,6 +13,30 @@ describe('PgBossQueueWorkers', () => {
     await assert.rejects(() => workers.registerQueues(), {
       message:
         'Logger is required for registerQueues — pass it explicitly or ensure singleton services are initialized first',
+    })
+  })
+})
+
+describe('mapPikkuWorkerToPgBoss', () => {
+  test('parallelism maps to independent workers (localConcurrency), never batch fetching', () => {
+    // batchSize: 1 keeps each worker single-job so a slow job can never hold its
+    // batch siblings — head-of-line blocking is impossible.
+    assert.deepEqual(mapPikkuWorkerToPgBoss(), {
+      localConcurrency: 10,
+      batchSize: 1,
+    })
+
+    assert.deepEqual(mapPikkuWorkerToPgBoss({ batchSize: 25 }), {
+      localConcurrency: 25,
+      batchSize: 1,
+    })
+  })
+
+  test('pollInterval is converted from ms to seconds', () => {
+    assert.deepEqual(mapPikkuWorkerToPgBoss({ pollInterval: 3000 }), {
+      localConcurrency: 10,
+      batchSize: 1,
+      pollingIntervalSeconds: 3,
     })
   })
 })

--- a/packages/services/queue-pg-boss/src/pg-boss-queue-worker.ts
+++ b/packages/services/queue-pg-boss/src/pg-boss-queue-worker.ts
@@ -18,12 +18,17 @@ import { mapPgBossJobToQueueJob } from './utils.js'
 export const mapPikkuWorkerToPgBoss = (
   workerConfig?: PikkuWorkerConfig
 ): WorkOptions => {
+  // Map the requested parallelism to pg-boss `localConcurrency` (independent
+  // per-job workers), NOT `batchSize`. A batch worker hands the whole fetched
+  // batch to one handler and only fetches again once that handler resolves — so
+  // a single slow job blocks every sibling in its batch AND stalls the next
+  // fetch. On a shared queue that is head-of-line blocking: one long job can
+  // freeze the entire worker and starve everything queued behind it.
+  // `localConcurrency` spawns N pollers that each fetch+process a single job and
+  // refill the instant they finish, so a slow job never holds up the others.
   const workerOptions: WorkOptions = {
-    batchSize: 10,
-  }
-
-  if (workerConfig?.batchSize !== undefined) {
-    workerOptions.batchSize = workerConfig.batchSize
+    localConcurrency: workerConfig?.batchSize ?? 10,
+    batchSize: 1,
   }
 
   if (workerConfig?.pollInterval !== undefined) {
@@ -51,9 +56,9 @@ export class PgBossQueueWorkers implements QueueWorkers {
     // Configurations that are directly supported
     supported: {
       batchSize: {
-        queueProperty: 'batchSize',
+        queueProperty: 'localConcurrency',
         description:
-          'Number of jobs to fetch and process concurrently in parallel',
+          'Number of independent workers processing jobs concurrently (maps to pg-boss localConcurrency, not batch fetching, to avoid head-of-line blocking)',
       },
       pollInterval: {
         queueProperty: 'pollingIntervalSeconds',


### PR DESCRIPTION
## Problem

The pg-boss worker mapped pikku's requested parallelism to pg-boss **`batchSize`**. pg-boss's batch handler receives the whole fetched batch and only fetches again once the handler resolves — and the handler `Promise.all`s the batch. So a single long-running job:

- blocks every **sibling** job in its batch until it finishes, and
- stalls the **next fetch**, so nothing queued behind it starts either.

On a shared queue that's classic **head-of-line blocking**. We hit this in production on the workflow-orchestrator queue: one long-running workflow step pinned all 10 batch slots for tens of minutes, starving short operational workflows (project deletes, deploys) queued behind it. Raising `batchSize` makes it *worse* — a bigger batch just freezes more siblings behind the slow one.

## Fix

Map parallelism to pg-boss **`localConcurrency`** with **`batchSize: 1`** instead. `localConcurrency` spawns N independent workers that each fetch and process a single job and refill the instant they finish — so a slow job never holds up the others. Same effective concurrency, no head-of-line blocking.

The existing `batchSize` worker-config knob is preserved (its documented meaning is "process concurrently in parallel"); it now drives `localConcurrency`. Default stays 10.

## Test

`mapPikkuWorkerToPgBoss` unit tests assert the mapping (`{ localConcurrency: N, batchSize: 1 }`) and `pollInterval` ms→s conversion. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)