### PR TITLE
fix(console): detect the project package manager instead of defaulting to yarn

### DIFF
--- a/.changeset/loud-pugs-shave.md
+++ b/.changeset/loud-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+'@pikku/addon-console': patch
+---
+
+Detect the project's package manager instead of defaulting to yarn when installing an addon

--- a/packages/addon/pikku-console/src/functions/install-addon.function.ts
+++ b/packages/addon/pikku-console/src/functions/install-addon.function.ts
@@ -10,6 +10,10 @@ import {
   readAddonDeclaredNames,
   type InstanceOverrides,
 } from '../lib/derive-instance-overrides.js'
+import {
+  installArgs,
+  resolvePackageManager,
+} from '../lib/resolve-package-manager.js'
 
 export const installAddon = pikkuSessionlessFunc<
   {
@@ -71,30 +75,11 @@ export const installAddon = pikkuSessionlessFunc<
 
     const pkg = version ? `${packageName}@${version}` : packageName
 
-    const pmLock: Record<string, string> = {
-      'yarn.lock': 'yarn',
-      'pnpm-lock.yaml': 'pnpm',
-      'package-lock.json': 'npm',
-      'bun.lockb': 'bun',
-    }
-    let pm = 'yarn'
-    for (const [lock, name] of Object.entries(pmLock)) {
-      if (existsSync(join(rootDir, lock))) {
-        pm = name
-        break
-      }
-    }
-
-    const installArgs: Record<string, string[]> = {
-      yarn: ['add', pkg],
-      npm: ['install', pkg],
-      pnpm: ['add', pkg],
-      bun: ['add', pkg],
-    }
+    const pm = resolvePackageManager(rootDir)
 
     const cp = 'node:child_process'
     const { execFileSync } = await import(cp)
-    execFileSync(pm, installArgs[pm]!, { cwd: rootDir, stdio: 'pipe' })
+    execFileSync(pm, installArgs[pm](pkg), { cwd: rootDir, stdio: 'pipe' })
 
     // A second-or-later instance of the SAME package would otherwise resolve to
     // the same secrets/variables/credentials as the first — namespace-scope the

--- a/packages/addon/pikku-console/src/functions/install-openapi-addon.function.ts
+++ b/packages/addon/pikku-console/src/functions/install-openapi-addon.function.ts
@@ -1,6 +1,10 @@
 import { LocalEnvironmentOnlyError } from '@pikku/core/errors'
 import { pikkuSessionlessFunc } from '#pikku'
 import { findProjectRoot } from '../lib/find-project-root.js'
+import {
+  execPrefix,
+  resolvePackageManager,
+} from '../lib/resolve-package-manager.js'
 
 export const installOpenapiAddon = pikkuSessionlessFunc<
   {
@@ -69,25 +73,14 @@ export const installOpenapiAddon = pikkuSessionlessFunc<
       pikkuArgs.push('--credential', credential)
     }
 
-    execFileSync('npx', pikkuArgs, {
+    const pm = resolvePackageManager(rootDir)
+    const [runner, ...runnerArgs] = execPrefix[pm]
+
+    execFileSync(runner, [...runnerArgs, ...pikkuArgs], {
       cwd: rootDir,
       stdio: 'pipe',
       timeout: 120_000,
     })
-
-    const pmLock: Record<string, string> = {
-      'yarn.lock': 'yarn',
-      'pnpm-lock.yaml': 'pnpm',
-      'package-lock.json': 'npm',
-      'bun.lockb': 'bun',
-    }
-    let pm = 'yarn'
-    for (const [lock, pmName] of Object.entries(pmLock)) {
-      if (existsSync(join(rootDir, lock))) {
-        pm = pmName
-        break
-      }
-    }
 
     execFileSync(pm, ['install'], {
       cwd: rootDir,
@@ -95,14 +88,14 @@ export const installOpenapiAddon = pikkuSessionlessFunc<
       timeout: 120_000,
     })
 
-    execFileSync('npx', ['pikku', 'all'], {
+    execFileSync(runner, [...runnerArgs, 'pikku', 'all'], {
       cwd: addonPath,
       stdio: 'pipe',
       timeout: 120_000,
     })
 
     try {
-      execFileSync('npx', ['tsc'], {
+      execFileSync(runner, [...runnerArgs, 'tsc'], {
         cwd: addonPath,
         stdio: 'pipe',
         timeout: 120_000,
@@ -125,7 +118,7 @@ export const installOpenapiAddon = pikkuSessionlessFunc<
       }
     }
 
-    execFileSync('npx', ['pikku', 'all'], {
+    execFileSync(runner, [...runnerArgs, 'pikku', 'all'], {
       cwd: rootDir,
       stdio: 'pipe',
       timeout: 120_000,

--- a/packages/addon/pikku-console/src/lib/resolve-package-manager.test.ts
+++ b/packages/addon/pikku-console/src/lib/resolve-package-manager.test.ts
@@ -1,0 +1,64 @@
+import { strict as assert } from 'assert'
+import { describe, test, beforeEach, afterEach } from 'node:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolvePackageManager } from './resolve-package-manager.js'
+
+describe('resolvePackageManager', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pm-detect-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const writePkg = (pkg: object) =>
+    writeFileSync(join(dir, 'package.json'), JSON.stringify(pkg), 'utf-8')
+
+  test('reads the packageManager field', () => {
+    writePkg({ packageManager: 'bun@1.3.14' })
+    assert.equal(resolvePackageManager(dir), 'bun')
+  })
+
+  test('packageManager wins over a stale lockfile', () => {
+    writePkg({ packageManager: 'bun@1.3.14' })
+    writeFileSync(join(dir, 'yarn.lock'), '', 'utf-8')
+    assert.equal(resolvePackageManager(dir), 'bun')
+  })
+
+  test('detects bun from the text lockfile (bun >= 1.2)', () => {
+    writePkg({})
+    writeFileSync(join(dir, 'bun.lock'), '', 'utf-8')
+    assert.equal(resolvePackageManager(dir), 'bun')
+  })
+
+  test('detects bun from the binary lockfile', () => {
+    writeFileSync(join(dir, 'bun.lockb'), '', 'utf-8')
+    assert.equal(resolvePackageManager(dir), 'bun')
+  })
+
+  test('detects yarn, pnpm and npm from their lockfiles', () => {
+    for (const [lock, pm] of [
+      ['yarn.lock', 'yarn'],
+      ['pnpm-lock.yaml', 'pnpm'],
+      ['package-lock.json', 'npm'],
+    ] as const) {
+      const d = mkdtempSync(join(tmpdir(), 'pm-detect-'))
+      writeFileSync(join(d, lock), '', 'utf-8')
+      assert.equal(resolvePackageManager(d), pm)
+      rmSync(d, { recursive: true, force: true })
+    }
+  })
+
+  test('ignores an unknown packageManager and falls back', () => {
+    writePkg({ packageManager: 'cargo@1.0.0' })
+    writeFileSync(join(dir, 'pnpm-lock.yaml'), '', 'utf-8')
+    assert.equal(resolvePackageManager(dir), 'pnpm')
+  })
+
+  test('defaults to npm with no signals', () => {
+    assert.equal(resolvePackageManager(dir), 'npm')
+  })
+})

--- a/packages/addon/pikku-console/src/lib/resolve-package-manager.ts
+++ b/packages/addon/pikku-console/src/lib/resolve-package-manager.ts
@@ -1,0 +1,65 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export type PackageManager = 'bun' | 'yarn' | 'pnpm' | 'npm'
+
+/** `<pm> <args...> <pkg>` for adding a dependency. */
+export const installArgs: Record<PackageManager, (pkg: string) => string[]> = {
+  bun: (pkg) => ['add', pkg],
+  yarn: (pkg) => ['add', pkg],
+  pnpm: (pkg) => ['add', pkg],
+  npm: (pkg) => ['install', pkg],
+}
+
+/**
+ * How each package manager runs a locally-installed binary. `npx` only exists
+ * where npm does — a bun-only image (no node, no npm) has `bunx` and nothing
+ * else, so the runner has to follow the detected manager.
+ */
+export const execPrefix: Record<PackageManager, [string, ...string[]]> = {
+  bun: ['bunx'],
+  yarn: ['yarn'],
+  pnpm: ['pnpm', 'exec'],
+  npm: ['npx'],
+}
+
+// bun.lock (bun >= 1.2, text) and bun.lockb (binary) are both valid.
+const LOCKFILES: Array<[string, PackageManager]> = [
+  ['bun.lock', 'bun'],
+  ['bun.lockb', 'bun'],
+  ['yarn.lock', 'yarn'],
+  ['pnpm-lock.yaml', 'pnpm'],
+  ['package-lock.json', 'npm'],
+]
+
+/**
+ * Which package manager runs in this project. `packageManager` in package.json
+ * (the corepack field) is authoritative — it states intent even before a
+ * lockfile exists, and a project can carry a stale lockfile from another tool.
+ * Lockfiles are the fallback, then npm, which every Node install ships with.
+ *
+ * Guessing wrong is not a soft failure: the install spawns a binary that isn't
+ * on PATH and the caller sees `Executable not found in $PATH: "yarn"`.
+ */
+export function resolvePackageManager(rootDir: string): PackageManager {
+  const pkgJsonPath = join(rootDir, 'package.json')
+  if (existsSync(pkgJsonPath)) {
+    try {
+      const declared = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'))
+        .packageManager
+      // e.g. "bun@1.3.14", "yarn@4.5.0+sha224.abc"
+      const name = typeof declared === 'string' ? declared.split('@')[0] : null
+      if (name && name in installArgs) return name as PackageManager
+    } catch (e) {
+      // A malformed root package.json is the project's problem, not ours —
+      // fall through to lockfile detection rather than failing the install.
+      console.warn(`Could not read packageManager from ${pkgJsonPath}:`, e)
+    }
+  }
+
+  for (const [lock, pm] of LOCKFILES) {
+    if (existsSync(join(rootDir, lock))) return pm
+  }
+
+  return 'npm'
+}


### PR DESCRIPTION
## Problem

`console:installAddon` failed in any bun-only environment with:

```
Executable not found in $PATH: "yarn"
  at execFileSync (.../@pikku/addon-console/dist/src/functions/install-addon.function.js:66)
```

Two bugs in one detection block:

1. The bun branch only matched `bun.lockb`. Bun ≥ 1.2 writes a **text** `bun.lock`, so a modern bun project never matched.
2. The fallback when nothing matched was `yarn` — a manager that isn't present in a bun-only image (no node, no npm, no yarn).

`install-openapi-addon` carried a copy of the same block, plus four hardcoded `npx` invocations, which are equally absent without npm.

## Fix

New `lib/resolve-package-manager.ts`:

- `packageManager` in the root `package.json` is authoritative — it states intent even before a lockfile exists, and survives a stale lockfile left by another tool.
- Lockfiles are the fallback, now including `bun.lock` alongside `bun.lockb`.
- Final fallback is `npm`, which ships with every Node install, not `yarn`.
- `execPrefix` maps each manager to its binary runner (`bunx` / `pnpm exec` / `yarn` / `npx`) so the OpenAPI installer stops assuming npm is around.

Both installers now use it. Unit tests cover field-over-lockfile precedence, both bun lockfiles, each other manager, an unknown `packageManager` value, and the no-signal default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Addon installation now detects the project’s package manager automatically, supporting npm, Yarn, pnpm, and Bun.
  * Local CLI commands use the detected package manager for improved workspace compatibility.

* **Bug Fixes**
  * Prevents installations from defaulting to Yarn when another package manager is configured.
  * Handles package-manager settings, lockfiles, and missing configuration more reliably.

* **Tests**
  * Added coverage for package-manager detection across supported configuration and lockfile scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->