### PR TITLE
feat(cli): client-side sealing for `pikku fabric secrets`

### DIFF
--- a/.changeset/fabric-secrets-client-side-sealing.md
+++ b/.changeset/fabric-secrets-client-side-sealing.md
@@ -1,0 +1,7 @@
+---
+'@pikku/cli': minor
+---
+
+`pikku fabric secrets set` now seals the value on this machine before sending it. The CLI fetches the stage's public key, encrypts against it, and sends only the sealed blob — so the plaintext never reaches fabric, and the value can be opened by the stage's own worker and by nothing else. `secrets list` returns names and write times; there is no value to show, which is the point.
+
+Both commands were previously calling RPCs fabric no longer serves (`setStageSecret`, `listStageSecrets`) and failing at runtime. `getFabricRPC` returned `any`, so nothing caught it — it is typed now, which is also what surfaced `getDeveloperLiteLLMKey` missing from the bundled RPC map.

--- a/.changeset/fabric-secrets-client-side-sealing.md
+++ b/.changeset/fabric-secrets-client-side-sealing.md
@@ -1,5 +1,5 @@
 ---
-'@pikku/cli': minor
+'@pikku/cli': patch
 ---
 
 `pikku fabric secrets set` now seals the value on this machine before sending it. The CLI fetches the stage's public key, encrypts against it, and sends only the sealed blob — so the plaintext never reaches fabric, and the value can be opened by the stage's own worker and by nothing else. `secrets list` returns names and write times; there is no value to show, which is the point.

--- a/.changeset/fabric-secrets-rotate.md
+++ b/.changeset/fabric-secrets-rotate.md
@@ -1,5 +1,5 @@
 ---
-'@pikku/cli': minor
+'@pikku/cli': patch
 ---
 
 `pikku fabric secrets rotate` retires a stage's sealing key so the next deploy issues a new one. This is the way out of the one dead end in client-side sealing: a worker that does not hold the stage's private key cannot read that stage's secrets, and fabric cannot hand it the key because fabric keeps no copy. Rotating makes every secret already set on the stage unreadable — fabric cannot re-seal values it cannot open — so it requires `--force` and says exactly that first.

--- a/.changeset/fabric-secrets-rotate.md
+++ b/.changeset/fabric-secrets-rotate.md
@@ -1,0 +1,5 @@
+---
+'@pikku/cli': minor
+---
+
+`pikku fabric secrets rotate` retires a stage's sealing key so the next deploy issues a new one. This is the way out of the one dead end in client-side sealing: a worker that does not hold the stage's private key cannot read that stage's secrets, and fabric cannot hand it the key because fabric keeps no copy. Rotating makes every secret already set on the stage unreadable — fabric cannot re-seal values it cannot open — so it requires `--force` and says exactly that first.

--- a/packages/cli/src/fabric/fabric-commands.ts
+++ b/packages/cli/src/fabric/fabric-commands.ts
@@ -48,6 +48,7 @@ import {
 import { FabricRollback } from './functions/rollback.function.js'
 import { FabricSecretsSet } from './functions/secrets-set.function.js'
 import { FabricSecretsList } from './functions/secrets-list.function.js'
+import { FabricSecretsRotate } from './functions/secrets-rotate.function.js'
 import { FabricLogs } from './functions/logs.function.js'
 import { FabricMetrics } from './functions/metrics.function.js'
 import { FabricTrace } from './functions/trace.function.js'
@@ -273,6 +274,17 @@ export const fabricCommands = defineCLICommands({
         options: {
           branch: { description: 'Target branch', short: 'b' },
           json: { description: 'Machine-readable output', default: false },
+        },
+      }),
+      rotate: pikkuCLICommand({
+        func: FabricSecretsRotate,
+        description: "Retire a stage's sealing key (secrets must be set again)",
+        options: {
+          branch: { description: 'Target branch', short: 'b' },
+          force: {
+            description: 'Confirm that existing secrets become unreadable',
+            default: false,
+          },
         },
       }),
     },

