### PR TITLE
feat(queue): job groups, so one shared queue stays fair

### DIFF
--- a/.changeset/pgboss-worker-hol-blocking.md
+++ b/.changeset/pgboss-worker-hol-blocking.md
@@ -1,0 +1,18 @@
+---
+'@pikku/queue-pg-boss': patch
+---
+
+Stop one slow job from holding an entire queue (head-of-line blocking).
+
+The worker mapped pikku's parallelism to pg-boss `batchSize`, whose handler
+receives the whole fetched batch and only fetches again once that handler
+resolves. Because the handler `Promise.all`s the batch, a single long-running
+job blocked every sibling in its batch *and* stalled the next fetch — so on a
+shared queue one slow job could freeze the worker and starve everything behind
+it (observed with workflow-orchestrator jobs, where a long step pinned all 10
+slots for tens of minutes).
+
+Parallelism now maps to pg-boss `localConcurrency` with `batchSize: 1`: N
+independent workers each fetch and process a single job and refill the instant
+they finish, so a slow job never holds up the others. Same effective
+concurrency, no head-of-line blocking.

--- a/.changeset/workflow-queue-group-fairness.md
+++ b/.changeset/workflow-queue-group-fairness.md
@@ -1,0 +1,29 @@
+---
+'@pikku/core': patch
+'@pikku/queue-pg-boss': patch
+'@pikku/queue-bullmq': patch
+'@pikku/kysely': patch
+'@pikku/redis': patch
+'@pikku/mongodb': patch
+---
+
+Add job groups, so one shared queue can stay fair without splitting into one
+queue per producer.
+
+A job may now carry `group: { id, tier }`, and a worker may cap how many jobs
+of any one group run at once via `groupConcurrency`. On pg-boss this maps to
+`localGroupConcurrency`, which excludes at-capacity groups from the fetch query
+itself, so a capped group costs nothing rather than being fetched and restored.
+BullMQ declares it unsupported (groups are a BullMQ Pro feature) — being
+push-based, it can simply use a queue per group at no polling cost.
+
+Workflow services accept a `queueStrategy`. The default `'per-workflow'` is
+unchanged: every workflow gets its own `wf-orchestrator-*` / `wf-step-*` queue,
+which is also what lets serverless providers deploy one unit per workflow. The
+new `'shared-groups'` routes every workflow through the shared
+orchestrator/step-worker queues and isolates them by group instead, so a
+monolith runs one set of pollers rather than one per workflow — on a
+pull-based backend with dozens of workflows that is the difference between
+hundreds of poll loops and twenty. It is for single-process runtimes only; a
+per-unit serverless deploy still needs the per-workflow queues to route to its
+units.

--- a/.changeset/workflow-queue-group-fairness.md
+++ b/.changeset/workflow-queue-group-fairness.md
@@ -3,6 +3,7 @@
 '@pikku/queue-pg-boss': patch
 '@pikku/queue-bullmq': patch
 '@pikku/kysely': patch
+'@pikku/kysely-postgres': patch
 '@pikku/redis': patch
 '@pikku/mongodb': patch
 ---

--- a/packages/core/src/services/in-memory-workflow-service.test.ts
+++ b/packages/core/src/services/in-memory-workflow-service.test.ts
@@ -2,7 +2,7 @@ import { describe, test, beforeEach } from 'node:test'
 import assert from 'node:assert'
 import { InMemoryWorkflowService } from './in-memory-workflow-service.js'
 import { getQueueWorkers } from '../wirings/queue/queue-runner.js'
-import { pikkuState } from '../pikku-state.js'
+import { pikkuState, resetPikkuState } from '../pikku-state.js'
 
 let service: InMemoryWorkflowService
 
