### PR TITLE
fix(cli): a new table on a covered source keeps its keys and indexes

### DIFF
--- a/.changeset/db-generate-new-table-real-sql.md
+++ b/.changeset/db-generate-new-table-real-sql.md
@@ -1,0 +1,9 @@
+---
+'@pikku/cli': patch
+---
+
+`pikku db generate` now writes a wholly-new table from the source's own SQL, instead of rendering it from a column list.
+
+When a schema source the migrations already cover grows a table — enabling a Better Auth plugin, upgrading an addon, a new `@pikku/kysely` runtime service — the generator took the diff path, which only had names and types to work from. The table it emitted had no primary key, no foreign keys and no indexes, and carried a `-- REVIEW:` note telling you to go copy the real statement by hand. Applied unreviewed, which is what an automated build does, it left a permanently degraded table.
+
+The source already ships the correct DDL, and the first-time path already used it. Now the new-table case does too: its `CREATE TABLE`, its indexes and any `ALTER TABLE` that constrains it are lifted out of the source's SQL in the order it wrote them. Column-level changes to a table that already exists still go through `ALTER TABLE … ADD COLUMN`, and the `-- REVIEW:` note for a `NOT NULL` column with no default is unchanged.

--- a/packages/cli/src/functions/db/local-db.test.ts
+++ b/packages/cli/src/functions/db/local-db.test.ts
@@ -27,6 +27,7 @@ import {
   reset as runReset,
   createKysely,
 } from './local-db.js'
+import type { ColumnInfo } from './db-introspector.js'
 import { MigrationDriftError } from './db-migrator.js'
 import { loadSqliteRuntime } from './sqlite/sqlite-runtime.js'
 
