### PR TITLE
perf(workflow): index the tables, cut the reads, and fix two lost-state bugs

### DIFF
--- a/.changeset/olive-pugs-shake.md
+++ b/.changeset/olive-pugs-shake.md
@@ -1,6 +1,8 @@
 ---
 '@pikku/core': patch
 '@pikku/kysely': patch
+'@pikku/kysely-mysql': patch
+'@pikku/kysely-postgres': patch
 '@pikku/mongodb': patch
 '@pikku/redis': patch
 '@pikku/cloudflare': patch

--- a/.changeset/olive-pugs-shake.md
+++ b/.changeset/olive-pugs-shake.md
@@ -35,3 +35,17 @@ dispatched.
 Also: dispatch no longer JSON round-trips every step payload before handing it
 to a queue that serialises it anyway — the in-process dev queue, which is the
 only one that was relying on it, does it itself now.
+
+Two more defects. A transition whose step had no live attempt wrote its status
+to the step row and silently nothing to history — the exact divergence the
+transaction exists to prevent — and now repairs the step and writes the
+missing row. And resolving a dynamic workflow was non-deterministic on all
+three backends: a name can hold several active versions, and none of them
+ordered the candidates, so which one ran could change between two calls
+reading identical data. The newest version wins, with the graph hash breaking
+a tie.
+
+The two attempt columns and the five indexes are declared in the workflow
+schema, so a fresh database gets them at boot. An existing one gets them from
+a migration — `pikku db generate` writes the declaration down — rather than
+from DDL issued at boot.

--- a/.changeset/olive-pugs-shake.md
+++ b/.changeset/olive-pugs-shake.md
@@ -1,0 +1,37 @@
+---
+'@pikku/core': patch
+'@pikku/kysely': patch
+'@pikku/mongodb': patch
+'@pikku/redis': patch
+'@pikku/cloudflare': patch
+---
+
+Make the workflow service cheaper to run, and fix two ways it lost state.
+
+The SQL workflow tables had no indexes at all, so every step read, every
+history walk and every orchestrator tick was a sequential scan; five indexes
+now cover the columns the engine actually queries by. A replay used to ask for
+each step's row individually — O(N) reads per replay, O(N^2) over a run — and
+now takes one read of the run's steps and serves the walk from it. A step
+transition wrote the step row and its history row as two separate statements,
+so a crash between them left a step saying `succeeded` whose history still said
+`running`; both halves are now one transaction, and the history row is found by
+attempt number rather than by sorting on `created_at`, which two attempts can
+share. Resolving a dynamic workflow read and parsed every AI-generated workflow
+in the deployment to `.find()` one by name; it is a point lookup now.
+
+Waiting on a run no longer polls at a fixed interval. `pollIntervalMs` became a
+ceiling rather than a cadence: polling starts at 10ms and widens towards it, so
+a workflow that finishes in milliseconds is no longer held for a full second,
+and a long-running one is not read at full rate for its whole life.
+
+Two backend-specific defects: Redis kept a run's state as one JSON blob and
+read-modified-wrote it, so parallel branches setting different variables
+overwrote each other — state is a field per variable now, with the old blob
+still read underneath so runs in flight keep what they had. Mongo's
+`setStepScheduled` never wrote history, leaving a queued step reading as never
+dispatched.
+
+Also: dispatch no longer JSON round-trips every step payload before handing it
+to a queue that serialises it anyway — the in-process dev queue, which is the
+only one that was relying on it, does it itself now.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -56,6 +56,18 @@ jobs:
           download-build: 'false'
       - uses: ./.github/actions/build
 
+  # Ran only on main until now, so a branch could go green with a red unit
+  # suite and only break once it had already landed.
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      - run: yarn test
+
   codegen-perf:
     name: Codegen Perf (500 functions ≤ 30s)
     runs-on: ubuntu-latest

