### PR TITLE
fix(cli): fabric validate type-checks frontends; link no longer clobbers pikkufabric.config.json

### DIFF
--- a/.changeset/fabric-validate-typecheck.md
+++ b/.changeset/fabric-validate-typecheck.md
@@ -1,0 +1,13 @@
+---
+'@pikku/cli': patch
+---
+
+`fabric validate` now type-checks every deployable frontend, the same compile the
+build container runs before it will deploy, so a type error fails locally in
+seconds instead of minutes into a deploy. Pass `--skip-typecheck` for the
+structural checks alone.
+
+Also fixes `fabric link` / `fabric init` clobbering `pikkufabric.config.json`:
+they wrote a fresh `{ projectId }` object, silently deleting `frontends`,
+`production` and `apiUrl`. Losing `frontends` means the build container deploys
+no frontend at all, long after the link that caused it. The config is now merged.

--- a/.changeset/fabric-validate-typecheck.md
+++ b/.changeset/fabric-validate-typecheck.md
@@ -7,7 +7,13 @@ build container runs before it will deploy, so a type error fails locally in
 seconds instead of minutes into a deploy. Pass `--skip-typecheck` for the
 structural checks alone.
 
+Declared frontends are shape-checked before they are used, so a malformed
+`frontends` entry is reported as a finding instead of throwing part-way through
+validation, and a deployable frontend whose directory does not exist is an error
+even in a project with no `apps/` directory.
+
 Also fixes `fabric link` / `fabric init` clobbering `pikkufabric.config.json`:
 they wrote a fresh `{ projectId }` object, silently deleting `frontends`,
 `production` and `apiUrl`. Losing `frontends` means the build container deploys
-no frontend at all, long after the link that caused it. The config is now merged.
+no frontend at all, long after the link that caused it. The config is now merged,
+and a config that cannot be read at all is left alone rather than overwritten.

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -73,6 +73,13 @@ export const fabricCommands = defineCLICommands({
     render: renderValidate,
     description:
       'Check the project structure for fabric compatibility — prints all missing or misconfigured items with fix hints',
+    options: {
+      skipTypecheck: {
+        description:
+          'Skip the frontend type-check the build container runs (structural checks only)',
+        default: false,
+      },
+    },
   }),
   smoke: pikkuCLICommand({
     func: FabricSmoke,

--- a/packages/cli/src/fabric/functions/validate.function.test.ts
+++ b/packages/cli/src/fabric/functions/validate.function.test.ts
@@ -1680,3 +1680,132 @@ describe('i18n + @pikku/mantine convergence — Paraglide (live validate.functio
     })
   })
 })