@@ -887,6 +888,174 @@ test('db generate adds only the columns a partially covered source is missing', 
   // what those rows should get is not the generator's decision to make.
   assert.deepEqual(migration.needsBackfill, ['todos.owner'])
   assert.match(body, /-- REVIEW: owner is NOT NULL with no default/)
+})
+
+/**
+ * Publish an addon's schema artifact under `root/node_modules`, overwriting any
+ * earlier one.
+ *
+ * Republishing is the point: a source growing a table between two `db generate`
+ * runs is what enabling a Better Auth plugin or upgrading an addon looks like.
+ */
+function publishAddonSchema(
+  pkg: string,
+  artifact: SchemaArtifact,
+  at: string
+): void {
+  const dir = join(at, 'node_modules', pkg)
+  mkdirSync(join(dir, '.pikku', 'db'), { recursive: true })
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({ name: pkg, version: '1.0.0' })
+  )
+  writeFileSync(
+    join(dir, '.pikku', 'db', 'pikku-db-meta.gen.json'),
+    JSON.stringify(artifact)
+  )
+}
+
+const column = (
+  name: string,
+  type: string,
+  extra: Partial<ColumnInfo> = {}
+): ColumnInfo => ({
+  name,
+  type,
+  notNull: false,
+  pk: false,
+  defaultValue: null,
+  ...extra,
+})
+
+/** The source before the plugin is enabled: one table, and nothing else. */
+const beforePlugin: SchemaArtifact['sqlite'] = {
+  sql: 'CREATE TABLE person (id TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL);',
+  tables: {
+    person: [
+      column('id', 'TEXT', { notNull: true, pk: true }),
+      column('name', 'TEXT', { notNull: true }),
+    ],
+  },
+}
+
+/** The same source after it: a new table, and a new column on the old one. */
+const afterPlugin: SchemaArtifact['sqlite'] = {
+  sql:
+    'CREATE TABLE person (id TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL, two_factor_enabled INTEGER);\n' +
+    'CREATE TABLE two_factor (id TEXT NOT NULL PRIMARY KEY, secret TEXT NOT NULL, person_id TEXT NOT NULL REFERENCES person (id));\n' +
+    'CREATE INDEX two_factor_person_id_idx ON two_factor (person_id);',
+  tables: {
+    person: [
+      column('id', 'TEXT', { notNull: true, pk: true }),
+      column('name', 'TEXT', { notNull: true }),
+      column('two_factor_enabled', 'INTEGER'),
+    ],
+    two_factor: [
+      column('id', 'TEXT', { notNull: true, pk: true }),
+      column('secret', 'TEXT', { notNull: true }),
+      column('person_id', 'TEXT', { notNull: true }),
+    ],
+  },
+}
+
+test('db generate writes a new table on a covered source from the source’s own SQL', async () => {
+  const resolved = resolveDb({ sqliteDb: '.pikku-runtime/dev.db' }, root, root)!
+  const generate = () =>
+    generateMigrations(
+      resolved,
+      root,
+      ['src'],
+      { error: (msg: string) => assert.fail(`unexpected error log: ${msg}`) },
+      [{ package: 'addon-auth' }]
+    )
+
+  publishAddonSchema('addon-auth', { sqlite: beforePlugin }, root)
+  const first = await generate()
+  const initial = first.written.find((w) => w.source === 'addon-auth')
+  assert.ok(initial, 'the source got its first migration')
+  assert.equal(
+    readFileSync(initial.file, 'utf8').includes(beforePlugin!.sql),
+    true,
+    'the first-time path still writes the source SQL verbatim'
+  )
+
+  // The plugin is enabled. `person` is already covered, so this goes through the
+  // diff path — the one that used to render a new table from its column list.
+  publishAddonSchema('addon-auth', { sqlite: afterPlugin }, root)
+  const second = await generate()
+  const migration = second.written.find((w) => w.source === 'addon-auth')
+  assert.ok(migration, 'the new table and column were written')
+  const body = readFileSync(migration.file, 'utf8')
+
+  // The table arrives whole: key, foreign key and index, none of which a column
+  // list can express.
+  assert.match(body, /CREATE TABLE two_factor \(id TEXT NOT NULL PRIMARY KEY/)
+  assert.match(body, /person_id TEXT NOT NULL REFERENCES person \(id\)/)
+  assert.match(
+    body,
+    /CREATE INDEX two_factor_person_id_idx ON two_factor \(person_id\);/
+  )
+  assert.doesNotMatch(body, /REVIEW/, 'nothing is left for a human to copy')
+
+  // And the column-level diff on the table that already exists is untouched.
+  assert.match(
+    body,
+    /ALTER TABLE person ADD COLUMN two_factor_enabled INTEGER;/
+  )
+  assert.doesNotMatch(body, /CREATE TABLE person/, 'person already exists')
+
+  // The whole thing is a real migration: it applies, and leaves no drift.
+  await migrateAndCodegen(resolved)
+  const drift = await driftOf(resolved)
+  assert.equal(drift.inSync, true)
+  assert.deepEqual(drift.extraTables, [])
+})
+
+test('the same holds on postgres', async () => {
+  usePostgresProject()
+  const resolved = resolveDb({}, root, root)!
+  const generate = () =>
+    generateMigrations(
+      resolved,
+      root,
+      ['src'],
+      { error: (msg: string) => assert.fail(`unexpected error log: ${msg}`) },
+      [{ package: 'addon-auth' }]
+    )
+
+  const before: SchemaArtifact = {
+    postgres: {
+      sql: 'CREATE TABLE person (id TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL);',
+      tables: beforePlugin!.tables,
+    },
+  }
+  const after: SchemaArtifact = {
+    postgres: {
+      sql: afterPlugin!.sql,
+      tables: afterPlugin!.tables,
+    },
+  }
+
+  publishAddonSchema('addon-auth', before, root)
+  await generate()
+  publishAddonSchema('addon-auth', after, root)
+  const migration = (await generate()).written.find(
+    (w) => w.source === 'addon-auth'
+  )
+  assert.ok(migration, 'the new table and column were written')
+  const body = readFileSync(migration.file, 'utf8')
+
+  assert.match(body, /CREATE TABLE two_factor \(id TEXT NOT NULL PRIMARY KEY/)
+  assert.match(body, /REFERENCES person \(id\)/)
+  assert.match(body, /CREATE INDEX two_factor_person_id_idx/)
+  assert.doesNotMatch(body, /REVIEW/)
+  assert.match(
+    body,
+    /ALTER TABLE person ADD COLUMN two_factor_enabled INTEGER;/
+  )
+
+  await migrateAndCodegen(resolved)
+  assert.equal((await driftOf(resolved)).inSync, true)
 })
 
 describe('parseDatabaseUrl', () => {

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -30,6 +30,7 @@ import { loadAuthOptions, getAuthMigrations } from './better-auth-schema.js'
 import { generateSchemaTypes, type CodegenResult } from './db-codegen.js'
 import { generateZodTypes, type ZodCodegenResult } from './zod-codegen.js'
 import { createCoercionPlugin, type CoercionMap } from './coercion-plugin.js'
+import { tableCreationSql } from './schema-sql.js'
 import { SqliteMigrationExecutor } from './sqlite/sqlite-migrator.js'
 import { SqliteIntrospector } from './sqlite/sqlite-introspector.js'
 import { createSqliteKysely } from './sqlite/sqlite-kysely.js'
@@ -1469,6 +1470,14 @@ export interface GenerateResult {
  * Partially covered writes the delta, because re-emitting the whole schema
  * would fail on the tables that already exist.
  *
+ * The delta is itself two different things, and only one of them is a diff. A
+ * table the migrations already have but a column short is a genuine alteration,
+ * so it becomes `ALTER TABLE … ADD COLUMN`. A table they do not have at all —
+ * what enabling a Better Auth plugin or upgrading an addon produces — has
+ * nothing to diff against, so it is lifted verbatim out of the source's own SQL
+ * for the same reason the first-time case is: the column map it would otherwise
+ * be rendered from knows nothing about keys, constraints or indexes.
+ *
  * Migrations are written one file per source, numbered in dependency order, so
  * a project can review and apply them independently.
  */
@@ -1516,10 +1525,22 @@ export async function generateMigrations(
     } else {
       const statements: string[] = []
       for (const table of missingTables) {
+        // A wholly new table is the first-time case in miniature: nothing to
+        // diff against, and the source's own SQL already says exactly how to
+        // build it. Rendering the column map instead would drop the primary
+        // key, the foreign keys and the indexes — a table that applies cleanly
+        // and is permanently wrong.
+        const own = tableCreationSql(source.desired.sql, table)
+        if (own.length > 0) {
+          statements.push(own.join('\n\n'))
+          continue
+        }
+
         const columns = source.desired.tables.get(table)
         statements.push(
-          `-- REVIEW: ${table} is new. Copy its CREATE TABLE from the source's own SQL —\n` +
-            `-- the column list below carries no indexes, constraints or foreign keys.\n` +
+          `-- REVIEW: ${table} is new, and its CREATE TABLE could not be found in the\n` +
+            `-- source's own SQL. The column list below carries no indexes, constraints\n` +
+            `-- or foreign keys — copy the real statement over it before applying.\n` +
             `CREATE TABLE ${table} (\n` +
             [...(columns?.values() ?? [])]
               .map(

--- a/packages/cli/src/functions/db/schema-sql.test.ts
+++ b/packages/cli/src/functions/db/schema-sql.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { splitStatements, tableCreationSql } from './schema-sql.js'
+
+test('a semicolon inside a string literal is not a statement boundary', () => {
+  const sql = `CREATE TABLE a (id TEXT, note TEXT DEFAULT 'one; two');
+CREATE TABLE b (id TEXT);`
+
+  assert.deepEqual(splitStatements(sql), [
+    `CREATE TABLE a (id TEXT, note TEXT DEFAULT 'one; two');`,
+    'CREATE TABLE b (id TEXT);',
+  ])
+})
+
+test('a doubled quote inside a literal does not end it', () => {
+  const sql = `CREATE TABLE a (note TEXT DEFAULT 'it''s; fine');`
+  assert.deepEqual(splitStatements(sql), [sql])
+})
+
+test('semicolons in comments and dollar-quoted bodies are ignored', () => {
+  const sql = `-- a comment; with a semicolon
+CREATE TABLE a (id TEXT);
+/* another; one */
+CREATE FUNCTION f() RETURNS void AS $$ BEGIN; END; $$ LANGUAGE plpgsql;`
+
+  assert.deepEqual(splitStatements(sql), [
+    `-- a comment; with a semicolon
+CREATE TABLE a (id TEXT);`,
+    `/* another; one */
+CREATE FUNCTION f() RETURNS void AS $$ BEGIN; END; $$ LANGUAGE plpgsql;`,
+  ])
+})
+
+test('a trailing statement with no semicolon still counts', () => {
+  assert.deepEqual(splitStatements('CREATE TABLE a (id TEXT)'), [
+    'CREATE TABLE a (id TEXT)',
+  ])
+})
+
+test("a table's own SQL comes back with its indexes and constraints", () => {
+  const sql = `CREATE TABLE "user" ("id" text primary key);
+CREATE TABLE "two_factor" ("id" text primary key, "user_id" text not null references "user" ("id"));
+CREATE UNIQUE INDEX "two_factor_user_id_idx" ON "two_factor" ("user_id");
+CREATE INDEX "user_id_idx" ON "user" ("id");
+ALTER TABLE "two_factor" ADD CONSTRAINT "two_factor_secret_check" CHECK (length("id") > 0);`
+
+  assert.deepEqual(tableCreationSql(sql, 'two_factor'), [
+    `CREATE TABLE "two_factor" ("id" text primary key, "user_id" text not null references "user" ("id"));`,
+    `CREATE UNIQUE INDEX "two_factor_user_id_idx" ON "two_factor" ("user_id");`,
+    `ALTER TABLE "two_factor" ADD CONSTRAINT "two_factor_secret_check" CHECK (length("id") > 0);`,
+  ])
+})
+
+test('quoting, casing and a schema qualifier all name the same table', () => {
+  const sql = 'create table if not exists public."Two_Factor" (id text);'
+  assert.deepEqual(tableCreationSql(sql, '"two_factor"'), [sql])
+  assert.deepEqual(tableCreationSql(sql, 'app.two_factor'), [sql])
+})
+
+test('a table the SQL never creates yields nothing to copy', () => {
+  const sql = `CREATE TABLE "user" ("id" text primary key);
+CREATE INDEX "orphan_idx" ON "orders" ("id");`
+
+  assert.deepEqual(tableCreationSql(sql, 'orders'), [])
+})

--- a/packages/cli/src/functions/db/schema-sql.ts
+++ b/packages/cli/src/functions/db/schema-sql.ts
@@ -1,0 +1,155 @@
+/**
+ * Reading a schema source's own SQL back out, one table at a time.
+ *
+ * A source hands `db generate` both what must exist (`tables`) and what creates
+ * it (`sql`). The column map is a comparison surface — it answers "is this
+ * table there, and does it have these columns" — and it is deliberately lossy:
+ * primary keys, foreign keys, uniqueness, check constraints and indexes are all
+ * absent from it. So the moment the generator has to *create* something, the
+ * only honest source is the SQL, and this is what pulls the relevant part of it
+ * out.
+ */
+
+/**
+ * Split a SQL script into its top-level statements, semicolons included.
+ *
+ * A naive `split(';')` is wrong in a way that only shows up later: a semicolon
+ * inside a string literal, a quoted identifier or a comment is not a statement
+ * boundary, and cutting there yields two fragments that are each valid-looking
+ * and neither of which does what the original did.
+ */
+export function splitStatements(sql: string): string[] {
+  const statements: string[] = []
+  let start = 0
+  let i = 0
+
+  const closeQuote = (quote: string) => {
+    i++
+    while (i < sql.length) {
+      if (sql[i] === '\\' && quote === "'") {
+        i += 2
+        continue
+      }
+      if (sql[i] === quote) {
+        // A doubled quote is an escaped one, not the end of the literal.
+        if (sql[i + 1] === quote) {
+          i += 2
+          continue
+        }
+        i++
+        return
+      }
+      i++
+    }
+  }
+
+  while (i < sql.length) {
+    const ch = sql[i]!
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      closeQuote(ch)
+      continue
+    }
+
+    if (ch === '-' && sql[i + 1] === '-') {
+      const end = sql.indexOf('\n', i)
+      i = end === -1 ? sql.length : end + 1
+      continue
+    }
+
+    if (ch === '/' && sql[i + 1] === '*') {
+      const end = sql.indexOf('*/', i + 2)
+      i = end === -1 ? sql.length : end + 2
+      continue
+    }
+
+    // Postgres dollar quoting: everything between `$tag$` and its twin is a
+    // literal, and a function body written that way is full of semicolons.
+    if (ch === '$') {
+      const tag = /^\$[A-Za-z_0-9]*\$/.exec(sql.slice(i))
+      if (tag) {
+        const end = sql.indexOf(tag[0], i + tag[0].length)
+        i = end === -1 ? sql.length : end + tag[0].length
+        continue
+      }
+    }
+
+    if (ch === ';') {
+      const statement = sql.slice(start, i + 1).trim()
+      if (statement.length > 1) statements.push(statement)
+      start = i + 1
+    }
+
+    i++
+  }
+
+  // A script whose last statement has no trailing semicolon still ran it.
+  const tail = sql.slice(start).trim()
+  if (tail.length > 0) statements.push(tail)
+
+  return statements
+}
+
+/**
+ * Reduce a written table name to the form two sources can be compared on.
+ *
+ * The same table is `two_factor` to one writer, `"two_factor"` to Kysely and
+ * `public.two_factor` to Postgres introspection. Dropping the schema qualifier,
+ * the quoting and the case is the only shape all three agree on.
+ */
+export function bareTableName(name: string): string {
+  const last = name.split('.').pop() ?? name
+  return last.replace(/^["'`[]|["'`\]]$/g, '').toLowerCase()
+}
+
+const CREATE_TABLE =
+  /^CREATE\s+(?:TEMP(?:ORARY)?\s+|UNLOGGED\s+)*TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([^\s(]+)/i
+
+const CREATE_INDEX =
+  /^CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?\S+\s+ON\s+(?:ONLY\s+)?([^\s(]+)/i
+
+const ALTER_TABLE = /^ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?([^\s(]+)/i
+
+/**
+ * Every statement in `sql` that builds `table`, in the order the source wrote
+ * them.
+ *
+ * The `CREATE TABLE` and its indexes, plus any `ALTER TABLE` the source uses to
+ * hang a constraint on it afterwards — which together are what the column list
+ * cannot express. Source order is preserved because it is load-bearing: an
+ * index cannot precede its table, and a table cannot precede one it references.
+ *
+ * An empty result means the source's SQL does not visibly create the table.
+ * That is a real answer rather than a failure — a source may create a table
+ * from something other than a literal `CREATE TABLE` — and the caller is
+ * expected to fall back rather than emit nothing.
+ */
+export function tableCreationSql(sql: string, table: string): string[] {
+  const wanted = bareTableName(table)
+  const statements: string[] = []
+  let creates = false
+
+  for (const statement of splitStatements(sql)) {
+    const create = CREATE_TABLE.exec(statement)
+    if (create && bareTableName(create[1]!) === wanted) {
+      creates = true
+      statements.push(statement)
+      continue
+    }
+
+    const index = CREATE_INDEX.exec(statement)
+    if (index && bareTableName(index[1]!) === wanted) {
+      statements.push(statement)
+      continue
+    }
+
+    const alter = ALTER_TABLE.exec(statement)
+    if (alter && bareTableName(alter[1]!) === wanted) {
+      statements.push(statement)
+    }
+  }
+
+  // Indexes and alters without the table they belong to would fail on their own,
+  // and their presence says the table came from somewhere this cannot read.
+  return creates ? statements : []
+}


### PR DESCRIPTION
## The bug

`generateMigrations` documents three cases per schema source:

> Fully covered is nothing to do. Nothing covered writes the source's own SQL verbatim, which is the one case where the source knows better than any diff. Partially covered writes the delta.

The first-time path is right. The **partially covered** path is not — it has only a column list to work from, so a table that is *wholly new* to an already-covered source came out as a stub.

Reproduced (starter-template shape, addon source already covered, then a "plugin" enabled):

```sql
-- REVIEW: two_factor is new. Copy its CREATE TABLE from the source's own SQL —
-- the column list below carries no indexes, constraints or foreign keys.
CREATE TABLE two_factor (
  id TEXT NOT NULL,
  secret TEXT NOT NULL,
  person_id TEXT NOT NULL
);

ALTER TABLE person ADD COLUMN two_factor_enabled INTEGER;
```

The `ALTER` is correct. The table is not: no primary key, no `REFERENCES person (id)`, no index — and the comment admits it, asking a human to go copy the real SQL. Applied as-is (what an automated build agent does) it leaves a permanently degraded table.

Enabling a Better Auth plugin is the ordinary way to hit this. Every source — `better-auth`, `pikku-runtime`, addons — shares the `SchemaSource` shape, so all of them did.

## The fix

A wholly new table is the first-time case in miniature: nothing to diff against, and the source already ships the correct DDL in `desired.sql`. It is now lifted from there rather than rendered.

Same input, after:

```sql
CREATE TABLE two_factor (id TEXT NOT NULL PRIMARY KEY, secret TEXT NOT NULL, person_id TEXT NOT NULL REFERENCES person (id));

CREATE INDEX two_factor_person_id_idx ON two_factor (person_id);

ALTER TABLE person ADD COLUMN two_factor_enabled INTEGER;
```

Deliberately unchanged:

- **Column-level diffs on an existing table** still go through `addColumnStatements` — that path was correct.
- **The `-- REVIEW:` note for a `NOT NULL` column with no default** (the `needsBackfill` case) still fires. It is a real decision only the author can make.
- **The first-time path** still writes the source's SQL verbatim.

The new-table `REVIEW` note survives only as a fallback for when the source's SQL contains no visible `CREATE TABLE` for the table — an honest "I could not find it" rather than silently emitting nothing.

## Design notes

`schema-sql.ts` is a small, dialect-neutral reader over a source's SQL:

- `splitStatements` respects string literals, quoted identifiers, `--` and `/* */` comments, and Postgres dollar quoting. A naive `split(';')` cuts a `DEFAULT ';'` in half into two valid-looking fragments.
- `tableCreationSql` returns the `CREATE TABLE`, its indexes, and any `ALTER TABLE` constraining it, **in source order** — order is load-bearing (an index cannot precede its table; a table cannot precede one it references).
- Names are matched on the bare, unquoted, case-folded form, because the same table is `two_factor` to one writer, `"two_factor"` to Kysely and `public.two_factor` to Postgres introspection.
- It returns `[]` unless it actually saw the `CREATE TABLE`, so a stray index never travels without its table.

## Files changed

| File | Why |
| --- | --- |
| `packages/cli/src/functions/db/schema-sql.ts` | New. Statement splitter + per-table statement extractor. |
| `packages/cli/src/functions/db/schema-sql.test.ts` | New. Unit cover for the splitter's quoting/comment/dollar-quote cases and the extractor's matching. |
| `packages/cli/src/functions/db/local-db.ts` | `generateMigrations` uses the source's own SQL for a wholly-new table; JSDoc now states that the delta is two different things. |
| `packages/cli/src/functions/db/local-db.test.ts` | Two integration tests (sqlite + postgres): plugin-enabled source emits the table with PK/FK/index and no REVIEW, the added column still ALTERs, the first-time path is verbatim, and the result applies with no drift. |

## Verification

```
node --import tsx --test src/functions/db/local-db.test.ts src/functions/db/schema-sql.test.ts
ℹ tests 52
ℹ pass 52
ℹ fail 0
```

Full `packages/cli` suite: 564/565. The one failure, `src/fabric/functions/validate.function.test.ts`, reproduces identically on a pristine checkout of `main` in this worktree (it wants `packages/cli/.pikku/pikku-types.gen.js`, which is not generated here) and is unrelated.

`yarn tsc` in `packages/cli` reports no errors in either touched file. Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)