--- a/packages/core/src/services/in-memory-queue-service.test.ts
+++ b/packages/core/src/services/in-memory-queue-service.test.ts
@@ -23,7 +23,10 @@ const registerWorker = (
 ) => {
   const calls = { count: 0 }
   const funcId = `queue_${queueName}`
-  pikkuState(null, 'queue', 'meta')[queueName] = { pikkuFuncId: funcId, name: queueName }
+  pikkuState(null, 'queue', 'meta')[queueName] = {
+    pikkuFuncId: funcId,
+    name: queueName,
+  }
   pikkuState(null, 'function', 'meta')[funcId] = {
     pikkuFuncId: funcId,
     inputSchemaName: null,

--- a/packages/core/src/services/in-memory-queue-service.test.ts
+++ b/packages/core/src/services/in-memory-queue-service.test.ts
@@ -55,6 +55,68 @@ const waitUntil = async (
   return predicate()
 }
 
+// Register a queue worker that records the payload each delivery carried.
+const registerRecordingWorker = (queueName: string) => {
+  const received: any[] = []
+  const funcId = `queue_${queueName}`
+  pikkuState(null, 'queue', 'meta')[queueName] = {
+    pikkuFuncId: funcId,
+    name: queueName,
+  }
+  pikkuState(null, 'function', 'meta')[funcId] = {
+    pikkuFuncId: funcId,
+    inputSchemaName: null,
+    outputSchemaName: null,
+    sessionless: true,
+  } as any
+  wireQueueWorker({
+    name: queueName,
+    func: {
+      auth: false,
+      func: async (_services: any, data: any) => {
+        received.push(data)
+      },
+    },
+  } as any)
+  return received
+}
+
+describe('InMemoryQueueService payload isolation', () => {
+  test('a job carries the payload as it was when added', async () => {
+    const received = registerRecordingWorker('mutated')
+    const queue = new InMemoryQueueService()
+    const payload = { items: ['a'] }
+
+    await queue.add('mutated', payload, { delay: 0 })
+    payload.items.push('b')
+
+    assert.equal(await waitUntil(() => received.length === 1), true)
+    assert.deepEqual(
+      received[0].items,
+      ['a'],
+      'the worker saw a mutation made after the job was queued — a real queue would have serialised it away'
+    )
+  })
+
+  test('a payload arrives shaped the way a real queue would deliver it', async () => {
+    const received = registerRecordingWorker('serialised')
+    const queue = new InMemoryQueueService()
+
+    await queue.add(
+      'serialised',
+      { when: new Date('2020-01-01T00:00:00.000Z') },
+      { delay: 0 }
+    )
+
+    assert.equal(await waitUntil(() => received.length === 1), true)
+    assert.equal(
+      received[0].when,
+      '2020-01-01T00:00:00.000Z',
+      'a Date survived as a Date, so dev behaviour diverges from every real queue backend'
+    )
+  })
+})
+
 describe('InMemoryQueueService retry', () => {
   test('redelivers a transiently-failing job until it succeeds', async () => {
     const calls = registerWorker('flaky', (count) => {

--- a/packages/core/src/services/in-memory-queue-service.ts
+++ b/packages/core/src/services/in-memory-queue-service.ts
@@ -49,7 +49,10 @@ export class InMemoryQueueService implements QueueService {
       } catch (e: any) {
         if (attemptsMade < maxAttempts) {
           // Transient failure — redeliver with backoff, mirroring a real queue.
-          setTimeout(runAttempt, this.backoffDelay(options?.backoff, attemptsMade))
+          setTimeout(
+            runAttempt,
+            this.backoffDelay(options?.backoff, attemptsMade)
+          )
         } else {
           console.error(
             `[InMemoryQueue] Job ${jobId} on ${queueName} failed after ${attemptsMade} attempt(s):`,

--- a/packages/core/src/services/in-memory-queue-service.ts
+++ b/packages/core/src/services/in-memory-queue-service.ts
@@ -11,6 +11,12 @@ import { runQueueJob } from '../wirings/queue/queue-runner.js'
  * a real queue — and redelivers a failed job up to `options.attempts` times with
  * backoff, so a transiently-failing workflow step recovers exactly as it would
  * on pg-boss/bullmq instead of being silently dropped on its first error.
+ *
+ * Payloads are JSON round-tripped on the way in, because every real backend
+ * puts the job on a wire (SQS body, Redis value, jsonb column) and the worker
+ * therefore never sees the caller's live object. Doing it here keeps dev
+ * behaviour honest, and keeps the callers — who cannot know which backend they
+ * are talking to — from having to serialise defensively.
  */
 export class InMemoryQueueService implements QueueService {
   readonly supportsResults = false
@@ -25,13 +31,15 @@ export class InMemoryQueueService implements QueueService {
     const maxAttempts = Math.max(1, options?.attempts ?? 1)
     let attemptsMade = 0
     const createdAt = new Date()
+    const payload: T =
+      data === undefined ? data : (JSON.parse(JSON.stringify(data)) as T)
 
     const runAttempt = async () => {
       attemptsMade++
       const job: QueueJob<T> = {
         id: jobId,
         queueName,
-        data,
+        data: payload,
         status: () => 'active',
         metadata: () => ({ attemptsMade, maxAttempts, createdAt }),
         pikkuUserId: options?.pikkuUserId,

--- a/packages/core/src/services/in-memory-workflow-service.ts
+++ b/packages/core/src/services/in-memory-workflow-service.ts
@@ -456,6 +456,18 @@ export class InMemoryWorkflowService
     return nodeIds.filter((id) => !existingSteps.has(id))
   }
 
+  protected override async listStepStates(
+    runId: string
+  ): Promise<Array<StepState & { stepName: string }>> {
+    const prefix = `${runId}:`
+    const steps: Array<StepState & { stepName: string }> = []
+    for (const [key, step] of this.steps.entries()) {
+      if (!key.startsWith(prefix)) continue
+      steps.push({ ...step, stepName: key.substring(prefix.length) })
+    }
+    return steps
+  }
+
   async getStepInstances(
     runId: string
   ): Promise<

--- a/packages/core/src/services/in-memory-workflow-service.ts
+++ b/packages/core/src/services/in-memory-workflow-service.ts
@@ -573,6 +573,22 @@ export class InMemoryWorkflowService
     return { graph: version.graph, source: version.source }
   }
 
+  override async getDynamicWorkflow(
+    name: string
+  ): Promise<{ workflowName: string; graphHash: string; graph: any } | null> {
+    for (const [key, value] of this.workflowVersions) {
+      if (value.source !== 'ai-agent' || value.status !== 'active') continue
+      const separatorIdx = key.lastIndexOf(':')
+      if (key.substring(0, separatorIdx) !== name) continue
+      return {
+        workflowName: name,
+        graphHash: key.substring(separatorIdx + 1),
+        graph: value.graph,
+      }
+    }
+    return null
+  }
+
   async getAIGeneratedWorkflows(
     agentName?: string
   ): Promise<Array<{ workflowName: string; graphHash: string; graph: any }>> {

--- a/packages/core/src/services/workflow-service.ts
+++ b/packages/core/src/services/workflow-service.ts
@@ -64,6 +64,13 @@ export interface WorkflowService {
     rpcService: any,
     options?: { inline?: boolean; startNode?: string }
   ): Promise<{ runId: string }>
+  /**
+   * Start a run and wait for it to end.
+   *
+   * `pollIntervalMs` is the ceiling on the wait between reads of the run, not a
+   * fixed cadence: polling starts far shorter than this and widens towards it,
+   * so a run that finishes quickly is not held for a whole interval.
+   */
   runToCompletion<I>(
     name: string,
     input: I,

--- a/packages/core/src/services/workflow-service.ts
+++ b/packages/core/src/services/workflow-service.ts
@@ -123,4 +123,12 @@ export interface WorkflowService {
   getAIGeneratedWorkflows(
     agentName?: string
   ): Promise<Array<{ workflowName: string; graphHash: string; graph: any }>>
+
+  /**
+   * One dynamic workflow by name, or `null` if there isn't one — the lookup
+   * both starting a run and every orchestrator tick actually need.
+   */
+  getDynamicWorkflow(
+    name: string
+  ): Promise<{ workflowName: string; graphHash: string; graph: any } | null>
 }

--- a/packages/core/src/wirings/workflow/graph/graph-runner.ts
+++ b/packages/core/src/wirings/workflow/graph/graph-runner.ts
@@ -538,8 +538,9 @@ export async function continueGraph(
     return
   }
 
-  const run = await workflowService.getRun(runId)
-  const triggerInput = run?.input
+  // The same run read a few lines up: nothing between here and there writes it,
+  // and `input` is fixed at creation anyway.
+  const triggerInput = currentRun?.input
 
   for (const fire of plan.toFire) {
     const node = nodes[fire.logical]

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -338,13 +338,65 @@ export interface WorkflowRunExtension {
 }
 
 /**
+ * States a run never leaves. `suspended` is deliberately absent: a suspended
+ * run stops a poll loop but can still be resumed, so anything the process holds
+ * for it has to survive.
+ */
+const WORKFLOW_TERMINAL_STATES: ReadonlySet<string> = new Set([
+  'completed',
+  'failed',
+  'cancelled',
+])
+
+/**
  * Abstract workflow state service
  * Implementations provide pluggable storage backends (SQLite, PostgreSQL, etc.)
  * Combines orchestration and step execution
  */
+/**
+ * Everything the engine holds in memory for a run that is executing in this
+ * process. One entry, one lifetime: created when the run starts executing here
+ * and dropped when nothing is holding it open any more.
+ *
+ * The `replay` half is rebuilt from scratch on every orchestrator tick; the
+ * rest outlives individual ticks and belongs to whoever started the run.
+ */
+type RunContext = {
+  /** Executing straight through in-process, without a queue. */
+  inline: boolean
+  replay?: {
+    /** How many times this walk has reached each logical step name. */
+    ordinals: Map<string, number>
+    /** The step key the walk last reached — the next step's predecessor. */
+    lastStep?: string
+    /** Every step of the run as this replay found it, keyed by step name. */
+    steps?: Map<string, StepState>
+    /** The run as this replay found it. Only its immutable half is reused. */
+    run?: WorkflowRun
+  }
+}
+
 export abstract class PikkuWorkflowService implements WorkflowService {
-  private inlineRuns = new Set<string>()
   private runExtension?: WorkflowRunExtension
+
+  private runContexts = new Map<string, RunContext>()
+
+  private contextFor(runId: string): RunContext {
+    let context = this.runContexts.get(runId)
+    if (!context) {
+      context = { inline: false }
+      this.runContexts.set(runId, context)
+    }
+    return context
+  }
+
+  /** Drop a run's context once nothing is holding it open. */
+  private releaseContext(runId: string): void {
+    const context = this.runContexts.get(runId)
+    if (!context) return
+    if (context.inline || context.replay) return
+    this.runContexts.delete(runId)
+  }
 
   protected get logger() {
     return getSingletonServices()?.logger
@@ -520,21 +572,24 @@ export abstract class PikkuWorkflowService implements WorkflowService {
    * Check if a run is executing inline (without queues)
    */
   protected isInline(runId: string): boolean {
-    return this.inlineRuns.has(runId)
+    return this.runContexts.get(runId)?.inline === true
   }
 
   /**
    * Register a run as inline (for graph-runner to use)
    */
   public registerInlineRun(runId: string): void {
-    this.inlineRuns.add(runId)
+    this.contextFor(runId).inline = true
   }
 
   /**
    * Unregister a run from inline tracking
    */
   public unregisterInlineRun(runId: string): void {
-    this.inlineRuns.delete(runId)
+    const context = this.runContexts.get(runId)
+    if (!context) return
+    context.inline = false
+    this.releaseContext(runId)
   }
 
   public async registerWorkflowVersions(): Promise<void> {
@@ -706,6 +761,13 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     await this.safeMirror(() =>
       this.mirror!.updateRunStatus(id, status, output, error)
     )
+    if (WORKFLOW_TERMINAL_STATES.has(status)) {
+      // The run is over: release whatever this process opened for it. Queued
+      // runs never pass through the inline path that does this, so their
+      // context was held for the life of the process.
+      this.runExtension?.detachRunContext(id)
+      this.releaseContext(id)
+    }
   }
 
   protected abstract updateRunStatusImpl(
@@ -1366,7 +1428,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     await this.runExtension?.attachRunContext(runId, workflowMeta, options)
 
     if (shouldInline) {
-      this.inlineRuns.add(runId)
+      this.registerInlineRun(runId)
       try {
         await this.runWorkflowJob(runId, rpcService)
       } catch (error: any) {
@@ -1399,7 +1461,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
           throw error
         }
       } finally {
-        this.inlineRuns.delete(runId)
+        this.unregisterInlineRun(runId)
         this.runExtension?.detachRunContext(runId)
       }
     } else {
@@ -1441,22 +1503,6 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     }
   }
 
-  // Per-run, per-replay ordinal counters (runId → stepName → count).
-  private stepOrdinals = new Map<string, Map<string, number>>()
-  // Previous step key reached in the current DSL walk (runId → stepName), so a
-  // new step records where it came from. Rebuilt each replay alongside ordinals.
-  private stepLineage = new Map<string, string>()
-
-  // Every step of the run as the current replay found it (runId → stepName →
-  // state). Absent when no replay is in flight, or when the backend cannot read
-  // the set in one go — either way the DSL falls back to per-step reads.
-  private stepSnapshots = new Map<string, Map<string, StepState>>()
-
-  private resetStepOrdinals(runId: string): void {
-    this.stepOrdinals.set(runId, new Map())
-    this.stepLineage.delete(runId)
-  }
-
   /**
    * Every step of a run in one read, or `null` if this backend has no bulk read.
    *
@@ -1478,19 +1524,21 @@ export abstract class PikkuWorkflowService implements WorkflowService {
    * steps it replays past are `succeeded` and therefore immutable.
    */
   private async beginReplay(runId: string): Promise<void> {
-    this.resetStepOrdinals(runId)
+    const context = this.contextFor(runId)
+    context.replay = { ordinals: new Map() }
     const steps = await this.listStepStates(runId)
     if (steps) {
-      this.stepSnapshots.set(
-        runId,
-        new Map(steps.map((step) => [step.stepName, step]))
+      context.replay.steps = new Map(
+        steps.map((step) => [step.stepName, step])
       )
     }
   }
 
   private endReplay(runId: string): void {
-    this.stepOrdinals.delete(runId)
-    this.stepSnapshots.delete(runId)
+    const context = this.runContexts.get(runId)
+    if (!context) return
+    context.replay = undefined
+    this.releaseContext(runId)
   }
 
   /**
@@ -1502,7 +1550,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepName: string,
     create: () => Promise<StepState>
   ): Promise<StepState> {
-    const snapshot = this.stepSnapshots.get(runId)
+    const snapshot = this.runContexts.get(runId)?.replay?.steps
     if (snapshot) {
       const cached = snapshot.get(stepName)
       if (cached) {
@@ -1533,9 +1581,30 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     return step
   }
 
+  /**
+   * The run's immutable half — which workflow it is, the wire it was started
+   * on, its input. `getRun` is otherwise called several times per step for
+   * answers that were all fixed at creation, so a replay reads it once and
+   * hands the same object to everyone who only needs that half.
+   *
+   * Anyone who needs `status`, `output`, `error` or `state` must call `getRun`:
+   * those move while the run executes, and a cached copy would be a lie.
+   */
+  private async getRunIdentity(runId: string): Promise<WorkflowRun | null> {
+    const replay = this.runContexts.get(runId)?.replay
+    if (replay?.run) {
+      return replay.run
+    }
+    const run = await this.getRun(runId)
+    if (run && replay) {
+      replay.run = run
+    }
+    return run
+  }
+
   /** The step the DSL walk last reached (the predecessor for the next step). */
   private lastStepName(runId: string): string | undefined {
-    return this.stepLineage.get(runId)
+    return this.runContexts.get(runId)?.replay?.lastStep
   }
 
   /**
@@ -1545,16 +1614,15 @@ export abstract class PikkuWorkflowService implements WorkflowService {
    * the rows clobbering. Deterministic given a deterministic DSL body.
    */
   private nextStepKey(runId: string, logicalStepName: string): string {
-    let perRun = this.stepOrdinals.get(runId)
-    if (!perRun) {
-      perRun = new Map()
-      this.stepOrdinals.set(runId, perRun)
-    }
-    const ordinal = perRun.get(logicalStepName) ?? 0
-    perRun.set(logicalStepName, ordinal + 1)
+    const context = this.contextFor(runId)
+    const replay: NonNullable<RunContext['replay']> = (context.replay ??= {
+      ordinals: new Map(),
+    })
+    const ordinal = replay.ordinals.get(logicalStepName) ?? 0
+    replay.ordinals.set(logicalStepName, ordinal + 1)
     const stepName =
       ordinal === 0 ? logicalStepName : `${logicalStepName}#${ordinal}`
-    this.stepLineage.set(runId, stepName)
+    replay.lastStep = stepName
     return stepName
   }
 
@@ -1573,7 +1641,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     runId: string,
     rpcService: any
   ): Promise<void> {
-    const run = await this.getRun(runId)
+    // Caches the run for the rest of this replay, so the steps it walks don't
+    // each re-read the workflow name and wire it already has.
+    const run = await this.getRunIdentity(runId)
     if (!run) {
       throw new WorkflowRunNotFoundError(runId)
     }
@@ -1915,7 +1985,8 @@ export abstract class PikkuWorkflowService implements WorkflowService {
             stepState,
             rpcName,
             data,
-            rpcService
+            rpcService,
+            run
           )
         }
       }
@@ -2020,11 +2091,12 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepState: StepState,
     rpcName: string,
     data: any,
-    rpcService: any
+    rpcService: any,
+    knownRun?: WorkflowRun | null
   ): Promise<any> {
     // Carry the run's pikkuUserId onto the step wire so authed steps rehydrate their
     // session on the queued path too (the bare job wire lacks it; inline already has it).
-    const run = await this.getRun(runId)
+    const run = knownRun ?? (await this.getRunIdentity(runId))
     return rpcService.rpcWithWire(rpcName, data, {
       ...(run?.wire?.pikkuUserId ? { pikkuUserId: run.wire.pikkuUserId } : {}),
       workflowStep: {

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -1447,9 +1447,90 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   // new step records where it came from. Rebuilt each replay alongside ordinals.
   private stepLineage = new Map<string, string>()
 
+  // Every step of the run as the current replay found it (runId → stepName →
+  // state). Absent when no replay is in flight, or when the backend cannot read
+  // the set in one go — either way the DSL falls back to per-step reads.
+  private stepSnapshots = new Map<string, Map<string, StepState>>()
+
   private resetStepOrdinals(runId: string): void {
     this.stepOrdinals.set(runId, new Map())
     this.stepLineage.delete(runId)
+  }
+
+  /**
+   * Every step of a run in one read, or `null` if this backend has no bulk read.
+   *
+   * A replay walks the DSL body from the top, and each step it passes asks for
+   * its own row — so a run of N steps costs N reads per replay and O(N^2) over
+   * its lifetime. Backends that can answer this in a single query collapse that
+   * to one read per replay.
+   */
+  protected async listStepStates(
+    _runId: string
+  ): Promise<Array<StepState & { stepName: string }> | null> {
+    return null
+  }
+
+  /**
+   * Begin a replay pass: fresh ordinal counters, and one read of the steps the
+   * run has already taken so the walk back to where it left off is served from
+   * memory. Safe because a pass reaches each step key at most once, and the
+   * steps it replays past are `succeeded` and therefore immutable.
+   */
+  private async beginReplay(runId: string): Promise<void> {
+    this.resetStepOrdinals(runId)
+    const steps = await this.listStepStates(runId)
+    if (steps) {
+      this.stepSnapshots.set(
+        runId,
+        new Map(steps.map((step) => [step.stepName, step]))
+      )
+    }
+  }
+
+  private endReplay(runId: string): void {
+    this.stepOrdinals.delete(runId)
+    this.stepSnapshots.delete(runId)
+  }
+
+  /**
+   * The step row for `stepName`, creating it if the run has not reached it
+   * before. Served from the replay snapshot when one is loaded.
+   */
+  private async loadOrCreateStep(
+    runId: string,
+    stepName: string,
+    create: () => Promise<StepState>
+  ): Promise<StepState> {
+    const snapshot = this.stepSnapshots.get(runId)
+    if (snapshot) {
+      const cached = snapshot.get(stepName)
+      if (cached) {
+        return cached
+      }
+    } else {
+      try {
+        return await this.getStepState(runId, stepName)
+      } catch {
+        // No row yet — fall through and create it.
+      }
+    }
+
+    let step: StepState
+    try {
+      step = await create()
+    } catch (error) {
+      // A concurrent replay of this run created the row after the snapshot was
+      // taken. Its state is the truth; if it isn't really there, the insert
+      // failed for its own reasons and that error is the one worth seeing.
+      try {
+        step = await this.getStepState(runId, stepName)
+      } catch {
+        throw error
+      }
+    }
+    snapshot?.set(stepName, step)
+    return step
   }
 
   /** The step the DSL walk last reached (the predecessor for the next step). */
@@ -1478,12 +1559,13 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   }
 
   public async runWorkflowJob(runId: string, rpcService: any): Promise<void> {
-    // Fresh ordinal counters per replay so step keys are deterministic.
-    this.resetStepOrdinals(runId)
+    // Fresh ordinal counters per replay so step keys are deterministic, and one
+    // read of the steps the run has already taken.
+    await this.beginReplay(runId)
     try {
       await this.runWorkflowJobInner(runId, rpcService)
     } finally {
-      this.stepOrdinals.delete(runId)
+      this.endReplay(runId)
     }
   }
 
@@ -2052,13 +2134,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       actor: stepOptions?.actor,
       onError: stepOptions?.onError,
     }
-    // Check if step already exists
-    let stepState: StepState
-    try {
-      stepState = await this.getStepState(runId, stepName)
-    } catch {
-      // Step doesn't exist - create it
-      stepState = await this.insertStepState(
+    // Reuse the step if the run already reached it, otherwise create it.
+    const stepState = await this.loadOrCreateStep(runId, stepName, () =>
+      this.insertStepState(
         runId,
         stepName,
         rpcName,
@@ -2066,7 +2144,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         resolvedStepOptions,
         fromStepName
       )
-    }
+    )
 
     if (stepState.status === 'succeeded') {
       // Return cached result
@@ -2222,13 +2300,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   ): Promise<any> {
     const fromStepName = this.lastStepName(runId)
     const stepName = this.nextStepKey(runId, logicalStepName)
-    // Check if step already exists
-    let stepState: StepState
-    try {
-      stepState = await this.getStepState(runId, stepName)
-    } catch {
-      // Step doesn't exist - create it (inline, so never dispatched)
-      stepState = await this.insertStepState(
+    // Reuse the step if the run already reached it, otherwise create it
+    // (inline, so never dispatched).
+    const stepState = await this.loadOrCreateStep(runId, stepName, () =>
+      this.insertStepState(
         runId,
         stepName,
         rpcName,
@@ -2236,7 +2311,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         stepOptions,
         fromStepName
       )
-    }
+    )
 
     if (stepState.status === 'succeeded') {
       // Return cached result
@@ -2288,13 +2363,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
   ) {
     const fromStepName = this.lastStepName(runId)
     const stepName = this.nextStepKey(runId, logicalStepName)
-    // Check if step already exists
-    let stepState: StepState
-    try {
-      stepState = await this.getStepState(runId, stepName)
-    } catch {
-      // Step doesn't exist - create it (sleep step, no RPC)
-      stepState = await this.insertStepState(
+    // Reuse the step if the run already reached it, otherwise create it
+    // (sleep step, no RPC).
+    const stepState = await this.loadOrCreateStep(runId, stepName, () =>
+      this.insertStepState(
         runId,
         stepName,
         null,
@@ -2302,7 +2374,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
         undefined,
         fromStepName
       )
-    }
+    )
 
     if (stepState.status === 'succeeded') {
       // Sleep already completed, return immediately

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -348,6 +348,19 @@ const WORKFLOW_TERMINAL_STATES: ReadonlySet<string> = new Set([
   'cancelled',
 ])
 
+/** First wait when polling a run, before the backoff starts widening it. */
+const WORKFLOW_POLL_MIN_MS = 10
+
+/** How much each successive wait grows, up to the caller's ceiling. */
+const WORKFLOW_POLL_FACTOR = 1.6
+
+/**
+ * Ceiling for the wait on an inline sub-workflow. Lower than a top-level run's
+ * default, because the parent step is blocked on it and every wait here is
+ * added latency in the middle of a workflow rather than at its edge.
+ */
+const WORKFLOW_CHILD_POLL_MAX_MS = 500
+
 /**
  * Abstract workflow state service
  * Implementations provide pluggable storage backends (SQLite, PostgreSQL, etc.)
@@ -1487,7 +1500,6 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     rpcService: any,
     options?: { pollIntervalMs?: number; wire?: WorkflowRunWire }
   ): Promise<any> {
-    const pollInterval = options?.pollIntervalMs ?? 1000
     const { runId } = await this.startWorkflow(
       name,
       input,
@@ -1495,21 +1507,40 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       rpcService,
       { inline: true }
     )
+    const run = await this.awaitRunEnd(runId, options?.pollIntervalMs ?? 1000)
+    if (run.status === 'failed') {
+      throw new WorkflowRunFailedError(run.error?.message)
+    }
+    if (run.status === 'cancelled') {
+      throw new WorkflowRunCancelledError()
+    }
+    return run.output
+  }
+
+  /**
+   * Read a run until it reaches an end state, backing off as it drags on.
+   *
+   * A fixed interval is wrong at both ends: it makes a workflow that finished
+   * in milliseconds wait out the whole interval anyway, and it keeps reading a
+   * long-running one at full rate for as long as it lasts. Starting short and
+   * growing to `maxIntervalMs` returns quick runs promptly while a slow run's
+   * read cost grows logarithmically rather than linearly with its duration.
+   */
+  protected async awaitRunEnd(
+    runId: string,
+    maxIntervalMs: number
+  ): Promise<WorkflowRun> {
+    let interval = Math.min(WORKFLOW_POLL_MIN_MS, maxIntervalMs)
     while (true) {
       const run = await this.getRun(runId)
       if (!run) {
         throw new WorkflowRunNotFoundError(runId)
       }
       if (WORKFLOW_END_STATES.has(run.status)) {
-        if (run.status === 'failed') {
-          throw new WorkflowRunFailedError(run.error?.message)
-        }
-        if (run.status === 'cancelled') {
-          throw new WorkflowRunCancelledError()
-        }
-        return run.output
+        return run
       }
-      await new Promise((resolve) => setTimeout(resolve, pollInterval))
+      await new Promise((resolve) => setTimeout(resolve, interval))
+      interval = Math.min(interval * WORKFLOW_POLL_FACTOR, maxIntervalMs)
     }
   }
 
@@ -2317,24 +2348,17 @@ export abstract class PikkuWorkflowService implements WorkflowService {
           )
           await this.setStepChildRunId(currentStepState.stepId, childRunId)
           // Poll until child workflow completes
-          while (true) {
-            const childRun = await this.getRun(childRunId)
-            if (!childRun) {
-              throw new WorkflowRunNotFoundError(childRunId)
-            }
-            if (WORKFLOW_END_STATES.has(childRun.status)) {
-              if (childRun.status === 'failed') {
-                throw new Error(
-                  childRun.error?.message || 'Sub-workflow failed'
-                )
-              }
-              if (childRun.status === 'cancelled') {
-                throw new Error('Sub-workflow was cancelled')
-              }
-              return childRun.output
-            }
-            await new Promise((resolve) => setTimeout(resolve, 500))
+          const childRun = await this.awaitRunEnd(
+            childRunId,
+            WORKFLOW_CHILD_POLL_MAX_MS
+          )
+          if (childRun.status === 'failed') {
+            throw new Error(childRun.error?.message || 'Sub-workflow failed')
           }
+          if (childRun.status === 'cancelled') {
+            throw new Error('Sub-workflow was cancelled')
+          }
+          return childRun.output
         }
         return this.invokeStepRpc(
           runId,

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -1109,6 +1109,21 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     agentName?: string
   ): Promise<Array<{ workflowName: string; graphHash: string; graph: any }>>
 
+  /**
+   * One dynamic workflow by name, or `null` if there isn't one.
+   *
+   * Starting a run and every orchestrator tick both need to resolve a single
+   * name, and used to do it by listing every dynamic workflow in the deployment
+   * and parsing each graph on the way past. Backends override this with a
+   * targeted lookup; the fallback keeps the old behavior for those that can't.
+   */
+  public async getDynamicWorkflow(
+    name: string
+  ): Promise<{ workflowName: string; graphHash: string; graph: any } | null> {
+    const workflows = await this.getAIGeneratedWorkflows()
+    return workflows.find((w) => w.workflowName === name) ?? null
+  }
+
   // ============================================================================
   // Workflow Lifecycle Methods
   // ============================================================================
@@ -1178,9 +1193,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     const queueService = this.verifyQueueService()
     await queueService.add(
       this.getStepWorkerQueueName(rpcName),
-      JSON.parse(
-        JSON.stringify({ runId, stepName, rpcName, data, fromStepName })
-      ),
+      { runId, stepName, rpcName, data, fromStepName },
       {
         ...this.resolveStepJobOptions(stepOptions),
         // Group by step function, mirroring how per-step queues split them —
@@ -1272,9 +1285,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     try {
       await getSingletonServices()!.queueService!.add(
         this.getStepWorkerQueueName(rpcName),
-        JSON.parse(
-          JSON.stringify({ runId, stepName, rpcName, data, fromStepName })
-        ),
+        { runId, stepName, rpcName, data, fromStepName },
         {
           ...this.resolveStepJobOptions(stepOptions),
           group: this.getJobGroup(rpcName),
@@ -1367,8 +1378,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     const packageName = resolved?.packageName ?? null
 
     if (!workflowMeta) {
-      const dynamicWorkflows = await this.getAIGeneratedWorkflows()
-      const match = dynamicWorkflows.find((w) => w.workflowName === name)
+      const match = await this.getDynamicWorkflow(name)
       if (match?.graph) {
         workflowMeta = match.graph
       }
@@ -1682,10 +1692,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     }
 
     if (!workflowMeta) {
-      const dynamicWorkflows = await this.getAIGeneratedWorkflows()
-      const match = dynamicWorkflows.find(
-        (w) => w.workflowName === run.workflow
-      )
+      const match = await this.getDynamicWorkflow(run.workflow)
       if (match?.graph) {
         await continueGraph(this, runId, run.workflow, match.graph)
         const updatedRun = await this.getRun(runId)

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -1573,9 +1573,21 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       if (WORKFLOW_END_STATES.has(run.status)) {
         return run
       }
-      await new Promise((resolve) => setTimeout(resolve, interval))
+      await this.waitBeforeNextRead(interval)
       interval = Math.min(interval * WORKFLOW_POLL_FACTOR, maxIntervalMs)
     }
+  }
+
+  /**
+   * Wait between two reads of a run.
+   *
+   * Its own method so the backoff schedule can be asserted on directly. Timing
+   * a poll loop by the clock measures the host's scheduler as much as the
+   * policy — `setTimeout(40)` routinely returns late on a loaded runner — which
+   * makes the obvious test both slow and flaky.
+   */
+  protected async waitBeforeNextRead(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms))
   }
 
   /**

--- a/packages/core/src/wirings/workflow/pikku-workflow-service.ts
+++ b/packages/core/src/wirings/workflow/pikku-workflow-service.ts
@@ -437,19 +437,36 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     }
   }
 
-  private async safeMirror(fn: () => Promise<void>): Promise<void> {
-    if (!this.mirror) return
-    try {
-      await fn()
-    } catch (err: any) {
+  /**
+   * Perform a state write, then shadow it to the mirror.
+   *
+   * The mirror is an observability sink, never a second source of truth, and
+   * both halves of that follow from this one shape: it is only ever told about
+   * a write that already landed, and a mirror that is down or throwing cannot
+   * fail — or even be seen by — the workflow it is watching.
+   *
+   * @param write - the authoritative write; its result is what the caller gets
+   * @param mirror - shadows the write, given the live mirror and what was written
+   */
+  private async mirrored<T>(
+    write: () => Promise<T>,
+    mirror: (mirror: WorkflowRunMirror, written: T) => Promise<void>
+  ): Promise<T> {
+    const written = await write()
+    if (this.mirror) {
       try {
-        this.logger?.warn?.(
-          `[pikku] WorkflowRunMirror write failed: ${err?.message ?? err}`
-        )
-      } catch {
-        // logger unavailable (e.g. singleton services not initialized) — swallow
+        await mirror(this.mirror, written)
+      } catch (err: any) {
+        try {
+          this.logger?.warn?.(
+            `[pikku] WorkflowRunMirror write failed: ${err?.message ?? err}`
+          )
+        } catch {
+          // logger unavailable (e.g. singleton services not initialized) — swallow
+        }
       }
     }
+    return written
   }
 
   /**
@@ -624,26 +641,27 @@ export abstract class PikkuWorkflowService implements WorkflowService {
       plannedSteps?: WorkflowPlannedStep[]
     }
   ): Promise<string> {
-    const runId = await this.createRunImpl(
-      workflowName,
-      input,
-      inline,
-      graphHash,
-      wire,
-      options
+    return this.mirrored(
+      () =>
+        this.createRunImpl(
+          workflowName,
+          input,
+          inline,
+          graphHash,
+          wire,
+          options
+        ),
+      (mirror, runId) =>
+        mirror.createRun(
+          runId,
+          workflowName,
+          input,
+          inline,
+          graphHash,
+          wire,
+          options
+        )
     )
-    await this.safeMirror(() =>
-      this.mirror!.createRun(
-        runId,
-        workflowName,
-        input,
-        inline,
-        graphHash,
-        wire,
-        options
-      )
-    )
-    return runId
   }
 
   protected abstract createRunImpl(
@@ -770,9 +788,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     output?: any,
     error?: SerializedError
   ): Promise<void> {
-    await this.updateRunStatusImpl(id, status, output, error)
-    await this.safeMirror(() =>
-      this.mirror!.updateRunStatus(id, status, output, error)
+    await this.mirrored(
+      () => this.updateRunStatusImpl(id, status, output, error),
+      (mirror) => mirror.updateRunStatus(id, status, output, error)
     )
     if (WORKFLOW_TERMINAL_STATES.has(status)) {
       // The run is over: release whatever this process opened for it. Queued
@@ -811,18 +829,19 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepOptions?: WorkflowStepOptions,
     fromStepName?: string
   ): Promise<StepState> {
-    const step = await this.insertStepStateImpl(
-      runId,
-      stepName,
-      rpcName,
-      data,
-      stepOptions,
-      fromStepName
+    return this.mirrored(
+      () =>
+        this.insertStepStateImpl(
+          runId,
+          stepName,
+          rpcName,
+          data,
+          stepOptions,
+          fromStepName
+        ),
+      (mirror, step) =>
+        mirror.insertStepState(runId, { ...step, stepName, rpcName, data })
     )
-    await this.safeMirror(() =>
-      this.mirror!.insertStepState(runId, { ...step, stepName, rpcName, data })
-    )
-    return step
   }
 
   protected abstract insertStepStateImpl(
@@ -848,8 +867,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
    * @param stepId - Step ID
    */
   public async setStepRunning(stepId: string): Promise<void> {
-    await this.setStepRunningImpl(stepId)
-    await this.safeMirror(() => this.mirror!.setStepRunning(stepId))
+    await this.mirrored(
+      () => this.setStepRunningImpl(stepId),
+      (mirror) => mirror.setStepRunning(stepId)
+    )
   }
 
   protected abstract setStepRunningImpl(stepId: string): Promise<void>
@@ -860,8 +881,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
    * @param stepId - Step ID
    */
   public async setStepScheduled(stepId: string): Promise<void> {
-    await this.setStepScheduledImpl(stepId)
-    await this.safeMirror(() => this.mirror!.setStepScheduled(stepId))
+    await this.mirrored(
+      () => this.setStepScheduledImpl(stepId),
+      (mirror) => mirror.setStepScheduled(stepId)
+    )
   }
 
   protected abstract setStepScheduledImpl(stepId: string): Promise<void>
@@ -873,8 +896,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
    * @param result - Step result
    */
   public async setStepResult(stepId: string, result: any): Promise<void> {
-    await this.setStepResultImpl(stepId, result)
-    await this.safeMirror(() => this.mirror!.setStepResult(stepId, result))
+    await this.mirrored(
+      () => this.setStepResultImpl(stepId, result),
+      (mirror) => mirror.setStepResult(stepId, result)
+    )
   }
 
   protected abstract setStepResultImpl(
@@ -891,9 +916,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepId: string,
     childRunId: string
   ): Promise<void> {
-    await this.setStepChildRunIdImpl(stepId, childRunId)
-    await this.safeMirror(() =>
-      this.mirror!.setStepChildRunId(stepId, childRunId)
+    await this.mirrored(
+      () => this.setStepChildRunIdImpl(stepId, childRunId),
+      (mirror) => mirror.setStepChildRunId(stepId, childRunId)
     )
   }
 
@@ -909,14 +934,18 @@ export abstract class PikkuWorkflowService implements WorkflowService {
    * @param error - Error object
    */
   public async setStepError(stepId: string, error: Error): Promise<void> {
-    await this.setStepErrorImpl(stepId, error)
-    const serialized: SerializedError = {
-      message: error.message,
-      stack: error.stack,
-      code: (error as any).code,
-      expected: isExpectedError(error),
-    }
-    await this.safeMirror(() => this.mirror!.setStepError(stepId, serialized))
+    await this.mirrored(
+      () => this.setStepErrorImpl(stepId, error),
+      (mirror) => {
+        const serialized: SerializedError = {
+          message: error.message,
+          stack: error.stack,
+          code: (error as any).code,
+          expected: isExpectedError(error),
+        }
+        return mirror.setStepError(stepId, serialized)
+      }
+    )
   }
 
   protected abstract setStepErrorImpl(
@@ -936,15 +965,14 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     failedStepId: string,
     status: 'pending' | 'running'
   ): Promise<StepState> {
-    const newStep = await this.createRetryAttemptImpl(failedStepId, status)
-    const stepName = (newStep as any).stepName ?? ''
-    await this.safeMirror(() =>
-      this.mirror!.createRetryAttempt(failedStepId, {
-        ...newStep,
-        stepName,
-      })
+    return this.mirrored(
+      () => this.createRetryAttemptImpl(failedStepId, status),
+      (mirror, newStep) =>
+        mirror.createRetryAttempt(failedStepId, {
+          ...newStep,
+          stepName: (newStep as any).stepName ?? '',
+        })
     )
-    return newStep
   }
 
   protected abstract createRetryAttemptImpl(
@@ -1038,8 +1066,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     stepId: string,
     branchKey: string
   ): Promise<void> {
-    await this.setBranchTakenImpl(stepId, branchKey)
-    await this.safeMirror(() => this.mirror!.setBranchTaken(stepId, branchKey))
+    await this.mirrored(
+      () => this.setBranchTakenImpl(stepId, branchKey),
+      (mirror) => mirror.setBranchTaken(stepId, branchKey)
+    )
   }
 
   protected abstract setBranchTakenImpl(
@@ -1058,8 +1088,10 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     name: string,
     value: unknown
   ): Promise<void> {
-    await this.updateRunStateImpl(runId, name, value)
-    await this.safeMirror(() => this.mirror!.updateRunState(runId, name, value))
+    await this.mirrored(
+      () => this.updateRunStateImpl(runId, name, value),
+      (mirror) => mirror.updateRunState(runId, name, value)
+    )
   }
 
   protected abstract updateRunStateImpl(
@@ -1082,9 +1114,11 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     source: string,
     status?: WorkflowVersionStatus
   ): Promise<void> {
-    await this.upsertWorkflowVersionImpl(name, graphHash, graph, source, status)
-    await this.safeMirror(() =>
-      this.mirror!.upsertWorkflowVersion(name, graphHash, graph, source, status)
+    await this.mirrored(
+      () =>
+        this.upsertWorkflowVersionImpl(name, graphHash, graph, source, status),
+      (mirror) =>
+        mirror.upsertWorkflowVersion(name, graphHash, graph, source, status)
     )
   }
 
@@ -1101,9 +1135,9 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     graphHash: string,
     status: WorkflowVersionStatus
   ): Promise<void> {
-    await this.updateWorkflowVersionStatusImpl(name, graphHash, status)
-    await this.safeMirror(() =>
-      this.mirror!.updateWorkflowVersionStatus(name, graphHash, status)
+    await this.mirrored(
+      () => this.updateWorkflowVersionStatusImpl(name, graphHash, status),
+      (mirror) => mirror.updateWorkflowVersionStatus(name, graphHash, status)
     )
   }
 
@@ -1569,9 +1603,7 @@ export abstract class PikkuWorkflowService implements WorkflowService {
     context.replay = { ordinals: new Map() }
     const steps = await this.listStepStates(runId)
     if (steps) {
-      context.replay.steps = new Map(
-        steps.map((step) => [step.stepName, step])
-      )
+      context.replay.steps = new Map(steps.map((step) => [step.stepName, step]))
     }
   }
 

--- a/packages/core/src/wirings/workflow/scenario-expectations.test.ts
+++ b/packages/core/src/wirings/workflow/scenario-expectations.test.ts
@@ -1,0 +1,153 @@
+import { describe, test, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createScenarioRunner } from './pikku-scenario-service.js'
+import type { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState, resetPikkuState } from '../../pikku-state.js'
+import type { ScenarioActor } from '../../services/scenario-actors-service.js'
+
+const noopLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+const fakeActor = (
+  name: string,
+  handler: (rpcName: string, data: unknown) => Promise<unknown>
+): ScenarioActor => ({
+  name,
+  email: `${name}@actors.local`,
+  invoke: async (rpcName: string, data: unknown) => handler(rpcName, data),
+  invokeRaw: async (rpcName: string, data: unknown) => ({
+    status: 200,
+    ok: true,
+    body: await handler(rpcName, data),
+  }),
+})
+
+const setup = async (ws: InMemoryWorkflowService) => {
+  pikkuState(null, 'package', 'singletonServices', {
+    logger: noopLogger,
+  } as any)
+  const runId = await ws.createRun('scenarioTest', {}, true, 'hash', {
+    type: 'test',
+  } as any)
+  ws.registerInlineRun(runId)
+  return runId
+}
+
+/**
+ * The scenario wire, wrapped rather than returned directly: it carries a
+ * `then` — the Gherkin phase, not a promise — so awaiting one is awaiting a
+ * thenable, and the runtime calls it as a step.
+ */
+const scenarioWire = async (rpcService: any = {}): Promise<{ wire: any }> => {
+  const { workflowService } = createScenarioRunner()
+  const ws = workflowService as InMemoryWorkflowService
+  const runId = await setup(ws)
+  return { wire: ws.createWorkflowWire('scenarioTest', runId, rpcService) }
+}
+
+describe('workflow.expectError', () => {
+  beforeEach(() => resetPikkuState())
+
+  test('returns the message when the call throws as expected', async () => {
+    const intruder = fakeActor('intruder', async () => {
+      throw new Error('Forbidden: not your todo')
+    })
+    const { wire } = await scenarioWire()
+
+    const message = await wire.expectError(
+      'intruder cannot delete',
+      'deleteTodo',
+      { todoId: 't1' },
+      { actor: intruder }
+    )
+
+    assert.equal(message, 'Forbidden: not your todo')
+  })
+
+  test('fails when the call succeeds instead of throwing', async () => {
+    const { wire } = await scenarioWire({
+      rpcWithWire: async () => ({ deleted: true }),
+    })
+
+    await assert.rejects(
+      wire.expectError('should have failed', 'deleteTodo', {}, { retries: 0 }),
+      /expected an error but the call succeeded/
+    )
+  })
+
+  test('fails when the error message does not match', async () => {
+    const { wire } = await scenarioWire({
+      rpcWithWire: async () => {
+        throw new Error('database offline')
+      },
+    })
+
+    await assert.rejects(
+      wire.expectError(
+        'wrong reason',
+        'deleteTodo',
+        {},
+        { matches: /Forbidden/, retries: 0 }
+      ),
+      /did not match .*database offline/
+    )
+  })
+})
+
+describe('workflow.expectService', () => {
+  beforeEach(() => resetPikkuState())
+
+  const stubCalls = (
+    calls: Array<{ service: string; method: string; args: unknown[] }>
+  ) => ({
+    rpcWithWire: async (rpcName: string) => {
+      assert.equal(rpcName, 'pikkuScenarioGetStubCalls')
+      return calls
+    },
+  })
+
+  const oneEmail = () =>
+    stubCalls([{ service: 'email', method: 'send', args: [{ to: 'a@b.c' }] }])
+
+  test('passes when the service method was called', async () => {
+    const { wire } = await scenarioWire(oneEmail())
+
+    await wire.expectService('an email went out', 'email.send')
+  })
+
+  test('a call count that does not match names what was recorded', async () => {
+    const { wire } = await scenarioWire(oneEmail())
+
+    await assert.rejects(
+      wire.expectService('two emails', 'email.send', {
+        times: 2,
+        retries: 0,
+      }),
+      /expected 2 call\(s\).*found 1.*email\.send/s
+    )
+  })
+
+  test('calledWith matches on the first argument', async () => {
+    const { wire } = await scenarioWire(oneEmail())
+
+    await wire.expectService('emailed the customer', 'email.send', {
+      calledWith: { to: 'a@b.c' },
+    })
+    await assert.rejects(
+      wire.expectService('emailed someone else', 'email.send', {
+        calledWith: { to: 'x@y.z' },
+        retries: 0,
+      }),
+      /found 0/
+    )
+  })
+
+  test('a name that is not service.method is rejected outright', async () => {
+    const { wire } = await scenarioWire(stubCalls([]))
+
+    await assert.rejects(
+      wire.expectService('bad name', 'emailsend'),
+      /needs 'service\.method'/
+    )
+  })
+})

--- a/packages/core/src/wirings/workflow/scenario-step.test.ts
+++ b/packages/core/src/wirings/workflow/scenario-step.test.ts
@@ -89,7 +89,7 @@ describe('scenario actor steps (workflow.do with `actor`)', () => {
 
     // Simulate replay: reset per-run ordinals so the same logical step name
     // resolves to the same durable step key.
-    ;(ws as any).resetStepOrdinals(runId)
+    await (ws as any).beginReplay(runId)
     const replayWire = ws.createWorkflowWire('scenarioTest', runId, {})
     const replayed = await replayWire.do(
       'step',

--- a/packages/core/src/wirings/workflow/workflow-dispatch-durability.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-dispatch-durability.test.ts
@@ -58,7 +58,7 @@ describe('dispatch durability: a transient queue failure is recoverable', () => 
     // and the step transitions to `scheduled`. A real replay runs through
     // runWorkflowJob which resets the ordinal counter; simulate that so the
     // second reach resolves to the same step key, not the next ordinal.
-    ;(ws as any).resetStepOrdinals(runId)
+    await (ws as any).beginReplay(runId)
     queueUp = true
     await assert.rejects(
       (ws as any).rpcStep(runId, 'thing', 'doThing', {}, {}),

--- a/packages/core/src/wirings/workflow/workflow-dispatch-payload.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-dispatch-payload.test.ts
@@ -1,0 +1,105 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState } from '../../pikku-state.js'
+
+const silentLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+/**
+ * Captures what the workflow service hands the queue, so a test can tell
+ * whether core serialised the payload on the way past.
+ */
+function serviceWithCapturingQueue() {
+  const added: Array<{ queueName: string; data: any }> = []
+  pikkuState(null, 'package', 'singletonServices', {
+    queueService: {
+      add: async (queueName: string, data: any) => {
+        added.push({ queueName, data })
+        return 'job-1'
+      },
+    },
+    logger: silentLogger,
+  } as any)
+  return { ws: new InMemoryWorkflowService() as any, added }
+}
+
+describe('dispatching a step does not serialise the payload twice', () => {
+  test('the queue receives the payload core was given', async () => {
+    const { ws, added } = serviceWithCapturingQueue()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    const payload = { when: new Date('2020-01-01T00:00:00.000Z'), n: 1 }
+
+    await ws.queueStepWorker(runId, 'step-1', 'rpc.fn', payload)
+
+    assert.equal(added.length, 1)
+    assert.ok(
+      added[0]!.data.data.when instanceof Date,
+      'core round-tripped the payload through JSON before handing it to a queue that serialises it anyway'
+    )
+    assert.equal(added[0]!.data.data.n, 1)
+    assert.equal(added[0]!.data.runId, runId)
+    assert.equal(added[0]!.data.stepName, 'step-1')
+  })
+
+  test('a payload the queue cannot serialise is still the queue’s problem, not a silent drop', async () => {
+    const { ws, added } = serviceWithCapturingQueue()
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    const circular: any = { name: 'loop' }
+    circular.self = circular
+
+    await ws.queueStepWorker(runId, 'step-1', 'rpc.fn', circular)
+
+    assert.equal(added[0]!.data.data.self, added[0]!.data.data)
+  })
+})
+
+describe('resolving a dynamic workflow', () => {
+  test('asks for the one workflow rather than listing them all', async () => {
+    const { ws } = serviceWithCapturingQueue()
+    for (let i = 0; i < 5; i++) {
+      await ws.upsertWorkflowVersion(
+        `ai:agent:wf-${i}`,
+        `hash-${i}`,
+        { nodes: {}, source: 'ai-agent' },
+        'ai-agent'
+      )
+    }
+
+    let listed = 0
+    const listAll = ws.getAIGeneratedWorkflows.bind(ws)
+    ws.getAIGeneratedWorkflows = async (...args: any[]) => {
+      listed++
+      return listAll(...args)
+    }
+
+    const match = await ws.getDynamicWorkflow('ai:agent:wf-3')
+    assert.equal(match?.graphHash, 'hash-3')
+    assert.equal(
+      listed,
+      0,
+      'resolving one name still walked and parsed every dynamic workflow in the deployment'
+    )
+  })
+
+  test('a name that is not a dynamic workflow resolves to null', async () => {
+    const { ws } = serviceWithCapturingQueue()
+    assert.equal(await ws.getDynamicWorkflow('ai:agent:missing'), null)
+  })
+
+  test('an inactive version is not resolved', async () => {
+    const { ws } = serviceWithCapturingQueue()
+    await ws.upsertWorkflowVersion(
+      'ai:agent:retired',
+      'hash-r',
+      { nodes: {} },
+      'ai-agent',
+      'archived'
+    )
+    assert.equal(await ws.getDynamicWorkflow('ai:agent:retired'), null)
+  })
+})

--- a/packages/core/src/wirings/workflow/workflow-mirror.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-mirror.test.ts
@@ -1,0 +1,178 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState } from '../../pikku-state.js'
+import type { WorkflowRunMirror } from './workflow.types.js'
+
+/**
+ * Every method on `WorkflowRunMirror`. A mirror method that is added to the
+ * interface but never wired into the service writes nothing at runtime, and
+ * nothing else would catch that — so the list is spelled out here.
+ */
+const MIRROR_METHODS = [
+  'createRun',
+  'updateRunStatus',
+  'insertStepState',
+  'setStepRunning',
+  'setStepScheduled',
+  'setStepResult',
+  'setStepChildRunId',
+  'setStepError',
+  'createRetryAttempt',
+  'setBranchTaken',
+  'updateRunState',
+  'upsertWorkflowVersion',
+  'updateWorkflowVersionStatus',
+] as const
+
+type Call = { method: string; args: any[] }
+
+/** A mirror that records every call, and optionally throws on all of them. */
+const recordingMirror = (
+  onCall?: (method: string) => void
+): { mirror: WorkflowRunMirror; calls: Call[] } => {
+  const calls: Call[] = []
+  const mirror = {} as any
+  for (const method of MIRROR_METHODS) {
+    mirror[method] = async (...args: any[]) => {
+      calls.push({ method, args })
+      onCall?.(method)
+    }
+  }
+  return { mirror, calls }
+}
+
+const service = (mirror?: WorkflowRunMirror) => {
+  pikkuState(null, 'package', 'singletonServices', {
+    logger: { error() {}, info() {}, warn() {}, debug() {} },
+  } as any)
+  const ws = new InMemoryWorkflowService() as any
+  ws.mirror = mirror
+  return ws
+}
+
+/** Drive every write the service mirrors, in dependency order. */
+const driveEveryWrite = async (ws: any) => {
+  const runId = await ws.createRun('flow', { a: 1 }, false, 'hash', {
+    type: 'test',
+  })
+  const step = await ws.insertStepState(runId, 'step-1', 'rpc.fn', { x: 1 })
+  await ws.setStepRunning(step.stepId)
+  await ws.setStepScheduled(step.stepId)
+  await ws.setStepResult(step.stepId, 'ok')
+  await ws.setStepChildRunId(step.stepId, 'child-1')
+  await ws.setStepError(step.stepId, new Error('boom'))
+  await ws.createRetryAttempt(step.stepId, 'pending')
+  await ws.setBranchTaken(step.stepId, 'left')
+  await ws.updateRunState(runId, 'total', 42)
+  await ws.upsertWorkflowVersion('flow', 'hash', { nodes: {} }, 'code')
+  await ws.updateWorkflowVersionStatus('flow', 'hash', 'archived')
+  await ws.updateRunStatus(runId, 'completed', 'output')
+  return { runId, step }
+}
+
+describe('mirroring workflow state', () => {
+  test('every mirror method is wired to the write it shadows', async () => {
+    const { mirror, calls } = recordingMirror()
+    await driveEveryWrite(service(mirror))
+
+    assert.deepEqual(
+      [...new Set(calls.map((c) => c.method))].sort(),
+      [...MIRROR_METHODS].sort()
+    )
+  })
+
+  test('a mirror write carries the same identifiers as the write it shadows', async () => {
+    const { mirror, calls } = recordingMirror()
+    const ws = service(mirror)
+    const { runId, step } = await driveEveryWrite(ws)
+
+    const call = (method: string) => calls.find((c) => c.method === method)!
+    assert.equal(call('createRun').args[0], runId)
+    assert.equal(call('createRun').args[1], 'flow')
+    assert.equal(call('insertStepState').args[0], runId)
+    assert.equal(call('insertStepState').args[1].stepId, step.stepId)
+    assert.equal(call('insertStepState').args[1].stepName, 'step-1')
+    assert.equal(call('insertStepState').args[1].rpcName, 'rpc.fn')
+    assert.equal(call('setStepResult').args[1], 'ok')
+    assert.equal(call('setStepChildRunId').args[1], 'child-1')
+    assert.equal(call('setBranchTaken').args[1], 'left')
+    assert.equal(call('updateRunState').args[2], 42)
+    assert.equal(call('updateRunStatus').args[1], 'completed')
+  })
+
+  test('a step error reaches the mirror serialised, not as a live Error', async () => {
+    const { mirror, calls } = recordingMirror()
+    await driveEveryWrite(service(mirror))
+
+    const serialised = calls.find((c) => c.method === 'setStepError')!.args[1]
+    assert.equal(serialised instanceof Error, false)
+    assert.equal(serialised.message, 'boom')
+    assert.equal(typeof serialised.stack, 'string')
+    assert.equal(typeof serialised.expected, 'boolean')
+  })
+
+  test('the mirror only ever sees a write that already landed', async () => {
+    const seen: Array<string | undefined> = []
+    const { mirror } = recordingMirror()
+    const ws = service(mirror)
+    ;(mirror as any).updateRunStatus = async () => {
+      seen.push((await ws.getRun(runIdRef.id))?.status)
+    }
+    const runIdRef = { id: '' }
+
+    runIdRef.id = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+    await ws.updateRunStatus(runIdRef.id, 'completed', 'output')
+
+    assert.deepEqual(
+      seen,
+      ['completed'],
+      'the mirror ran before the write it was mirroring'
+    )
+  })
+
+  test('a write that fails is not mirrored', async () => {
+    const { mirror, calls } = recordingMirror()
+    const ws = service(mirror)
+    ws.updateRunStatusImpl = async () => {
+      throw new Error('database down')
+    }
+    const runId = await ws.createRun('flow', {}, false, 'hash', {
+      type: 'test',
+    })
+
+    await assert.rejects(
+      ws.updateRunStatus(runId, 'completed'),
+      /database down/
+    )
+    assert.equal(
+      calls.some((c) => c.method === 'updateRunStatus'),
+      false,
+      'a status the store rejected was reported to the mirror as if it had happened'
+    )
+  })
+})
+
+describe('a mirror that is broken', () => {
+  test('no write fails because the mirror did', async () => {
+    const { mirror } = recordingMirror((method) => {
+      throw new Error(`mirror down on ${method}`)
+    })
+    const ws = service(mirror)
+
+    const { runId } = await driveEveryWrite(ws)
+
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+    assert.equal((await ws.getRun(runId))?.output, 'output')
+    assert.deepEqual(await ws.getRunState(runId), { total: 42 })
+  })
+
+  test('no mirror configured is not an error path', async () => {
+    const ws = service(undefined)
+    const { runId } = await driveEveryWrite(ws)
+    assert.equal((await ws.getRun(runId))?.status, 'completed')
+  })
+})

--- a/packages/core/src/wirings/workflow/workflow-replay-snapshot.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-replay-snapshot.test.ts
@@ -31,7 +31,7 @@ function countStepReads(ws: any) {
 
 async function seedRun(ws: any, steps: number) {
   const runId = await ws.createRun('flow', {}, true, 'hash', { type: 'test' })
-  ws.inlineRuns.add(runId)
+  ws.registerInlineRun(runId)
   await ws.beginReplay(runId)
   for (let i = 0; i < steps; i++) {
     await ws.inlineStep(runId, `step-${i}`, async () => i)

--- a/packages/core/src/wirings/workflow/workflow-replay-snapshot.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-replay-snapshot.test.ts
@@ -1,0 +1,139 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState } from '../../pikku-state.js'
+
+const silentLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+function inlineService() {
+  pikkuState(null, 'package', 'singletonServices', {
+    queueService: { add: async () => {} },
+    logger: silentLogger,
+  } as any)
+  return new InMemoryWorkflowService()
+}
+
+/**
+ * Every per-step read the service issues. In a real backend each one is its own
+ * round-trip, so a replay that walks N completed steps costs N of them — and
+ * over the life of a run that is O(N^2).
+ */
+function countStepReads(ws: any) {
+  const counter = { reads: 0 }
+  const original = ws.getStepState.bind(ws)
+  ws.getStepState = async (...args: any[]) => {
+    counter.reads++
+    return original(...args)
+  }
+  return counter
+}
+
+async function seedRun(ws: any, steps: number) {
+  const runId = await ws.createRun('flow', {}, true, 'hash', { type: 'test' })
+  ws.inlineRuns.add(runId)
+  await ws.beginReplay(runId)
+  for (let i = 0; i < steps; i++) {
+    await ws.inlineStep(runId, `step-${i}`, async () => i)
+  }
+  ws.endReplay(runId)
+  return runId
+}
+
+describe('replay reads the run steps once, not once per step', () => {
+  test('a replay over completed steps issues no per-step reads', async () => {
+    const ws: any = inlineService()
+    const runId = await seedRun(ws, 8)
+
+    const counter = countStepReads(ws)
+    await ws.beginReplay(runId)
+    for (let i = 0; i < 8; i++) {
+      await ws.inlineStep(runId, `step-${i}`, async () => {
+        throw new Error(`step-${i} re-ran instead of replaying its cached result`)
+      })
+    }
+    ws.endReplay(runId)
+
+    assert.equal(
+      counter.reads,
+      0,
+      `the replay still read each step individually (${counter.reads} reads for 8 steps)`
+    )
+  })
+
+  test('the snapshot still returns each step its own cached result', async () => {
+    const ws: any = inlineService()
+    const runId = await seedRun(ws, 4)
+
+    await ws.beginReplay(runId)
+    const replayed: unknown[] = []
+    for (let i = 0; i < 4; i++) {
+      replayed.push(
+        await ws.inlineStep(runId, `step-${i}`, async () => 'must not run')
+      )
+    }
+    ws.endReplay(runId)
+
+    assert.deepEqual(replayed, [0, 1, 2, 3])
+  })
+
+  test('a step reached for the first time mid-replay is created, not mistaken for a miss', async () => {
+    const ws: any = inlineService()
+    const runId = await seedRun(ws, 2)
+
+    await ws.beginReplay(runId)
+    await ws.inlineStep(runId, 'step-0', async () => 'cached')
+    await ws.inlineStep(runId, 'step-1', async () => 'cached')
+    const fresh = await ws.inlineStep(runId, 'step-new', async () => 'ran')
+    ws.endReplay(runId)
+
+    assert.equal(fresh, 'ran')
+    assert.equal((await ws.getStepState(runId, 'step-new')).result, 'ran')
+  })
+
+  test('a second replay sees what the previous one wrote', async () => {
+    const ws: any = inlineService()
+    const runId = await seedRun(ws, 1)
+
+    await ws.beginReplay(runId)
+    await ws.inlineStep(runId, 'step-0', async () => 'must not run')
+    await ws.inlineStep(runId, 'late', async () => 'first')
+    ws.endReplay(runId)
+
+    await ws.beginReplay(runId)
+    await ws.inlineStep(runId, 'step-0', async () => 'must not run')
+    const late = await ws.inlineStep(runId, 'late', async () => 'must not run')
+    ws.endReplay(runId)
+
+    assert.equal(late, 'first', 'the second replay re-ran a step the first one completed')
+  })
+
+  test('outside a replay, steps are still read one at a time', async () => {
+    const ws: any = inlineService()
+    const runId = await seedRun(ws, 3)
+
+    const counter = countStepReads(ws)
+    await ws.inlineStep(runId, 'step-0', async () => 'must not run')
+
+    assert.equal(
+      counter.reads,
+      1,
+      'a call outside a replay must read the step directly rather than trust a stale snapshot'
+    )
+  })
+
+  test('a backend with no bulk read falls back to per-step reads', async () => {
+    const ws: any = inlineService()
+    const runId = await seedRun(ws, 3)
+    ws.listStepStates = async () => null
+
+    const counter = countStepReads(ws)
+    await ws.beginReplay(runId)
+    for (let i = 0; i < 3; i++) {
+      await ws.inlineStep(runId, `step-${i}`, async () => 'must not run')
+    }
+    ws.endReplay(runId)
+
+    assert.equal(counter.reads, 3)
+  })
+})

--- a/packages/core/src/wirings/workflow/workflow-run-context.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-run-context.test.ts
@@ -1,0 +1,177 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState } from '../../pikku-state.js'
+
+const silentLogger = { error() {}, info() {}, warn() {}, debug() {} }
+
+function service() {
+  pikkuState(null, 'package', 'singletonServices', {
+    queueService: { add: async () => {} },
+    logger: silentLogger,
+  } as any)
+  return new InMemoryWorkflowService() as any
+}
+
+const newRun = (ws: any, inline = false) =>
+  ws.createRun('flow', {}, inline, 'hash', { type: 'test' })
+
+const trackDetaches = (ws: any): string[] => {
+  const detached: string[] = []
+  ws.setRunExtension(() => ({
+    attachRunContext: async () => {},
+    detachRunContext: (runId: string) => detached.push(runId),
+    decorateRunWire: () => {},
+    decorateWorkflowWire: () => {},
+    onBeforeRunFunc: async () => {},
+    onAfterRunFunc: async () => {},
+  }))
+  return detached
+}
+
+/**
+ * A long-lived process orchestrates many runs. Anything it keeps per run has to
+ * be released when that run stops executing here, or the engine grows for the
+ * life of the deployment.
+ */
+describe('per-run state is released when the run stops executing here', () => {
+  test('a finished replay leaves nothing behind', async () => {
+    const ws = service()
+    const runId = await newRun(ws)
+
+    await ws.beginReplay(runId)
+    await ws.inlineStep(runId, 'a', async () => 1)
+    ws.endReplay(runId)
+
+    assert.equal(
+      ws.runContexts.size,
+      0,
+      'the replay held on to its ordinals, lineage or step snapshot'
+    )
+  })
+
+  test('the step the walk last reached does not survive its replay', async () => {
+    const ws = service()
+    const runId = await newRun(ws)
+
+    await ws.beginReplay(runId)
+    await ws.inlineStep(runId, 'a', async () => 1)
+    ws.endReplay(runId)
+
+    assert.equal(ws.lastStepName(runId), undefined)
+  })
+
+  test('unregistering an inline run releases it', async () => {
+    const ws = service()
+    const runId = await newRun(ws)
+
+    ws.registerInlineRun(runId)
+    assert.equal(ws.isInline(runId), true)
+
+    ws.unregisterInlineRun(runId)
+    assert.equal(ws.isInline(runId), false)
+    assert.equal(ws.runContexts.size, 0)
+  })
+
+  test('a replay inside an inline run does not release the inline flag', async () => {
+    const ws = service()
+    const runId = await newRun(ws)
+
+    ws.registerInlineRun(runId)
+    await ws.beginReplay(runId)
+    ws.endReplay(runId)
+
+    assert.equal(
+      ws.isInline(runId),
+      true,
+      'ending a replay dropped state the run still needs'
+    )
+  })
+
+  test("a queued run's extension context is released when the run reaches a terminal state", async () => {
+    const ws = service()
+    const runId = await newRun(ws)
+    const detached = trackDetaches(ws)
+
+    await ws.updateRunStatus(runId, 'completed', null)
+
+    assert.deepEqual(
+      detached,
+      [runId],
+      'an extension holds live per-run state; a completed run must not keep it'
+    )
+    assert.equal(ws.runContexts.size, 0)
+  })
+
+  test('a suspended run keeps its extension context, because it can still be resumed', async () => {
+    const ws = service()
+    const runId = await newRun(ws)
+    const detached = trackDetaches(ws)
+
+    await ws.updateRunStatus(runId, 'suspended')
+
+    assert.deepEqual(detached, [])
+  })
+})
+
+describe('a replay reads the run once', () => {
+  test('the steps of a replay share one read of the run', async () => {
+    const ws = service()
+    const runId = await newRun(ws)
+
+    let reads = 0
+    const getRun = ws.getRun.bind(ws)
+    ws.getRun = async (id: string) => {
+      reads++
+      return getRun(id)
+    }
+
+    await ws.beginReplay(runId)
+    await ws.getRunIdentity(runId)
+    await ws.getRunIdentity(runId)
+    await ws.getRunIdentity(runId)
+    ws.endReplay(runId)
+
+    assert.equal(reads, 1, `the run was read ${reads} times in one replay`)
+  })
+
+  test('the next replay re-reads the run rather than trusting the last one', async () => {
+    const ws = service()
+    const runId = await newRun(ws)
+
+    let reads = 0
+    const getRun = ws.getRun.bind(ws)
+    ws.getRun = async (id: string) => {
+      reads++
+      return getRun(id)
+    }
+
+    await ws.beginReplay(runId)
+    await ws.getRunIdentity(runId)
+    ws.endReplay(runId)
+    await ws.beginReplay(runId)
+    await ws.getRunIdentity(runId)
+    ws.endReplay(runId)
+
+    assert.equal(reads, 2)
+  })
+
+  test('outside a replay the run is read every time', async () => {
+    const ws = service()
+    const runId = await newRun(ws)
+
+    let reads = 0
+    const getRun = ws.getRun.bind(ws)
+    ws.getRun = async (id: string) => {
+      reads++
+      return getRun(id)
+    }
+
+    await ws.getRunIdentity(runId)
+    await ws.getRunIdentity(runId)
+
+    assert.equal(reads, 2, 'a cached run outside a replay would go stale')
+    assert.equal(ws.runContexts.size, 0, 'reading a run must not create state')
+  })
+})

--- a/packages/core/src/wirings/workflow/workflow-run-polling.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-run-polling.test.ts
@@ -78,7 +78,10 @@ describe('waiting for a run to finish', () => {
     for (const gap of ws.gaps()) {
       assert.ok(gap < 80, `a wait of ${gap}ms overshot the 40ms ceiling`)
     }
-    assert.ok(ws.gaps().some((gap) => gap >= 35), 'never reached the ceiling')
+    assert.ok(
+      ws.gaps().some((gap) => gap >= 35),
+      'never reached the ceiling'
+    )
   })
 
   test('a run that is already finished is returned without any wait', async () => {

--- a/packages/core/src/wirings/workflow/workflow-run-polling.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-run-polling.test.ts
@@ -1,0 +1,123 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { InMemoryWorkflowService } from '../../services/in-memory-workflow-service.js'
+import { pikkuState } from '../../pikku-state.js'
+import type { WorkflowRun } from './workflow.types.js'
+
+/**
+ * A workflow service whose run reads are counted and timestamped, and whose
+ * run finishes only once it has been read `endAfter` times.
+ */
+class PollProbe extends InMemoryWorkflowService {
+  readonly reads: number[] = []
+  endAfter = 1
+
+  override async startWorkflow(): Promise<{ runId: string }> {
+    return { runId: 'run-1' }
+  }
+
+  override async getRun(_runId: string): Promise<WorkflowRun | null> {
+    this.reads.push(Date.now())
+    const done = this.reads.length >= this.endAfter
+    return {
+      id: 'run-1',
+      status: done ? 'completed' : 'running',
+      output: 'result',
+    } as WorkflowRun
+  }
+
+  gaps(): number[] {
+    return this.reads.slice(1).map((t, i) => t - this.reads[i]!)
+  }
+}
+
+const probe = () => {
+  pikkuState(null, 'package', 'singletonServices', {
+    logger: { error() {}, info() {}, warn() {}, debug() {} },
+  } as any)
+  return new PollProbe()
+}
+
+describe('waiting for a run to finish', () => {
+  test('a run that finishes quickly is not held for a whole poll interval', async () => {
+    const ws = probe()
+    ws.endAfter = 2
+    const started = Date.now()
+
+    const output = await ws.runToCompletion('flow', {}, {} as any)
+
+    assert.equal(output, 'result')
+    const elapsed = Date.now() - started
+    assert.ok(
+      elapsed < 200,
+      `a run that was done after one poll took ${elapsed}ms — a fixed interval makes every fast workflow pay the full wait`
+    )
+  })
+
+  test('reads spread out as a run keeps running', async () => {
+    const ws = probe()
+    ws.endAfter = 8
+
+    await ws.runToCompletion('flow', {}, {} as any)
+
+    const gaps = ws.gaps()
+    assert.ok(gaps.length >= 6)
+    assert.ok(
+      gaps.at(-1)! > gaps[0]! * 2,
+      `waits stayed flat (${gaps.join('ms, ')}ms) — a run that drags on keeps costing the same read rate forever`
+    )
+  })
+
+  test('the wait never grows past the configured interval', async () => {
+    const ws = probe()
+    ws.endAfter = 12
+
+    await ws.runToCompletion('flow', {}, {} as any, { pollIntervalMs: 40 })
+
+    for (const gap of ws.gaps()) {
+      assert.ok(gap < 80, `a wait of ${gap}ms overshot the 40ms ceiling`)
+    }
+    assert.ok(ws.gaps().some((gap) => gap >= 35), 'never reached the ceiling')
+  })
+
+  test('a run that is already finished is returned without any wait', async () => {
+    const ws = probe()
+    ws.endAfter = 1
+    const started = Date.now()
+
+    await ws.runToCompletion('flow', {}, {} as any)
+
+    assert.equal(ws.reads.length, 1)
+    assert.ok(Date.now() - started < 50)
+  })
+})
+
+describe('a run that ends badly', () => {
+  test('a failed run surfaces its error message', async () => {
+    const ws = probe()
+    ws.getRun = async () =>
+      ({
+        id: 'run-1',
+        status: 'failed',
+        error: { message: 'step blew up' },
+      }) as WorkflowRun
+
+    await assert.rejects(ws.runToCompletion('flow', {}, {} as any), /blew up/)
+  })
+
+  test('a cancelled run rejects', async () => {
+    const ws = probe()
+    ws.getRun = async () =>
+      ({ id: 'run-1', status: 'cancelled' }) as WorkflowRun
+
+    await assert.rejects(ws.runToCompletion('flow', {}, {} as any))
+  })
+
+  test('a run that disappears rejects rather than polling forever', async () => {
+    const ws = probe()
+    ws.getRun = async () => null
+
+    await assert.rejects(ws.runToCompletion('flow', {}, {} as any), /run-1/)
+  })
+})

--- a/packages/core/src/wirings/workflow/workflow-run-polling.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-run-polling.test.ts
@@ -11,7 +11,13 @@ import type { WorkflowRun } from './workflow.types.js'
  */
 class PollProbe extends InMemoryWorkflowService {
   readonly reads: number[] = []
+  /** Every wait the loop asked for, in order — the schedule, not the clock. */
+  readonly waits: number[] = []
   endAfter = 1
+
+  override async waitBeforeNextRead(ms: number): Promise<void> {
+    this.waits.push(ms)
+  }
 
   override async startWorkflow(): Promise<{ runId: string }> {
     return { runId: 'run-1' }
@@ -26,10 +32,6 @@ class PollProbe extends InMemoryWorkflowService {
       output: 'result',
     } as WorkflowRun
   }
-
-  gaps(): number[] {
-    return this.reads.slice(1).map((t, i) => t - this.reads[i]!)
-  }
 }
 
 const probe = () => {
@@ -43,15 +45,14 @@ describe('waiting for a run to finish', () => {
   test('a run that finishes quickly is not held for a whole poll interval', async () => {
     const ws = probe()
     ws.endAfter = 2
-    const started = Date.now()
 
     const output = await ws.runToCompletion('flow', {}, {} as any)
 
     assert.equal(output, 'result')
-    const elapsed = Date.now() - started
+    assert.equal(ws.waits.length, 1)
     assert.ok(
-      elapsed < 200,
-      `a run that was done after one poll took ${elapsed}ms — a fixed interval makes every fast workflow pay the full wait`
+      ws.waits[0]! < 1000,
+      `a run done after one poll waited the full ${ws.waits[0]}ms default — a fixed interval makes every fast workflow pay for it`
     )
   })
 
@@ -61,12 +62,17 @@ describe('waiting for a run to finish', () => {
 
     await ws.runToCompletion('flow', {}, {} as any)
 
-    const gaps = ws.gaps()
-    assert.ok(gaps.length >= 6)
+    assert.ok(ws.waits.length >= 6)
     assert.ok(
-      gaps.at(-1)! > gaps[0]! * 2,
-      `waits stayed flat (${gaps.join('ms, ')}ms) — a run that drags on keeps costing the same read rate forever`
+      ws.waits.at(-1)! > ws.waits[0]! * 2,
+      `waits stayed flat (${ws.waits.join('ms, ')}ms) — a run that drags on keeps costing the same read rate forever`
     )
+    for (let i = 1; i < ws.waits.length; i++) {
+      assert.ok(
+        ws.waits[i]! >= ws.waits[i - 1]!,
+        `wait ${i} shrank (${ws.waits.join('ms, ')}ms)`
+      )
+    }
   })
 
   test('the wait never grows past the configured interval', async () => {
@@ -75,24 +81,24 @@ describe('waiting for a run to finish', () => {
 
     await ws.runToCompletion('flow', {}, {} as any, { pollIntervalMs: 40 })
 
-    for (const gap of ws.gaps()) {
-      assert.ok(gap < 80, `a wait of ${gap}ms overshot the 40ms ceiling`)
+    for (const wait of ws.waits) {
+      assert.ok(wait <= 40, `a wait of ${wait}ms overshot the 40ms ceiling`)
     }
-    assert.ok(
-      ws.gaps().some((gap) => gap >= 35),
-      'never reached the ceiling'
+    assert.equal(
+      ws.waits.at(-1),
+      40,
+      `the ceiling was never reached (${ws.waits.join('ms, ')}ms)`
     )
   })
 
   test('a run that is already finished is returned without any wait', async () => {
     const ws = probe()
     ws.endAfter = 1
-    const started = Date.now()
 
     await ws.runToCompletion('flow', {}, {} as any)
 
     assert.equal(ws.reads.length, 1)
-    assert.ok(Date.now() - started < 50)
+    assert.deepEqual(ws.waits, [])
   })
 })
 

--- a/packages/core/src/wirings/workflow/workflow-step-ordinal.test.ts
+++ b/packages/core/src/wirings/workflow/workflow-step-ordinal.test.ts
@@ -19,7 +19,7 @@ describe('same step name invoked multiple times in one run', () => {
   test('each reach gets its own row + invocationId (no clobber)', async () => {
     const ws = inlineService()
     const runId = await ws.createRun('flow', {}, true, 'hash', { type: 'test' })
-    ;(ws as any).inlineRuns.add(runId)
+    ws.registerInlineRun(runId)
 
     // Two `do('process', fn)` reaches in the SAME replay (no reset between).
     const r1 = await (ws as any).inlineStep(runId, 'process', async () => 'first')
@@ -45,7 +45,7 @@ describe('same step name invoked multiple times in one run', () => {
   test('ordinal 0 is unchanged: a single call keeps the bare name + its old invocationId', async () => {
     const ws = inlineService()
     const runId = await ws.createRun('flow', {}, true, 'hash', { type: 'test' })
-    ;(ws as any).inlineRuns.add(runId)
+    ws.registerInlineRun(runId)
 
     await (ws as any).inlineStep(runId, 'solo', async () => 'x')
     // Stored under the bare name, and the dedupe key matches the pre-ordinal hash.
@@ -57,7 +57,7 @@ describe('same step name invoked multiple times in one run', () => {
   test('a fresh replay resets ordinals so the same call resolves to the same row', async () => {
     const ws = inlineService()
     const runId = await ws.createRun('flow', {}, true, 'hash', { type: 'test' })
-    ;(ws as any).inlineRuns.add(runId)
+    ws.registerInlineRun(runId)
 
     let runs = 0
     const r1 = await (ws as any).inlineStep(runId, 'once', async () => {
@@ -66,7 +66,7 @@ describe('same step name invoked multiple times in one run', () => {
     })
     // Next replay resets the counter; the same `do('once')` must hit the cached
     // row, not mint 'once#1'.
-    ;(ws as any).resetStepOrdinals(runId)
+    await (ws as any).beginReplay(runId)
     const r2 = await (ws as any).inlineStep(runId, 'once', async () => {
       runs++
       return 'v2'

--- a/packages/runtimes/cloudflare/src/workflow-do/pikku-workflow-do-client.ts
+++ b/packages/runtimes/cloudflare/src/workflow-do/pikku-workflow-do-client.ts
@@ -260,4 +260,10 @@ export class PikkuWorkflowDoClient implements WorkflowService {
   ): Promise<Array<{ workflowName: string; graphHash: string; graph: any }>> {
     return Promise.reject(notSupported('getAIGeneratedWorkflows'))
   }
+
+  getDynamicWorkflow(
+    _name: string
+  ): Promise<{ workflowName: string; graphHash: string; graph: any } | null> {
+    return Promise.reject(notSupported('getDynamicWorkflow'))
+  }
 }

--- a/packages/runtimes/cloudflare/src/workflow-do/pikku-workflow-do-service.test.ts
+++ b/packages/runtimes/cloudflare/src/workflow-do/pikku-workflow-do-service.test.ts
@@ -279,7 +279,7 @@ describe('PikkuWorkflowDoService — transport hooks', () => {
   })
 
   test('dispatchStep returns false for inline runs (does not call worker)', async () => {
-    ;(service as any).inlineRuns.add(RUN_ID)
+    ;(service as any).registerInlineRun(RUN_ID)
     const ok = await (service as any).dispatchStep(RUN_ID, 's', 'r', {})
     assert.equal(ok, false)
     assert.equal(dispatched.length, 0)

--- a/packages/services/kysely-mysql/src/mysql-kysely-workflow-service.ts
+++ b/packages/services/kysely-mysql/src/mysql-kysely-workflow-service.ts
@@ -11,6 +11,14 @@ export class MySQLKyselyWorkflowService extends KyselyWorkflowService {
     this.lockTimeout = lockTimeout
   }
 
+  /**
+   * MySQL has `JSON_SET` but no `json()`; a JSON literal is cast instead, so
+   * the value lands as a JSON value rather than as a quoted string.
+   */
+  protected override jsonSetState(path: string, json: string) {
+    return sql<string>`JSON_SET(COALESCE(state, '{}'), ${path}, CAST(${json} AS JSON))`
+  }
+
   async withRunLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
     const lockName = `pikku:run:${id}`
     const timeout = this.lockTimeout

--- a/packages/services/kysely-postgres/package.json
+++ b/packages/services/kysely-postgres/package.json
@@ -11,7 +11,10 @@
     "tsc": "tsc",
     "ncu": "npx npm-check-updates",
     "build": "tsc -b",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "test": "bash run-tests.sh",
+    "test:watch": "bash run-tests.sh --watch",
+    "test:coverage": "bash run-tests.sh --coverage"
   },
   "dependencies": {
     "@pikku/kysely": "^0.13.3",
@@ -23,6 +26,7 @@
     "@pikku/core": "^0.12.69"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.1",
     "@pikku/core": "^0.12.69",
     "typescript": "^6.0.3"
   },

--- a/packages/services/kysely-postgres/run-tests.sh
+++ b/packages/services/kysely-postgres/run-tests.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Enable nullglob to handle cases where no files match the pattern
+shopt -s nullglob
+
+# Initialize variables for options
+watch_mode=false
+coverage_mode=false
+
+# Parse command-line options
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --watch)
+      watch_mode=true
+      shift
+      ;;
+    --coverage)
+      coverage_mode=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Define the pattern to match your test files
+pattern="src/*.test.ts"
+
+# Expand the pattern into an array of files
+files=($(find src -type f -name "*.test.ts"))
+
+# Check if any files matched the pattern
+if [ ${#files[@]} -eq 0 ]; then
+  echo "No test files found matching pattern: $pattern"
+  exit 0
+fi
+
+# Construct the node command
+node_cmd=(node --import tsx --test)
+
+# Append options based on flags
+if [ "$watch_mode" = true ]; then
+  node_cmd+=(--watch)
+fi
+
+if [ "$coverage_mode" = true ]; then
+  node_cmd+=(--test-coverage-include="src/**/*.{ts,js}" --test-coverage-exclude="**/dist/**" --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info)
+fi
+
+# Execute the node command with the expanded list of files
+"${node_cmd[@]}" "${files[@]}"

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
@@ -1,0 +1,352 @@
+import { describe, test, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  CamelCasePlugin,
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  sql,
+  type DatabaseConnection,
+  type Dialect,
+  type Driver,
+  type QueryResult,
+} from 'kysely'
+import { PGlite } from '@electric-sql/pglite'
+import type { KyselyPikkuDB } from '@pikku/kysely'
+
+import { PgKyselyWorkflowService } from './pg-kysely-workflow-service.js'
+
+/**
+ * Kysely over an in-process Postgres.
+ *
+ * The Postgres workflow service had no coverage at all — its SQL only ever ran
+ * against a real server, so a dialect mistake surfaced in production rather
+ * than in CI. PGlite is genuine Postgres compiled to WASM, so `jsonb`,
+ * advisory locks, transactional DDL and the real error codes all behave as
+ * they do on a server, with no Docker to install.
+ *
+ * PGlite is a single session, so connections are handed out one at a time.
+ * That is what makes `BEGIN`/`COMMIT` from Kysely's transaction API safe here:
+ * without the queue two overlapping transactions would interleave onto the one
+ * underlying session and corrupt each other.
+ */
+class PGliteDriver implements Driver {
+  #connection: DatabaseConnection
+  #queue: Promise<void> = Promise.resolve()
+
+  constructor(private readonly pglite: PGlite) {
+    this.#connection = {
+      executeQuery: async <R>(compiled: {
+        sql: string
+        parameters: readonly unknown[]
+      }): Promise<QueryResult<R>> => {
+        const result = await this.pglite.query<R>(compiled.sql, [
+          ...compiled.parameters,
+        ])
+        return {
+          rows: result.rows,
+          numAffectedRows: BigInt(result.affectedRows ?? 0),
+        }
+      },
+      async *streamQuery() {
+        throw new Error('streaming is not supported by the PGlite test driver')
+      },
+    }
+  }
+
+  async init(): Promise<void> {}
+
+  async acquireConnection(): Promise<DatabaseConnection> {
+    let release!: () => void
+    const held = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const mine = this.#queue.then(() => this.#connection)
+    this.#queue = this.#queue.then(() => held)
+    const connection = await mine
+    releases.set(connection, [...(releases.get(connection) ?? []), release])
+    return connection
+  }
+
+  async beginTransaction(connection: DatabaseConnection): Promise<void> {
+    await connection.executeQuery({ sql: 'begin', parameters: [] } as any)
+  }
+
+  async commitTransaction(connection: DatabaseConnection): Promise<void> {
+    await connection.executeQuery({ sql: 'commit', parameters: [] } as any)
+  }
+
+  async rollbackTransaction(connection: DatabaseConnection): Promise<void> {
+    await connection.executeQuery({ sql: 'rollback', parameters: [] } as any)
+  }
+
+  async releaseConnection(connection: DatabaseConnection): Promise<void> {
+    releases.get(connection)?.shift()?.()
+  }
+
+  async destroy(): Promise<void> {
+    await this.pglite.close()
+  }
+}
+
+const releases = new Map<DatabaseConnection, Array<() => void>>()
+
+class PGliteDialect implements Dialect {
+  constructor(private readonly pglite: PGlite) {}
+  createAdapter() {
+    return new PostgresAdapter()
+  }
+  createDriver() {
+    return new PGliteDriver(this.pglite)
+  }
+  createIntrospector(db: Kysely<any>) {
+    return new PostgresIntrospector(db)
+  }
+  createQueryCompiler() {
+    return new PostgresQueryCompiler()
+  }
+}
+
+let db: Kysely<KyselyPikkuDB>
+let service: PgKyselyWorkflowService
+let open: Kysely<KyselyPikkuDB>[] = []
+
+const createDb = () => {
+  const created = new Kysely<KyselyPikkuDB>({
+    dialect: new PGliteDialect(new PGlite()),
+    // `CamelCasePlugin` alone, matching `PikkuKysely` — the SQLite-style
+    // `SerializePlugin` is deliberately absent on Postgres, which takes JSON
+    // and booleans natively.
+    plugins: [new CamelCasePlugin()],
+  })
+  open.push(created)
+  return created
+}
+
+beforeEach(async () => {
+  open = []
+  db = createDb()
+  service = new PgKyselyWorkflowService(db, { wireQueues: false } as any)
+  await service.init()
+})
+
+afterEach(async () => {
+  await Promise.all(open.map((it) => it.destroy()))
+})
+
+const seedRun = (name = 'wf') =>
+  service.createRun(name, { foo: 1 }, false, 'hash1', {
+    type: 'internal',
+  } as any)
+
+const seedStep = async () => {
+  const runId = await seedRun()
+  const step = await service.insertStepState(runId, 'step-1', 'rpc.fn', {
+    x: 1,
+  })
+  return { runId, step }
+}
+
+describe('the schema Postgres actually gets', () => {
+  test('init creates every workflow table', async () => {
+    const { rows } = await sql<{ tablename: string }>`
+      SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+    `.execute(db)
+    const tables = rows.map((r) => r.tablename).sort()
+
+    assert.deepEqual(tables, [
+      'workflow_runs',
+      'workflow_step',
+      'workflow_step_history',
+      'workflow_versions',
+    ])
+  })
+
+  test('init creates the indexes the engine reads by', async () => {
+    const { rows } = await sql<{ indexname: string }>`
+      SELECT indexname FROM pg_indexes WHERE schemaname = 'public'
+    `.execute(db)
+    const indexes = rows.map((r) => r.indexname)
+
+    for (const expected of [
+      'idx_workflow_step_history_step',
+      'idx_workflow_step_run_status',
+      'idx_workflow_runs_status_created',
+      'idx_workflow_runs_workflow_created',
+      'idx_workflow_versions_source_status',
+    ]) {
+      assert.ok(
+        indexes.includes(expected),
+        `${expected} is missing, so its query is a sequential scan on Postgres`
+      )
+    }
+  })
+
+  test('init is idempotent, so a second boot does not throw', async () => {
+    const again = new PgKyselyWorkflowService(db, { wireQueues: false } as any)
+    await again.init()
+  })
+})
+
+describe('run state on jsonb', () => {
+  test('a key survives the text/jsonb round trip', async () => {
+    const runId = await seedRun()
+
+    await service.updateRunState(runId, 'alpha', 1)
+
+    assert.deepEqual(await service.getRunState(runId), { alpha: 1 })
+  })
+
+  test('separate keys merge rather than replace', async () => {
+    const runId = await seedRun()
+
+    await service.updateRunState(runId, 'alpha', 1)
+    await service.updateRunState(runId, 'beta', 2)
+    await service.updateRunState(runId, 'gamma', 3)
+
+    assert.deepEqual(await service.getRunState(runId), {
+      alpha: 1,
+      beta: 2,
+      gamma: 3,
+    })
+  })
+
+  test('a key is replaced, not merged into, on rewrite', async () => {
+    const runId = await seedRun()
+
+    await service.updateRunState(runId, 'alpha', { a: 1 })
+    await service.updateRunState(runId, 'alpha', { b: 2 })
+
+    assert.deepEqual(await service.getRunState(runId), { alpha: { b: 2 } })
+  })
+
+  test('values keep their JSON type instead of becoming strings', async () => {
+    const runId = await seedRun()
+
+    await service.updateRunState(runId, 'empty', [])
+    await service.updateRunState(runId, 'zero', 0)
+    await service.updateRunState(runId, 'no', false)
+    await service.updateRunState(runId, 'nothing', null)
+    await service.updateRunState(runId, 'deep', { a: [1, { b: true }] })
+
+    assert.deepEqual(await service.getRunState(runId), {
+      empty: [],
+      zero: 0,
+      no: false,
+      nothing: null,
+      deep: { a: [1, { b: true }] },
+    })
+  })
+
+  test('a key containing a dot stays one key', async () => {
+    const runId = await seedRun()
+
+    await service.updateRunState(runId, 'a.b', 'flat')
+
+    assert.deepEqual(
+      await service.getRunState(runId),
+      { 'a.b': 'flat' },
+      'the key was read as a nested path instead of a literal name'
+    )
+  })
+
+  test('a key containing a quote does not break the statement', async () => {
+    const runId = await seedRun()
+
+    await service.updateRunState(runId, 'it\'s "quoted"', 1)
+
+    assert.deepEqual(await service.getRunState(runId), { 'it\'s "quoted"': 1 })
+  })
+})
+
+describe('a step transition on Postgres', () => {
+  test('running, then succeeded, reaches both the step and its history', async () => {
+    const { runId, step } = await seedStep()
+
+    await service.setStepRunning(step.stepId)
+    await service.setStepResult(step.stepId, { ok: true })
+
+    const state = await service.getStepState(runId, 'step-1')
+    assert.equal(state.status, 'succeeded')
+    assert.deepEqual(state.result, { ok: true })
+
+    const [attempt] = await service.getRunHistory(runId)
+    assert.equal(attempt!.status, 'succeeded')
+    assert.deepEqual(attempt!.result, { ok: true })
+  })
+
+  test('a failure carries the error to both rows', async () => {
+    const { runId, step } = await seedStep()
+
+    await service.setStepRunning(step.stepId)
+    await service.setStepError(step.stepId, new Error('exploded'))
+
+    const state = await service.getStepState(runId, 'step-1')
+    assert.equal(state.status, 'failed')
+    assert.equal(state.error?.message, 'exploded')
+
+    const [attempt] = await service.getRunHistory(runId)
+    assert.equal(attempt!.status, 'failed')
+    assert.equal(attempt!.error?.message, 'exploded')
+  })
+
+  test('a retry writes the new attempt and leaves the failed one intact', async () => {
+    const { runId, step } = await seedStep()
+
+    await service.setStepRunning(step.stepId)
+    await service.setStepError(step.stepId, new Error('first go'))
+    await service.createRetryAttempt(step.stepId, 'pending')
+    await service.setStepRunning(step.stepId)
+    await service.setStepResult(step.stepId, 'second go')
+
+    const history = await service.getRunHistory(runId)
+    assert.equal(history.length, 2)
+    assert.equal(history[0]!.status, 'failed')
+    assert.equal(history[0]!.error?.message, 'first go')
+    assert.equal(history[1]!.status, 'succeeded')
+    assert.equal(history[1]!.result, 'second go')
+
+    const state = await service.getStepState(runId, 'step-1')
+    assert.equal(state.attemptCount, 2)
+    assert.equal(state.error, undefined)
+  })
+
+  test('two attempts in the same millisecond still resolve the newer row', async () => {
+    const { runId, step } = await seedStep()
+
+    await service.setStepError(step.stepId, new Error('first go'))
+    await service.createRetryAttempt(step.stepId, 'pending')
+    await service.setStepResult(step.stepId, 'second go')
+
+    const history = await service.getRunHistory(runId)
+    assert.equal(history[0]!.status, 'failed')
+    assert.equal(
+      history[1]!.status,
+      'succeeded',
+      'the transition landed on the wrong attempt'
+    )
+  })
+})
+
+describe('advisory locks', () => {
+  test('a run lock serialises its critical section', async () => {
+    const order: string[] = []
+    const hold = async (tag: string, ms: number) => {
+      await service.withRunLock('run-1', async () => {
+        order.push(`${tag}:in`)
+        await new Promise((r) => setTimeout(r, ms))
+        order.push(`${tag}:out`)
+      })
+    }
+
+    await Promise.all([hold('a', 20), hold('b', 0)])
+
+    assert.deepEqual(order, ['a:in', 'a:out', 'b:in', 'b:out'])
+  })
+
+  test('a step lock returns its callback value', async () => {
+    const result = await service.withStepLock('run-1', 'step-1', async () => 42)
+    assert.equal(result, 42)
+  })
+})

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.test.ts
@@ -49,7 +49,7 @@ class PGliteDriver implements Driver {
           numAffectedRows: BigInt(result.affectedRows ?? 0),
         }
       },
-      async *streamQuery() {
+      streamQuery(): never {
         throw new Error('streaming is not supported by the PGlite test driver')
       },
     }

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
@@ -9,6 +9,21 @@ export class PgKyselyWorkflowService extends KyselyWorkflowService {
     super(db, options)
   }
 
+  /**
+   * Postgres has no `json_set`. The column is text, so it is cast to jsonb for
+   * the merge and back afterwards; `||` is used rather than `jsonb_set` because
+   * `jsonb_set` will not create a key that is not already present.
+   *
+   * The value is cast explicitly to jsonb rather than passed as a bare
+   * parameter, so it lands as a JSON value and not as a JSON string that
+   * happens to contain JSON.
+   */
+  protected override jsonSetState(path: string, json: string) {
+    // The base builds `$."key"`; Postgres addresses jsonb keys by bare name.
+    const key = JSON.parse(path.slice(2))
+    return sql<string>`(coalesce(state, '{}')::jsonb || jsonb_build_object(${key}::text, ${json}::jsonb))::text`
+  }
+
   private hashStringToInt(str: string): number {
     let hash = 0
     for (let i = 0; i < str.length; i++) {

--- a/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
+++ b/packages/services/kysely-postgres/src/pg-kysely-workflow-service.ts
@@ -14,14 +14,17 @@ export class PgKyselyWorkflowService extends KyselyWorkflowService {
    * the merge and back afterwards; `||` is used rather than `jsonb_set` because
    * `jsonb_set` will not create a key that is not already present.
    *
-   * The value is cast explicitly to jsonb rather than passed as a bare
-   * parameter, so it lands as a JSON value and not as a JSON string that
-   * happens to contain JSON.
+   * The value is carried as text and only then cast to jsonb, so it lands as a
+   * JSON value and not as a JSON string that happens to contain JSON. The
+   * intermediate `::text` is what makes that true for every driver: postgres.js
+   * infers a parameter's type from the cast that follows it and JSON-encodes
+   * anything it believes is jsonb, so a bare `$1::jsonb` would arrive
+   * double-encoded — `1` stored as `"1"`, and a counter read back as a string.
    */
   protected override jsonSetState(path: string, json: string) {
     // The base builds `$."key"`; Postgres addresses jsonb keys by bare name.
     const key = JSON.parse(path.slice(2))
-    return sql<string>`(coalesce(state, '{}')::jsonb || jsonb_build_object(${key}::text, ${json}::jsonb))::text`
+    return sql<string>`(coalesce(state, '{}')::jsonb || jsonb_build_object(${key}::text, (${json}::text)::jsonb))::text`
   }
 
   private hashStringToInt(str: string): number {

--- a/packages/services/kysely/src/kysely-tables.ts
+++ b/packages/services/kysely/src/kysely-tables.ts
@@ -52,6 +52,8 @@ export interface WorkflowStepTable {
   retries: number | null
   retryDelay: string | null
   fromStepName: string | null
+  /** The history attempt currently in flight; see WorkflowStepHistoryTable.attempt. */
+  currentAttempt: number | null
   createdAt: Generated<Date>
   updatedAt: Generated<Date>
 }
@@ -62,6 +64,12 @@ export interface WorkflowStepHistoryTable {
   status: StepStatus
   result: string | null
   error: string | null
+  /**
+   * Monotonic attempt number within the step, starting at 1. Orders attempts
+   * and identifies the live one without relying on `createdAt`, which cannot
+   * separate a retry from the attempt it replaces in the same millisecond.
+   */
+  attempt: number | null
   createdAt: Generated<Date>
   runningAt: Date | null
   scheduledAt: Date | null

--- a/packages/services/kysely/src/kysely-workflow-mirror.test.ts
+++ b/packages/services/kysely/src/kysely-workflow-mirror.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { CamelCasePlugin, Kysely, SqliteDialect } from 'kysely'
+import { CamelCasePlugin, Kysely, SqliteDialect, sql } from 'kysely'
 import { SerializePlugin } from './serialize-plugin.js'
 import Database from 'better-sqlite3'
 

--- a/packages/services/kysely/src/kysely-workflow-mirror.ts
+++ b/packages/services/kysely/src/kysely-workflow-mirror.ts
@@ -114,12 +114,13 @@ export class KyselyWorkflowMirror implements WorkflowRunMirror {
         retries: step.retries ?? null,
         retryDelay: step.retryDelay?.toString() ?? null,
         fromStepName: step.fromStepName ?? null,
+        currentAttempt: 1,
         createdAt: now,
         updatedAt: now,
       })
       .execute()
 
-    await this.insertHistoryRecord(step.stepId, step.status)
+    await this.insertHistoryRecord(step.stepId, step.status, 1)
   }
 
   async setStepRunning(stepId: string): Promise<void> {
@@ -178,17 +179,25 @@ export class KyselyWorkflowMirror implements WorkflowRunMirror {
     failedStepId: string,
     newStep: StepState & { stepName: string }
   ): Promise<void> {
+    const previous = await this.db
+      .selectFrom('workflowStep')
+      .select('currentAttempt')
+      .where('workflowStepId', '=', failedStepId)
+      .executeTakeFirst()
+    const attempt = (previous?.currentAttempt ?? 0) + 1
+
     await this.db
       .updateTable('workflowStep')
       .set({
         status: newStep.status,
         result: null,
         error: null,
+        currentAttempt: attempt,
         updatedAt: new Date(),
       })
       .where('workflowStepId', '=', failedStepId)
       .execute()
-    await this.insertHistoryRecord(failedStepId, newStep.status)
+    await this.insertHistoryRecord(failedStepId, newStep.status, attempt)
   }
 
   async setBranchTaken(stepId: string, branchKey: string): Promise<void> {
@@ -274,6 +283,7 @@ export class KyselyWorkflowMirror implements WorkflowRunMirror {
   private async insertHistoryRecord(
     stepId: string,
     status: string,
+    attempt: number,
     resultJson?: string | null,
     errorJson?: string | null
   ): Promise<void> {
@@ -282,6 +292,7 @@ export class KyselyWorkflowMirror implements WorkflowRunMirror {
       historyId: crypto.randomUUID(),
       workflowStepId: stepId,
       status,
+      attempt,
       result: resultJson ?? null,
       error: errorJson ?? null,
       createdAt: now,
@@ -309,27 +320,40 @@ export class KyselyWorkflowMirror implements WorkflowRunMirror {
     resultJson?: string,
     errorJson?: string
   ): Promise<void> {
-    const latest = await this.db
-      .selectFrom('workflowStepHistory')
-      .select('historyId')
+    const update: Record<string, any> = { status }
+    if (resultJson !== undefined) update.result = resultJson
+    if (errorJson !== undefined) update.error = errorJson
+    const tsField = timestampFieldFor(status)
+    if (tsField) update[tsField] = new Date()
+
+    const result = await this.db
+      .updateTable('workflowStepHistory')
+      .set(update)
       .where('workflowStepId', '=', stepId)
-      .orderBy('createdAt', 'desc')
-      .limit(1)
+      // Correlate through the step row rather than sorting this table by
+      // createdAt: two attempts can land in the same millisecond, and the
+      // step row already knows which attempt is current.
+      .where('attempt', '=', (eb) =>
+        eb
+          .selectFrom('workflowStep')
+          .select('currentAttempt')
+          .where('workflowStepId', '=', stepId)
+      )
       .executeTakeFirst()
 
-    if (latest) {
-      const update: Record<string, any> = { status }
-      if (resultJson !== undefined) update.result = resultJson
-      if (errorJson !== undefined) update.error = errorJson
-      const tsField = timestampFieldFor(status)
-      if (tsField) update[tsField] = new Date()
-      await this.db
-        .updateTable('workflowStepHistory')
-        .set(update)
-        .where('historyId', '=', latest.historyId)
-        .execute()
-    } else {
-      await this.insertHistoryRecord(stepId, status, resultJson, errorJson)
+    if (Number(result?.numUpdatedRows ?? 0n) === 0) {
+      const step = await this.db
+        .selectFrom('workflowStep')
+        .select('currentAttempt')
+        .where('workflowStepId', '=', stepId)
+        .executeTakeFirst()
+      await this.insertHistoryRecord(
+        stepId,
+        status,
+        step?.currentAttempt ?? 1,
+        resultJson,
+        errorJson
+      )
     }
   }
 }

--- a/packages/services/kysely/src/kysely-workflow-run-service.ts
+++ b/packages/services/kysely/src/kysely-workflow-run-service.ts
@@ -198,6 +198,7 @@ export class KyselyWorkflowRunService implements WorkflowRunService {
         'h.status',
         'h.result',
         'h.error',
+        'h.attempt',
         'h.createdAt',
         'h.runningAt',
         'h.scheduledAt',
@@ -205,7 +206,10 @@ export class KyselyWorkflowRunService implements WorkflowRunService {
         'h.failedAt',
       ])
       .where('s.workflowRunId', '=', runId)
+      // `attempt` breaks the tie when a retry lands in the same millisecond as
+      // the attempt it replaces, which `createdAt` alone cannot order.
       .orderBy('h.createdAt', 'asc')
+      .orderBy('h.attempt', 'asc')
       .execute()
 
     let attemptCounters: Record<string, number> = {}

--- a/packages/services/kysely/src/kysely-workflow-service.test.ts
+++ b/packages/services/kysely/src/kysely-workflow-service.test.ts
@@ -237,7 +237,11 @@ describe('KyselyWorkflowService — step transitions stay consistent', () => {
     await service.setStepResult(retry.stepId, { ok: true })
 
     const history = await service.getRunHistory(runId)
-    assert.equal(history.length, 2, 'expected one attempt row plus one retry row')
+    assert.equal(
+      history.length,
+      2,
+      'expected one attempt row plus one retry row'
+    )
     assert.deepEqual(
       history.map((h) => h.status),
       ['failed', 'succeeded'],
@@ -290,10 +294,14 @@ describe('KyselyWorkflowService — attempt counting', () => {
       1,
       `expected one query for the whole run, got ${queries.length}`
     )
-    assert.deepEqual(
-      steps.map((s: any) => s.stepName).sort(),
-      ['s0', 's1', 's2', 's3', 's4', 's5']
-    )
+    assert.deepEqual(steps.map((s: any) => s.stepName).sort(), [
+      's0',
+      's1',
+      's2',
+      's3',
+      's4',
+      's5',
+    ])
   })
 })
 
@@ -331,6 +339,44 @@ describe('KyselyWorkflowService — run state writes', () => {
     assert.deepEqual(await service.getRunState(runId), {
       alpha: { nested: true },
     })
+  })
+
+  test('values keep their JSON type instead of becoming strings', async () => {
+    const runId = await seedRun('wf5')
+
+    await service.updateRunState(runId, 'empty', [])
+    await service.updateRunState(runId, 'zero', 0)
+    await service.updateRunState(runId, 'no', false)
+    await service.updateRunState(runId, 'nothing', null)
+    await service.updateRunState(runId, 'deep', { a: [1, { b: true }] })
+
+    assert.deepEqual(await service.getRunState(runId), {
+      empty: [],
+      zero: 0,
+      no: false,
+      nothing: null,
+      deep: { a: [1, { b: true }] },
+    })
+  })
+
+  test('a key containing a dot stays one key', async () => {
+    const runId = await seedRun('wf6')
+
+    await service.updateRunState(runId, 'a.b', 'flat')
+
+    assert.deepEqual(
+      await service.getRunState(runId),
+      { 'a.b': 'flat' },
+      'the key was read as a nested path instead of a literal name'
+    )
+  })
+
+  test('a key containing a quote does not break the statement', async () => {
+    const runId = await seedRun('wf7')
+
+    await service.updateRunState(runId, 'it\'s "quoted"', 1)
+
+    assert.deepEqual(await service.getRunState(runId), { 'it\'s "quoted"': 1 })
   })
 })
 

--- a/packages/services/kysely/src/kysely-workflow-service.test.ts
+++ b/packages/services/kysely/src/kysely-workflow-service.test.ts
@@ -1,0 +1,365 @@
+import { describe, test, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { CamelCasePlugin, Kysely, SqliteDialect, sql } from 'kysely'
+import Database from 'better-sqlite3'
+
+import type { KyselyPikkuDB } from './kysely-tables.js'
+import { SerializePlugin } from './serialize-plugin.js'
+import { KyselyWorkflowService } from './kysely-workflow-service.js'
+
+let db: Kysely<KyselyPikkuDB>
+let service: KyselyWorkflowService
+let queries: string[]
+
+/**
+ * Every statement the service issues, so a test can assert on round-trip count
+ * rather than on wall-clock — the only measure that stays stable in CI.
+ */
+const createDb = () => {
+  queries = []
+  return new Kysely<KyselyPikkuDB>({
+    dialect: new SqliteDialect({ database: new Database(':memory:') }),
+    plugins: [new CamelCasePlugin(), new SerializePlugin()],
+    log: (event) => {
+      if (event.level === 'query') {
+        queries.push(event.query.sql)
+      }
+    },
+  })
+}
+
+beforeEach(async () => {
+  db = createDb()
+  service = new KyselyWorkflowService(db, { wireQueues: false } as any)
+  await service.init()
+})
+
+afterEach(async () => {
+  await db.destroy()
+})
+
+const listIndexes = async (table: string): Promise<string[]> => {
+  const rows = await sql<{
+    name: string
+  }>`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ${table} AND name NOT LIKE 'sqlite_%'`.execute(
+    db
+  )
+  return rows.rows.map((r) => r.name)
+}
+
+const indexedColumns = async (indexName: string): Promise<string[]> => {
+  const rows = await sql<{
+    name: string
+  }>`SELECT name FROM pragma_index_info(${indexName})`.execute(db)
+  return rows.rows.map((r) => r.name)
+}
+
+const seedRun = (name = 'wf') =>
+  service.createRun(name, { foo: 1 }, false, 'hash1', {
+    type: 'internal',
+  } as any)
+
+describe('KyselyWorkflowService — schema indexes', () => {
+  test('workflow_step_history is indexed by its step, the column every hot query filters on', async () => {
+    const indexes = await listIndexes('workflow_step_history')
+    assert.notEqual(
+      indexes.length,
+      0,
+      'workflow_step_history has no indexes; the attempt-count subquery and the latest-attempt lookup both seq-scan it'
+    )
+
+    const columnsPerIndex = await Promise.all(
+      indexes.map((name) => indexedColumns(name))
+    )
+    assert.ok(
+      columnsPerIndex.some((cols) => cols[0] === 'workflow_step_id'),
+      `expected an index led by workflow_step_id, got ${JSON.stringify(columnsPerIndex)}`
+    )
+  })
+
+  test('the step-history index also orders by created_at, so the latest attempt is a lookup not a sort', async () => {
+    const indexes = await listIndexes('workflow_step_history')
+    const columnsPerIndex = await Promise.all(
+      indexes.map((name) => indexedColumns(name))
+    )
+    assert.ok(
+      columnsPerIndex.some(
+        (cols) => cols[0] === 'workflow_step_id' && cols[1] === 'created_at'
+      ),
+      `expected a (workflow_step_id, created_at) index, got ${JSON.stringify(columnsPerIndex)}`
+    )
+  })
+
+  test('workflow_runs is indexed for the status + recency listing', async () => {
+    const indexes = await listIndexes('workflow_runs')
+    const columnsPerIndex = await Promise.all(
+      indexes.map((name) => indexedColumns(name))
+    )
+    assert.ok(
+      columnsPerIndex.some((cols) => cols.includes('status')),
+      `expected an index covering status, got ${JSON.stringify(columnsPerIndex)}`
+    )
+  })
+
+  test('workflow_step is indexed for the per-run status scan the graph runner does every tick', async () => {
+    const indexes = await listIndexes('workflow_step')
+    const columnsPerIndex = await Promise.all(
+      indexes.map((name) => indexedColumns(name))
+    )
+    assert.ok(
+      columnsPerIndex.some(
+        (cols) => cols[0] === 'workflow_run_id' && cols.includes('status')
+      ),
+      `expected a (workflow_run_id, status) index, got ${JSON.stringify(columnsPerIndex)}`
+    )
+  })
+
+  test('workflow_versions is indexed for the dynamic-workflow lookup', async () => {
+    const indexes = await listIndexes('workflow_versions')
+    assert.notEqual(
+      indexes.length,
+      0,
+      'getAIGeneratedWorkflows filters on (source, status) with no index'
+    )
+  })
+
+  test('init() is idempotent — a second call does not throw on existing indexes', async () => {
+    await service.init()
+    const indexes = await listIndexes('workflow_step_history')
+    assert.ok(indexes.length > 0)
+  })
+})
+
+/**
+ * A step transition writes the step row and its history row, and nothing else.
+ * BEGIN/COMMIT are excluded: they are the price of writing the pair atomically,
+ * and counting them would make the assertion about transaction framing rather
+ * than about the work being done.
+ */
+const dataStatements = () =>
+  queries.filter((q) => !/^\s*(begin|commit|rollback)/i.test(q))
+
+describe('KyselyWorkflowService — step transition round-trips', () => {
+  const transitions: Array<[string, (stepId: string) => Promise<void>]> = [
+    ['setStepRunning', (id) => service.setStepRunning(id)],
+    ['setStepResult', (id) => service.setStepResult(id, { ok: true })],
+    ['setStepError', (id) => service.setStepError(id, new Error('boom'))],
+  ]
+
+  for (const [name, run] of transitions) {
+    test(`${name} writes two rows and reads none`, async () => {
+      const runId = await seedRun()
+      const step = await service.insertStepState(runId, 's1', 'rpc.fn', {
+        x: 1,
+      })
+
+      queries.length = 0
+      await run(step.stepId)
+
+      const statements = dataStatements()
+      assert.equal(
+        statements.length,
+        2,
+        `${name} issued ${statements.length} statements:\n${statements.join('\n')}`
+      )
+      assert.ok(
+        statements.every((q) => /^\s*update/i.test(q)),
+        `${name} still reads before it writes — the latest-attempt lookup used to sort an unindexed history table:\n${statements.join('\n')}`
+      )
+    })
+
+    test(`${name} writes both rows atomically`, async () => {
+      const runId = await seedRun()
+      const step = await service.insertStepState(runId, 's1', 'rpc.fn', {
+        x: 1,
+      })
+
+      queries.length = 0
+      await run(step.stepId)
+
+      assert.ok(
+        /^\s*begin/i.test(queries[0] ?? ''),
+        `${name} wrote the step and its history outside a transaction; a crash between them leaves the two disagreeing`
+      )
+      assert.ok(/^\s*commit/i.test(queries.at(-1) ?? ''))
+    })
+  }
+})
+
+describe('KyselyWorkflowService — step transitions stay consistent', () => {
+  test('setStepResult writes the step row and its history row together', async () => {
+    const runId = await seedRun()
+    const step = await service.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+    await service.setStepRunning(step.stepId)
+    await service.setStepResult(step.stepId, { ok: true })
+
+    const state = await service.getStepState(runId, 's1')
+    assert.equal(state.status, 'succeeded')
+    assert.deepEqual(state.result, { ok: true })
+
+    const history = await service.getRunHistory(runId)
+    const latest = history.at(-1)
+    assert.equal(
+      latest?.status,
+      'succeeded',
+      'the step row says succeeded but its latest history row does not'
+    )
+    assert.deepEqual(latest?.result, { ok: true })
+    assert.ok(latest?.succeededAt, 'succeededAt was not stamped on history')
+  })
+
+  test('setStepError records the failure on both the step and its history', async () => {
+    const runId = await seedRun()
+    const step = await service.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+    await service.setStepRunning(step.stepId)
+    await service.setStepError(step.stepId, new Error('boom'))
+
+    const state = await service.getStepState(runId, 's1')
+    assert.equal(state.status, 'failed')
+    assert.equal(state.error?.message, 'boom')
+
+    const history = await service.getRunHistory(runId)
+    const latest = history.at(-1)
+    assert.equal(latest?.status, 'failed')
+    assert.equal(latest?.error?.message, 'boom')
+    assert.ok(latest?.failedAt, 'failedAt was not stamped on history')
+  })
+
+  test('a same-millisecond retry resolves the retry attempt, not the failed one', async () => {
+    const runId = await seedRun()
+    const step = await service.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+    await service.setStepRunning(step.stepId)
+    await service.setStepError(step.stepId, new Error('first'))
+
+    // No delay: both history rows land in the same millisecond, so created_at
+    // alone cannot say which is newest.
+    const retry = await service.createRetryAttempt(step.stepId, 'running')
+    await service.setStepResult(retry.stepId, { ok: true })
+
+    const history = await service.getRunHistory(runId)
+    assert.equal(history.length, 2, 'expected one attempt row plus one retry row')
+    assert.deepEqual(
+      history.map((h) => h.status),
+      ['failed', 'succeeded'],
+      `the retry resolved the wrong history row: ${JSON.stringify(
+        history.map((h) => h.status)
+      )}`
+    )
+  })
+})
+
+describe('KyselyWorkflowService — attempt counting', () => {
+  test('attemptCount tracks retries', async () => {
+    const runId = await seedRun()
+    const step = await service.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+    assert.equal((await service.getStepState(runId, 's1')).attemptCount, 1)
+
+    await service.setStepError(step.stepId, new Error('one'))
+    await service.createRetryAttempt(step.stepId, 'running')
+    assert.equal((await service.getStepState(runId, 's1')).attemptCount, 2)
+
+    await service.setStepError(step.stepId, new Error('two'))
+    const third = await service.createRetryAttempt(step.stepId, 'running')
+    assert.equal(third.attemptCount, 3)
+    assert.equal((await service.getStepState(runId, 's1')).attemptCount, 3)
+  })
+
+  test('reading a step does not touch the history table', async () => {
+    const runId = await seedRun()
+    await service.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+
+    queries.length = 0
+    await service.getStepState(runId, 's1')
+    assert.ok(
+      !queries.join('\n').includes('workflow_step_history'),
+      `the hottest read in the engine still aggregates over the history table:\n${queries.join('\n')}`
+    )
+  })
+
+  test('a replay reads every step of a run in one query', async () => {
+    const runId = await seedRun()
+    for (let i = 0; i < 6; i++) {
+      await service.insertStepState(runId, `s${i}`, 'rpc.fn', { i })
+    }
+
+    queries.length = 0
+    const steps = await (service as any).listStepStates(runId)
+    assert.equal(steps.length, 6)
+    assert.equal(
+      queries.length,
+      1,
+      `expected one query for the whole run, got ${queries.length}`
+    )
+    assert.deepEqual(
+      steps.map((s: any) => s.stepName).sort(),
+      ['s0', 's1', 's2', 's3', 's4', 's5']
+    )
+  })
+})
+
+describe('KyselyWorkflowService — run state writes', () => {
+  test('concurrent updateRunState calls for different keys do not clobber each other', async () => {
+    const runId = await seedRun('wf2')
+
+    await Promise.all([
+      service.updateRunState(runId, 'alpha', 1),
+      service.updateRunState(runId, 'beta', 2),
+      service.updateRunState(runId, 'gamma', 3),
+    ])
+
+    assert.deepEqual(
+      await service.getRunState(runId),
+      { alpha: 1, beta: 2, gamma: 3 },
+      'a concurrent read-modify-write over the whole state blob lost a key'
+    )
+  })
+
+  test('updateRunState costs a single statement', async () => {
+    const runId = await seedRun('wf3')
+    queries.length = 0
+    await service.updateRunState(runId, 'alpha', 1)
+    assert.ok(
+      queries.length <= 1,
+      `updateRunState issued ${queries.length} statements:\n${queries.join('\n')}`
+    )
+  })
+
+  test('updateRunState still replaces an existing key', async () => {
+    const runId = await seedRun('wf4')
+    await service.updateRunState(runId, 'alpha', 1)
+    await service.updateRunState(runId, 'alpha', { nested: true })
+    assert.deepEqual(await service.getRunState(runId), {
+      alpha: { nested: true },
+    })
+  })
+})
+
+describe('KyselyWorkflowService — dynamic workflow lookup', () => {
+  test('resolving one dynamic workflow does not fetch and parse every version', async () => {
+    for (let i = 0; i < 25; i++) {
+      await service.upsertWorkflowVersion(
+        `ai:agent:wf-${i}`,
+        `hash-${i}`,
+        { nodes: {}, source: 'dynamic-workflow' },
+        'dynamic-workflow'
+      )
+    }
+
+    queries.length = 0
+    const match = await service.getDynamicWorkflow('ai:agent:wf-7')
+    assert.equal(match?.graphHash, 'hash-7')
+    assert.equal(
+      queries.length,
+      1,
+      `expected a single targeted query, got ${queries.length}`
+    )
+    assert.ok(
+      queries[0]?.includes('workflow_name'),
+      `expected the query to filter by workflow_name, got: ${queries[0]}`
+    )
+  })
+
+  test('a dynamic workflow that does not exist resolves to null', async () => {
+    assert.equal(await service.getDynamicWorkflow('ai:agent:nope'), null)
+  })
+})

--- a/packages/services/kysely/src/kysely-workflow-service.test.ts
+++ b/packages/services/kysely/src/kysely-workflow-service.test.ts
@@ -123,8 +123,12 @@ describe('KyselyWorkflowService — schema indexes', () => {
     )
   })
 
-  test('init() is idempotent — a second call does not throw on existing indexes', async () => {
-    await service.init()
+  test('init() is idempotent — a second boot does not throw on existing indexes', async () => {
+    // A fresh instance, because `init()` returns at its `initialized` guard on
+    // the same one — so calling it twice re-issues no DDL and never exercises
+    // the duplicate-index path this is here to cover.
+    await new KyselyWorkflowService(db, { wireQueues: false } as any).init()
+
     const indexes = await listIndexes('workflow_step_history')
     assert.ok(indexes.length > 0)
   })
@@ -409,3 +413,95 @@ describe('KyselyWorkflowService — dynamic workflow lookup', () => {
     assert.equal(await service.getDynamicWorkflow('ai:agent:nope'), null)
   })
 })
+
+/**
+ * A step whose `current_attempt` is NULL addresses no history row, so the
+ * history half of a transition silently writes nothing while the step half
+ * commits — the divergence the transaction exists to prevent.
+ */
+describe('KyselyWorkflowService — a transition that addresses no history row', () => {
+  const orphanStep = async () => {
+    const runId = await seedRun('wf-orphan')
+    const step = await service.insertStepState(runId, 's1', 'rpc.fn', { x: 1 })
+    await sql`UPDATE workflow_step SET current_attempt = NULL WHERE workflow_step_id = ${step.stepId}`.execute(
+      db
+    )
+    return { runId, step }
+  }
+
+  test('the history still records the outcome', async () => {
+    const { runId, step } = await orphanStep()
+
+    await service.setStepResult(step.stepId, { ok: true })
+
+    const history = await service.getRunHistory(runId)
+    assert.equal(
+      history.at(-1)?.status,
+      'succeeded',
+      'the step row says succeeded but no history row does'
+    )
+    assert.deepEqual(history.at(-1)?.result, { ok: true })
+  })
+
+  test('the step is repaired, so the next transition lands in place', async () => {
+    const { runId, step } = await orphanStep()
+
+    await service.setStepRunning(step.stepId)
+    await service.setStepResult(step.stepId, { ok: true })
+
+    const history = await service.getRunHistory(runId)
+    assert.equal(
+      history.length,
+      1,
+      'each transition appended a row instead of updating the one already there'
+    )
+    assert.equal(history[0]!.status, 'succeeded')
+  })
+})
+
+/**
+ * `(workflowName, graphHash)` is the primary key, so one name can hold several
+ * rows marked `active`. Which one a lookup returns has to be a decision, not
+ * whatever order the storage engine happens to scan in.
+ */
+describe('KyselyWorkflowService — resolving a dynamic workflow', () => {
+  const publishVersion = async (graphHash: string, createdAt: Date) => {
+    await db
+      .insertInto('workflowVersions')
+      .values({
+        workflowName: 'dyn',
+        graphHash,
+        graph: JSON.stringify({ hash: graphHash }),
+        source: 'dynamic-workflow',
+        status: 'active',
+        createdAt,
+      } as any)
+      .execute()
+  }
+
+  test('the newest active version wins', async () => {
+    await publishVersion('older', new Date('2020-01-01T00:00:00Z'))
+    await publishVersion('newer', new Date('2021-01-01T00:00:00Z'))
+
+    const resolved = await service.getDynamicWorkflow('dyn')
+
+    assert.equal(
+      resolved?.graphHash,
+      'newer',
+      'an older version resolved, so a redeploy is not picked up'
+    )
+  })
+
+  test('versions sharing a timestamp still resolve to the same one twice', async () => {
+    const sameInstant = new Date('2020-01-01T00:00:00Z')
+    await publishVersion('aaa', sameInstant)
+    await publishVersion('zzz', sameInstant)
+
+    const first = await service.getDynamicWorkflow('dyn')
+    const second = await service.getDynamicWorkflow('dyn')
+
+    assert.equal(first?.graphHash, second?.graphHash)
+    assert.equal(first?.graphHash, 'zzz')
+  })
+})
+

--- a/packages/services/kysely/src/kysely-workflow-service.ts
+++ b/packages/services/kysely/src/kysely-workflow-service.ts
@@ -10,7 +10,7 @@ import {
   type WorkflowStatus,
   type WorkflowVersionStatus,
 } from '@pikku/core/workflow'
-import type { Kysely } from 'kysely'
+import { sql, type Kysely } from 'kysely'
 import type { KyselyPikkuDB } from './kysely-tables.js'
 import { KyselyWorkflowRunService } from './kysely-workflow-run-service.js'
 import { parseJson } from './kysely-json.js'
@@ -112,12 +112,13 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
         retries: stepOptions?.retries ?? null,
         retryDelay: stepOptions?.retryDelay?.toString() ?? null,
         fromStepName: fromStepName ?? null,
+        currentAttempt: 1,
         createdAt: now,
         updatedAt: now,
       })
       .execute()
 
-    await this.insertHistoryRecord(stepId, 'pending')
+    await this.insertHistoryRecord(stepId, 'pending', 1)
 
     return {
       stepId,
@@ -135,31 +136,24 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
 
   async getStepState(runId: string, stepName: string): Promise<StepState> {
     const row = await this.db
-      .selectFrom('workflowStep as s')
+      .selectFrom('workflowStep')
       .select([
-        's.workflowStepId',
-        's.status',
-        's.result',
-        's.error',
-        's.retries',
-        's.retryDelay',
-        's.fromStepName',
-        's.createdAt',
-        's.updatedAt',
+        'workflowStepId',
+        'status',
+        'result',
+        'error',
+        'retries',
+        'retryDelay',
+        'fromStepName',
+        // `current_attempt` is bumped alongside every history insert, so it is
+        // already the count this used to aggregate — and reading it keeps the
+        // engine's hottest query off a table that grows for the life of the run.
+        'currentAttempt',
+        'createdAt',
+        'updatedAt',
       ])
-      .select((eb) =>
-        eb
-          .selectFrom('workflowStepHistory')
-          .select(eb.fn.countAll<number>().as('cnt'))
-          .whereRef(
-            'workflowStepHistory.workflowStepId',
-            '=',
-            's.workflowStepId'
-          )
-          .as('attemptCount')
-      )
-      .where('s.workflowRunId', '=', runId)
-      .where('s.stepName', '=', stepName)
+      .where('workflowRunId', '=', runId)
+      .where('stepName', '=', stepName)
       .executeTakeFirst()
 
     if (!row) {
@@ -173,13 +167,49 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       status: row.status as StepState['status'],
       result: parseJson(row.result),
       error: parseJson(row.error),
-      attemptCount: Number(row.attemptCount),
+      attemptCount: Number(row.currentAttempt ?? 1),
       retries: row.retries != null ? Number(row.retries) : undefined,
       retryDelay: row.retryDelay ?? undefined,
       fromStepName: row.fromStepName ?? undefined,
       createdAt: new Date(row.createdAt),
       updatedAt: new Date(row.updatedAt),
     }
+  }
+
+  protected override async listStepStates(
+    runId: string
+  ): Promise<Array<StepState & { stepName: string }>> {
+    const rows = await this.db
+      .selectFrom('workflowStep')
+      .select([
+        'workflowStepId',
+        'stepName',
+        'status',
+        'result',
+        'error',
+        'retries',
+        'retryDelay',
+        'fromStepName',
+        'currentAttempt',
+        'createdAt',
+        'updatedAt',
+      ])
+      .where('workflowRunId', '=', runId)
+      .execute()
+
+    return rows.map((row) => ({
+      stepId: row.workflowStepId,
+      stepName: row.stepName,
+      status: row.status as StepState['status'],
+      result: parseJson(row.result),
+      error: parseJson(row.error),
+      attemptCount: Number(row.currentAttempt ?? 1),
+      retries: row.retries != null ? Number(row.retries) : undefined,
+      retryDelay: row.retryDelay ?? undefined,
+      fromStepName: row.fromStepName ?? undefined,
+      createdAt: new Date(row.createdAt),
+      updatedAt: new Date(row.updatedAt),
+    }))
   }
 
   async getRunHistory(
@@ -189,27 +219,9 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
   }
 
   protected async setStepRunningImpl(stepId: string): Promise<void> {
-    await this.db
-      .updateTable('workflowStep')
-      .set({ status: 'running', updatedAt: new Date() })
-      .where('workflowStepId', '=', stepId)
-      .execute()
-
-    const latestHistory = await this.db
-      .selectFrom('workflowStepHistory')
-      .select('historyId')
-      .where('workflowStepId', '=', stepId)
-      .orderBy('createdAt', 'desc')
-      .limit(1)
-      .executeTakeFirst()
-
-    if (latestHistory) {
-      await this.db
-        .updateTable('workflowStepHistory')
-        .set({ status: 'running', runningAt: new Date() })
-        .where('historyId', '=', latestHistory.historyId)
-        .execute()
-    }
+    await this.writeStepTransition(stepId, 'running', {
+      runningAt: new Date(),
+    })
   }
 
   protected async setStepScheduledImpl(stepId: string): Promise<void> {
@@ -220,9 +232,58 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       .execute()
   }
 
+  /**
+   * Move a step and its current history attempt to the same status in one
+   * transaction.
+   *
+   * Both halves matter: a crash between them used to leave the step row saying
+   * `succeeded` while its history row still said `running`, which silently
+   * corrupts `getRunHistory` and every timeline reconstruction built on it.
+   * The history row is targeted by its `attempt` rather than by a `LIMIT 1`
+   * over `created_at`, so a retry that lands in the same millisecond as the
+   * attempt it replaces still resolves the newer row.
+   */
+  private async writeStepTransition(
+    stepId: string,
+    status: StepStatus,
+    historyValues: Record<string, unknown>
+  ): Promise<void> {
+    const now = new Date()
+    const stepValues: Record<string, unknown> = { status, updatedAt: now }
+    if ('result' in historyValues) stepValues.result = historyValues.result
+    if ('error' in historyValues) stepValues.error = historyValues.error
+    // A step carries only its latest outcome, so the other half is cleared.
+    if (status === 'succeeded') stepValues.error = null
+    if (status === 'failed') stepValues.result = null
+
+    await this.db.transaction().execute(async (trx) => {
+      await trx
+        .updateTable('workflowStep')
+        .set(stepValues as any)
+        .where('workflowStepId', '=', stepId)
+        .execute()
+
+      await trx
+        .updateTable('workflowStepHistory')
+        .set({ status, ...historyValues } as any)
+        .where('workflowStepId', '=', stepId)
+        // Correlate through the step row rather than a MAX() over this table:
+        // MySQL rejects a subquery that reads the table being updated, and a
+        // primary-key lookup is cheaper than an aggregate anyway.
+        .where('attempt', '=', (eb) =>
+          eb
+            .selectFrom('workflowStep')
+            .select('currentAttempt')
+            .where('workflowStepId', '=', stepId)
+        )
+        .execute()
+    })
+  }
+
   private async insertHistoryRecord(
     stepId: string,
     status: string,
+    attempt: number,
     result?: any,
     error?: SerializedError
   ): Promise<void> {
@@ -231,6 +292,7 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       historyId: crypto.randomUUID(),
       workflowStepId: stepId,
       status,
+      attempt,
       result: result != null ? JSON.stringify(result) : null,
       error: error != null ? JSON.stringify(error) : null,
       createdAt: now,
@@ -280,38 +342,10 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
     stepId: string,
     result: any
   ): Promise<void> {
-    const resultJson = JSON.stringify(result)
-
-    await this.db
-      .updateTable('workflowStep')
-      .set({
-        status: 'succeeded',
-        result: resultJson,
-        error: null,
-        updatedAt: new Date(),
-      })
-      .where('workflowStepId', '=', stepId)
-      .execute()
-
-    const latestHistory = await this.db
-      .selectFrom('workflowStepHistory')
-      .select('historyId')
-      .where('workflowStepId', '=', stepId)
-      .orderBy('createdAt', 'desc')
-      .limit(1)
-      .executeTakeFirst()
-
-    if (latestHistory) {
-      await this.db
-        .updateTable('workflowStepHistory')
-        .set({
-          status: 'succeeded',
-          result: resultJson,
-          succeededAt: new Date(),
-        })
-        .where('historyId', '=', latestHistory.historyId)
-        .execute()
-    }
+    await this.writeStepTransition(stepId, 'succeeded', {
+      result: JSON.stringify(result),
+      succeededAt: new Date(),
+    })
   }
 
   protected async setStepErrorImpl(
@@ -323,73 +357,54 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       stack: error.stack,
       code: (error as any).code,
     }
-    const errorJson = JSON.stringify(serializedError)
-
-    await this.db
-      .updateTable('workflowStep')
-      .set({
-        status: 'failed',
-        error: errorJson,
-        result: null,
-        updatedAt: new Date(),
-      })
-      .where('workflowStepId', '=', stepId)
-      .execute()
-
-    const latestHistory = await this.db
-      .selectFrom('workflowStepHistory')
-      .select('historyId')
-      .where('workflowStepId', '=', stepId)
-      .orderBy('createdAt', 'desc')
-      .limit(1)
-      .executeTakeFirst()
-
-    if (latestHistory) {
-      await this.db
-        .updateTable('workflowStepHistory')
-        .set({ status: 'failed', error: errorJson, failedAt: new Date() })
-        .where('historyId', '=', latestHistory.historyId)
-        .execute()
-    }
+    await this.writeStepTransition(stepId, 'failed', {
+      error: JSON.stringify(serializedError),
+      failedAt: new Date(),
+    })
   }
 
   protected async createRetryAttemptImpl(
     stepId: string,
     status: 'pending' | 'running'
   ): Promise<StepState> {
+    // Read before writing: the new attempt number comes from the history this
+    // step already has, and the row it reads is the one returned below.
+    const previous = await this.db
+      .selectFrom('workflowStep')
+      .select('currentAttempt')
+      .where('workflowStepId', '=', stepId)
+      .executeTakeFirst()
+    const attempt = (previous?.currentAttempt ?? 0) + 1
+
     await this.db
       .updateTable('workflowStep')
-      .set({ status, result: null, error: null, updatedAt: new Date() })
+      .set({
+        status,
+        result: null,
+        error: null,
+        currentAttempt: attempt,
+        updatedAt: new Date(),
+      })
       .where('workflowStepId', '=', stepId)
       .execute()
 
-    await this.insertHistoryRecord(stepId, status)
+    await this.insertHistoryRecord(stepId, status, attempt)
 
     const row = await this.db
-      .selectFrom('workflowStep as s')
+      .selectFrom('workflowStep')
       .select([
-        's.workflowStepId',
-        's.status',
-        's.result',
-        's.error',
-        's.retries',
-        's.retryDelay',
-        's.fromStepName',
-        's.createdAt',
-        's.updatedAt',
+        'workflowStepId',
+        'status',
+        'result',
+        'error',
+        'retries',
+        'retryDelay',
+        'fromStepName',
+        'currentAttempt',
+        'createdAt',
+        'updatedAt',
       ])
-      .select((eb) =>
-        eb
-          .selectFrom('workflowStepHistory')
-          .select(eb.fn.countAll<number>().as('cnt'))
-          .whereRef(
-            'workflowStepHistory.workflowStepId',
-            '=',
-            's.workflowStepId'
-          )
-          .as('attemptCount')
-      )
-      .where('s.workflowStepId', '=', stepId)
+      .where('workflowStepId', '=', stepId)
       .executeTakeFirstOrThrow()
 
     return {
@@ -397,7 +412,7 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       status: row.status as StepState['status'],
       result: parseJson(row.result),
       error: parseJson(row.error),
-      attemptCount: Number(row.attemptCount),
+      attemptCount: Number(row.currentAttempt ?? 1),
       retries: row.retries != null ? Number(row.retries) : undefined,
       retryDelay: row.retryDelay ?? undefined,
       fromStepName: row.fromStepName ?? undefined,
@@ -526,23 +541,48 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       .execute()
   }
 
+  /**
+   * Merge one key into the run's JSON state, as a single expression evaluated
+   * by the database.
+   *
+   * The SQL is dialect-specific, so subclasses override this rather than the
+   * caller. The default is the SQLite form; MySQL and Postgres differ in how
+   * they cast a JSON literal.
+   *
+   * @param path - JSON path to the key, already quoted (`$."key"`)
+   * @param json - The value as JSON text
+   */
+  protected jsonSetState(path: string, json: string) {
+    return sql<string>`json_set(coalesce(state, '{}'), ${path}, json(${json}))`
+  }
+
+  /**
+   * A JSON path for an arbitrary key. State keys are user-supplied (a graph's
+   * `setState` name, an approval's hex-encoded reason), so the key is quoted
+   * rather than interpolated bare — an unquoted `$.a.b` would silently address
+   * a nested path instead of the key literally called `a.b`.
+   */
+  private jsonPathFor(name: string): string {
+    return `$.${JSON.stringify(name)}`
+  }
+
   protected async updateRunStateImpl(
     runId: string,
     name: string,
     value: unknown
   ): Promise<void> {
-    const row = await this.db
-      .selectFrom('workflowRuns')
-      .select('state')
-      .where('workflowRunId', '=', runId)
-      .executeTakeFirst()
-
-    const state: Record<string, unknown> = parseJson(row?.state) ?? {}
-    state[name] = value
-
+    // Merged by the database, not read-modify-written in JS: two graph nodes
+    // calling setState concurrently used to race, and the later write silently
+    // dropped whichever key the earlier one had added.
     await this.db
       .updateTable('workflowRuns')
-      .set({ state: JSON.stringify(state), updatedAt: new Date() })
+      .set({
+        state: this.jsonSetState(
+          this.jsonPathFor(name),
+          JSON.stringify(value ?? null)
+        ),
+        updatedAt: new Date(),
+      })
       .where('workflowRunId', '=', runId)
       .execute()
   }
@@ -596,6 +636,30 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
     graphHash: string
   ): Promise<{ graph: any; source: string } | null> {
     return this.runService.getWorkflowVersion(name, graphHash)
+  }
+
+  /**
+   * Resolve one dynamic workflow by name. Callers that need a single workflow
+   * used to pull every version and `.find()` through them, parsing each graph
+   * on the way past.
+   */
+  async getDynamicWorkflow(
+    name: string
+  ): Promise<{ workflowName: string; graphHash: string; graph: any } | null> {
+    const row = await this.db
+      .selectFrom('workflowVersions')
+      .select(['workflowName', 'graphHash', 'graph'])
+      .where('workflowName', '=', name)
+      .where('source', '=', 'dynamic-workflow')
+      .where('status', '=', 'active')
+      .executeTakeFirst()
+
+    if (!row) return null
+    return {
+      workflowName: row.workflowName,
+      graphHash: row.graphHash,
+      graph: parseJson(row.graph),
+    }
   }
 
   async getAIGeneratedWorkflows(

--- a/packages/services/kysely/src/kysely-workflow-service.ts
+++ b/packages/services/kysely/src/kysely-workflow-service.ts
@@ -259,11 +259,18 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
     await this.db.transaction().execute(async (trx) => {
       await trx
         .updateTable('workflowStep')
-        .set(stepValues as any)
+        .set({
+          ...stepValues,
+          // A step that somehow reaches a transition without a live attempt
+          // addresses no history row at all, so give it one here. Written as an
+          // expression over the row's own column rather than a subquery, which
+          // MySQL would reject against the table being updated.
+          currentAttempt: sql`coalesce(current_attempt, 1)`,
+        } as any)
         .where('workflowStepId', '=', stepId)
         .execute()
 
-      await trx
+      const written = await trx
         .updateTable('workflowStepHistory')
         .set({ status, ...historyValues } as any)
         .where('workflowStepId', '=', stepId)
@@ -276,7 +283,30 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
             .select('currentAttempt')
             .where('workflowStepId', '=', stepId)
         )
-        .execute()
+        .executeTakeFirst()
+
+      // Matching nothing means the attempt has no history row to move, which
+      // would commit the step's new status with no record of it — precisely
+      // the divergence this transaction exists to prevent. Write the missing
+      // row instead of letting the pair drift apart.
+      if (Number(written?.numUpdatedRows ?? 0n) === 0) {
+        const step = await trx
+          .selectFrom('workflowStep')
+          .select('currentAttempt')
+          .where('workflowStepId', '=', stepId)
+          .executeTakeFirst()
+        await trx
+          .insertInto('workflowStepHistory')
+          .values({
+            historyId: crypto.randomUUID(),
+            workflowStepId: stepId,
+            status,
+            attempt: step?.currentAttempt ?? 1,
+            createdAt: now,
+            ...historyValues,
+          } as any)
+          .execute()
+      }
     })
   }
 
@@ -652,6 +682,11 @@ export class KyselyWorkflowService extends PikkuWorkflowService {
       .where('workflowName', '=', name)
       .where('source', '=', 'dynamic-workflow')
       .where('status', '=', 'active')
+      // A name is keyed with its hash, so it can hold several active versions.
+      // Newest wins, and the hash breaks a tie between two published in the
+      // same instant — without both, which one resolves is up to the planner.
+      .orderBy('createdAt', 'desc')
+      .orderBy('graphHash', 'desc')
       .executeTakeFirst()
 
     if (!row) return null

--- a/packages/services/kysely/src/schema/workflow.schema.ts
+++ b/packages/services/kysely/src/schema/workflow.schema.ts
@@ -8,8 +8,10 @@ import type { PikkuSchema } from './pikku-schema.types.js'
  * primary keys had `defaultTo(sql.raw("'" + crypto.randomUUID() + "'"))`, which
  * evaluates once while the statement is built — every row would have taken the
  * same default, so it was never a generator; the services supply the id. And
- * `workflowStep.fromStepName` was backfilled by an `alterTable(...).catch(() =>
- * {})` bolted on after the fact, which is the job a migration does.
+ * `workflowStep.fromStepName`, `workflowStep.currentAttempt` and
+ * `workflowStepHistory.attempt` were each backfilled by an
+ * `alterTable(...).catch(() => {})` bolted on after the fact, which is the job a
+ * migration does — they are declared here and nowhere else.
  *
  * `KyselyWorkflowMirror` created these same four tables separately. There is one
  * declaration now, and both services read it.
@@ -62,6 +64,7 @@ export const workflowSchema: PikkuSchema = {
         .addColumn('retries', 'integer')
         .addColumn('retryDelay', 'text')
         .addColumn('fromStepName', 'text')
+        .addColumn('currentAttempt', 'integer')
         .addColumn('createdAt', 'timestamp', (col) =>
           col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull()
         )
@@ -86,6 +89,7 @@ export const workflowSchema: PikkuSchema = {
         .addColumn('status', 'text', (col) => col.notNull())
         .addColumn('result', 'text')
         .addColumn('error', 'text')
+        .addColumn('attempt', 'integer')
         .addColumn('createdAt', 'timestamp', (col) =>
           col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull()
         )
@@ -109,5 +113,37 @@ export const workflowSchema: PikkuSchema = {
           'workflowName',
           'graphHash',
         ]),
+
+    // The indexes trail the tables so that a table is never indexed before it
+    // exists, whatever order the declarations are read in.
+    (db) =>
+      db.schema
+        .createIndex('idx_workflow_runs_status_created')
+        .on('workflowRuns')
+        .columns(['status', 'createdAt']),
+
+    (db) =>
+      db.schema
+        .createIndex('idx_workflow_runs_workflow_created')
+        .on('workflowRuns')
+        .columns(['workflow', 'createdAt']),
+
+    (db) =>
+      db.schema
+        .createIndex('idx_workflow_step_run_status')
+        .on('workflowStep')
+        .columns(['workflowRunId', 'status']),
+
+    (db) =>
+      db.schema
+        .createIndex('idx_workflow_step_history_step')
+        .on('workflowStepHistory')
+        .columns(['workflowStepId', 'createdAt']),
+
+    (db) =>
+      db.schema
+        .createIndex('idx_workflow_versions_source_status')
+        .on('workflowVersions')
+        .columns(['source', 'status']),
   ],
 }

--- a/packages/services/mongodb/src/mongodb-workflow-service.test.ts
+++ b/packages/services/mongodb/src/mongodb-workflow-service.test.ts
@@ -119,3 +119,46 @@ describe('a step transition reaches the history', () => {
     assert.equal(state.attemptCount, 2)
   })
 })
+
+/**
+ * `findOne` with no sort returns whatever the storage engine reaches first, so
+ * a name holding several active versions resolved unpredictably.
+ */
+describe('resolving a dynamic workflow', () => {
+  const publishVersion = async (graphHash: string, createdAt: Date) => {
+    await ws.upsertWorkflowVersion(
+      'dyn',
+      graphHash,
+      { hash: graphHash },
+      'ai-agent'
+    )
+    await db
+      .collection('workflowVersions')
+      .updateOne({ workflowName: 'dyn', graphHash }, { $set: { createdAt } })
+  }
+
+  test('the newest active version wins', async () => {
+    await publishVersion('older', new Date('2020-01-01T00:00:00Z'))
+    await publishVersion('newer', new Date('2021-01-01T00:00:00Z'))
+
+    const resolved = await ws.getDynamicWorkflow('dyn')
+
+    assert.equal(
+      resolved?.graphHash,
+      'newer',
+      'an older version resolved, so a redeploy is not picked up'
+    )
+  })
+
+  test('versions sharing a timestamp resolve to the same one twice', async () => {
+    const sameInstant = new Date('2020-01-01T00:00:00Z')
+    await publishVersion('aaa', sameInstant)
+    await publishVersion('zzz', sameInstant)
+
+    const first = await ws.getDynamicWorkflow('dyn')
+    const second = await ws.getDynamicWorkflow('dyn')
+
+    assert.equal(first?.graphHash, second?.graphHash)
+    assert.equal(first?.graphHash, 'zzz')
+  })
+})

--- a/packages/services/mongodb/src/mongodb-workflow-service.test.ts
+++ b/packages/services/mongodb/src/mongodb-workflow-service.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { MongoClient, type Db } from 'mongodb'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+
+import { MongoDBWorkflowService } from './mongodb-workflow-service.js'
+
+let mongod: MongoMemoryServer
+let client: MongoClient
+let db: Db
+let ws: MongoDBWorkflowService
+let dbCount = 0
+
+before(async () => {
+  mongod = await MongoMemoryServer.create()
+  client = new MongoClient(mongod.getUri())
+  await client.connect()
+})
+
+after(async () => {
+  await client?.close()
+  await mongod?.stop()
+})
+
+beforeEach(async () => {
+  db = client.db(`wf-${++dbCount}`)
+  ws = new MongoDBWorkflowService(db)
+  await ws.init()
+})
+
+const seedStep = async () => {
+  const runId = await ws.createRun('flow', {}, false, 'hash', {
+    type: 'test',
+  } as any)
+  const step = await ws.insertStepState(runId, 'step-1', 'rpc.fn', { x: 1 })
+  return { runId, step }
+}
+
+/** The history rows of a run, oldest first. */
+const historyOf = async (runId: string) => ws.getRunHistory(runId)
+
+describe('a step transition reaches the history', () => {
+  test('running stamps the attempt it is running', async () => {
+    const { runId, step } = await seedStep()
+
+    await ws.setStepRunning(step.stepId)
+
+    const [attempt] = await historyOf(runId)
+    assert.equal(attempt!.status, 'running')
+    assert.ok(attempt!.runningAt, 'no runningAt, so the step has no duration')
+  })
+
+  test('scheduled stamps the attempt it is queueing', async () => {
+    const { runId, step } = await seedStep()
+
+    await ws.setStepScheduled(step.stepId)
+
+    const [attempt] = await historyOf(runId)
+    assert.equal(
+      attempt!.status,
+      'scheduled',
+      'the history still says pending, so a queued step reads as never dispatched'
+    )
+    assert.ok(attempt!.scheduledAt, 'no scheduledAt on the queued attempt')
+  })
+
+  test('succeeded carries the result', async () => {
+    const { runId, step } = await seedStep()
+
+    await ws.setStepRunning(step.stepId)
+    await ws.setStepResult(step.stepId, { ok: true })
+
+    const [attempt] = await historyOf(runId)
+    assert.equal(attempt!.status, 'succeeded')
+    assert.deepEqual(attempt!.result, { ok: true })
+    assert.ok(attempt!.succeededAt)
+  })
+
+  test('failed carries the error', async () => {
+    const { runId, step } = await seedStep()
+
+    await ws.setStepRunning(step.stepId)
+    await ws.setStepError(step.stepId, new Error('exploded'))
+
+    const [attempt] = await historyOf(runId)
+    assert.equal(attempt!.status, 'failed')
+    assert.equal(attempt!.error?.message, 'exploded')
+    assert.ok(attempt!.failedAt)
+  })
+
+  test('a retry writes to the new attempt, leaving the failed one intact', async () => {
+    const { runId, step } = await seedStep()
+
+    await ws.setStepRunning(step.stepId)
+    await ws.setStepError(step.stepId, new Error('first go'))
+    await ws.createRetryAttempt(step.stepId, 'pending')
+    await ws.setStepRunning(step.stepId)
+    await ws.setStepResult(step.stepId, 'second go')
+
+    const history = await historyOf(runId)
+    assert.equal(history.length, 2)
+    assert.equal(history[0]!.status, 'failed')
+    assert.equal(history[0]!.error?.message, 'first go')
+    assert.equal(history[1]!.status, 'succeeded')
+    assert.equal(history[1]!.result, 'second go')
+  })
+
+  test('the step row keeps only its latest outcome', async () => {
+    const { runId, step } = await seedStep()
+
+    await ws.setStepError(step.stepId, new Error('first go'))
+    await ws.createRetryAttempt(step.stepId, 'pending')
+    await ws.setStepResult(step.stepId, 'second go')
+
+    const state = await ws.getStepState(runId, 'step-1')
+    assert.equal(state.status, 'succeeded')
+    assert.equal(state.result, 'second go')
+    assert.equal(state.error, undefined)
+    assert.equal(state.attemptCount, 2)
+  })
+})

--- a/packages/services/mongodb/src/mongodb-workflow-service.ts
+++ b/packages/services/mongodb/src/mongodb-workflow-service.ts
@@ -622,6 +622,22 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
     return this.runService.getWorkflowVersion(name, graphHash)
   }
 
+  override async getDynamicWorkflow(
+    name: string
+  ): Promise<{ workflowName: string; graphHash: string; graph: any } | null> {
+    const doc = await this.versions.findOne({
+      workflowName: name,
+      source: 'ai-agent',
+      status: 'active',
+    })
+    if (!doc) return null
+    return {
+      workflowName: doc.workflowName,
+      graphHash: doc.graphHash,
+      graph: doc.graph,
+    }
+  }
+
   async getAIGeneratedWorkflows(
     agentName?: string
   ): Promise<Array<{ workflowName: string; graphHash: string; graph: any }>> {

--- a/packages/services/mongodb/src/mongodb-workflow-service.ts
+++ b/packages/services/mongodb/src/mongodb-workflow-service.ts
@@ -255,25 +255,42 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
       { _id: stepId },
       { $set: { status: 'running', updatedAt: new Date() } }
     )
-
-    const latestHistory = await this.stepHistory
-      .find({ workflowStepId: stepId })
-      .sort({ createdAt: -1 })
-      .limit(1)
-      .toArray()
-
-    if (latestHistory.length > 0) {
-      await this.stepHistory.updateOne(
-        { _id: latestHistory[0]!._id },
-        { $set: { status: 'running', runningAt: new Date() } }
-      )
-    }
+    await this.writeLatestHistory(stepId, 'running')
   }
 
   protected async setStepScheduledImpl(stepId: string): Promise<void> {
     await this.steps.updateOne(
       { _id: stepId },
       { $set: { status: 'scheduled', updatedAt: new Date() } }
+    )
+    await this.writeLatestHistory(stepId, 'scheduled')
+  }
+
+  /**
+   * Move the current attempt of a step's history to a status.
+   *
+   * Finding the newest attempt and then updating it by `_id` was two round
+   * trips with a window in between; `findOneAndUpdate` applies the same sort
+   * server-side and writes the row it selected, so nothing can move underneath
+   * it. The attempt is still identified by `createdAt` because Mongo keeps no
+   * attempt number — see `getStepState`, which counts history documents.
+   */
+  private async writeLatestHistory(
+    stepId: string,
+    status: string,
+    values: Record<string, unknown> = {}
+  ): Promise<void> {
+    const now = new Date()
+    const update: Record<string, unknown> = { status, ...values }
+    const timestampField = this.getTimestampFieldForStatus(status)
+    if (timestampField !== 'createdAt') {
+      update[timestampField] = now
+    }
+
+    await this.stepHistory.findOneAndUpdate(
+      { workflowStepId: stepId },
+      { $set: update as any },
+      { sort: { createdAt: -1 } }
     )
   }
 
@@ -351,18 +368,7 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
       }
     )
 
-    const latestHistory = await this.stepHistory
-      .find({ workflowStepId: stepId })
-      .sort({ createdAt: -1 })
-      .limit(1)
-      .toArray()
-
-    if (latestHistory.length > 0) {
-      await this.stepHistory.updateOne(
-        { _id: latestHistory[0]!._id },
-        { $set: { status: 'succeeded', result, succeededAt: new Date() } }
-      )
-    }
+    await this.writeLatestHistory(stepId, 'succeeded', { result })
   }
 
   protected async setStepErrorImpl(
@@ -387,18 +393,9 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
       }
     )
 
-    const latestHistory = await this.stepHistory
-      .find({ workflowStepId: stepId })
-      .sort({ createdAt: -1 })
-      .limit(1)
-      .toArray()
-
-    if (latestHistory.length > 0) {
-      await this.stepHistory.updateOne(
-        { _id: latestHistory[0]!._id },
-        { $set: { status: 'failed', error: serializedError, failedAt: new Date() } }
-      )
-    }
+    await this.writeLatestHistory(stepId, 'failed', {
+      error: serializedError,
+    })
   }
 
   protected async createRetryAttemptImpl(
@@ -508,7 +505,9 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
     return nodeIds.filter((id) => !existingStepNames.has(id))
   }
 
-  async getStepInstances(runId: string): Promise<
+  async getStepInstances(
+    runId: string
+  ): Promise<
     Array<{ stepName: string; status: StepStatus; fromStepName?: string }>
   > {
     const rows = await this.steps

--- a/packages/services/mongodb/src/mongodb-workflow-service.ts
+++ b/packages/services/mongodb/src/mongodb-workflow-service.ts
@@ -624,11 +624,16 @@ export class MongoDBWorkflowService extends PikkuWorkflowService {
   override async getDynamicWorkflow(
     name: string
   ): Promise<{ workflowName: string; graphHash: string; graph: any } | null> {
-    const doc = await this.versions.findOne({
-      workflowName: name,
-      source: 'ai-agent',
-      status: 'active',
-    })
+    const doc = await this.versions.findOne(
+      {
+        workflowName: name,
+        source: 'ai-agent',
+        status: 'active',
+      },
+      // A name can hold several active versions; newest wins, with the hash
+      // breaking a tie between two published in the same instant.
+      { sort: { createdAt: -1, graphHash: -1 } }
+    )
     if (!doc) return null
     return {
       workflowName: doc.workflowName,

--- a/packages/services/redis/src/redis-workflow-service.test.ts
+++ b/packages/services/redis/src/redis-workflow-service.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import Redis from 'ioredis-mock'
+
+import { RedisWorkflowService } from './redis-workflow-service.js'
+
+let ws: RedisWorkflowService
+let redis: any
+
+const newRun = () =>
+  ws.createRun('flow', {}, false, 'hash', { type: 'test' } as any)
+
+beforeEach(() => {
+  redis = new Redis()
+  ws = new RedisWorkflowService(redis)
+})
+
+afterEach(() => {
+  redis.disconnect()
+})
+
+describe('workflow run state in redis', () => {
+  test('two branches setting different keys both survive', async () => {
+    const runId = await newRun()
+
+    await Promise.all([
+      ws.updateRunState(runId, 'left', 'a'),
+      ws.updateRunState(runId, 'right', 'b'),
+    ])
+
+    assert.deepEqual(
+      await ws.getRunState(runId),
+      { left: 'a', right: 'b' },
+      'a parallel branch overwrote the other branch’s state'
+    )
+  })
+
+  test('many concurrent writers all land', async () => {
+    const runId = await newRun()
+    const keys = Array.from({ length: 20 }, (_, i) => `k${i}`)
+
+    await Promise.all(keys.map((k, i) => ws.updateRunState(runId, k, i)))
+
+    const state = await ws.getRunState(runId)
+    assert.equal(Object.keys(state).length, keys.length)
+    keys.forEach((k, i) => assert.equal(state[k], i))
+  })
+
+  test('an empty array stays an array when another key is written', async () => {
+    const runId = await newRun()
+
+    await ws.updateRunState(runId, 'items', [])
+    await ws.updateRunState(runId, 'count', 0)
+
+    const state = await ws.getRunState(runId)
+    assert.ok(
+      Array.isArray(state.items),
+      `an empty array came back as ${JSON.stringify(state.items)}`
+    )
+    assert.equal(state.count, 0)
+  })
+
+  test('values keep their types, including null and nested objects', async () => {
+    const runId = await newRun()
+
+    await ws.updateRunState(runId, 'nothing', null)
+    await ws.updateRunState(runId, 'nested', { a: [1, { b: true }] })
+    await ws.updateRunState(runId, 'flag', false)
+
+    assert.deepEqual(await ws.getRunState(runId), {
+      nothing: null,
+      nested: { a: [1, { b: true }] },
+      flag: false,
+    })
+  })
+
+  test('a later write to the same key replaces it', async () => {
+    const runId = await newRun()
+
+    await ws.updateRunState(runId, 'attempt', 1)
+    await ws.updateRunState(runId, 'attempt', 2)
+
+    assert.deepEqual(await ws.getRunState(runId), { attempt: 2 })
+  })
+
+  test('the state of a run that has none is empty', async () => {
+    assert.deepEqual(await ws.getRunState(await newRun()), {})
+  })
+
+  test('state written before the per-key layout is still readable', async () => {
+    const runId = await newRun()
+    const redis = (ws as any).redis
+    await redis.hset(
+      (ws as any).runKey(runId),
+      'state',
+      JSON.stringify({ legacy: 'kept', shared: 'old' })
+    )
+
+    assert.deepEqual(await ws.getRunState(runId), {
+      legacy: 'kept',
+      shared: 'old',
+    })
+
+    await ws.updateRunState(runId, 'shared', 'new')
+    await ws.updateRunState(runId, 'fresh', 1)
+
+    assert.deepEqual(
+      await ws.getRunState(runId),
+      { legacy: 'kept', shared: 'new', fresh: 1 },
+      'a run in flight across the deploy lost the state it already had'
+    )
+  })
+})

--- a/packages/services/redis/src/redis-workflow-service.test.ts
+++ b/packages/services/redis/src/redis-workflow-service.test.ts
@@ -4,6 +4,8 @@ import Redis from 'ioredis-mock'
 
 import { RedisWorkflowService } from './redis-workflow-service.js'
 
+const KEY_PREFIX = 'workflows'
+
 let ws: RedisWorkflowService
 let redis: any
 
@@ -12,7 +14,7 @@ const newRun = () =>
 
 beforeEach(() => {
   redis = new Redis()
-  ws = new RedisWorkflowService(redis)
+  ws = new RedisWorkflowService(redis, KEY_PREFIX)
 })
 
 afterEach(() => {
@@ -134,7 +136,7 @@ describe('resolving a dynamic workflow', () => {
       'ai-agent'
     )
     await redis.hset(
-      `pikku:version:${name}:${graphHash}`,
+      `${KEY_PREFIX}:version:${name}:${graphHash}`,
       'createdAt',
       String(createdAt)
     )

--- a/packages/services/redis/src/redis-workflow-service.test.ts
+++ b/packages/services/redis/src/redis-workflow-service.test.ts
@@ -111,3 +111,56 @@ describe('workflow run state in redis', () => {
     )
   })
 })
+
+/**
+ * SCAN promises no ordering, so a name holding several active versions used to
+ * resolve to whichever key the scan happened to yield first.
+ */
+describe('resolving a dynamic workflow', () => {
+  // ioredis-mock shares one store between instances constructed alike, so the
+  // per-test `new Redis()` does not isolate keys. A name per test does.
+  let names = 0
+  let name = 'dyn'
+
+  beforeEach(() => {
+    name = `dyn-${++names}`
+  })
+
+  const publishVersion = async (graphHash: string, createdAt: number) => {
+    await ws.upsertWorkflowVersion(
+      name,
+      graphHash,
+      { hash: graphHash },
+      'ai-agent'
+    )
+    await redis.hset(
+      `pikku:version:${name}:${graphHash}`,
+      'createdAt',
+      String(createdAt)
+    )
+  }
+
+  test('the newest active version wins', async () => {
+    await publishVersion('older', 1_000)
+    await publishVersion('newer', 2_000)
+
+    const resolved = await ws.getDynamicWorkflow(name)
+
+    assert.equal(
+      resolved?.graphHash,
+      'newer',
+      'an older version resolved, so a redeploy is not picked up'
+    )
+  })
+
+  test('versions sharing a timestamp resolve to the same one twice', async () => {
+    await publishVersion('aaa', 1_000)
+    await publishVersion('zzz', 1_000)
+
+    const first = await ws.getDynamicWorkflow(name)
+    const second = await ws.getDynamicWorkflow(name)
+
+    assert.equal(first?.graphHash, second?.graphHash)
+    assert.equal(first?.graphHash, 'zzz')
+  })
+})

--- a/packages/services/redis/src/redis-workflow-service.ts
+++ b/packages/services/redis/src/redis-workflow-service.ts
@@ -840,7 +840,9 @@ export class RedisWorkflowService extends PikkuWorkflowService {
     return result
   }
 
-  async getStepInstances(runId: string): Promise<
+  async getStepInstances(
+    runId: string
+  ): Promise<
     Array<{ stepName: string; status: StepStatus; fromStepName?: string }>
   > {
     const instances: Array<{
@@ -920,37 +922,50 @@ export class RedisWorkflowService extends PikkuWorkflowService {
     )
   }
 
+  /**
+   * Hash holding one field per state variable of a run.
+   *
+   * The whole state used to be a single JSON blob on the run hash, which made
+   * every write a read-modify-write: two parallel branches each setting their
+   * own variable would both read the blob, add their key, and write it back,
+   * so whichever wrote second silently dropped the other's variable.
+   */
+  private runStateKey(runId: string): string {
+    return `${this.keyPrefix}:run-state:${runId}`
+  }
+
   protected async updateRunStateImpl(
     runId: string,
     name: string,
     value: unknown
   ): Promise<void> {
-    const key = this.runKey(runId)
-    const now = Date.now()
-
-    // Get existing state or create empty object
-    const existingState = await this.redis.hget(key, 'state')
-    const state = existingState ? JSON.parse(existingState) : {}
-
-    // Update the specific field
-    state[name] = value
-
-    await this.redis.hmset(
-      key,
-      'state',
-      JSON.stringify(state),
+    // HSET touches only the field it is named, so concurrent writers to
+    // different variables no longer race, and nothing has to parse and
+    // re-encode the values it is not writing.
+    await this.redis.hset(
+      this.runStateKey(runId),
+      name,
+      JSON.stringify(value) ?? 'null'
+    )
+    await this.redis.hset(
+      this.runKey(runId),
       'updatedAt',
-      now.toString()
+      Date.now().toString()
     )
   }
 
   async getRunState(runId: string): Promise<Record<string, unknown>> {
-    const key = this.runKey(runId)
-    const stateStr = await this.redis.hget(key, 'state')
-    if (!stateStr) {
-      return {}
+    // The blob is what a run started before the per-key layout still holds; a
+    // field written since wins, so a run in flight across the deploy keeps
+    // everything it had.
+    const blob = await this.redis.hget(this.runKey(runId), 'state')
+    const state: Record<string, unknown> = blob ? JSON.parse(blob) : {}
+
+    const fields = await this.redis.hgetall(this.runStateKey(runId))
+    for (const [name, value] of Object.entries(fields)) {
+      state[name] = JSON.parse(value)
     }
-    return JSON.parse(stateStr)
+    return state
   }
 
   private versionKey(name: string, graphHash: string): string {

--- a/packages/services/redis/src/redis-workflow-service.ts
+++ b/packages/services/redis/src/redis-workflow-service.ts
@@ -1031,6 +1031,11 @@ export class RedisWorkflowService extends PikkuWorkflowService {
     const escaped = name.replace(/[?*[\]\\]/g, (ch) => `\\${ch}`)
     const pattern = `${this.keyPrefix}:version:${escaped}:*`
     let cursor = '0'
+    const candidates: Array<{
+      graphHash: string
+      graph: any
+      createdAt: number
+    }> = []
     do {
       const [nextCursor, keys] = await this.redis.scan(
         cursor,
@@ -1049,14 +1054,30 @@ export class RedisWorkflowService extends PikkuWorkflowService {
         )
           continue
         if (data.workflowName !== name || !data.graphHash) continue
-        return {
-          workflowName: name,
+        candidates.push({
           graphHash: data.graphHash,
           graph: JSON.parse(data.graph),
-        }
+          createdAt: Number(data.createdAt ?? 0),
+        })
       }
     } while (cursor !== '0')
-    return null
+
+    if (candidates.length === 0) return null
+
+    // A name can hold several active versions, and SCAN promises no order, so
+    // taking the first key it yielded meant the version that resolved could
+    // change between two calls reading identical data. Newest wins, with the
+    // hash breaking a tie between two written in the same millisecond.
+    candidates.sort(
+      (a, b) =>
+        b.createdAt - a.createdAt || b.graphHash.localeCompare(a.graphHash)
+    )
+    const winner = candidates[0]!
+    return {
+      workflowName: name,
+      graphHash: winner.graphHash,
+      graph: winner.graph,
+    }
   }
 
   async getAIGeneratedWorkflows(

--- a/packages/services/redis/src/redis-workflow-service.ts
+++ b/packages/services/redis/src/redis-workflow-service.ts
@@ -1007,6 +1007,43 @@ export class RedisWorkflowService extends PikkuWorkflowService {
     }
   }
 
+  override async getDynamicWorkflow(
+    name: string
+  ): Promise<{ workflowName: string; graphHash: string; graph: any } | null> {
+    // Versions are keyed `…:version:<name>:<hash>`, so one name still means a
+    // scan — but over that name's handful of hashes rather than over every
+    // dynamic workflow in the deployment.
+    const escaped = name.replace(/[?*[\]\\]/g, (ch) => `\\${ch}`)
+    const pattern = `${this.keyPrefix}:version:${escaped}:*`
+    let cursor = '0'
+    do {
+      const [nextCursor, keys] = await this.redis.scan(
+        cursor,
+        'MATCH',
+        pattern,
+        'COUNT',
+        100
+      )
+      cursor = nextCursor
+      for (const key of keys) {
+        const data = await this.redis.hgetall(key)
+        if (
+          !data.graph ||
+          data.source !== 'ai-agent' ||
+          data.status !== 'active'
+        )
+          continue
+        if (data.workflowName !== name || !data.graphHash) continue
+        return {
+          workflowName: name,
+          graphHash: data.graphHash,
+          graph: JSON.parse(data.graph),
+        }
+      }
+    } while (cursor !== '0')
+    return null
+  }
+
   async getAIGeneratedWorkflows(
     agentName?: string
   ): Promise<Array<{ workflowName: string; graphHash: string; graph: any }>> {

--- a/packages/services/redis/src/redis-workflow-service.ts
+++ b/packages/services/redis/src/redis-workflow-service.ts
@@ -42,9 +42,17 @@ export class RedisWorkflowService extends PikkuWorkflowService {
     super(options)
     this.keyPrefix = keyPrefix
 
-    // Check if it's a Redis instance or config options
-    if (connectionOrConfig instanceof Redis) {
-      this.redis = connectionOrConfig
+    // An already-connected client is recognised by the commands it exposes
+    // rather than by `instanceof Redis`, so a compatible client that is not an
+    // ioredis subclass — a test double, a wrapper — is used as given instead of
+    // being silently ignored in favour of a fresh connection to localhost.
+    if (
+      typeof connectionOrConfig === 'object' &&
+      connectionOrConfig !== null &&
+      'hgetall' in connectionOrConfig &&
+      'hset' in connectionOrConfig
+    ) {
+      this.redis = connectionOrConfig as Redis
       this.ownsConnection = false
     } else {
       this.redis = new Redis(connectionOrConfig as any)

--- a/verifiers/workflows/package.json
+++ b/verifiers/workflows/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@pikku/core": "workspace:*",
     "@pikku/kysely": "workspace:*",
+    "@pikku/kysely-postgres": "workspace:*",
     "@pikku/queue-bullmq": "workspace:*",
     "@pikku/queue-pg-boss": "workspace:*",
     "@pikku/redis": "workspace:*",

--- a/verifiers/workflows/src/runners/cyclic-graph.runner.ts
+++ b/verifiers/workflows/src/runners/cyclic-graph.runner.ts
@@ -13,7 +13,7 @@
  *      terminal node reproduces the exact walked path, cycle included.
  *
  * Usage:
- *   yarn test:cyclic-graph:pg      # pg-boss + Postgres (KyselyWorkflowService)
+ *   yarn test:cyclic-graph:pg      # pg-boss + Postgres (PgKyselyWorkflowService)
  *   yarn test:cyclic-graph:redis   # bullmq + Redis (RedisWorkflowService)
  */
 
@@ -44,7 +44,7 @@ async function setup(backend: Backend): Promise<{
   const config = await createConfig()
 
   if (backend === 'pg') {
-    const { KyselyWorkflowService } = await import('@pikku/kysely')
+    const { PgKyselyWorkflowService } = await import('@pikku/kysely-postgres')
     const { PgBossServiceFactory } = await import('@pikku/queue-pg-boss')
     const { Kysely, CamelCasePlugin } = await import('kysely')
     const { PostgresJSDialect } = await import('kysely-postgres-js')
@@ -60,7 +60,7 @@ async function setup(backend: Backend): Promise<{
       dialect: new PostgresJSDialect({ postgres: sql }),
       plugins: [new CamelCasePlugin()],
     })
-    const workflowService = new KyselyWorkflowService(db)
+    const workflowService = new PgKyselyWorkflowService(db)
     await workflowService.init()
 
     const singletonServices = await createSingletonServices(config, {
@@ -181,7 +181,9 @@ function assertAllNodesCorrect(steps: HistoryStep[]): void {
   }
 
   // The provenance chain reconstructs the exact walked path, cycle included.
-  const from = new Map(steps.map((s) => [s.stepName, s.fromStepName ?? undefined]))
+  const from = new Map(
+    steps.map((s) => [s.stepName, s.fromStepName ?? undefined])
+  )
   const path: string[] = []
   let cursor: string | undefined = 'finish'
   while (cursor) {
@@ -271,107 +273,102 @@ async function main(): Promise<void> {
 
   let queuedNodes: ReturnType<typeof normalizeNodes> | null = null
 
-  await test(
-    'QUEUED cyclic graph: every node is correct (status, result, provenance)',
-    async () => {
-      const { status, runId } = await runQueued('graphCyclicRetry', {
-        attempts: 3,
-      })
-      assert(status === 'completed', `expected completed, got ${status}`)
-      const steps = (await workflowService.getRunHistory(runId)) as HistoryStep[]
-      assertAllNodesCorrect(steps)
-      queuedNodes = normalizeNodes(steps)
-    }
-  )
+  await test('QUEUED cyclic graph: every node is correct (status, result, provenance)', async () => {
+    const { status, runId } = await runQueued('graphCyclicRetry', {
+      attempts: 3,
+    })
+    assert(status === 'completed', `expected completed, got ${status}`)
+    const steps = (await workflowService.getRunHistory(runId)) as HistoryStep[]
+    assertAllNodesCorrect(steps)
+    queuedNodes = normalizeNodes(steps)
+  })
 
-  await test(
-    'INLINE cyclic graph: every node is correct (proves inline supports cycles)',
-    async () => {
-      const { status, runId } = await runInline('graphCyclicRetry', {
-        attempts: 3,
-      })
-      assert(status === 'completed', `expected completed, got ${status}`)
-      const steps = (await workflowService.getRunHistory(runId)) as HistoryStep[]
-      assertAllNodesCorrect(steps)
-    }
-  )
+  await test('INLINE cyclic graph: every node is correct (proves inline supports cycles)', async () => {
+    const { status, runId } = await runInline('graphCyclicRetry', {
+      attempts: 3,
+    })
+    assert(status === 'completed', `expected completed, got ${status}`)
+    const steps = (await workflowService.getRunHistory(runId)) as HistoryStep[]
+    assertAllNodesCorrect(steps)
+  })
 
-  await test(
-    'INLINE and QUEUED produce byte-identical node state (transport independence)',
-    async () => {
-      assert(queuedNodes !== null, 'queued run did not record node state')
-      const { status, runId } = await runInline('graphCyclicRetry', {
-        attempts: 3,
-      })
-      assert(status === 'completed', `expected completed, got ${status}`)
-      const steps = (await workflowService.getRunHistory(runId)) as HistoryStep[]
-      const inlineNodes = normalizeNodes(steps)
-      assert(
-        JSON.stringify(inlineNodes) === JSON.stringify(queuedNodes),
-        `inline vs queued node state diverged\n  inline: ${JSON.stringify(inlineNodes)}\n  queued: ${JSON.stringify(queuedNodes)}`
-      )
-    }
-  )
+  await test('INLINE and QUEUED produce byte-identical node state (transport independence)', async () => {
+    assert(queuedNodes !== null, 'queued run did not record node state')
+    const { status, runId } = await runInline('graphCyclicRetry', {
+      attempts: 3,
+    })
+    assert(status === 'completed', `expected completed, got ${status}`)
+    const steps = (await workflowService.getRunHistory(runId)) as HistoryStep[]
+    const inlineNodes = normalizeNodes(steps)
+    assert(
+      JSON.stringify(inlineNodes) === JSON.stringify(queuedNodes),
+      `inline vs queued node state diverged\n  inline: ${JSON.stringify(inlineNodes)}\n  queued: ${JSON.stringify(queuedNodes)}`
+    )
+  })
 
-  await test(
-    'TIMELINE time-travel reconstructs run state at any point (cycle included)',
-    async () => {
-      const { status, runId } = await runInline('graphCyclicRetry', {
-        attempts: 3,
-      })
-      assert(status === 'completed', `expected completed, got ${status}`)
+  await test('TIMELINE time-travel reconstructs run state at any point (cycle included)', async () => {
+    const { status, runId } = await runInline('graphCyclicRetry', {
+      attempts: 3,
+    })
+    assert(status === 'completed', `expected completed, got ${status}`)
 
-      // Final state: the reconstructed path + results must match EXPECTED_NODES
-      // exactly — same durable history the provenance test reads, now folded.
-      const final = await workflowService.reconstructRunStateAt(runId)
-      assert(final !== null, 'reconstructRunStateAt returned null for a real run')
+    // Final state: the reconstructed path + results must match EXPECTED_NODES
+    // exactly — same durable history the provenance test reads, now folded.
+    const final = await workflowService.reconstructRunStateAt(runId)
+    assert(final !== null, 'reconstructRunStateAt returned null for a real run')
+    assert(
+      JSON.stringify(final!.path) ===
+        JSON.stringify([
+          'begin',
+          'attempt',
+          'attempt#1',
+          'attempt#2',
+          'finish',
+        ]),
+      `final path mismatch, got ${JSON.stringify(final!.path)}`
+    )
+    for (const [name, expected] of Object.entries(EXPECTED_NODES)) {
       assert(
-        JSON.stringify(final!.path) ===
-          JSON.stringify(['begin', 'attempt', 'attempt#1', 'attempt#2', 'finish']),
-        `final path mismatch, got ${JSON.stringify(final!.path)}`
-      )
-      for (const [name, expected] of Object.entries(EXPECTED_NODES)) {
-        assert(
-          JSON.stringify(final!.results[name]) === JSON.stringify(expected.result),
-          `final result for '${name}' mismatch — expected ${JSON.stringify(expected.result)}, got ${JSON.stringify(final!.results[name])}`
-        )
-      }
-
-      // Time-travel: rewind to the instant the 2nd cycle pass (attempt#1) is
-      // created. begin + attempt have succeeded; attempt#1 is freshly pending;
-      // attempt#2 and finish do not exist yet.
-      const timeline = await workflowService.getRunTimeline(runId)
-      assert(timeline !== null, 'getRunTimeline returned null for a real run')
-      const created = timeline!.find(
-        (e) => e.type === 'pending' && e.stepName === 'attempt#1'
-      )
-      assert(created !== undefined, 'no created event for attempt#1')
-      const mid = await workflowService.reconstructRunStateAt(runId, created!.seq)
-      assert(
-        JSON.stringify(mid!.path) ===
-          JSON.stringify(['begin', 'attempt', 'attempt#1']),
-        `mid-run path mismatch, got ${JSON.stringify(mid!.path)}`
-      )
-      const attempt1 = mid!.steps.find((s) => s.stepName === 'attempt#1')!
-      assert(
-        attempt1.status === 'pending',
-        `attempt#1 should be pending mid-run, got ${attempt1.status}`
-      )
-      assert(
-        mid!.phase === 'running',
-        `mid-run phase should be running, got ${mid!.phase}`
-      )
-      assert(
-        mid!.results.begin !== undefined && mid!.results.attempt !== undefined,
-        'begin + attempt results must be in the replay cache mid-run'
-      )
-      assert(
-        mid!.results['attempt#1'] === undefined &&
-          mid!.results.finish === undefined,
-        'future steps must NOT be in the replay cache mid-run'
+        JSON.stringify(final!.results[name]) ===
+          JSON.stringify(expected.result),
+        `final result for '${name}' mismatch — expected ${JSON.stringify(expected.result)}, got ${JSON.stringify(final!.results[name])}`
       )
     }
-  )
+
+    // Time-travel: rewind to the instant the 2nd cycle pass (attempt#1) is
+    // created. begin + attempt have succeeded; attempt#1 is freshly pending;
+    // attempt#2 and finish do not exist yet.
+    const timeline = await workflowService.getRunTimeline(runId)
+    assert(timeline !== null, 'getRunTimeline returned null for a real run')
+    const created = timeline!.find(
+      (e) => e.type === 'pending' && e.stepName === 'attempt#1'
+    )
+    assert(created !== undefined, 'no created event for attempt#1')
+    const mid = await workflowService.reconstructRunStateAt(runId, created!.seq)
+    assert(
+      JSON.stringify(mid!.path) ===
+        JSON.stringify(['begin', 'attempt', 'attempt#1']),
+      `mid-run path mismatch, got ${JSON.stringify(mid!.path)}`
+    )
+    const attempt1 = mid!.steps.find((s) => s.stepName === 'attempt#1')!
+    assert(
+      attempt1.status === 'pending',
+      `attempt#1 should be pending mid-run, got ${attempt1.status}`
+    )
+    assert(
+      mid!.phase === 'running',
+      `mid-run phase should be running, got ${mid!.phase}`
+    )
+    assert(
+      mid!.results.begin !== undefined && mid!.results.attempt !== undefined,
+      'begin + attempt results must be in the replay cache mid-run'
+    )
+    assert(
+      mid!.results['attempt#1'] === undefined &&
+        mid!.results.finish === undefined,
+      'future steps must NOT be in the replay cache mid-run'
+    )
+  })
 
   console.log('\n=== Summary ===')
   const passed = results.filter((r) => r.ok).length

--- a/verifiers/workflows/src/runners/function-versioning.runner.ts
+++ b/verifiers/workflows/src/runners/function-versioning.runner.ts
@@ -29,7 +29,7 @@ async function createWorkflowService(backend: Backend): Promise<{
   cleanup: () => Promise<void>
 }> {
   if (backend === 'pg') {
-    const { KyselyWorkflowService } = await import('@pikku/kysely')
+    const { PgKyselyWorkflowService } = await import('@pikku/kysely-postgres')
     const postgres = (await import('postgres')).default
     const { Kysely } = await import('kysely')
     const { PostgresJSDialect } = await import('kysely-postgres-js')
@@ -40,7 +40,7 @@ async function createWorkflowService(backend: Backend): Promise<{
     const db = new Kysely<KyselyPikkuDB>({
       dialect: new PostgresJSDialect({ postgres: sql }),
     })
-    const workflowService = new KyselyWorkflowService(db)
+    const workflowService = new PgKyselyWorkflowService(db)
     await workflowService.init()
     return {
       workflowService,

--- a/verifiers/workflows/src/runners/pgboss.runner.ts
+++ b/verifiers/workflows/src/runners/pgboss.runner.ts
@@ -3,7 +3,7 @@
  * Executes all workflows using PG-Boss queue service and PostgreSQL workflow storage
  */
 
-import { KyselyWorkflowService } from '@pikku/kysely'
+import { PgKyselyWorkflowService } from '@pikku/kysely-postgres'
 import type { KyselyPikkuDB } from '@pikku/kysely'
 import { PgBossServiceFactory } from '@pikku/queue-pg-boss'
 import { pikkuState } from '@pikku/core/internal'
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
   const db = new Kysely<KyselyPikkuDB>({
     dialect: new PostgresJSDialect({ postgres: sql }),
   })
-  const workflowService = new KyselyWorkflowService(db)
+  const workflowService = new PgKyselyWorkflowService(db)
   await workflowService.init()
 
   await createSingletonServices(config, {

--- a/verifiers/workflows/src/runners/retry-idempotency.runner.ts
+++ b/verifiers/workflows/src/runners/retry-idempotency.runner.ts
@@ -17,7 +17,7 @@
  *      default budget and the workflow completes.
  *
  * Usage:
- *   yarn test:retry-idempotency:pg      # pg-boss + Postgres (KyselyWorkflowService)
+ *   yarn test:retry-idempotency:pg      # pg-boss + Postgres (PgKyselyWorkflowService)
  *   yarn test:retry-idempotency:redis   # bullmq + Redis (RedisWorkflowService)
  */
 
@@ -48,7 +48,7 @@ async function setup(backend: Backend): Promise<{
   const config = await createConfig()
 
   if (backend === 'pg') {
-    const { KyselyWorkflowService } = await import('@pikku/kysely')
+    const { PgKyselyWorkflowService } = await import('@pikku/kysely-postgres')
     const { PgBossServiceFactory } = await import('@pikku/queue-pg-boss')
     const { Kysely, CamelCasePlugin } = await import('kysely')
     const { PostgresJSDialect } = await import('kysely-postgres-js')
@@ -60,13 +60,13 @@ async function setup(backend: Backend): Promise<{
     const pgBossFactory = new PgBossServiceFactory(connectionString)
     await pgBossFactory.init()
     const sql = postgres(connectionString)
-    // KyselyWorkflowService creates snake_case tables but queries in camelCase —
+    // PgKyselyWorkflowService creates snake_case tables but queries in camelCase —
     // it requires the CamelCasePlugin to bridge the two.
     const db = new Kysely<any>({
       dialect: new PostgresJSDialect({ postgres: sql }),
       plugins: [new CamelCasePlugin()],
     })
-    const workflowService = new KyselyWorkflowService(db)
+    const workflowService = new PgKyselyWorkflowService(db)
     await workflowService.init()
 
     await createSingletonServices(config, {
@@ -120,7 +120,8 @@ function assert(condition: boolean, message: string): void {
 const attemptCounts = (execs: StepExecution[]) =>
   execs.map((e) => e.attemptCount)
 const allSameInvocationId = (execs: StepExecution[]) =>
-  execs.length > 0 && execs.every((e) => e.invocationId === execs[0]!.invocationId)
+  execs.length > 0 &&
+  execs.every((e) => e.invocationId === execs[0]!.invocationId)
 
 async function main(): Promise<void> {
   const backend = parseBackend()
@@ -174,103 +175,91 @@ async function main(): Promise<void> {
   }
 
   // 1) Idempotent dedupe across retries
-  await test(
-    'idempotent dedupe: same invocationId across retries, side effect once',
-    async () => {
-      const key = 'dedupe'
-      tracker.reset(key)
-      const status = await runToTerminal('idempotentDedupeWorkflow', {
-        trackerKey: key,
-        failTimes: 2,
-      })
-      const execs = tracker.executions(key)
-      assert(status === 'completed', `expected completed, got ${status}`)
-      assert(execs.length === 3, `expected 3 executions, got ${execs.length}`)
-      assert(
-        allSameInvocationId(execs),
-        `invocationId must be stable across retries, got ${JSON.stringify(execs.map((e) => e.invocationId))}`
-      )
-      assert(
-        JSON.stringify(attemptCounts(execs)) === JSON.stringify([1, 2, 3]),
-        `expected attemptCounts [1,2,3], got ${JSON.stringify(attemptCounts(execs))}`
-      )
-      // The payoff: a side effect keyed on the stable invocationId runs exactly
-      // once even though the step body executed 3 times. (stepId is deliberately
-      // NOT asserted here — whether it changes per attempt is store-specific;
-      // invocationId is the cross-store dedupe key, which is the whole point.)
-      assert(
-        tracker.sideEffectCount(key) === 1,
-        `idempotent side effect must run once, ran ${tracker.sideEffectCount(key)} times`
-      )
-    }
-  )
+  await test('idempotent dedupe: same invocationId across retries, side effect once', async () => {
+    const key = 'dedupe'
+    tracker.reset(key)
+    const status = await runToTerminal('idempotentDedupeWorkflow', {
+      trackerKey: key,
+      failTimes: 2,
+    })
+    const execs = tracker.executions(key)
+    assert(status === 'completed', `expected completed, got ${status}`)
+    assert(execs.length === 3, `expected 3 executions, got ${execs.length}`)
+    assert(
+      allSameInvocationId(execs),
+      `invocationId must be stable across retries, got ${JSON.stringify(execs.map((e) => e.invocationId))}`
+    )
+    assert(
+      JSON.stringify(attemptCounts(execs)) === JSON.stringify([1, 2, 3]),
+      `expected attemptCounts [1,2,3], got ${JSON.stringify(attemptCounts(execs))}`
+    )
+    // The payoff: a side effect keyed on the stable invocationId runs exactly
+    // once even though the step body executed 3 times. (stepId is deliberately
+    // NOT asserted here — whether it changes per attempt is store-specific;
+    // invocationId is the cross-store dedupe key, which is the whole point.)
+    assert(
+      tracker.sideEffectCount(key) === 1,
+      `idempotent side effect must run once, ran ${tracker.sideEffectCount(key)} times`
+    )
+  })
 
   // 2) retries: 0 is honored — exactly one execution, workflow fails
-  await test(
-    'retries:0 honored: step runs exactly once and workflow fails',
-    async () => {
-      const key = 'noretry'
-      tracker.reset(key)
-      const status = await runToTerminal('noRetryWorkflow', { trackerKey: key })
-      const execs = tracker.executions(key)
-      assert(status === 'failed', `expected failed, got ${status}`)
-      assert(
-        execs.length === 1,
-        `retries:0 must run exactly once, ran ${execs.length} times`
-      )
-      assert(
-        execs[0]!.attemptCount === 1,
-        `expected attemptCount 1, got ${execs[0]?.attemptCount}`
-      )
-    }
-  )
+  await test('retries:0 honored: step runs exactly once and workflow fails', async () => {
+    const key = 'noretry'
+    tracker.reset(key)
+    const status = await runToTerminal('noRetryWorkflow', { trackerKey: key })
+    const execs = tracker.executions(key)
+    assert(status === 'failed', `expected failed, got ${status}`)
+    assert(
+      execs.length === 1,
+      `retries:0 must run exactly once, ran ${execs.length} times`
+    )
+    assert(
+      execs[0]!.attemptCount === 1,
+      `expected attemptCount 1, got ${execs[0]?.attemptCount}`
+    )
+  })
 
   // 3) Default retries exhausted — exactly DEFAULT_STEP_RETRIES + 1 executions
-  await test(
-    `default retries: exhausts at DEFAULT_STEP_RETRIES+1 (${DEFAULT_STEP_RETRIES + 1}) then fails`,
-    async () => {
-      const key = 'exhaust'
-      tracker.reset(key)
-      const status = await runToTerminal('defaultRetryExhaustWorkflow', {
-        trackerKey: key,
-      })
-      const execs = tracker.executions(key)
-      assert(status === 'failed', `expected failed, got ${status}`)
-      assert(
-        execs.length === DEFAULT_STEP_RETRIES + 1,
-        `expected ${DEFAULT_STEP_RETRIES + 1} executions, got ${execs.length}`
-      )
-      assert(
-        allSameInvocationId(execs),
-        `invocationId must be stable across all attempts`
-      )
-      const expected = Array.from(
-        { length: DEFAULT_STEP_RETRIES + 1 },
-        (_, i) => i + 1
-      )
-      assert(
-        JSON.stringify(attemptCounts(execs)) === JSON.stringify(expected),
-        `expected attemptCounts ${JSON.stringify(expected)}, got ${JSON.stringify(attemptCounts(execs))}`
-      )
-    }
-  )
+  await test(`default retries: exhausts at DEFAULT_STEP_RETRIES+1 (${DEFAULT_STEP_RETRIES + 1}) then fails`, async () => {
+    const key = 'exhaust'
+    tracker.reset(key)
+    const status = await runToTerminal('defaultRetryExhaustWorkflow', {
+      trackerKey: key,
+    })
+    const execs = tracker.executions(key)
+    assert(status === 'failed', `expected failed, got ${status}`)
+    assert(
+      execs.length === DEFAULT_STEP_RETRIES + 1,
+      `expected ${DEFAULT_STEP_RETRIES + 1} executions, got ${execs.length}`
+    )
+    assert(
+      allSameInvocationId(execs),
+      `invocationId must be stable across all attempts`
+    )
+    const expected = Array.from(
+      { length: DEFAULT_STEP_RETRIES + 1 },
+      (_, i) => i + 1
+    )
+    assert(
+      JSON.stringify(attemptCounts(execs)) === JSON.stringify(expected),
+      `expected attemptCounts ${JSON.stringify(expected)}, got ${JSON.stringify(attemptCounts(execs))}`
+    )
+  })
 
   // 4) Default retries recover — completes within the default budget
-  await test(
-    'default retries: recovers within the default budget and completes',
-    async () => {
-      const key = 'recover'
-      tracker.reset(key)
-      const status = await runToTerminal('defaultRetryRecoverWorkflow', {
-        trackerKey: key,
-        failTimes: 2,
-      })
-      const execs = tracker.executions(key)
-      assert(status === 'completed', `expected completed, got ${status}`)
-      assert(execs.length === 3, `expected 3 executions, got ${execs.length}`)
-      assert(allSameInvocationId(execs), `invocationId must be stable`)
-    }
-  )
+  await test('default retries: recovers within the default budget and completes', async () => {
+    const key = 'recover'
+    tracker.reset(key)
+    const status = await runToTerminal('defaultRetryRecoverWorkflow', {
+      trackerKey: key,
+      failTimes: 2,
+    })
+    const execs = tracker.executions(key)
+    assert(status === 'completed', `expected completed, got ${status}`)
+    assert(execs.length === 3, `expected 3 executions, got ${execs.length}`)
+    assert(allSameInvocationId(execs), `invocationId must be stable`)
+  })
 
   console.log('\n=== Summary ===')
   const passed = results.filter((r) => r.ok).length

--- a/verifiers/workflows/src/runners/version-mismatch.runner.ts
+++ b/verifiers/workflows/src/runners/version-mismatch.runner.ts
@@ -50,7 +50,7 @@ async function createWorkflowService(backend: Backend): Promise<{
   cleanup: () => Promise<void>
 }> {
   if (backend === 'pg') {
-    const { KyselyWorkflowService } = await import('@pikku/kysely')
+    const { PgKyselyWorkflowService } = await import('@pikku/kysely-postgres')
     const postgres = (await import('postgres')).default
     const { Kysely } = await import('kysely')
     const { PostgresJSDialect } = await import('kysely-postgres-js')
@@ -61,7 +61,7 @@ async function createWorkflowService(backend: Backend): Promise<{
     const db = new Kysely<KyselyPikkuDB>({
       dialect: new PostgresJSDialect({ postgres: sql }),
     })
-    const workflowService = new KyselyWorkflowService(db)
+    const workflowService = new PgKyselyWorkflowService(db)
     await workflowService.init()
     return {
       workflowService,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7396,6 +7396,7 @@ __metadata:
     "@pikku/core": "workspace:*"
     "@pikku/inspector": "workspace:*"
     "@pikku/kysely": "workspace:*"
+    "@pikku/kysely-postgres": "workspace:*"
     "@pikku/queue-bullmq": "workspace:*"
     "@pikku/queue-pg-boss": "workspace:*"
     "@pikku/redis": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6227,6 +6227,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pikku/kysely-postgres@workspace:packages/services/kysely-postgres"
   dependencies:
+    "@electric-sql/pglite": "npm:^0.5.1"
     "@pikku/core": "npm:^0.12.69"
     "@pikku/kysely": "npm:^0.13.3"
     kysely: "npm:^0.29.0"


### PR DESCRIPTION
Works through all eleven items of #1039.

## Tier 1 — the ones that cost the most

**No indexes on any workflow table.** Every step read, history walk and orchestrator tick was a sequential scan. Five indexes now cover the columns the engine actually queries by, created through a `createIndexSafe` that tolerates an existing index.

**Replay was O(N²) in round trips.** A replay walks the DSL body from the top and each step it passes asked for its own row — N reads per replay, N² over a run. `listStepStates(runId)` reads them all once at the start of a replay pass and serves the walk from that snapshot. Backends without a bulk read return `null` and fall back to the old path. The two lock-protected sites (`suspendStep`, `approvalStep`) and the worker entry points deliberately do *not* use the snapshot.

**A step transition was three non-transactional round trips.** A crash between them left a step row saying `succeeded` whose history row still said `running`, which silently corrupts `getRunHistory` and every timeline built on it. Both halves are now one transaction. The history row is found by attempt number rather than by sorting on `created_at` — two attempts can land in the same millisecond — which needed a `current_attempt` column, added with an in-memory backfill for existing databases (MySQL rejects the correlated subquery that would have done it in SQL).

## Tier 2

- `updateRunState` was a lossy read-modify-write; it now goes through a dialect `jsonSetState` hook.
- `getRun` was re-read 3–5x per step; one read per orchestrator tick now, cached for the replay.
- `getDynamicWorkflow(name)` replaces reading and parsing every AI-generated workflow in the deployment to `.find()` one by name. Implemented per backend.
- Dispatch no longer JSON round-trips every step payload. SQS, BullMQ and pg-boss all serialise on the way to the wire, so it was waste on every production path; its one real effect was giving the in-process dev queue the isolation a real backend provides, so that moved into `InMemoryQueueService`.
- Waiting on a run backs off instead of polling flat. `pollIntervalMs` is now a ceiling, not a cadence: it starts at 10ms and widens by 1.6x. An 8-read run in the new suite drops from 7.0s to 0.43s.

## Tier 3

- Per-run state (`stepLineage`, `runActors`, inline flags, ordinals) collapsed into one `RunContext` map, released when a run reaches a terminal state — `suspended` deliberately excluded, since a suspended run can still be resumed.
- The scenario assertion surface (`expectEventually`, `expectError`, `expectService`, `runScheduledTask`) moved out of the engine into `scenario-wire.ts`.
- The thirteen copy-pasted `x` / `xImpl` / `safeMirror` triples became one `mirrored(write, mirror)`.

## Two defects found while porting to the other backends

**Redis lost run state.** State was one JSON blob read-modified-written on every `setState`, so two parallel branches setting different variables overwrote each other — twenty concurrent writers left one survivor. It is a field per variable now. `getRunState` still reads the old blob underneath, so a run in flight across the deploy keeps what it had.

**Mongo never wrote scheduled history.** `setStepScheduled` wrote the step row and nothing else, so a queued step's history stayed at `pending` and read as never dispatched. Its other three transitions also found the newest history document and then updated it by `_id`; `findOneAndUpdate` with the same sort does it in one.

## Verification

1618 tests green: core 1349, kysely 177, mongodb 76, redis 16. All five touched packages typecheck clean.

New suites, each proven red before the change: workflow table indexes, step-transition round trips and consistency, attempt counting, run-state writes, upgrading a pre-attempt database, dynamic workflow lookup, replay snapshot, run context lifetime, run polling backoff, dispatch payload, redis run state, mongo step history.

Two commits are behaviour-preserving refactors (`mirrored`, the scenario extraction) so their tests are characterisation rather than red-first. Both were mutation-checked: the mirror suite catches dropping a mirror call, mirroring before the write, and letting a mirror failure escape. `expectError` and `expectService` had no coverage at all before this and now do.

## Not done

Mongo's step and history writes are still two operations — multi-document transactions need a replica set, and that would break standalone deployments and the package's own `mongodb-memory-server` tests. Redis's step transitions likewise still read `attemptCount` before writing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic dynamic workflow selection, choosing the newest active version.
  * Improved workflow state handling across retries, replays, and concurrent updates.
  * Added safer per-variable run-state storage while preserving compatibility with existing runs.

* **Bug Fixes**
  * Fixed missing or inconsistent step history during transitions and retries.
  * Reduced replay reads and improved polling responsiveness with bounded backoff.
  * Improved JSON state updates across supported databases and preserved queued payload data accurately.

* **Chores**
  * Added database migration support and indexes for improved workflow performance.
  * Expanded automated testing in continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->