### PR TITLE
fix(cli,core): emit queue meta for workflow-only projects

### DIFF
--- a/.changeset/queue-meta-workflow-only.md
+++ b/.changeset/queue-meta-workflow-only.md
@@ -1,0 +1,21 @@
+---
+'@pikku/cli': patch
+'@pikku/core': patch
+---
+
+Emit queue meta for workflow-only projects, so per-workflow orchestrator queues actually work.
+
+Workflows synthesise their own `wf-orchestrator-*` / `wf-step-*` queue meta during
+post-processing, and those entries have no declaring source file. The queue codegen
+bailed early on `queueWorkers.files.size === 0`, so a project that uses workflows but
+hand-declares no `wireQueueWorker` wrote no queue meta at all — and the generated
+bootstrap therefore never imported it.
+
+With `queue.meta` empty at runtime, `getOrchestratorQueueName()` never found a
+per-workflow queue and every workflow silently fell back to the single shared
+`pikku-workflow-orchestrator` queue. Nothing failed, but the isolation was gone: one
+long-running workflow step head-of-line-blocked every other workflow queued behind it.
+
+The codegen now gates on the meta alone. `@pikku/core` additionally warns at wiring
+time when workflows are registered but no per-workflow orchestrator queue is present,
+so this degradation can't recur silently.

--- a/packages/cli/src/functions/wirings/queue/pikku-command-queue.ts
+++ b/packages/cli/src/functions/wirings/queue/pikku-command-queue.ts
@@ -27,10 +27,16 @@ export const pikkuCommandQueue = pikkuSessionlessFunc<
     } = config
     const { queueWorkers } = visitState
 
-    if (
-      queueWorkers.files.size === 0 ||
-      Object.keys(queueWorkers.meta).length === 0
-    ) {
+    // Gate on the meta alone, never on `files`. Workflows synthesise their own
+    // `wf-orchestrator-*` / `wf-step-*` queue meta during post-processing, and
+    // those entries have no declaring source file — so a project that uses
+    // workflows but hand-declares no `wireQueueWorker` has a full `meta` and an
+    // empty `files`. Bailing on `files.size === 0` there skipped writing the
+    // queue meta entirely, which left `pikkuState(queue,meta)` empty at runtime:
+    // `getOrchestratorQueueName()` then never found a per-workflow queue and
+    // EVERY workflow fell back to the single shared `pikku-workflow-orchestrator`,
+    // where one slow job head-of-line-blocks everything queued behind it.
+    if (Object.keys(queueWorkers.meta).length === 0) {
       return undefined
     }
 

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.test.ts
@@ -29,6 +29,77 @@ describe('pikku-workflow-service worker registration', () => {
   })
 })
 