--- a/packages/cli/src/fabric/functions/secrets-list.function.ts
+++ b/packages/cli/src/fabric/functions/secrets-list.function.ts
@@ -2,17 +2,20 @@ import { z } from 'zod'
 import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
 import { resolveApiContext } from '../lib/config.js'
 import { getFabricRPC } from '../lib/http.js'
+import { resolveStageId } from '../lib/stage.js'
 
 export const FabricSecretsListInput = z.object({
   branch: z.string(),
   json: z.boolean().optional(),
 })
 
-export const FabricSecretsListOutput = z.object({ names: z.array(z.string()) })
+export const FabricSecretsListOutput = z.object({
+  secrets: z.array(z.object({ name: z.string(), updatedAt: z.string() })),
+})
 
 export const FabricSecretsList = pikkuSessionlessFunc({
   description:
-    'List secret names visible to a stage (values never leave the server).',
+    'List the secrets set on a stage, by name. Values are sealed to the stage and never leave it.',
   input: FabricSecretsListInput,
   output: FabricSecretsListOutput,
   func: async (_services, { branch, json }) => {
@@ -25,16 +28,17 @@ export const FabricSecretsList = pikkuSessionlessFunc({
       )
 
     const rpc = getFabricRPC({ apiUrl: ctx.apiUrl, token: ctx.token })
-    const result = await rpc.invoke('listStageSecrets', {
-      projectId: ctx.projectId,
-      branch,
-    })
+    const stageId = await resolveStageId(rpc, ctx.projectId, branch)
+    const result = await rpc.invoke('listStageSecretNames', { stageId })
+
     if (json) {
-      console.log(JSON.stringify({ branch, names: result.names }, null, 2))
-    } else if (result.names.length === 0) {
+      console.log(JSON.stringify({ branch, secrets: result.secrets }, null, 2))
+    } else if (result.secrets.length === 0) {
       console.log(`[fabric] no secrets set on ${branch}`)
     } else {
-      for (const name of result.names) console.log(name)
+      for (const { name, updatedAt } of result.secrets) {
+        console.log(`${name}\t${updatedAt}`)
+      }
     }
     return result
   },

--- a/packages/cli/src/fabric/functions/secrets-rotate.function.ts
+++ b/packages/cli/src/fabric/functions/secrets-rotate.function.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod'
+import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
+import { resolveApiContext } from '../lib/config.js'
+import { getFabricRPC } from '../lib/http.js'
+import { resolveStageId } from '../lib/stage.js'
+
+export const FabricSecretsRotateInput = z.object({
+  branch: z.string(),
+  force: z.boolean().optional(),
+})
+
+export const FabricSecretsRotateOutput = z.object({
+  retiredKeyId: z.string(),
+})
+
+export const FabricSecretsRotate = pikkuSessionlessFunc({
+  description:
+    "Retire a stage's sealing key so the next deploy issues a new one. Secrets sealed to the old key must be set again.",
+  input: FabricSecretsRotateInput,
+  output: FabricSecretsRotateOutput,
+  func: async (_services, { branch, force }) => {
+    const ctx = await resolveApiContext()
+    if (!ctx.token)
+      throw new Error('Not logged in. Run `pikku fabric login` first.')
+    if (!ctx.projectId)
+      throw new Error(
+        'No fabric project linked. Run `pikku fabric link` first.'
+      )
+
+    if (!force) {
+      // Not a confirmation for politeness — this is the one operation here
+      // that destroys access to data. Fabric cannot read the sealed values, so
+      // it cannot carry them over, and nobody can undo it afterwards.
+      throw new Error(
+        `Rotating the sealing key on ${branch} makes every secret already set on it unreadable — fabric cannot re-seal values it cannot open, so each one must be set again after the next deploy. Re-run with --force if that is what you want.`
+      )
+    }
+
+    const rpc = getFabricRPC({ apiUrl: ctx.apiUrl, token: ctx.token })
+    const stageId = await resolveStageId(rpc, ctx.projectId, branch)
+    const result = await rpc.invoke('rotateStageSealingKey', { stageId })
+
+    console.log(
+      `[fabric] retired sealing key ${result.retiredKeyId} on ${branch}`
+    )
+    console.log(
+      '[fabric] deploy the stage to issue a new key, then set its secrets again'
+    )
+    return result
+  },
+})

--- a/packages/cli/src/fabric/functions/secrets-set.function.ts
+++ b/packages/cli/src/fabric/functions/secrets-set.function.ts
@@ -3,6 +3,8 @@ import { pikkuSessionlessFunc } from '../../../.pikku/pikku-types.gen.js'
 import { resolveApiContext } from '../lib/config.js'
 import { getFabricRPC } from '../lib/http.js'
 import { promptSecret } from '../lib/prompt.js'
+import { resolveStageId } from '../lib/stage.js'
+import { seal, serializeSealedValue } from '../lib/sealed-box.js'
 
 export const FabricSecretsSetInput = z.object({
   name: z.string(),
@@ -11,11 +13,14 @@ export const FabricSecretsSetInput = z.object({
   force: z.boolean().optional(),
 })
 
-export const FabricSecretsSetOutput = z.object({ ok: z.boolean() })
+export const FabricSecretsSetOutput = z.object({
+  name: z.string(),
+  keyId: z.string(),
+})
 
 export const FabricSecretsSet = pikkuSessionlessFunc({
   description:
-    'Set a stage-scoped secret. Encrypted with the stage KEK and stored in the project D1.',
+    'Set a stage-scoped secret. Sealed here to the stage public key — the plaintext never leaves this machine.',
   input: FabricSecretsSetInput,
   output: FabricSecretsSetOutput,
   func: async (_services, { name, branch, value }) => {
@@ -31,13 +36,23 @@ export const FabricSecretsSet = pikkuSessionlessFunc({
     if (!plaintext) throw new Error('Empty secret value — aborting.')
 
     const rpc = getFabricRPC({ apiUrl: ctx.apiUrl, token: ctx.token })
-    const result = await rpc.invoke('setStageSecret', {
-      projectId: ctx.projectId,
-      branch,
+    const stageId = await resolveStageId(rpc, ctx.projectId, branch)
+
+    // Fabric holds only the public half of this keypair. The private half went
+    // to the stage's worker at deploy time and was dropped there, so the value
+    // sealed below can be opened by that worker and by nothing else — including
+    // by the fabric process that stores it.
+    const key = await rpc.invoke('getStageSealingKey', { stageId })
+    const sealed = seal(key.publicKey, key.keyId, plaintext)
+
+    const result = await rpc.invoke('setStageSealedSecret', {
+      stageId,
       name,
-      value: plaintext,
+      sealedValue: serializeSealedValue(sealed),
     })
-    console.log(`[fabric] ${name} set on ${branch}.`)
+    console.log(
+      `[fabric] ${name} sealed to ${result.keyId} and set on ${branch}.`
+    )
     return result
   },
 })

--- a/packages/cli/src/fabric/lib/http.ts
+++ b/packages/cli/src/fabric/lib/http.ts
@@ -8,7 +8,7 @@ import { PikkuRPC } from '../sdk/pikku-rpc.gen.js'
 export function getFabricRPC(opts: {
   apiUrl: string
   token: string | null
-}): any {
+}): PikkuRPC {
   const rpc = new PikkuRPC()
   rpc.setServerUrl(opts.apiUrl)
   rpc.setAuthorizationJWT(opts.token)

--- a/packages/cli/src/fabric/lib/sealed-box.test.ts
+++ b/packages/cli/src/fabric/lib/sealed-box.test.ts
@@ -1,0 +1,148 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createDecipheriv,
+  createPrivateKey,
+  createPublicKey,
+  diffieHellman,
+  generateKeyPairSync,
+  hkdfSync,
+} from 'node:crypto'
+import {
+  seal,
+  serializeSealedValue,
+  SEALED_BOX_ALGORITHM,
+} from './sealed-box.js'
+
+const KEY_ID = '9c1d7f30-4b62-4a1e-9d55-6f0e2a8b3c47'
+
+function x25519Keypair() {
+  const { publicKey, privateKey } = generateKeyPairSync('x25519')
+  return {
+    publicKey: publicKey
+      .export({ type: 'spki', format: 'der' })
+      .toString('base64'),
+    privateKey: privateKey
+      .export({ type: 'pkcs8', format: 'der' })
+      .toString('base64'),
+  }
+}
+
+/**
+ * The recipient's half, written out longhand rather than imported.
+ *
+ * This module deliberately ships no `unseal` — the CLI holds no private key —
+ * so the only way to check that `seal` produces something openable is to open
+ * it here from the spec: HKDF-SHA256 over the ECDH secret, salt
+ * `pikkufabric/sealed-box/v1`, info `epk || recipientPublicKey`, AES-256-GCM.
+ * Fabric's worker-side implementation follows the same recipe; if this stops
+ * matching, so has that.
+ */
+function openAsFabricWould(
+  privateKey: string,
+  sealed: ReturnType<typeof seal>
+) {
+  const recipientPrivate = createPrivateKey({
+    key: Buffer.from(privateKey, 'base64'),
+    type: 'pkcs8',
+    format: 'der',
+  })
+  const epk = Buffer.from(sealed.epk, 'base64')
+  const shared = diffieHellman({
+    privateKey: recipientPrivate,
+    publicKey: createPublicKey({ key: epk, type: 'spki', format: 'der' }),
+  })
+  const contentKey = Buffer.from(
+    hkdfSync(
+      'sha256',
+      shared,
+      Buffer.from('pikkufabric/sealed-box/v1'),
+      Buffer.concat([
+        epk,
+        createPublicKey(recipientPrivate).export({
+          type: 'spki',
+          format: 'der',
+        }),
+      ]),
+      32
+    )
+  )
+  const decipher = createDecipheriv(
+    'aes-256-gcm',
+    contentKey,
+    Buffer.from(sealed.iv, 'base64')
+  )
+  decipher.setAuthTag(Buffer.from(sealed.tag, 'base64'))
+  return Buffer.concat([
+    decipher.update(Buffer.from(sealed.ct, 'base64')),
+    decipher.final(),
+  ]).toString('utf8')
+}
+
+describe('sealed-box (client side)', () => {
+  test('a sealed value opens with the recipient private key', () => {
+    const { publicKey, privateKey } = x25519Keypair()
+    const sealed = seal(publicKey, KEY_ID, 'sk_live_51H8xQ2KzZ9vRtY7wPqL3mN')
+    assert.equal(
+      openAsFabricWould(privateKey, sealed),
+      'sk_live_51H8xQ2KzZ9vRtY7wPqL3mN'
+    )
+  })
+
+  test('the envelope carries the algorithm tag and key id', () => {
+    const { publicKey } = x25519Keypair()
+    const sealed = seal(publicKey, KEY_ID, 'v')
+    assert.equal(sealed.alg, SEALED_BOX_ALGORITHM)
+    assert.equal(sealed.kid, KEY_ID)
+    for (const field of ['epk', 'iv', 'ct', 'tag'] as const) {
+      assert.equal(typeof sealed[field], 'string')
+      assert.ok(sealed[field].length > 0, `${field} is empty`)
+    }
+  })
+
+  test('the plaintext appears nowhere in what gets sent', () => {
+    const { publicKey } = x25519Keypair()
+    const wire = serializeSealedValue(seal(publicKey, KEY_ID, 'the-secret'))
+    assert.ok(!wire.includes('the-secret'))
+  })
+
+  test('another recipient cannot open it', () => {
+    const { publicKey } = x25519Keypair()
+    const other = x25519Keypair()
+    const sealed = seal(publicKey, KEY_ID, 'the-secret')
+    assert.throws(() => openAsFabricWould(other.privateKey, sealed))
+  })
+
+  test('sealing the same value twice differs', () => {
+    // Otherwise identical ciphertexts would reveal that two stages, or two
+    // names, hold the same secret.
+    const { publicKey } = x25519Keypair()
+    const a = seal(publicKey, KEY_ID, 'same')
+    const b = seal(publicKey, KEY_ID, 'same')
+    assert.notEqual(a.ct, b.ct)
+    assert.notEqual(a.epk, b.epk)
+    assert.notEqual(a.iv, b.iv)
+  })
+
+  test('unicode and long values survive', () => {
+    const { publicKey, privateKey } = x25519Keypair()
+    for (const value of ['—key–with–dashes—🔐', ' ', 'x'.repeat(4096)]) {
+      assert.equal(
+        openAsFabricWould(privateKey, seal(publicKey, KEY_ID, value)),
+        value
+      )
+    }
+  })
+
+  test('a key of the wrong type is refused before anything is encrypted', () => {
+    const { publicKey } = generateKeyPairSync('ed25519')
+    const spki = publicKey
+      .export({ type: 'spki', format: 'der' })
+      .toString('base64')
+    assert.throws(() => seal(spki, KEY_ID, 'v'), /expected x25519/)
+  })
+
+  test('garbage in place of a key fails loudly', () => {
+    assert.throws(() => seal('not-a-key', KEY_ID, 'v'), /X25519 public key/)
+  })
+})

--- a/packages/cli/src/fabric/lib/sealed-box.ts
+++ b/packages/cli/src/fabric/lib/sealed-box.ts
@@ -1,0 +1,122 @@
+/**
+ * Sealing a value to a stage's public key, here on the client.
+ *
+ * `pikku fabric secrets set` seals before it sends, so the plaintext never
+ * reaches fabric — not the ingress in front of it, not a request log, not the
+ * process handling the write. Fabric stores the sealed blob and hands it to the
+ * worker, which holds the only private key that opens it.
+ *
+ * This is the seal half of fabric's `sealed-x25519-v1`, and the two must stay
+ * byte-compatible: an ephemeral X25519 keypair, ECDH against the recipient,
+ * HKDF-SHA256 to a content key, AES-256-GCM to seal. Everything below is
+ * `node:crypto` on purpose — a sealing primitive that pulled in a dependency
+ * would be a supply-chain question sitting directly on the plaintext.
+ *
+ * There is deliberately no `unseal` here. The CLI has no private key and no
+ * business having one; opening a value happens in the worker.
+ */
+import {
+  createCipheriv,
+  createPublicKey,
+  diffieHellman,
+  generateKeyPairSync,
+  hkdfSync,
+  randomBytes,
+} from 'node:crypto'
+
+/** Algorithm tag carried by every sealed value. Must match fabric's. */
+export const SEALED_BOX_ALGORITHM = 'sealed-x25519-v1'
+
+/** HKDF domain separator. Must match fabric's byte for byte. */
+const SEAL_SALT = 'pikkufabric/sealed-box/v1'
+
+export interface SealedValue {
+  alg: typeof SEALED_BOX_ALGORITHM
+  /** The `encryption_key` row whose public key sealed this. */
+  kid: string
+  /** Ephemeral public key, SPKI DER as base64. */
+  epk: string
+  iv: string
+  ct: string
+  tag: string
+}
+
+/** Seal a value to a stage's public key. */
+export function seal(
+  publicKey: string,
+  keyId: string,
+  plaintext: string
+): SealedValue {
+  const recipient = importPublicKey(publicKey)
+  const ephemeral = generateKeyPairSync('x25519')
+  const epk = ephemeral.publicKey.export({ type: 'spki', format: 'der' })
+
+  const contentKey = deriveContentKey(
+    diffieHellman({ privateKey: ephemeral.privateKey, publicKey: recipient }),
+    epk,
+    recipient.export({ type: 'spki', format: 'der' })
+  )
+
+  const iv = randomBytes(12)
+  const cipher = createCipheriv('aes-256-gcm', contentKey, iv)
+  const ct = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+
+  return {
+    alg: SEALED_BOX_ALGORITHM,
+    kid: keyId,
+    epk: epk.toString('base64'),
+    iv: iv.toString('base64'),
+    ct: ct.toString('base64'),
+    tag: cipher.getAuthTag().toString('base64'),
+  }
+}
+
+/** Wire form. Fabric stores exactly this string. */
+export function serializeSealedValue(sealed: SealedValue): string {
+  return JSON.stringify(sealed)
+}
+
+/**
+ * Both public keys go into the HKDF `info`, which is what stops a sealed value
+ * being redirected: change either the ephemeral key or the recipient and the
+ * derived content key changes with it.
+ */
+function deriveContentKey(
+  shared: Buffer,
+  epk: Buffer,
+  recipientPublic: Buffer
+): Buffer {
+  return Buffer.from(
+    hkdfSync(
+      'sha256',
+      shared,
+      Buffer.from(SEAL_SALT),
+      Buffer.concat([epk, recipientPublic]),
+      32
+    )
+  )
+}
+
+function importPublicKey(publicKey: string) {
+  let key
+  try {
+    key = createPublicKey({
+      key: Buffer.from(publicKey, 'base64'),
+      type: 'spki',
+      format: 'der',
+    })
+  } catch (error) {
+    throw new Error(
+      `Not a valid X25519 public key (${error instanceof Error ? error.message : String(error)})`
+    )
+  }
+  // A public key of the wrong curve would still ECDH, just against a key the
+  // stage's worker cannot match — the failure would surface as an unopenable
+  // secret much later, so refuse it at the point the type is still knowable.
+  if (key.asymmetricKeyType !== 'x25519') {
+    throw new Error(
+      `Stage sealing key is ${key.asymmetricKeyType}, expected x25519 — this CLI is too old for it, run \`npm i -g @pikku/cli\``
+    )
+  }
+  return key
+}

--- a/packages/cli/src/fabric/sdk/rpc-map.gen.d.ts
+++ b/packages/cli/src/fabric/sdk/rpc-map.gen.d.ts
@@ -782,12 +782,27 @@ export type ListStageCustomHostnamesOutput = {
     createdAt: string
   }[]
 }
-export type ListStageSecretsInput = {
-  projectId: string
-  branch: string
+export type GetDeveloperLiteLLMKeyInput = {}
+export type GetDeveloperLiteLLMKeyOutput = {
+  proxyUrl: string
+  apiKey: string
 }
-export type ListStageSecretsOutput = {
-  names: string[]
+export type GetStageSealingKeyInput = {
+  stageId: string
+}
+export type GetStageSealingKeyOutput = {
+  keyId: string
+  publicKey: string
+  algorithm: string
+}
+export type ListStageSecretNamesInput = {
+  stageId: string
+}
+export type ListStageSecretNamesOutput = {
+  secrets: {
+    name: string
+    updatedAt: string
+  }[]
 }
 export type ListStagesInput = {
   /** Project UUID or slug */
@@ -1005,14 +1020,14 @@ export type SetStageAutoDeployOutput = {
   stageId: string
   autoDeployOnPush: boolean
 }
-export type SetStageSecretInput = {
-  projectId: string
-  branch: string
+export type SetStageSealedSecretInput = {
+  stageId: string
   name: string
-  value: string
+  sealedValue: string
 }
-export type SetStageSecretOutput = {
-  ok: boolean
+export type SetStageSealedSecretOutput = {
+  name: string
+  keyId: string
 }
 export type SignContentKeyInput = {
   contentKey: string
@@ -1254,9 +1269,17 @@ export type RPCMap = {
     ListStageCustomHostnamesInput,
     ListStageCustomHostnamesOutput
   >
-  readonly listStageSecrets: RPCHandler<
-    ListStageSecretsInput,
-    ListStageSecretsOutput
+  readonly getDeveloperLiteLLMKey: RPCHandler<
+    GetDeveloperLiteLLMKeyInput,
+    GetDeveloperLiteLLMKeyOutput
+  >
+  readonly getStageSealingKey: RPCHandler<
+    GetStageSealingKeyInput,
+    GetStageSealingKeyOutput
+  >
+  readonly listStageSecretNames: RPCHandler<
+    ListStageSecretNamesInput,
+    ListStageSecretNamesOutput
   >
   readonly listStages: RPCHandler<ListStagesInput, ListStagesOutput>
   readonly mintConsoleToken: RPCHandler<
@@ -1280,7 +1303,10 @@ export type RPCMap = {
     SetStageAutoDeployInput,
     SetStageAutoDeployOutput
   >
-  readonly setStageSecret: RPCHandler<SetStageSecretInput, SetStageSecretOutput>
+  readonly setStageSealedSecret: RPCHandler<
+    SetStageSealedSecretInput,
+    SetStageSealedSecretOutput
+  >
   readonly syncStage: RPCHandler<SyncStageInput, SyncStageOutput>
   readonly confirmCliAuth: RPCHandler<ConfirmCliAuthInput, ConfirmCliAuthOutput>
   readonly pollCliAuth: RPCHandler<PollCliAuthInput, PollCliAuthOutput>

--- a/packages/cli/src/fabric/sdk/rpc-map.gen.d.ts
+++ b/packages/cli/src/fabric/sdk/rpc-map.gen.d.ts
@@ -804,6 +804,13 @@ export type ListStageSecretNamesOutput = {
     updatedAt: string
   }[]
 }
+export type RotateStageSealingKeyInput = {
+  stageId: string
+}
+export type RotateStageSealingKeyOutput = {
+  /** The key that will no longer be handed out. */
+  retiredKeyId: string
+}
 export type ListStagesInput = {
   /** Project UUID or slug */
   projectId: string
@@ -1282,6 +1289,10 @@ export type RPCMap = {
     ListStageSecretNamesOutput
   >
   readonly listStages: RPCHandler<ListStagesInput, ListStagesOutput>
+  readonly rotateStageSealingKey: RPCHandler<
+    RotateStageSealingKeyInput,
+    RotateStageSealingKeyOutput
+  >
   readonly mintConsoleToken: RPCHandler<
     MintConsoleTokenInput,
     MintConsoleTokenOutput


### PR DESCRIPTION
Two commits that were stranded on `feat/1034-scenario-step` after PR #1047 (the pikkuScenario migration) was rebase-and-merged. The scenario work is in `main`; these were stacked on top of it and are unrelated to it, so they're rebased onto `main` here on their own branch.

## What it does

**`pikku fabric secrets set` seals the value locally before sending it.** The CLI fetches the stage's public key, encrypts against it, and sends only the sealed blob — plaintext never reaches fabric, and the value can be opened by the stage's own worker and by nothing else. `secrets list` returns names and write times; there is no value to show, which is the point.

Both commands were previously calling RPCs fabric no longer serves (`setStageSecret`, `listStageSecrets`) and failing at runtime. `getFabricRPC` returned `any`, so nothing caught it — it's typed now, which is also what surfaced `getDeveloperLiteLLMKey` missing from the bundled RPC map.

**`pikku fabric secrets rotate`** retires a stage's sealing key so the next deploy issues a new one. That's the way out of the one dead end in client-side sealing: a worker that doesn't hold the stage's private key can't read that stage's secrets, and fabric can't hand it the key because fabric keeps no copy. Rotating makes every secret already set on the stage unreadable — fabric can't re-seal values it can't open — so it requires `--force` and says exactly that first.

## Changes on top of the original commits

The two changesets were authored as `minor`; this repo releases as patch, so a third commit downgrades both. Nothing else was touched.

## Verification

- `yarn build:packages` — clean
- `npx tsc --noEmit -p packages/cli/tsconfig.json` — clean
- `yarn workspace @pikku/cli test` — 628 pass, 0 fail (includes the new `sealed-box.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)