+
+describe('declared frontends + type-check (live validate.function)', () => {
+  // pikkufabric.config.json is unvalidated JSON — validate has to survive
+  // whatever is in it and report the problem, not crash on a property access.
+  const declareFrontends = async (root: string, frontends: unknown) => {
+    await writeJson(join(root, 'pikkufabric.config.json'), {
+      projectId: 'proj-abc123',
+      frontends,
+    })
+  }
+
+  const findingIds = (findings: Array<{ id: string }>) =>
+    JSON.stringify(findings.map((f) => f.id))
+
+  test('a null frontend entry is reported, not thrown', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await declareFrontends(tmp, { app: null })
+      const result = await runLiveValidate(tmp)
+      const f = result.findings.find(
+        (f) => f.id === 'frontend-entry-invalid-app'
+      )
+      assert.ok(
+        f,
+        `expected frontend-entry-invalid-app, got: ${findingIds(result.findings)}`
+      )
+      assert.strictEqual(f!.severity, 'error')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('a non-string cwd is reported, not thrown', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await declareFrontends(tmp, { app: { cwd: 42 } })
+      const result = await runLiveValidate(tmp)
+      const f = result.findings.find((f) => f.id === 'frontend-cwd-invalid-app')
+      assert.ok(
+        f,
+        `expected frontend-cwd-invalid-app, got: ${findingIds(result.findings)}`
+      )
+      assert.strictEqual(f!.severity, 'error')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('a non-object "frontends" is reported', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await declareFrontends(tmp, 'apps/app')
+      const result = await runLiveValidate(tmp)
+      const f = result.findings.find((f) => f.id === 'frontends-invalid')
+      assert.ok(
+        f,
+        `expected frontends-invalid, got: ${findingIds(result.findings)}`
+      )
+      assert.strictEqual(f!.severity, 'error')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('a deployable frontend with a missing directory errors even without apps/', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await declareFrontends(tmp, { app: { cwd: './apps/app' } })
+      const result = await runLiveValidate(tmp)
+      const f = result.findings.find((f) => f.id === 'frontend-cwd-missing-app')
+      assert.ok(
+        f,
+        `expected frontend-cwd-missing-app, got: ${findingIds(result.findings)}`
+      )
+      assert.strictEqual(f!.severity, 'error')
+      assert.strictEqual(result.ok, false)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('a frontend that cannot be type-checked warns — and --skip-typecheck suppresses it', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await declareFrontends(tmp, { app: { cwd: 'apps/app' } })
+      await mkdir(join(tmp, 'apps', 'app'), { recursive: true })
+      await writeJson(join(tmp, 'apps', 'app', 'package.json'), { name: 'app' })
+
+      const checked = await runLiveValidate(tmp)
+      assert.ok(
+        checked.findings.some((f) => f.id === 'frontend-typecheck-skipped-app'),
+        `expected frontend-typecheck-skipped-app, got: ${findingIds(checked.findings)}`
+      )
+
+      const skipped = await runLiveValidate(tmp, { skipTypecheck: true })
+      assert.ok(
+        !skipped.findings.some((f) => f.id.startsWith('frontend-typecheck-')),
+        `expected no type-check findings, got: ${findingIds(skipped.findings)}`
+      )
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('a frontend declared with deploy:false is not type-checked', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidProject(tmp)
+      await declareFrontends(tmp, {
+        app: { cwd: 'apps/app', deploy: false },
+      })
+      await mkdir(join(tmp, 'apps', 'app'), { recursive: true })
+      await writeJson(join(tmp, 'apps', 'app', 'package.json'), { name: 'app' })
+
+      const result = await runLiveValidate(tmp)
+      assert.ok(
+        !result.findings.some((f) => f.id.startsWith('frontend-typecheck-')),
+        `expected no type-check findings, got: ${findingIds(result.findings)}`
+      )
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/fabric/functions/validate.function.ts
+++ b/packages/cli/src/fabric/functions/validate.function.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
 import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
 import { added, changed, removed, dim } from '../lib/output.js'
+import { typeCheckFrontends } from '../lib/frontend-typecheck.js'
 
 const FindingSchema = z.object({
   id: z.string(),
@@ -15,7 +16,14 @@ const FindingSchema = z.object({
 })
 type Finding = z.infer<typeof FindingSchema>
 
-export const FabricValidateInput = z.object({})
+export const FabricValidateInput = z.object({
+  skipTypecheck: z
+    .boolean()
+    .optional()
+    .describe(
+      'Skip the frontend type-check stage (structural checks only, much faster)'
+    ),
+})
 
 export const FabricValidateOutput = z.object({
   ok: z.boolean(),
@@ -200,7 +208,8 @@ const POSTGRES_SQL_PATTERNS: Array<{ re: RegExp; label: string }> = [
 ]
 
 export async function runValidate(
-  startDir = process.cwd()
+  startDir = process.cwd(),
+  opts: { skipTypecheck?: boolean } = {}
 ): Promise<z.infer<typeof FabricValidateOutput>> {
   const root = await findProjectRoot(startDir)
   const findings: Finding[] = []
@@ -1841,6 +1850,55 @@ export async function runValidate(
     )
   }
 
+  // ── frontend type-check (what the build container actually runs) ───────
+  // Every check above is a heuristic standing in for this compile. The build
+  // container type-checks each deployable frontend and aborts the deploy on a
+  // non-zero exit, so running the same compile here is the difference between
+  // a 20-second local failure and a burned deploy out of the daily 10.
+  if (!opts.skipTypecheck) {
+    const frontends = Object.entries(
+      (fabricConfig?.frontends ?? {}) as Record<
+        string,
+        { cwd?: string; deploy?: boolean }
+      >
+    )
+      .filter(([, fe]) => fe.deploy !== false && fe.cwd)
+      .map(([name, fe]) => ({
+        name,
+        dir: join(root, fe.cwd!.replace(/^\.\//, '')),
+      }))
+      .filter(({ dir }) => existsSync(dir))
+
+    for (const result of await typeCheckFrontends(root, frontends)) {
+      if (result.skipped) {
+        w(
+          `frontend-typecheck-skipped-${result.name}`,
+          `could not type-check frontend "${result.name}" — ${result.skipped}`,
+          result.dir,
+          lines(
+            'The build container type-checks every deployable frontend and aborts the deploy if it fails.',
+            'Give the app a tsconfig.json and a "tsc" script so the same check runs locally.'
+          )
+        )
+        continue
+      }
+      if (result.errors.length === 0) continue
+      const shown = result.errors.slice(0, 20)
+      const extra = result.errors.length - shown.length
+      e(
+        `frontend-typecheck-${result.name}`,
+        `frontend "${result.name}" does not type-check — the build container aborts the deploy on this`,
+        result.dir,
+        lines(
+          ...shown,
+          ...(extra > 0 ? [`… and ${extra} more`] : []),
+          '',
+          `Reproduce with: cd ${result.dir.slice(root.length + 1)} && npm run tsc`
+        )
+      )
+    }
+  }
+
   const ok = !findings.some((f) => f.severity === 'error')
   return { ok, root, findings }
 }
@@ -1850,7 +1908,8 @@ export const FabricValidate = pikkuSessionlessFunc({
     'Check the current project structure for fabric compatibility. Prints all missing or misconfigured items with fix hints so an AI agent or developer can resolve them.',
   input: FabricValidateInput,
   output: FabricValidateOutput,
-  func: async (_services) => runValidate(),
+  func: async (_services, { skipTypecheck }) =>
+    runValidate(process.cwd(), { skipTypecheck }),
 })
 
 export const renderValidate = (

--- a/packages/cli/src/fabric/functions/validate.function.ts
+++ b/packages/cli/src/fabric/functions/validate.function.ts
@@ -1361,31 +1361,77 @@ export async function runValidate(
     }
   }
 
+  // ── declared frontends ────────────────────────────────────────────────
+  // pikkufabric.config.json is unvalidated JSON, so every field below is a
+  // claim, not a guarantee: a null entry or a non-string cwd used to throw on
+  // property access and take down the whole validation run — the one thing that
+  // was supposed to report the broken config. Shape-check the entries once here
+  // and let the apps/ and type-check passes consume the narrowed list.
+  const declaredFrontends: Array<{
+    slug: string
+    cwd: string
+    dir: string
+    deploy: boolean
+  }> = []
+  /** every syntactically valid cwd, including ones whose directory is missing */
+  const declaredCwdList: string[] = []
+  const rawFrontends = fabricConfig?.frontends
+  if (
+    rawFrontends !== undefined &&
+    (!rawFrontends || typeof rawFrontends !== 'object')
+  ) {
+    e(
+      'frontends-invalid',
+      'pikkufabric.config.json "frontends" is not an object — no frontend will be built or type-checked',
+      fabricConfigPath,
+      `Set "frontends" to an object keyed by slug: { "app": { "cwd": "apps/app", "kind": "ssr" } }`
+    )
+  } else if (rawFrontends) {
+    for (const [slug, entry] of Object.entries(
+      rawFrontends as Record<string, unknown>
+    )) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        e(
+          `frontend-entry-invalid-${slug}`,
+          `pikkufabric.config.json frontend "${slug}" is not an object`,
+          fabricConfigPath,
+          `Give "${slug}" an object value: { "cwd": "apps/${slug}", "kind": "ssr" }`
+        )
+        continue
+      }
+      const { cwd, deploy } = entry as { cwd?: unknown; deploy?: unknown }
+      if (typeof cwd !== 'string' || cwd.trim() === '') {
+        e(
+          `frontend-cwd-invalid-${slug}`,
+          `pikkufabric.config.json frontend "${slug}" has no string "cwd" — the build container has nothing to build`,
+          fabricConfigPath,
+          `Set "cwd" to the app directory, e.g. { "${slug}": { "cwd": "apps/${slug}" } }`
+        )
+        continue
+      }
+      const rel = cwd.replace(/^\.\//, '')
+      declaredCwdList.push(rel)
+      const dir = join(root, rel)
+      if (!existsSync(dir)) {
+        // Reported here rather than inside the apps/ block below: a project
+        // without an apps/ directory used to validate cleanly while declaring a
+        // deployable frontend that does not exist.
+        e(
+          `frontend-cwd-missing-${slug}`,
+          `fabric.config.json frontend "${slug}" declares cwd "${rel}" but that directory does not exist`,
+          dir,
+          `Create the directory or update the cwd in fabric.config.json`
+        )
+        continue
+      }
+      declaredFrontends.push({ slug, cwd: rel, dir, deploy: deploy !== false })
+    }
+  }
+
   // ── apps/ vs fabric.config.json frontends ─────────────────────────────
   const appsDir = join(root, 'apps')
 
   if (existsSync(appsDir)) {
-    type FrontendEntry = { cwd?: string }
-
-    // Check declared frontends have a real directory on disk
-    if (fabricConfig) {
-      const frontends = (fabricConfig.frontends ?? {}) as Record<
-        string,
-        FrontendEntry
-      >
-      for (const [slug, fe] of Object.entries(frontends)) {
-        const cwd = fe.cwd?.replace(/^\.\//, '')
-        if (cwd && !existsSync(join(root, cwd))) {
-          e(
-            `frontend-cwd-missing-${slug}`,
-            `fabric.config.json frontend "${slug}" declares cwd "${cwd}" but that directory does not exist`,
-            join(root, cwd),
-            `Create the directory or update the cwd in fabric.config.json`
-          )
-        }
-      }
-    }
-
     // Check each app/ subdir is declared and has correct local deps
     let appEntries: string[] = []
     try {
@@ -1396,13 +1442,7 @@ export async function runValidate(
       /* ignore */
     }
 
-    const declaredCwds = fabricConfig
-      ? new Set(
-          Object.values(
-            (fabricConfig.frontends ?? {}) as Record<string, FrontendEntry>
-          ).map((f) => f.cwd?.replace(/^\.\//, '') ?? '')
-        )
-      : null
+    const declaredCwds = fabricConfig ? new Set(declaredCwdList) : null
 
     for (const name of appEntries) {
       const appPath = join(appsDir, name)
@@ -1856,18 +1896,9 @@ export async function runValidate(
   // non-zero exit, so running the same compile here is the difference between
   // a 20-second local failure and a burned deploy out of the daily 10.
   if (!opts.skipTypecheck) {
-    const frontends = Object.entries(
-      (fabricConfig?.frontends ?? {}) as Record<
-        string,
-        { cwd?: string; deploy?: boolean }
-      >
-    )
-      .filter(([, fe]) => fe.deploy !== false && fe.cwd)
-      .map(([name, fe]) => ({
-        name,
-        dir: join(root, fe.cwd!.replace(/^\.\//, '')),
-      }))
-      .filter(({ dir }) => existsSync(dir))
+    const frontends = declaredFrontends
+      .filter((fe) => fe.deploy)
+      .map((fe) => ({ name: fe.slug, dir: fe.dir }))
 
     for (const result of await typeCheckFrontends(root, frontends)) {
       if (result.skipped) {
@@ -1893,7 +1924,7 @@ export async function runValidate(
           ...shown,
           ...(extra > 0 ? [`… and ${extra} more`] : []),
           '',
-          `Reproduce with: cd ${result.dir.slice(root.length + 1)} && npm run tsc`
+          `Reproduce with: cd ${result.dir.slice(root.length + 1)} && ${result.command}`
         )
       )
     }

--- a/packages/cli/src/fabric/lib/config.test.ts
+++ b/packages/cli/src/fabric/lib/config.test.ts
@@ -1,0 +1,157 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm, writeFile, chmod } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { writeProjectConfig } from './config.js'
+
+const configName = 'pikkufabric.config.json'
+
+async function makeTmp() {
+  return mkdtemp(join(tmpdir(), 'pikku-fabric-config-'))
+}
+
+async function readConfig(root: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(join(root, configName), 'utf8'))
+}
+
+/** Swallow the warn a rewrite prints so the test output stays readable. */
+async function withoutWarnings<T>(fn: () => Promise<T>): Promise<T> {
+  const warn = console.warn
+  console.warn = () => {}
+  try {
+    return await fn()
+  } finally {
+    console.warn = warn
+  }
+}
+
+describe('writeProjectConfig', () => {
+  test('preserves frontends, production and unknown keys when relinking', async () => {
+    const tmp = await makeTmp()
+    try {
+      await writeFile(
+        join(tmp, configName),
+        JSON.stringify({
+          projectId: 'proj-old',
+          apiUrl: 'https://api.example.com',
+          frontends: { app: { cwd: 'apps/app', kind: 'ssr' } },
+          production: { domain: 'example.com' },
+          somethingWeDoNotUnderstand: { keep: true },
+        }),
+        'utf8'
+      )
+
+      await writeProjectConfig(tmp, { projectId: 'proj-new' })
+
+      const config = await readConfig(tmp)
+      assert.equal(config.projectId, 'proj-new')
+      assert.equal(config.apiUrl, 'https://api.example.com')
+      assert.deepEqual(config.frontends, {
+        app: { cwd: 'apps/app', kind: 'ssr' },
+      })
+      assert.deepEqual(config.production, { domain: 'example.com' })
+      assert.deepEqual(config.somethingWeDoNotUnderstand, { keep: true })
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('applies a partial update without dropping the other keys', async () => {
+    const tmp = await makeTmp()
+    try {
+      await writeFile(
+        join(tmp, configName),
+        JSON.stringify({
+          projectId: 'proj-abc',
+          apiUrl: 'https://api.example.com',
+          frontends: { app: { cwd: 'apps/app' } },
+        }),
+        'utf8'
+      )
+
+      await writeProjectConfig(tmp, {
+        projectId: 'proj-abc',
+        apiUrl: 'http://localhost:4002',
+      })
+
+      const config = await readConfig(tmp)
+      assert.equal(config.apiUrl, 'http://localhost:4002')
+      assert.deepEqual(config.frontends, { app: { cwd: 'apps/app' } })
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('writes a fresh config when none exists', async () => {
+    const tmp = await makeTmp()
+    try {
+      const path = await writeProjectConfig(tmp, { projectId: 'proj-abc' })
+      assert.equal(path, join(tmp, configName))
+      assert.deepEqual(await readConfig(tmp), { projectId: 'proj-abc' })
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('rewrites an unparseable config rather than failing the link', async () => {
+    const tmp = await makeTmp()
+    try {
+      await writeFile(join(tmp, configName), '{ not json', 'utf8')
+
+      await withoutWarnings(() =>
+        writeProjectConfig(tmp, { projectId: 'proj-abc' })
+      )
+
+      assert.deepEqual(await readConfig(tmp), { projectId: 'proj-abc' })
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('rewrites valid JSON that is not an object', async () => {
+    const tmp = await makeTmp()
+    try {
+      await writeFile(join(tmp, configName), '["not", "a", "config"]', 'utf8')
+
+      await withoutWarnings(() =>
+        writeProjectConfig(tmp, { projectId: 'proj-abc' })
+      )
+
+      assert.deepEqual(await readConfig(tmp), { projectId: 'proj-abc' })
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('refuses to overwrite a config it could not read', async (t) => {
+    if (process.getuid?.() === 0) {
+      t.skip('root ignores file permissions')
+      return
+    }
+    const tmp = await makeTmp()
+    const path = join(tmp, configName)
+    try {
+      const original = JSON.stringify({
+        projectId: 'proj-abc',
+        frontends: { app: { cwd: 'apps/app' } },
+      })
+      await writeFile(path, original, 'utf8')
+      await chmod(path, 0o000)
+
+      await assert.rejects(
+        writeProjectConfig(tmp, { projectId: 'proj-new' }),
+        /refusing to overwrite/
+      )
+
+      await chmod(path, 0o600)
+      assert.equal(await readFile(path, 'utf8'), original)
+    } finally {
+      await chmod(path, 0o600).catch((error) => {
+        // Only affects cleanup of a temp dir we remove next; note it and move on.
+        console.warn(`[test] could not restore ${path} mode: ${error.message}`)
+      })
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/fabric/lib/config.ts
+++ b/packages/cli/src/fabric/lib/config.ts
@@ -76,13 +76,40 @@ export function isLinkedProjectId(projectId?: string | null): boolean {
   return !/^__.*__$/.test(projectId)
 }
 
+/**
+ * Merge into the existing config rather than replacing it. `link` and `init`
+ * only know the projectId, so a plain write silently deleted every other key —
+ * including `frontends`, which is what tells the build container an app exists.
+ * The symptom is a deploy that succeeds having built no frontend at all, long
+ * after the link that caused it. Unknown keys are preserved too; nothing here
+ * has any business dropping config it does not understand.
+ */
 export async function writeProjectConfig(
   cwd: string,
-  config: ProjectConfig
+  config: Partial<ProjectConfig> & { projectId: string }
 ): Promise<string> {
   const path = join(cwd, projectConfigName)
+  let existing: Record<string, unknown> = {}
+  if (existsSync(path)) {
+    try {
+      const parsed = JSON.parse(await readFile(path, 'utf8')) as unknown
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        existing = parsed as Record<string, unknown>
+      }
+    } catch (error: any) {
+      // An unparseable config is not a reason to lose the link; warn and start
+      // fresh rather than throwing away the command the user just ran.
+      console.warn(
+        `[fabric] ${projectConfigName} is not valid JSON (${error.message}) — rewriting it`
+      )
+    }
+  }
   await mkdir(dirname(path), { recursive: true })
-  await writeFile(path, JSON.stringify(config, null, 2) + '\n', 'utf8')
+  await writeFile(
+    path,
+    JSON.stringify({ ...existing, ...config }, null, 2) + '\n',
+    'utf8'
+  )
   return path
 }
 

--- a/packages/cli/src/fabric/lib/config.ts
+++ b/packages/cli/src/fabric/lib/config.ts
@@ -91,10 +91,28 @@ export async function writeProjectConfig(
   const path = join(cwd, projectConfigName)
   let existing: Record<string, unknown> = {}
   if (existsSync(path)) {
+    // A read that fails for any reason other than the file's contents —
+    // permissions, a transient I/O error — tells us nothing about what the file
+    // holds. Rewriting it then is the exact clobber this function exists to
+    // prevent, so refuse the write instead.
+    let raw: string
     try {
-      const parsed = JSON.parse(await readFile(path, 'utf8')) as unknown
+      raw = await readFile(path, 'utf8')
+    } catch (error: any) {
+      throw new Error(
+        `Cannot read ${projectConfigName} at ${path} (${error.message}) — refusing to overwrite it`
+      )
+    }
+    try {
+      const parsed = JSON.parse(raw) as unknown
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         existing = parsed as Record<string, unknown>
+      } else {
+        // Valid JSON that is not an object holds nothing we can merge, but it is
+        // still the user's file — say so rather than dropping it silently.
+        console.warn(
+          `[fabric] ${projectConfigName} is not a JSON object — rewriting it`
+        )
       }
     } catch (error: any) {
       // An unparseable config is not a reason to lose the link; warn and start

--- a/packages/cli/src/fabric/lib/frontend-typecheck.test.ts
+++ b/packages/cli/src/fabric/lib/frontend-typecheck.test.ts
@@ -1,0 +1,248 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, rm, writeFile, chmod } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  parseTscErrors,
+  resolveTypeCheckCommand,
+  typeCheckFrontends,
+} from './frontend-typecheck.js'
+
+async function makeTmp() {
+  return mkdtemp(join(tmpdir(), 'pikku-typecheck-'))
+}
+
+async function writeJson(path: string, data: unknown) {
+  await writeFile(path, JSON.stringify(data, null, 2), 'utf8')
+}
+
+/**
+ * A stand-in package manager, so a test can drive the runner end-to-end without
+ * depending on which one happens to be installed. `packageManager` is read as
+ * `name@version`, and an absolute path has no `@` — so it resolves to itself.
+ */
+async function fakePackageManager(dir: string, body: string): Promise<string> {
+  const path = join(dir, 'fake-pm')
+  await writeFile(path, `#!/bin/sh\n${body}\n`, 'utf8')
+  await chmod(path, 0o755)
+  return path
+}
+
+describe('parseTscErrors', () => {
+  test('keeps tsc diagnostics and drops the runner chatter', () => {
+    const errors = parseTscErrors(
+      [
+        'yarn run v1.22.19',
+        '$ tsc --noEmit',
+        "src/routes/index.tsx(12,7): error TS2353: Object literal may only specify known properties, and 'component' does not exist.",
+        'src/lib/env.ts(4,1): error TS2304: Cannot find name "process".',
+        'error Command failed with exit code 2.',
+      ].join('\n')
+    )
+    assert.deepEqual(errors, [
+      "src/routes/index.tsx(12,7): error TS2353: Object literal may only specify known properties, and 'component' does not exist.",
+      'src/lib/env.ts(4,1): error TS2304: Cannot find name "process".',
+    ])
+  })
+
+  test('falls back to the output tail when nothing parses', () => {
+    const errors = parseTscErrors(
+      'error TS5083: Cannot read file tsconfig.json.\n'
+    )
+    assert.deepEqual(errors, ['error TS5083: Cannot read file tsconfig.json.'])
+  })
+
+  test('a silent non-zero exit still reports a failure', () => {
+    // An empty list here reads as "compiled fine" and lets the deploy through.
+    assert.deepEqual(parseTscErrors(''), [
+      'type-check exited non-zero without producing any output',
+    ])
+    assert.deepEqual(parseTscErrors('   \n\n'), [
+      'type-check exited non-zero without producing any output',
+    ])
+  })
+})
+
+describe('resolveTypeCheckCommand', () => {
+  test('runs the frontend own tsc script through the declared package manager', async () => {
+    const tmp = await makeTmp()
+    try {
+      const app = join(tmp, 'apps', 'app')
+      await mkdir(app, { recursive: true })
+      await writeJson(join(tmp, 'package.json'), {
+        packageManager: 'yarn@4.1.0',
+      })
+      await writeJson(join(app, 'package.json'), { scripts: { tsc: 'tsc' } })
+
+      assert.deepEqual(await resolveTypeCheckCommand(tmp, app), {
+        command: 'yarn',
+        args: ['run', 'tsc'],
+      })
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('falls back to tsc --noEmit when the frontend has no tsc script', async () => {
+    const tmp = await makeTmp()
+    try {
+      const app = join(tmp, 'apps', 'app')
+      await mkdir(app, { recursive: true })
+      await writeFile(join(tmp, 'pnpm-lock.yaml'), '', 'utf8')
+      await writeJson(join(app, 'package.json'), { scripts: { build: 'vite' } })
+
+      assert.deepEqual(await resolveTypeCheckCommand(tmp, app), {
+        command: 'pnpm',
+        args: ['tsc', '--noEmit'],
+      })
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('the npm fallback goes through npx', async () => {
+    const tmp = await makeTmp()
+    try {
+      const app = join(tmp, 'apps', 'app')
+      await mkdir(app, { recursive: true })
+
+      assert.deepEqual(await resolveTypeCheckCommand(tmp, app), {
+        command: 'npx',
+        args: ['tsc', '--noEmit'],
+      })
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('typeCheckFrontends', () => {
+  test('skips a frontend with no tsconfig.json, and reports the command', async () => {
+    const tmp = await makeTmp()
+    try {
+      const app = join(tmp, 'apps', 'app')
+      await mkdir(app, { recursive: true })
+      await writeFile(join(tmp, 'yarn.lock'), '', 'utf8')
+
+      const [result] = await typeCheckFrontends(tmp, [
+        { name: 'app', dir: app },
+      ])
+      assert.equal(result?.skipped, 'no tsconfig.json')
+      assert.equal(result?.command, 'yarn tsc --noEmit')
+      assert.deepEqual(result?.errors, [])
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('skips — rather than passes — when the runner is not on PATH', async () => {
+    const tmp = await makeTmp()
+    try {
+      const app = join(tmp, 'apps', 'app')
+      await mkdir(app, { recursive: true })
+      await writeJson(join(app, 'tsconfig.json'), {})
+      await writeJson(join(app, 'package.json'), {
+        packageManager: 'pikku-no-such-package-manager@1.0.0',
+        scripts: { tsc: 'tsc' },
+      })
+
+      const [result] = await typeCheckFrontends(tmp, [
+        { name: 'app', dir: app },
+      ])
+      assert.match(result?.skipped ?? '', /not found on PATH/)
+      assert.deepEqual(result?.errors, [])
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('reports the diagnostics of a failing type-check', async (t) => {
+    if (process.platform === 'win32') {
+      t.skip('the stub package manager is a shell script')
+      return
+    }
+    const tmp = await makeTmp()
+    try {
+      const app = join(tmp, 'apps', 'app')
+      await mkdir(app, { recursive: true })
+      await writeJson(join(app, 'tsconfig.json'), {})
+      const pm = await fakePackageManager(
+        tmp,
+        [
+          'echo "$ tsc --noEmit"',
+          'echo "src/app.tsx(3,5): error TS2322: Type X is not assignable to type Y."',
+          'exit 2',
+        ].join('\n')
+      )
+      await writeJson(join(app, 'package.json'), {
+        packageManager: pm,
+        scripts: { tsc: 'tsc' },
+      })
+
+      const [result] = await typeCheckFrontends(tmp, [
+        { name: 'app', dir: app },
+      ])
+      assert.equal(result?.skipped, undefined)
+      assert.deepEqual(result?.errors, [
+        'src/app.tsx(3,5): error TS2322: Type X is not assignable to type Y.',
+      ])
+      assert.equal(result?.command, `${pm} run tsc`)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('a clean type-check produces no errors', async (t) => {
+    if (process.platform === 'win32') {
+      t.skip('the stub package manager is a shell script')
+      return
+    }
+    const tmp = await makeTmp()
+    try {
+      const app = join(tmp, 'apps', 'app')
+      await mkdir(app, { recursive: true })
+      await writeJson(join(app, 'tsconfig.json'), {})
+      const pm = await fakePackageManager(tmp, 'exit 0')
+      await writeJson(join(app, 'package.json'), {
+        packageManager: pm,
+        scripts: { tsc: 'tsc' },
+      })
+
+      const [result] = await typeCheckFrontends(tmp, [
+        { name: 'app', dir: app },
+      ])
+      assert.deepEqual(result?.errors, [])
+      assert.equal(result?.skipped, undefined)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('a non-zero exit with no output is still a failure', async (t) => {
+    if (process.platform === 'win32') {
+      t.skip('the stub package manager is a shell script')
+      return
+    }
+    const tmp = await makeTmp()
+    try {
+      const app = join(tmp, 'apps', 'app')
+      await mkdir(app, { recursive: true })
+      await writeJson(join(app, 'tsconfig.json'), {})
+      const pm = await fakePackageManager(tmp, 'exit 1')
+      await writeJson(join(app, 'package.json'), {
+        packageManager: pm,
+        scripts: { tsc: 'tsc' },
+      })
+
+      const [result] = await typeCheckFrontends(tmp, [
+        { name: 'app', dir: app },
+      ])
+      assert.deepEqual(result?.errors, [
+        'type-check exited non-zero without producing any output',
+      ])
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/fabric/lib/frontend-typecheck.ts
+++ b/packages/cli/src/fabric/lib/frontend-typecheck.ts
@@ -1,0 +1,139 @@
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export interface FrontendTypeCheckResult {
+  /** fabric.config.json frontend key, e.g. "app" */
+  name: string
+  /** absolute directory that was type-checked */
+  dir: string
+  /** raw `file(line,col): error TSxxxx: message` lines, in tsc's order */
+  errors: string[]
+  /** set when the frontend could not be checked at all (no tsconfig, tsc missing) */
+  skipped?: string
+}
+
+/**
+ * Run each deployable frontend's type-check exactly as the Fabric build
+ * container does, so a type error fails `fabric validate` on the developer's
+ * machine instead of eight minutes into a deploy.
+ *
+ * The container runs the frontend's own `tsc` script (falling back to
+ * `tsc --noEmit`) and aborts the deploy on a non-zero exit; the deploy budget
+ * is 10/day, so spending one on a TS2353 is expensive. Everything else in
+ * validate is a structural heuristic *approximating* this compile — this is the
+ * compile.
+ */
+export async function typeCheckFrontends(
+  root: string,
+  frontendDirs: Array<{ name: string; dir: string }>
+): Promise<FrontendTypeCheckResult[]> {
+  const results: FrontendTypeCheckResult[] = []
+  for (const { name, dir } of frontendDirs) {
+    if (!existsSync(join(dir, 'tsconfig.json'))) {
+      results.push({ name, dir, errors: [], skipped: 'no tsconfig.json' })
+      continue
+    }
+    const pkg = await readPackageJson(dir)
+    const runner = await resolveRunner(root, dir)
+    const { command, args } = pkg?.scripts?.tsc
+      ? { command: runner, args: ['run', 'tsc'] }
+      : { command: runner === 'npm' ? 'npx' : runner, args: ['tsc', '--noEmit'] }
+
+    const { code, output, spawnError } = await run(command, args, dir)
+    if (spawnError) {
+      results.push({ name, dir, errors: [], skipped: spawnError })
+      continue
+    }
+    results.push({
+      name,
+      dir,
+      errors: code === 0 ? [] : parseTscErrors(output),
+    })
+  }
+  return results
+}
+
+interface PackageJson {
+  scripts?: Record<string, string>
+  packageManager?: string
+}
+
+async function readPackageJson(dir: string): Promise<PackageJson | null> {
+  try {
+    return JSON.parse(
+      await readFile(join(dir, 'package.json'), 'utf-8')
+    ) as PackageJson
+  } catch {
+    // A frontend without a readable package.json still gets checked via the
+    // `tsc --noEmit` fallback — the missing manifest is reported by other checks.
+    return null
+  }
+}
+
+/**
+ * The package manager the project declares, so `run tsc` resolves the same
+ * workspace-local typescript the deploy would. Falls back to npm.
+ */
+async function resolveRunner(root: string, dir: string): Promise<string> {
+  for (const candidate of [dir, root]) {
+    const pkg = await readPackageJson(candidate)
+    const declared = pkg?.packageManager
+    if (declared) return declared.split('@')[0]!
+  }
+  if (existsSync(join(root, 'bun.lock')) || existsSync(join(root, 'bun.lockb')))
+    return 'bun'
+  if (existsSync(join(root, 'yarn.lock'))) return 'yarn'
+  if (existsSync(join(root, 'pnpm-lock.yaml'))) return 'pnpm'
+  return 'npm'
+}
+
+function run(
+  command: string,
+  args: string[],
+  cwd: string
+): Promise<{ code: number; output: string; spawnError?: string }> {
+  return new Promise((resolve) => {
+    let output = ''
+    const child = spawn(command, args, {
+      cwd,
+      shell: process.platform === 'win32',
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+    })
+    child.stdout?.on('data', (chunk) => {
+      output += chunk.toString()
+    })
+    child.stderr?.on('data', (chunk) => {
+      output += chunk.toString()
+    })
+    child.on('error', (error: NodeJS.ErrnoException) => {
+      resolve({
+        code: 1,
+        output,
+        spawnError:
+          error.code === 'ENOENT'
+            ? `${command} not found on PATH`
+            : error.message,
+      })
+    })
+    child.on('close', (code) => resolve({ code: code ?? 1, output }))
+  })
+}
+
+/**
+ * Keep only tsc's diagnostic lines. The runner wraps the command with its own
+ * chatter ("$ tsc --noEmit", "error Command failed with exit code 2"), which is
+ * noise in a finding.
+ */
+function parseTscErrors(output: string): string[] {
+  const diagnostic = /^\S.*?\(\d+,\d+\): (?:error|warning) TS\d+: /
+  const errors = output
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => diagnostic.test(line))
+  if (errors.length > 0) return errors
+  // A non-zero exit with no parseable diagnostic still failed the build — keep
+  // the tail rather than reporting a clean pass.
+  return output.trim().split('\n').slice(-5).filter(Boolean)
+}

--- a/packages/cli/src/fabric/lib/frontend-typecheck.ts
+++ b/packages/cli/src/fabric/lib/frontend-typecheck.ts
@@ -8,6 +8,12 @@ export interface FrontendTypeCheckResult {
   name: string
   /** absolute directory that was type-checked */
   dir: string
+  /**
+   * The invocation that actually ran, e.g. `yarn run tsc` or `npx tsc --noEmit`.
+   * A finding tells the user to reproduce it, so it has to be the command this
+   * check chose — not a guess at their package manager.
+   */
+  command: string
   /** raw `file(line,col): error TSxxxx: message` lines, in tsc's order */
   errors: string[]
   /** set when the frontend could not be checked at all (no tsconfig, tsc missing) */
@@ -31,28 +37,54 @@ export async function typeCheckFrontends(
 ): Promise<FrontendTypeCheckResult[]> {
   const results: FrontendTypeCheckResult[] = []
   for (const { name, dir } of frontendDirs) {
+    const { command, args } = await resolveTypeCheckCommand(root, dir)
+    const invocation = [command, ...args].join(' ')
     if (!existsSync(join(dir, 'tsconfig.json'))) {
-      results.push({ name, dir, errors: [], skipped: 'no tsconfig.json' })
+      results.push({
+        name,
+        dir,
+        command: invocation,
+        errors: [],
+        skipped: 'no tsconfig.json',
+      })
       continue
     }
-    const pkg = await readPackageJson(dir)
-    const runner = await resolveRunner(root, dir)
-    const { command, args } = pkg?.scripts?.tsc
-      ? { command: runner, args: ['run', 'tsc'] }
-      : { command: runner === 'npm' ? 'npx' : runner, args: ['tsc', '--noEmit'] }
 
     const { code, output, spawnError } = await run(command, args, dir)
     if (spawnError) {
-      results.push({ name, dir, errors: [], skipped: spawnError })
+      results.push({
+        name,
+        dir,
+        command: invocation,
+        errors: [],
+        skipped: spawnError,
+      })
       continue
     }
     results.push({
       name,
       dir,
+      command: invocation,
       errors: code === 0 ? [] : parseTscErrors(output),
     })
   }
   return results
+}
+
+/**
+ * The frontend's own `tsc` script when it has one — that is what the build
+ * container runs — otherwise `tsc --noEmit` through the project's package
+ * manager, so the compiler resolved is the workspace-local one.
+ */
+export async function resolveTypeCheckCommand(
+  root: string,
+  dir: string
+): Promise<{ command: string; args: string[] }> {
+  const pkg = await readPackageJson(dir)
+  const runner = await resolveRunner(root, dir)
+  return pkg?.scripts?.tsc
+    ? { command: runner, args: ['run', 'tsc'] }
+    : { command: runner === 'npm' ? 'npx' : runner, args: ['tsc', '--noEmit'] }
 }
 
 interface PackageJson {
@@ -126,7 +158,7 @@ function run(
  * chatter ("$ tsc --noEmit", "error Command failed with exit code 2"), which is
  * noise in a finding.
  */
-function parseTscErrors(output: string): string[] {
+export function parseTscErrors(output: string): string[] {
   const diagnostic = /^\S.*?\(\d+,\d+\): (?:error|warning) TS\d+: /
   const errors = output
     .split('\n')
@@ -134,6 +166,11 @@ function parseTscErrors(output: string): string[] {
     .filter((line) => diagnostic.test(line))
   if (errors.length > 0) return errors
   // A non-zero exit with no parseable diagnostic still failed the build — keep
-  // the tail rather than reporting a clean pass.
-  return output.trim().split('\n').slice(-5).filter(Boolean)
+  // the tail rather than reporting a clean pass. A silent failure (no output at
+  // all) must still return something: an empty list here reads as "compiled
+  // fine" and lets the deploy the check exists to prevent go ahead.
+  const tail = output.trim().split('\n').slice(-5).filter(Boolean)
+  return tail.length > 0
+    ? tail
+    : ['type-check exited non-zero without producing any output']
 }


### PR DESCRIPTION
## Why

Two failures from the same afternoon, one deploy apart.

**1. `validate` never ran tsc.** The build container type-checks each deployable frontend and aborts the deploy if it fails. `fabric validate` approximated that with ~1900 lines of structural heuristics (several literally commented "type-checks locally but fails in the clean build container") but never invoked the compiler. A `TS2353` on a Mantine `component={Link}` sailed past validate and burned a deploy eight minutes in.

**2. `link`/`init` clobbered the project config.** `writeProjectConfig` wrote whatever object it was handed; both callers hand it `{ projectId }`. That silently deleted `frontends`, so the *next* deploy built and type-checked no frontend at all — succeeding, with nothing shipped. The cause is separated from the symptom by however long it takes to deploy again.

## What

- `packages/cli/src/fabric/lib/frontend-typecheck.ts` — runs each deployable frontend's own `tsc` script (falls back to `tsc --noEmit`), via the package manager the project declares, and parses tsc's diagnostic lines out of the runner's chatter.
- `validate` reports them as errors with the raw diagnostics and a reproduce line. `--skip-typecheck` for structural-only.
- `writeProjectConfig` merges into the existing file (unknown keys preserved) instead of replacing it.

## Verified

Against a real Fabric project: clean tree → no finding; one injected type error → `ok = false` with the exact tsc diagnostic, 1.4s incremental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `fabric validate` now performs frontend TypeScript type-checking for every deployable frontend before deployment.
  * Added `--skip-typecheck` to run structural checks only.
* **Bug Fixes**
  * `fabric link` and `fabric init` now merge configuration instead of overwriting it, preserving existing frontend and deployment settings.
  * Malformed or missing deployable `frontends` are reported as findings/errors during validation (rather than failing unexpectedly).
  * Invalid configuration files now warn and continue instead of stopping the command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->