+describe('pikku-workflow-service per-workflow queue warning', () => {
+  // Losing the per-workflow orchestrator queues is silent — dispatch just falls
+  // back to the single shared queue and one slow step starves every workflow
+  // behind it. These assert the misconfiguration is announced at wiring time.
+  const setup = (workflowNames: string[], perWorkflowQueues: string[] = []) => {
+    resetPikkuState()
+    const warnings: string[] = []
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: {
+        error: () => {},
+        info: () => {},
+        debug: () => {},
+        warn: (message: string) => warnings.push(message),
+      },
+    } as any)
+
+    const metaState = pikkuState(null, 'workflows', 'meta')
+    for (const name of workflowNames) {
+      metaState[name] = {
+        name,
+        pikkuFuncId: name,
+        source: 'dsl',
+        graphHash: `${name}-hash`,
+      } as any
+    }
+
+    const queueMeta = pikkuState(null, 'queue', 'meta')
+    for (const queueName of perWorkflowQueues) {
+      queueMeta[queueName] = {
+        pikkuFuncId: queueName,
+        name: queueName,
+      } as any
+    }
+
+    return warnings
+  }
+
+  test('warns when workflows exist but no per-workflow orchestrator queue is registered', () => {
+    const warnings = setup(['someWorkflow'])
+
+    new InMemoryWorkflowService().wireQueueWorkers()
+
+    assert.ok(
+      warnings.some((w) => /no per-workflow orchestrator queues/.test(w)),
+      `expected a per-workflow queue warning, got: ${JSON.stringify(warnings)}`
+    )
+  })
+
+  test('does not warn when per-workflow orchestrator queues are present', () => {
+    const warnings = setup(['someWorkflow'], ['wf-orchestrator-some-workflow'])
+
+    new InMemoryWorkflowService().wireQueueWorkers()
+
+    assert.ok(
+      !warnings.some((w) => /no per-workflow orchestrator queues/.test(w)),
+      `expected no warning, got: ${JSON.stringify(warnings)}`
+    )
+  })
+
+  test('does not warn when the app registers no workflows at all', () => {
+    const warnings = setup([])
+
+    new InMemoryWorkflowService().wireQueueWorkers()
+
+    assert.ok(
+      !warnings.some((w) => /no per-workflow orchestrator queues/.test(w)),
+      `expected no warning, got: ${JSON.stringify(warnings)}`
+    )
+  })
+})
+
 describe('pikku-workflow-service run-level inline', () => {
   test('workflow runs inline (and queues nothing) when no queue service is configured', async () => {
     const ws = new InMemoryWorkflowService()

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -363,6 +363,27 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       }
     }
 
+    // Workflows exist but no per-workflow orchestrator queue was registered:
+    // the generated queue meta never reached the runtime (most often the
+    // bootstrap doesn't import the queue-workers meta, so `queue.meta` is
+    // empty). Everything still "works" — dispatch silently falls back to the
+    // single shared orchestrator queue — but the isolation is gone: one slow
+    // workflow step head-of-line-blocks every other workflow behind it. That
+    // is invisible until a queue starves, so say so loudly at wiring time.
+    const workflowCount = Object.keys(
+      pikkuState(null, 'workflows', 'meta') ?? {}
+    ).length
+    const perWorkflowQueues = Object.keys(queueMeta).filter((name) =>
+      name.startsWith('wf-orchestrator-')
+    ).length
+    if (workflowCount > 0 && perWorkflowQueues === 0) {
+      this.logger?.warn?.(
+        `[pikku] ${workflowCount} workflow(s) registered but no per-workflow orchestrator queues were found in queue meta. ` +
+          `All workflows will share a single orchestrator queue, where one slow step blocks every other workflow behind it. ` +
+          `Check that the generated bootstrap imports the queue-workers meta (pikku-queue-workers-wirings-meta.gen.js).`
+      )
+    }
+
     if (!functions.has('pikkuWorkflowSleeper')) {
       addFunction('pikkuWorkflowSleeper', {
         func: pikkuWorkflowSleeperFunc,


### PR DESCRIPTION
## Problem

Workflows synthesise their own `wf-orchestrator-*` / `wf-step-*` queue meta during post-processing. Those entries have **no declaring source file**, so they never land in `queueWorkers.files`.

`pikkuCommandQueue` bailed early on:

```ts
if (queueWorkers.files.size === 0 || Object.keys(queueWorkers.meta).length === 0) return undefined
```

So a project that uses workflows but hand-declares no `wireQueueWorker` has a **full `meta` and an empty `files`** — and wrote no queue meta at all. Because the command returned `undefined`, `all.workflow.ts`'s `if (queues)` was false and the generated bootstrap also omitted the queue-workers meta import.

With `queue.meta` empty at runtime, `getOrchestratorQueueName()` never finds a per-workflow queue and **every workflow falls back to the single shared `pikku-workflow-orchestrator` queue**. Nothing errors — but the isolation is gone, and one long-running workflow step head-of-line-blocks every other workflow queued behind it.

We hit this in production: project-teardown workflows sat `created` for tens of minutes behind a long build/deploy wait step, because all ~200 workflow jobs in a 6h window landed on the one shared queue and zero on any `wf-orchestrator-*`.

## Fix

Gate on the **meta alone** — it is what the runtime consumes. The wiring file still serialises whatever declaring files exist (correctly empty here; `serializeFileImports` on an empty set yields a valid comment-only module).

`@pikku/core` additionally **warns at wiring time** when workflows are registered but no per-workflow orchestrator queue is present. The failure mode was completely silent for weeks, so making it loud matters as much as the fix.

## Tests

Three new cases in `pikku-workflow-service.test.ts` covering warn / no-warn-when-present / no-warn-when-no-workflows. Full file passes (20/20), `tsc --noEmit` clean on core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)