@@ -389,6 +389,55 @@ describe('InMemoryWorkflowService', () => {
 
       assert.strictEqual(getQueueWorkers().has(stepQueue), true)
       assert.strictEqual(getQueueWorkers().has(orchQueue), true)
+    })
+
+    test('shared-groups leaves per-workflow queues unconsumed', () => {
+      const orchQueue = 'wf-orchestrator-shared-strategy-check'
+
+      const queueMeta = pikkuState(null, 'queue', 'meta')
+      queueMeta[orchQueue] = {
+        name: orchQueue,
+        pikkuFuncId: 'pikkuWorkflowOrchestrator:sharedStrategyCheck',
+      }
+
+      const ws = new InMemoryWorkflowService({
+        queueStrategy: 'shared-groups',
+      })
+      ws.wireQueueWorkers()
+
+      // The whole point: one set of pollers, not one per workflow.
+      assert.strictEqual(getQueueWorkers().has(orchQueue), false)
+      assert.strictEqual(
+        getQueueWorkers().has('pikku-workflow-orchestrator'),
+        true
+      )
+    })
+
+    test('shared-groups caps how much of the shared queue one workflow takes', () => {
+      // registerWorkflowFunc is first-write-wins, so start from clean state
+      // rather than inheriting the shared queues an earlier test registered.
+      resetPikkuState()
+      const ws = new InMemoryWorkflowService({
+        queueStrategy: 'shared-groups',
+        queueConcurrency: 20,
+        queueGroupConcurrency: 3,
+      })
+      ws.wireQueueWorkers()
+
+      const worker = getQueueWorkers().get('pikku-workflow-orchestrator')
+      assert.deepStrictEqual(worker?.config, {
+        batchSize: 20,
+        groupConcurrency: 3,
+      })
+    })
+
+    test('per-workflow (the default) leaves the shared queues unconstrained', () => {
+      resetPikkuState()
+      const ws = new InMemoryWorkflowService()
+      ws.wireQueueWorkers()
+
+      const worker = getQueueWorkers().get('pikku-workflow-orchestrator')
+      assert.strictEqual(worker?.config, undefined)
     })
   })
 })

--- a/packages/core/src/services/in-memory-workflow-service.ts
+++ b/packages/core/src/services/in-memory-workflow-service.ts
@@ -4,6 +4,7 @@ import { isExpectedError } from '../errors/error-handler.js'
 import type { SerializedError } from '../types/core.types.js'
 import type {
   WorkflowPlannedStep,
+  WorkflowQueueOptions,
   WorkflowRun,
   WorkflowRunService,
   WorkflowRunWire,
@@ -39,8 +40,8 @@ export class InMemoryWorkflowService
   extends PikkuWorkflowService
   implements WorkflowRunService
 {
-  constructor() {
-    super({ wireQueues: false })
+  constructor(options: WorkflowQueueOptions = {}) {
+    super({ ...options, wireQueues: false })
   }
 
   private sleepTimers = new Set<ReturnType<typeof setTimeout>>()

--- a/packages/core/src/wirings/queue/index.ts
+++ b/packages/core/src/wirings/queue/index.ts
@@ -1,6 +1,8 @@
 export type {
   ConfigValidationResult,
   CoreQueueWorker,
+  GroupConcurrencyConfig,
+  JobGroup,
   JobOptions,
   PikkuJobConfig,
   PikkuWorkerConfig,

--- a/packages/core/src/wirings/queue/queue.types.ts
+++ b/packages/core/src/wirings/queue/queue.types.ts
@@ -31,6 +31,36 @@ export interface PikkuWorkerConfig {
   maxStalledCount?: number
   /** Condition to start processor at instance creation */
   autorun?: boolean
+  /**
+   * Cap how many jobs of any one group ({@link JobOptions.group}) may run at
+   * once, so a single group can't occupy the whole worker. Lets one shared
+   * queue stay fair across producers instead of splitting it into one queue
+   * per producer — which multiplies polling cost on pull-based backends.
+   * Must not exceed {@link batchSize}.
+   */
+  groupConcurrency?: number | GroupConcurrencyConfig
+}
+
+/**
+ * Per-group concurrency limits, optionally varied by tier so slow groups can
+ * be allowed more (or fewer) slots than the default.
+ */
+export interface GroupConcurrencyConfig {
+  /** Limit applied to any group without a matching tier */
+  default: number
+  /** Per-tier overrides, keyed by {@link JobGroup.tier} */
+  tiers?: Record<string, number>
+}
+
+/**
+ * Fairness key for a job. Jobs sharing an `id` count against the same
+ * {@link PikkuWorkerConfig.groupConcurrency} limit.
+ */
+export interface JobGroup {
+  /** Group this job belongs to (e.g. a workflow name) */
+  id: string
+  /** Optional tier selecting a per-tier limit */
+  tier?: string
 }
 
 /**
@@ -113,6 +143,8 @@ export interface JobOptions {
   jobId?: string
   /** Pikku user ID to propagate to the queue worker for credential resolution */
   pikkuUserId?: string
+  /** Fairness key — counts against the worker's {@link PikkuWorkerConfig.groupConcurrency} */
+  group?: JobGroup
 }
 
 /**

--- a/packages/core/src/wirings/workflow/index.ts
+++ b/packages/core/src/wirings/workflow/index.ts
@@ -59,6 +59,7 @@ export type {
 // Re-export all types from workflow.types
 export type {
   WorkflowService,
+  WorkflowQueueOptions,
   WorkflowServiceConfig,
   WorkflowPlannedStep,
   WorkflowRunWire,

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -60,6 +60,7 @@ import type {
   WorkflowRunWire,
   WorkflowStatus,
   WorkflowVersionStatus,
+  WorkflowQueueOptions,
   WorkflowServiceConfig,
   WorkflowStepOptions,
   WorkflowExpectEventuallyOptions,
@@ -88,7 +89,12 @@ import {
   type RunTimeline,
   type ReconstructedRunState,
 } from './run-timeline.js'
-import type { JobOptions } from '../queue/queue.types.js'
+import type {
+  GroupConcurrencyConfig,
+  JobGroup,
+  JobOptions,
+  PikkuWorkerConfig,
+} from '../queue/queue.types.js'
 
 /**
  * Default number of retries for a workflow step when none is specified. The
@@ -257,11 +263,21 @@ export abstract class PikkuWorkflowService implements WorkflowService {
 
   protected mirror?: WorkflowRunMirror
 
+  protected readonly queueStrategy: 'per-workflow' | 'shared-groups'
+  protected readonly queueConcurrency: number
+  protected readonly queueGroupConcurrency: number | GroupConcurrencyConfig
+
   constructor(
-    options: { wireQueues?: boolean; mirror?: WorkflowRunMirror } = {}
+    options: {
+      wireQueues?: boolean
+      mirror?: WorkflowRunMirror
+    } & WorkflowQueueOptions = {}
   ) {
     const wireQueues = options.wireQueues ?? true
     this.mirror = options.mirror
+    this.queueStrategy = options.queueStrategy ?? 'per-workflow'
+    this.queueConcurrency = options.queueConcurrency ?? 20
+    this.queueGroupConcurrency = options.queueGroupConcurrency ?? 2
     if (wireQueues) {
       this.wireQueueWorkers()
     }
@@ -306,29 +322,44 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     const registerWorkflowFunc = (
       funcId: string,
       func: { func: unknown },
-      queueName: string
+      queueName: string,
+      config?: PikkuWorkerConfig
     ) => {
       if (functions.has(funcId)) return
       addFunction(funcId, func as never)
       if (!queueMeta[queueName]) {
         queueMeta[queueName] = { pikkuFuncId: funcId, name: queueName }
       }
-      wireQueueWorker({ name: queueName, func } as never)
+      wireQueueWorker({ name: queueName, func, config } as never)
       if (!functionsMeta[funcId]) {
         functionsMeta[funcId] = mkMeta(funcId)
       }
     }
 
+    // Under 'shared-groups' every workflow runs through these two queues and is
+    // kept from hogging them by the per-group cap, so the per-workflow queues
+    // below are left unconsumed — one set of pollers for the whole system
+    // instead of one per workflow.
+    const sharedGroups = this.queueStrategy === 'shared-groups'
+    const sharedQueueConfig: PikkuWorkerConfig | undefined = sharedGroups
+      ? {
+          batchSize: this.queueConcurrency,
+          groupConcurrency: this.queueGroupConcurrency,
+        }
+      : undefined
+
     // Register shared queue workers for monolith deployments
     registerWorkflowFunc(
       'pikkuWorkflowOrchestrator',
       { func: pikkuWorkflowOrchestratorFunc },
-      'pikku-workflow-orchestrator'
+      'pikku-workflow-orchestrator',
+      sharedQueueConfig
     )
     registerWorkflowFunc(
       'pikkuWorkflowStepWorker',
       { func: pikkuWorkflowWorkerFunc },
-      'pikku-workflow-step-worker'
+      'pikku-workflow-step-worker',
+      sharedQueueConfig
     )
 
     // Register per-workflow queue workers (root + addon packages)
@@ -351,14 +382,16 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       }
     }
 
-    registerQueueWorkers(pikkuState(null, 'queue', 'meta'))
+    if (!sharedGroups) {
+      registerQueueWorkers(pikkuState(null, 'queue', 'meta'))
 
-    const addons = pikkuState(null, 'addons', 'packages')
-    if (addons) {
-      for (const [, addon] of addons) {
-        const addonQueueMeta = pikkuState(addon.package, 'queue', 'meta')
-        if (addonQueueMeta) {
-          registerQueueWorkers(addonQueueMeta)
+      const addons = pikkuState(null, 'addons', 'packages')
+      if (addons) {
+        for (const [, addon] of addons) {
+          const addonQueueMeta = pikkuState(addon.package, 'queue', 'meta')
+          if (addonQueueMeta) {
+            registerQueueWorkers(addonQueueMeta)
+          }
         }
       }
     }
@@ -927,7 +960,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     await queueService.add(
       this.getOrchestratorQueueName(workflowName),
       { runId },
-      this.resolveStepJobOptions()
+      {
+        ...this.resolveStepJobOptions(),
+        group: this.getJobGroup(workflowName),
+      }
     )
   }
 
@@ -970,7 +1006,12 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       JSON.parse(
         JSON.stringify({ runId, stepName, rpcName, data, fromStepName })
       ),
-      this.resolveStepJobOptions(stepOptions)
+      {
+        ...this.resolveStepJobOptions(stepOptions),
+        // Group by step function, mirroring how per-step queues split them —
+        // one slow step function can't monopolise the shared step worker.
+        group: this.getJobGroup(rpcName),
+      }
     )
   }
 
@@ -1005,7 +1046,12 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     await queueService.add(
       this.getOrchestratorQueueName(workflowName),
       { runId },
-      retryDelay ? { delay: getDurationInMilliseconds(retryDelay) } : undefined
+      {
+        ...(retryDelay
+          ? { delay: getDurationInMilliseconds(retryDelay) }
+          : undefined),
+        group: this.getJobGroup(workflowName),
+      }
     )
   }
 
@@ -1054,7 +1100,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         JSON.parse(
           JSON.stringify({ runId, stepName, rpcName, data, fromStepName })
         ),
-        this.resolveStepJobOptions(stepOptions)
+        {
+          ...this.resolveStepJobOptions(stepOptions),
+          group: this.getJobGroup(rpcName),
+        }
       )
     } catch (cause) {
       // The queue is down/unreachable — NOT a step failure. Surface it as a
@@ -2225,7 +2274,11 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       await queueService.add(
         this.getOrchestratorQueueName(run.workflow),
         { runId },
-        { ...this.resolveStepJobOptions(), delay }
+        {
+          ...this.resolveStepJobOptions(),
+          delay,
+          group: this.getJobGroup(run.workflow),
+        }
       )
     } catch (error) {
       this.logger?.warn(
@@ -2655,7 +2708,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
    * queues — but it produces to them — so registrations would miss them.
    */
   protected getOrchestratorQueueName(workflowName?: string): string {
-    if (workflowName) {
+    if (workflowName && this.queueStrategy !== 'shared-groups') {
       const perWorkflow = `wf-orchestrator-${toKebab(workflowName)}`
       const meta = pikkuState(null, 'queue', 'meta')
       if (meta[perWorkflow]) {
@@ -2666,7 +2719,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   }
 
   protected getStepWorkerQueueName(rpcName?: string): string {
-    if (rpcName) {
+    if (rpcName && this.queueStrategy !== 'shared-groups') {
       const perStep = `wf-step-${toKebab(rpcName)}`
       const meta = pikkuState(null, 'queue', 'meta')
       if (meta[perStep]) {
@@ -2674,5 +2727,21 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       }
     }
     return this.getConfig().stepWorkerQueueName
+  }
+
+  /**
+   * Fairness key for a job on a shared queue. Under `'per-workflow'` the queue
+   * name already isolates workflows, so no group is needed — returning one
+   * anyway would cap a workflow inside its own dedicated queue.
+   *
+   * The tier repeats the id so a workflow can be given its own limit purely
+   * from config, with no per-workflow wiring; an unmatched tier falls back to
+   * the default limit.
+   */
+  protected getJobGroup(id?: string): JobGroup | undefined {
+    if (!id || this.queueStrategy !== 'shared-groups') {
+      return undefined
+    }
+    return { id, tier: id }
   }
 }

--- a/packages/core/src/wirings/workflow/workflow.types.ts
+++ b/packages/core/src/wirings/workflow/workflow.types.ts
@@ -1,5 +1,6 @@
 import type { SerializedError, CommonWireMeta } from '../../types/core.types.js'
 import type { CorePikkuFunctionConfig } from '../../function/functions.types.js'
+import type { GroupConcurrencyConfig } from '../queue/queue.types.js'
 
 // Re-export WorkflowService from services module
 export type { WorkflowService } from '../../services/workflow-service.js'
@@ -60,6 +61,44 @@ export interface WorkflowServiceConfig {
   orchestratorQueueName: string
   stepWorkerQueueName: string
   sleeperRPCName: string
+}
+
+/**
+ * How a workflow service spreads its jobs across queues.
+ *
+ * Passed to the service constructor rather than read from `config.workflow`:
+ * the queues are wired during construction, before singleton services (and so
+ * before `config`) exist.
+ */
+export interface WorkflowQueueOptions {
+  /**
+   * - `'per-workflow'` (default) — each workflow gets its own
+   *   `wf-orchestrator-*` / `wf-step-*` queue. Complete isolation, and it's
+   *   what lets serverless providers deploy one unit per workflow. Costs one
+   *   set of pollers per queue, which adds up on pull-based backends.
+   * - `'shared-groups'` — every workflow shares the orchestrator/step-worker
+   *   queues and stays isolated via {@link queueGroupConcurrency}, so no
+   *   workflow can occupy more than its share. One set of pollers total.
+   *   Only for single-process (monolith) runtimes; a per-unit serverless
+   *   deploy needs the per-workflow queues to route to its units.
+   */
+  queueStrategy?: 'per-workflow' | 'shared-groups'
+  /**
+   * Total concurrent workflow jobs per node under `'shared-groups'`.
+   * Defaults to 20.
+   */
+  queueConcurrency?: number
+  /**
+   * How many jobs of one workflow may run at once under `'shared-groups'`.
+   * Defaults to 2. Tiers are keyed by workflow name, so a specific workflow
+   * can be given its own limit without any extra wiring.
+   *
+   * Note tiers can only lower a workflow's limit, not raise it above
+   * `default`: the backend's pre-fetch exclusion is applied per group using
+   * `default` alone. To give one workflow more room, raise `default` and
+   * restrict the others by tier.
+   */
+  queueGroupConcurrency?: number | GroupConcurrencyConfig
 }
 
 export interface WorkflowPlannedStep {

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
@@ -1,11 +1,12 @@
 import { KyselyWorkflowService } from '@pikku/kysely'
 import type { KyselyPikkuDB } from '@pikku/kysely'
+import type { WorkflowQueueOptions } from '@pikku/core/workflow'
 import type { Kysely } from 'kysely'
 import { sql } from 'kysely'
 
 export class PgKyselyWorkflowService extends KyselyWorkflowService {
-  constructor(db: Kysely<KyselyPikkuDB>) {
-    super(db)
+  constructor(db: Kysely<KyselyPikkuDB>, options: WorkflowQueueOptions = {}) {
+    super(db, options)
   }
 
   private hashStringToInt(str: string): number {

--- a/packages/services/kysely/src/kysely-workflow-service.ts
+++ b/packages/services/kysely/src/kysely-workflow-service.ts
@@ -2,6 +2,7 @@ import type { SerializedError } from '@pikku/core'
 import {
   PikkuWorkflowService,
   type WorkflowPlannedStep,
+  type WorkflowQueueOptions,
   type WorkflowRun,
   type WorkflowRunWire,
   type StepState,
@@ -19,8 +20,11 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
   private initialized = false
   private runService: KyselyWorkflowRunService
 
-  constructor(protected db: Kysely<KyselyPikkuDB>) {
-    super()
+  constructor(
+    protected db: Kysely<KyselyPikkuDB>,
+    options: WorkflowQueueOptions = {}
+  ) {
+    super(options)
     this.runService = new KyselyWorkflowRunService(db)
   }
 

--- a/packages/services/mongodb/src/mongodb-workflow-service.ts
+++ b/packages/services/mongodb/src/mongodb-workflow-service.ts
@@ -2,6 +2,7 @@ import type { SerializedError } from '@pikku/core'
 import {
   PikkuWorkflowService,
   type WorkflowPlannedStep,
+  type WorkflowQueueOptions,
   type WorkflowRun,
   type WorkflowRunWire,
   type StepState,
@@ -77,8 +78,8 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
   private stepHistory: Collection<WorkflowStepHistoryDoc>
   private versions: Collection<WorkflowVersionDoc>
 
-  constructor(db: Db) {
-    super()
+  constructor(db: Db, options: WorkflowQueueOptions = {}) {
+    super(options)
     this.runService = new MongoDBWorkflowRunService(db)
     this.runs = db.collection<WorkflowRunDoc>('workflow_runs')
     this.steps = db.collection<WorkflowStepDoc>('workflow_step')

--- a/packages/services/queue-bullmq/src/bull-queue-worker.ts
+++ b/packages/services/queue-bullmq/src/bull-queue-worker.ts
@@ -111,6 +111,11 @@ export class BullQueueWorkers implements QueueWorkers {
 
     // Configurations that are not supported
     unsupported: {
+      groupConcurrency: {
+        reason: 'Job groups are a BullMQ Pro feature, not available in BullMQ',
+        explanation:
+          'Give each group its own queue instead — BullMQ is push-based, so extra queues cost no polling',
+      },
       visibilityTimeout: {
         reason: 'Bull does not use visibility timeout',
         explanation:

--- a/packages/services/queue-pg-boss/src/pg-boss-queue-service.test.ts
+++ b/packages/services/queue-pg-boss/src/pg-boss-queue-service.test.ts
@@ -57,3 +57,22 @@ describe('mapPikkuJobToPgBoss — retry mapping', () => {
     assert.equal(opts.retryBackoff, undefined)
   })
 })
+
+describe('mapPikkuJobToPgBoss — group mapping', () => {
+  test('group id is forwarded so the worker can enforce a per-group limit', () => {
+    assert.deepEqual(mapPikkuJobToPgBoss({ group: { id: 'deployWorkflow' } })
+      .group, { id: 'deployWorkflow' })
+  })
+
+  test('tier is only set when provided', () => {
+    const opts = mapPikkuJobToPgBoss({
+      group: { id: 'deployWorkflow', tier: 'slow' },
+    })
+    assert.deepEqual(opts.group, { id: 'deployWorkflow', tier: 'slow' })
+    assert.equal('tier' in mapPikkuJobToPgBoss({ group: { id: 'a' } }).group!, false)
+  })
+
+  test('no group → no group field', () => {
+    assert.equal(mapPikkuJobToPgBoss({ attempts: 2 }).group, undefined)
+  })
+})

--- a/packages/services/queue-pg-boss/src/pg-boss-queue-service.ts
+++ b/packages/services/queue-pg-boss/src/pg-boss-queue-service.ts
@@ -19,6 +19,13 @@ export const mapPikkuJobToPgBoss = (
     pgBossOptions.singletonKey = options.jobId
   }
 
+  if (options?.group !== undefined) {
+    pgBossOptions.group = {
+      id: options.group.id,
+      ...(options.group.tier !== undefined ? { tier: options.group.tier } : {}),
+    }
+  }
+
   // Map retry options
   if (options?.attempts !== undefined) {
     pgBossOptions.retryLimit = options.attempts - 1

--- a/packages/services/queue-pg-boss/src/pg-boss-queue-worker.test.ts
+++ b/packages/services/queue-pg-boss/src/pg-boss-queue-worker.test.ts
@@ -39,4 +39,55 @@ describe('mapPikkuWorkerToPgBoss', () => {
       pollingIntervalSeconds: 3,
     })
   })
+
+  test('groupConcurrency caps how much of the worker one group can take', () => {
+    assert.deepEqual(mapPikkuWorkerToPgBoss({ groupConcurrency: 2 }), {
+      localConcurrency: 10,
+      batchSize: 1,
+      localGroupConcurrency: 2,
+    })
+  })
+
+  test('tiered groupConcurrency passes tiers through', () => {
+    assert.deepEqual(
+      mapPikkuWorkerToPgBoss({
+        batchSize: 20,
+        groupConcurrency: { default: 2, tiers: { slowWorkflow: 1 } },
+      }),
+      {
+        localConcurrency: 20,
+        batchSize: 1,
+        localGroupConcurrency: { default: 2, tiers: { slowWorkflow: 1 } },
+      }
+    )
+  })
+
+  test('group limits are clamped to the worker concurrency', () => {
+    // pg-boss asserts every group limit is <= localConcurrency and throws at
+    // worker start otherwise — clamp so an over-eager config degrades to "this
+    // group may use the whole worker" instead of failing to start.
+    assert.deepEqual(
+      mapPikkuWorkerToPgBoss({
+        batchSize: 4,
+        groupConcurrency: { default: 10, tiers: { greedy: 99 } },
+      }),
+      {
+        localConcurrency: 4,
+        batchSize: 1,
+        localGroupConcurrency: { default: 4, tiers: { greedy: 4 } },
+      }
+    )
+
+    assert.deepEqual(
+      mapPikkuWorkerToPgBoss({ batchSize: 3, groupConcurrency: 8 }),
+      { localConcurrency: 3, batchSize: 1, localGroupConcurrency: 3 }
+    )
+  })
+
+  test('no group config means no group limits', () => {
+    assert.equal(
+      'localGroupConcurrency' in mapPikkuWorkerToPgBoss({ batchSize: 5 }),
+      false
+    )
+  })
 })

--- a/packages/services/queue-pg-boss/src/pg-boss-queue-worker.test.ts
+++ b/packages/services/queue-pg-boss/src/pg-boss-queue-worker.test.ts
@@ -1,7 +1,10 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { PgBossQueueWorkers } from './pg-boss-queue-worker.js'
+import {
+  PgBossQueueWorkers,
+  mapPikkuWorkerToPgBoss,
+} from './pg-boss-queue-worker.js'
 
 describe('PgBossQueueWorkers', () => {
   test('requires a logger (explicit or from singleton services)', async () => {
@@ -10,6 +13,30 @@ describe('PgBossQueueWorkers', () => {
     await assert.rejects(() => workers.registerQueues(), {
       message:
         'Logger is required for registerQueues — pass it explicitly or ensure singleton services are initialized first',
+    })
+  })
+})
+
+describe('mapPikkuWorkerToPgBoss', () => {
+  test('parallelism maps to independent workers (localConcurrency), never batch fetching', () => {
+    // batchSize: 1 keeps each worker single-job so a slow job can never hold its
+    // batch siblings — head-of-line blocking is impossible.
+    assert.deepEqual(mapPikkuWorkerToPgBoss(), {
+      localConcurrency: 10,
+      batchSize: 1,
+    })
+
+    assert.deepEqual(mapPikkuWorkerToPgBoss({ batchSize: 25 }), {
+      localConcurrency: 25,
+      batchSize: 1,
+    })
+  })
+
+  test('pollInterval is converted from ms to seconds', () => {
+    assert.deepEqual(mapPikkuWorkerToPgBoss({ pollInterval: 3000 }), {
+      localConcurrency: 10,
+      batchSize: 1,
+      pollingIntervalSeconds: 3,
     })
   })
 })

--- a/packages/services/queue-pg-boss/src/pg-boss-queue-worker.ts
+++ b/packages/services/queue-pg-boss/src/pg-boss-queue-worker.ts
@@ -26,8 +26,9 @@ export const mapPikkuWorkerToPgBoss = (
   // freeze the entire worker and starve everything queued behind it.
   // `localConcurrency` spawns N pollers that each fetch+process a single job and
   // refill the instant they finish, so a slow job never holds up the others.
+  const localConcurrency = workerConfig?.batchSize ?? 10
   const workerOptions: WorkOptions = {
-    localConcurrency: workerConfig?.batchSize ?? 10,
+    localConcurrency,
     batchSize: 1,
   }
 
@@ -35,6 +36,30 @@ export const mapPikkuWorkerToPgBoss = (
     workerOptions.pollingIntervalSeconds = Math.round(
       workerConfig.pollInterval / 1000
     )
+  }
+
+  // Per-group fairness. `localGroupConcurrency` is in-memory and free — groups
+  // already at capacity are excluded from the fetch itself, so an at-capacity
+  // group costs nothing rather than being fetched and restored. pg-boss asserts
+  // every limit is <= localConcurrency, so clamp instead of letting a config
+  // that reads as "let this tier use more" throw at worker start.
+  if (workerConfig?.groupConcurrency !== undefined) {
+    const clamp = (limit: number) => Math.min(limit, localConcurrency)
+    workerOptions.localGroupConcurrency =
+      typeof workerConfig.groupConcurrency === 'number'
+        ? clamp(workerConfig.groupConcurrency)
+        : {
+            default: clamp(workerConfig.groupConcurrency.default),
+            ...(workerConfig.groupConcurrency.tiers
+              ? {
+                  tiers: Object.fromEntries(
+                    Object.entries(workerConfig.groupConcurrency.tiers).map(
+                      ([tier, limit]) => [tier, clamp(limit)]
+                    )
+                  ),
+                }
+              : {}),
+          }
   }
 
   return workerOptions
@@ -57,8 +82,12 @@ export class PgBossQueueWorkers implements QueueWorkers {
     supported: {
       batchSize: {
         queueProperty: 'localConcurrency',
+        description: 'Number of jobs to process concurrently',
+      },
+      groupConcurrency: {
+        queueProperty: 'localGroupConcurrency',
         description:
-          'Number of independent workers processing jobs concurrently (maps to pg-boss localConcurrency, not batch fetching, to avoid head-of-line blocking)',
+          'Maximum concurrent jobs per group, keeping one shared queue fair across groups',
       },
       pollInterval: {
         queueProperty: 'pollingIntervalSeconds',

--- a/packages/services/queue-pg-boss/src/pg-boss-queue-worker.ts
+++ b/packages/services/queue-pg-boss/src/pg-boss-queue-worker.ts
@@ -18,12 +18,17 @@ import { mapPgBossJobToQueueJob } from './utils.js'
 export const mapPikkuWorkerToPgBoss = (
   workerConfig?: PikkuWorkerConfig
 ): WorkOptions => {
+  // Map the requested parallelism to pg-boss `localConcurrency` (independent
+  // per-job workers), NOT `batchSize`. A batch worker hands the whole fetched
+  // batch to one handler and only fetches again once that handler resolves — so
+  // a single slow job blocks every sibling in its batch AND stalls the next
+  // fetch. On a shared queue that is head-of-line blocking: one long job can
+  // freeze the entire worker and starve everything queued behind it.
+  // `localConcurrency` spawns N pollers that each fetch+process a single job and
+  // refill the instant they finish, so a slow job never holds up the others.
   const workerOptions: WorkOptions = {
-    batchSize: 10,
-  }
-
-  if (workerConfig?.batchSize !== undefined) {
-    workerOptions.batchSize = workerConfig.batchSize
+    localConcurrency: workerConfig?.batchSize ?? 10,
+    batchSize: 1,
   }
 
   if (workerConfig?.pollInterval !== undefined) {
@@ -51,9 +56,9 @@ export class PgBossQueueWorkers implements QueueWorkers {
     // Configurations that are directly supported
     supported: {
       batchSize: {
-        queueProperty: 'batchSize',
+        queueProperty: 'localConcurrency',
         description:
-          'Number of jobs to fetch and process concurrently in parallel',
+          'Number of independent workers processing jobs concurrently (maps to pg-boss localConcurrency, not batch fetching, to avoid head-of-line blocking)',
       },
       pollInterval: {
         queueProperty: 'pollingIntervalSeconds',

--- a/packages/services/redis/src/redis-workflow-service.ts
+++ b/packages/services/redis/src/redis-workflow-service.ts
@@ -2,6 +2,7 @@ import type { SerializedError } from '@pikku/core'
 import {
   PikkuWorkflowService,
   type WorkflowPlannedStep,
+  type WorkflowQueueOptions,
   type WorkflowRun,
   type WorkflowRunWire,
   type StepState,
@@ -35,9 +36,10 @@ export class RedisWorkflowService extends PikkuWorkflowService {
    */
   constructor(
     connectionOrConfig: Redis | RedisOptions | string | undefined,
-    keyPrefix = 'workflows'
+    keyPrefix = 'workflows',
+    options: WorkflowQueueOptions = {}
   ) {
-    super()
+    super(options)
     this.keyPrefix = keyPrefix
 
     // Check if it's a Redis instance or config options


### PR DESCRIPTION
Supersedes #1020, which is folded in as the first commit.

## Why

A queue per producer is the obvious way to stop one slow producer starving the others, and it's what workflows do today (`wf-orchestrator-*` / `wf-step-*`). But on a pull-based backend it multiplies polling: pg-boss spawns an independent poll loop per worker per queue (`manager.js:317-322`, `worker.js:42-70`), each firing a fetch every `pollingInterval` (default 2s). At 37 workflow queues × concurrency 10 that's ~185 fetches/sec where one queue would be ~10. That cost is exactly why workflows shared a single orchestrator queue to begin with — the split bought isolation and paid for it in polling.

This makes the shared queue fair, so you can have isolation without the polling bill.

## What

**1. Parallelism maps to `localConcurrency`, not `batchSize`** (was #1020).

pg-boss's batch handler receives the whole fetched batch and only fetches again once the handler resolves; ours `Promise.all`s it. So a slow job blocked its batch siblings *and* stalled the next fetch. `localConcurrency` spawns N pollers that each fetch and process a single job and refill the instant they finish. This also matches BullMQ, which has always mapped `batchSize` → `concurrency` — pg-boss was the outlier. And `localGroupConcurrency` below is asserted `<= localConcurrency`, so it depends on this mapping.

**2. Job groups.** A job can carry `group: { id, tier }`; a worker can cap concurrent jobs per group with `groupConcurrency`.

- **pg-boss** → `localGroupConcurrency`. Groups at capacity are excluded from the fetch query itself via `ignoreGroups::text[]` (`plans.js:698-732`, index `job_i7`), so a capped group costs nothing rather than being fetched and restored. Limits are clamped to the worker's concurrency — pg-boss asserts `<= localConcurrency` and throws at worker start otherwise.
- **BullMQ** → declared unsupported. Groups are a BullMQ Pro feature, and being push-based it can use a queue per group at no polling cost.

**3. Workflow strategy.** `queueStrategy` defaults to `'per-workflow'` — unchanged, and still required for per-unit serverless deploys, which route to units by queue name. `'shared-groups'` routes every workflow through the shared orchestrator/step-worker queues and isolates them by group, so a monolith runs one set of pollers instead of one per workflow. Orchestrator jobs group by workflow name, step jobs by step function — mirroring how the per-workflow queues split them.

It's a constructor option rather than `config.workflow`: queues are wired during construction, before singleton services exist, so reading config there would throw (`pikku-state.ts:191`). Forwarded through the Kysely, PgKysely, Redis, MongoDB and in-memory services.

## Caveat worth knowing

Tiers can only *lower* a group's limit, not raise it above `default`. pg-boss's pre-fetch exclusion has no tier information and applies `default` to every group (`manager.js:78-80`), so a group with a higher tier limit still stops being fetched at `default`. Documented on the option; to give one workflow more room, raise `default` and restrict the others by tier.

## Test

`mapPikkuWorkerToPgBoss` covers the concurrency mapping, `pollInterval` conversion, group mapping, tier passthrough, clamping, and absence; `mapPikkuJobToPgBoss` covers group/tier forwarding. Core tests assert `'shared-groups'` leaves per-workflow queues unconsumed, applies the group cap to the shared queue, and that the default leaves it unconstrained. Full core suite 1303 pass / 0 fail; `tsc` clean across core, both queue adapters, kysely, kysely-postgres, redis, mongodb, and the cloudflare runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)