### PR TITLE
feat(cli): let scenario run target a URL known only at run time

### DIFF
--- a/.changeset/scenario-run-dynamic-target.md
+++ b/.changeset/scenario-run-dynamic-target.md
@@ -1,0 +1,12 @@
+---
+'@pikku/cli': patch
+'@pikku/playwright': patch
+---
+
+`pikku scenario run` can now target a URL that only exists at run time.
+
+The environment named on the command line was the whole answer: its `apiUrl` and `appUrl` are literal strings in `pikku.config.json`, frozen when the config was written. A suite that wants to run against something provisioned moments earlier — a freshly deployed sandbox with a unique origin — had nowhere to put that address short of synthesising a config file per run.
+
+`--api-url` and `--app-url` now override the named environment's URLs for one invocation. The environment is still looked up by name and must still exist, so the flags override a target rather than inventing one, and the override is applied once where the environment is resolved: actors, raw-HTTP steps, the browser driver and a `--spawn`ed server all see the same address. A value that is not an absolute http(s) URL is rejected where it was typed, and `--spawn` with a non-local `--api-url` is refused instead of trying to bind a server to a host this machine does not own.
+
+Browser steps get the same reach. A driver that knows the target from its own environment — `@pikku/playwright` reading `SANDBOX_HOSTNAME`, `E2E_APP_URL` or `APP_URL` — is now allowed to supply the `appUrl` when the config names none; previously the runner refused before the driver was ever consulted. The check still fires when nothing resolved a real target: a driver reporting `appUrlSource: 'default'`, as `@pikku/playwright` now does for its `http://localhost:5001` placeholder, fails the run exactly as a missing `appUrl` always did.

--- a/packages/cli/src/cli.wiring.ts
+++ b/packages/cli/src/cli.wiring.ts
@@ -511,6 +511,14 @@ wireCLI({
                 'Keep every stack frame on a failure. Without it, only the project’s own frames are shown',
               default: false,
             },
+            apiUrl: {
+              description:
+                "Override the environment's apiUrl for this run — for a target that only exists at run time, such as a freshly deployed sandbox",
+            },
+            appUrl: {
+              description:
+                "Override the environment's appUrl for this run (the frontend browser steps navigate against)",
+            },
           },
         }),
         list: pikkuCLICommand({

--- a/packages/cli/src/functions/commands/scenario-browser.test.ts
+++ b/packages/cli/src/functions/commands/scenario-browser.test.ts
@@ -147,8 +147,71 @@ describe('resolveScenarioBrowserProvider', () => {
         ...options({ appUrl: undefined }),
         importDriver: driver().importDriver,
       } as any),
-      /environment 'local' has browser steps but no 'appUrl'/
+      /environment 'local' has browser steps but no 'appUrl'[\s\S]*--app-url/
     )
+  })
+
+  test('a driver that knows the target from its own environment supplies the appUrl', async () => {
+    let seen: any
+    await resolveScenarioBrowserProvider({
+      ...options({ appUrl: undefined }),
+      driver: '@acme/sandbox-driver',
+      importDriver: async () => ({
+        // The sandbox case: the driver reads a hostname nothing in the config
+        // could have known.
+        browserConfigFromEnv: (overrides: any) => ({
+          ...overrides,
+          appUrl: overrides.appUrl ?? 'https://sandbox-a1b2.example.com',
+          appUrlSource: overrides.appUrl ? 'override' : 'env',
+        }),
+        createScenarioBrowserProvider: (opts: any) => {
+          seen = opts
+          return { sessionFor: async () => ({}) as any, close: async () => {} }
+        },
+      }),
+    } as any)
+
+    assert.equal(seen.config.appUrl, 'https://sandbox-a1b2.example.com')
+  })
+
+  test('a driver falling back to its own placeholder is reported as a missing appUrl', async () => {
+    await assert.rejects(
+      resolveScenarioBrowserProvider({
+        ...options({ appUrl: undefined }),
+        driver: '@acme/sandbox-driver',
+        importDriver: async () => ({
+          browserConfigFromEnv: () => ({
+            appUrl: 'http://localhost:5001',
+            appUrlSource: 'default',
+          }),
+          createScenarioBrowserProvider: () => ({
+            sessionFor: async () => ({}) as any,
+            close: async () => {},
+          }),
+        }),
+      } as any),
+      /environment 'local' has browser steps but no 'appUrl'[\s\S]*resolved none from the environment/
+    )
+  })
+
+  test('the configured appUrl still wins over anything the driver would resolve', async () => {
+    let seen: any
+    await resolveScenarioBrowserProvider({
+      ...options(),
+      driver: '@acme/sandbox-driver',
+      importDriver: async () => ({
+        browserConfigFromEnv: (overrides: any) => ({
+          appUrl: overrides.appUrl ?? 'https://sandbox-a1b2.example.com',
+          appUrlSource: overrides.appUrl ? 'override' : 'env',
+        }),
+        createScenarioBrowserProvider: (opts: any) => {
+          seen = opts
+          return { sessionFor: async () => ({}) as any, close: async () => {} }
+        },
+      }),
+    } as any)
+
+    assert.equal(seen.config.appUrl, 'http://localhost:4077/console')
   })
 
   test('a missing driver names the scenarios that needed it and how to install it', async () => {
@@ -204,6 +267,22 @@ describe('resolveScenarioBrowserProvider', () => {
       appUrl: 'http://localhost:4077/console',
       apiUrl: 'http://localhost:4077',
     })
+  })
+
+  test('a driver with no config of its own cannot rescue a missing appUrl', async () => {
+    await assert.rejects(
+      resolveScenarioBrowserProvider({
+        ...options({ appUrl: undefined }),
+        driver: '@acme/minimal-driver',
+        importDriver: async () => ({
+          createScenarioBrowserProvider: () => ({
+            sessionFor: async () => ({}) as any,
+            close: async () => {},
+          }),
+        }),
+      } as any),
+      /environment 'local' has browser steps but no 'appUrl'/
+    )
   })
 
   test('a package that is not a driver at all says so, rather than crashing later', async () => {

--- a/packages/cli/src/functions/commands/scenario-browser.ts
+++ b/packages/cli/src/functions/commands/scenario-browser.ts
@@ -39,9 +39,17 @@ export interface ScenarioBrowserDriver {
   PlaywrightScenarioBrowserProvider?: new (
     options: ScenarioBrowserDriverOptions
   ) => ScenarioBrowserProvider
-  /** Driver-specific config (headed, slowMo, timeouts) resolved from the env. */
+  /**
+   * Driver-specific config (headed, slowMo, timeouts) resolved from the env.
+   *
+   * A driver may resolve `appUrl` itself when the caller passes none — that is
+   * how a target known only at run time (a sandbox hostname in the env) is
+   * reached without a config file per deployment. A driver that answers with a
+   * placeholder rather than a real target must say so with
+   * `appUrlSource: 'default'`, which the runner reports as a missing appUrl.
+   */
   browserConfigFromEnv?: (overrides: {
-    appUrl: string
+    appUrl?: string
     apiUrl: string
   }) => unknown
 }
@@ -64,9 +72,26 @@ export interface ResolveScenarioBrowserProviderOptions {
 }
 
 /**
+ * What the driver answered with, once it has had its say about `appUrl`.
+ * `appUrlSource` is optional: a driver that resolves a URL and does not
+ * classify it is taken at its word.
+ */
+interface ResolvedBrowserConfig {
+  appUrl?: string
+  appUrlSource?: 'override' | 'env' | 'default'
+}
+
+/**
  * Both failure modes here are discovered before the first scenario starts. A
  * missing `appUrl` or an uninstalled driver found mid-run costs a whole run to
  * learn about.
+ *
+ * `appUrl` is checked after the driver has resolved its config rather than
+ * before, so a driver that knows the target from its own environment (a
+ * sandbox hostname) is allowed to supply it. The check is not dropped: a driver
+ * reporting `appUrlSource: 'default'` resolved nothing and fails the same way,
+ * because a run against a placeholder URL is worse than one that refuses to
+ * start.
  */
 export const resolveScenarioBrowserProvider = async ({
   environment,
@@ -81,12 +106,6 @@ export const resolveScenarioBrowserProvider = async ({
   importDriver = (specifier) =>
     import(specifier) as unknown as Promise<ScenarioBrowserDriver>,
 }: ResolveScenarioBrowserProviderOptions): Promise<ScenarioBrowserProvider> => {
-  if (!appUrl) {
-    throw new Error(
-      `Scenario environment '${environment}' has browser steps but no 'appUrl'. ` +
-        `Add it to scenarios.environments.${environment} in pikku.config.json, or run with --no-browser to skip them.`
-    )
-  }
   const module = await importDriver(driver).catch(() => {
     const install =
       driver === DEFAULT_BROWSER_DRIVER
@@ -97,15 +116,22 @@ export const resolveScenarioBrowserProvider = async ({
         `${install}, or run with --no-browser to skip them.`
     )
   })
+  const config = (module.browserConfigFromEnv?.({ appUrl, apiUrl }) ?? {
+    appUrl,
+    apiUrl,
+  }) as ResolvedBrowserConfig
+  if (!config.appUrl || config.appUrlSource === 'default') {
+    throw new Error(
+      `Scenario environment '${environment}' has browser steps but no 'appUrl', and '${driver}' resolved none from the environment. ` +
+        `Add it to scenarios.environments.${environment} in pikku.config.json, pass --app-url for a target that only exists at run time, or run with --no-browser to skip them.`
+    )
+  }
   const options: ScenarioBrowserDriverOptions = {
     secret,
     actors,
     signInPath,
     failureDir,
-    config: module.browserConfigFromEnv?.({ appUrl, apiUrl }) ?? {
-      appUrl,
-      apiUrl,
-    },
+    config,
   }
   if (module.createScenarioBrowserProvider) {
     return module.createScenarioBrowserProvider(options)

--- a/packages/cli/src/functions/commands/scenario-environment.test.ts
+++ b/packages/cli/src/functions/commands/scenario-environment.test.ts
@@ -1,0 +1,135 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { resolveScenarioEnvironment } from './scenario-environment.js'
+
+const environments = {
+  local: {
+    apiUrl: 'http://localhost:4077',
+    appUrl: 'http://localhost:5001',
+    signInPath: '/auth/sign-in/actor',
+    rpcPath: '/rpc',
+  },
+}
+
+describe('resolveScenarioEnvironment', () => {
+  test('an unknown environment names the ones that are configured', () => {
+    assert.throws(
+      () => resolveScenarioEnvironment({ environment: 'staging', environments }),
+      /Unknown scenario environment 'staging'[\s\S]*Configured environments: local/
+    )
+  })
+
+  test('an unknown environment with nothing configured shows what to add', () => {
+    assert.throws(
+      () =>
+        resolveScenarioEnvironment({ environment: 'staging', environments: {} }),
+      /Add scenarios.environments to pikku.config.json/
+    )
+  })
+
+  test('without overrides the configured environment is used verbatim', () => {
+    assert.deepEqual(
+      resolveScenarioEnvironment({ environment: 'local', environments }),
+      environments.local
+    )
+  })
+
+  test('overrides replace the urls a run targets and leave the rest of the environment alone', () => {
+    const env = resolveScenarioEnvironment({
+      environment: 'local',
+      environments,
+      apiUrl: 'https://sandbox-a1b2.example.com/api',
+      appUrl: 'https://sandbox-a1b2.example.com',
+    })
+
+    assert.deepEqual(env, {
+      apiUrl: 'https://sandbox-a1b2.example.com/api',
+      appUrl: 'https://sandbox-a1b2.example.com',
+      signInPath: '/auth/sign-in/actor',
+      rpcPath: '/rpc',
+    })
+  })
+
+  test('the environment must still exist — the flags override it, they do not invent one', () => {
+    assert.throws(
+      () =>
+        resolveScenarioEnvironment({
+          environment: 'sandbox',
+          environments,
+          apiUrl: 'https://sandbox-a1b2.example.com/api',
+        }),
+      /Unknown scenario environment 'sandbox'/
+    )
+  })
+
+  test('an appUrl override alone leaves the configured apiUrl in place', () => {
+    const env = resolveScenarioEnvironment({
+      environment: 'local',
+      environments,
+      appUrl: 'https://sandbox-a1b2.example.com',
+    })
+
+    assert.equal(env.apiUrl, 'http://localhost:4077')
+    assert.equal(env.appUrl, 'https://sandbox-a1b2.example.com')
+  })
+
+  test('a relative --api-url is rejected where it was typed, not deep in the run', () => {
+    assert.throws(
+      () =>
+        resolveScenarioEnvironment({
+          environment: 'local',
+          environments,
+          apiUrl: '/api',
+        }),
+      /--api-url '\/api' is not a valid absolute URL/
+    )
+  })
+
+  test('a non-http --app-url is rejected', () => {
+    assert.throws(
+      () =>
+        resolveScenarioEnvironment({
+          environment: 'local',
+          environments,
+          appUrl: 'ftp://example.com',
+        }),
+      /--app-url 'ftp:\/\/example.com' must be an http\(s\) URL/
+    )
+  })
+
+  test('--spawn against a remote --api-url is refused rather than binding a server nobody reaches', () => {
+    assert.throws(
+      () =>
+        resolveScenarioEnvironment({
+          environment: 'local',
+          environments,
+          apiUrl: 'https://sandbox-a1b2.example.com/api',
+          spawn: true,
+        }),
+      /--spawn starts a server on this machine, but --api-url points at 'sandbox-a1b2.example.com'/
+    )
+  })
+
+  test('--spawn with a local --api-url is a port override, and stands', () => {
+    const env = resolveScenarioEnvironment({
+      environment: 'local',
+      environments,
+      apiUrl: 'http://localhost:5555',
+      spawn: true,
+    })
+
+    assert.equal(env.apiUrl, 'http://localhost:5555')
+  })
+
+  test('--spawn does not object to an --app-url elsewhere: the frontend need not be the spawned server', () => {
+    const env = resolveScenarioEnvironment({
+      environment: 'local',
+      environments,
+      appUrl: 'https://preview-a1b2.example.com',
+      spawn: true,
+    })
+
+    assert.equal(env.appUrl, 'https://preview-a1b2.example.com')
+  })
+})

--- a/packages/cli/src/functions/commands/scenario-environment.ts
+++ b/packages/cli/src/functions/commands/scenario-environment.ts
@@ -1,0 +1,101 @@
+/**
+ * Resolving `pikku scenario run <environment>` to the URLs the run targets.
+ *
+ * The configured environment is the base; `--api-url`/`--app-url` override it
+ * for one invocation, which is what makes a suite runnable against a target
+ * that only exists at run time (a freshly provisioned sandbox) without writing
+ * a pikku.config.json per deployment.
+ */
+
+/** One entry of `scenarios.environments` in pikku.config.json. */
+export interface ScenarioEnvironment {
+  apiUrl: string
+  signInPath?: string
+  rpcPath?: string
+  appUrl?: string
+}
+
+export interface ResolveScenarioEnvironmentOptions {
+  /** The name given on the command line. Must exist in config. */
+  environment: string
+  environments: Record<string, ScenarioEnvironment>
+  /** `--api-url`, overriding the configured `apiUrl`. */
+  apiUrl?: string
+  /** `--app-url`, overriding the configured `appUrl`. */
+  appUrl?: string
+  /** `--spawn`, which is only coherent against a local `apiUrl`. */
+  spawn?: boolean
+}
+
+const LOCAL_HOSTNAMES = new Set([
+  'localhost',
+  '127.0.0.1',
+  '0.0.0.0',
+  '::1',
+  '[::1]',
+])
+
+/**
+ * Absolute URLs only: the value is concatenated with paths (`${apiUrl}/rpc`)
+ * and parsed by the spawn path, so a relative one fails far from its cause.
+ */
+const assertAbsoluteUrl = (flag: string, value: string): URL => {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(
+      `${flag} '${value}' is not a valid absolute URL — pass one including the scheme, e.g. ${flag} https://sandbox-a1b2.example.com/api`
+    )
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(
+      `${flag} '${value}' must be an http(s) URL, not '${url.protocol.replace(':', '')}'.`
+    )
+  }
+  return url
+}
+
+/**
+ * Applied once, so actors, step env, the browser driver and the spawned server
+ * all see the same target. The environment is still looked up by name: the
+ * flags override fields on a configured environment, they do not invent one.
+ */
+export const resolveScenarioEnvironment = ({
+  environment,
+  environments,
+  apiUrl,
+  appUrl,
+  spawn = false,
+}: ResolveScenarioEnvironmentOptions): ScenarioEnvironment => {
+  const configured = environments[environment]
+  if (!configured) {
+    const known = Object.keys(environments)
+    throw new Error(
+      `Unknown scenario environment '${environment}'. ` +
+        (known.length
+          ? `Configured environments: ${known.join(', ')}`
+          : `Add scenarios.environments to pikku.config.json, e.g. { "${environment}": { "apiUrl": "https://app.example.com/api" } }`)
+    )
+  }
+
+  const resolved: ScenarioEnvironment = { ...configured }
+
+  if (apiUrl !== undefined) {
+    const url = assertAbsoluteUrl('--api-url', apiUrl)
+    if (spawn && !LOCAL_HOSTNAMES.has(url.hostname)) {
+      throw new Error(
+        `--spawn starts a server on this machine, but --api-url points at '${url.hostname}'. ` +
+          `Drop --spawn to run against an already-serving target, or point --api-url at localhost.`
+      )
+    }
+    resolved.apiUrl = apiUrl
+  }
+
+  if (appUrl !== undefined) {
+    assertAbsoluteUrl('--app-url', appUrl)
+    resolved.appUrl = appUrl
+  }
+
+  return resolved
+}

--- a/packages/cli/src/functions/commands/scenario.ts
+++ b/packages/cli/src/functions/commands/scenario.ts
@@ -31,6 +31,7 @@ import { resolveScenarioActors } from '../../utils/resolve-scenario-actors.js'
 import { spawnDevServer } from '../../server/spawn-dev-server.js'
 import { buildScenarioPlan } from './scenario-plan.js'
 import type { ScenarioPlanGroup } from './scenario-plan.js'
+import { resolveScenarioEnvironment } from './scenario-environment.js'
 
 const isScenario = (wf: any) => wf?.scenario === true
 
@@ -132,6 +133,8 @@ export const scenarioRun = pikkuSessionlessFunc<
     spawn?: boolean
     keepAlive?: boolean
     trace?: boolean
+    apiUrl?: string
+    appUrl?: string
   },
   void
 >({
@@ -148,19 +151,25 @@ export const scenarioRun = pikkuSessionlessFunc<
       spawn = false,
       keepAlive = false,
       trace = false,
+      apiUrl,
+      appUrl,
     }
   ) => {
     const state = await getInspectorState(true, false, false, true)
 
-    const environments = config.scenarios?.environments ?? {}
-    const env = environments[environment]
-    if (!env) {
-      const known = Object.keys(environments)
-      throw new Error(
-        `Unknown scenario environment '${environment}'. ` +
-          (known.length
-            ? `Configured environments: ${known.join(', ')}`
-            : `Add scenarios.environments to pikku.config.json, e.g. { "${environment}": { "apiUrl": "https://app.example.com/api" } }`)
+    // Resolved once, so actors, step env, the browser driver and any spawned
+    // server all target the same place — including when the target only exists
+    // at run time and arrives through --api-url/--app-url.
+    const env = resolveScenarioEnvironment({
+      environment,
+      environments: config.scenarios?.environments ?? {},
+      apiUrl,
+      appUrl,
+      spawn,
+    })
+    if (apiUrl || appUrl) {
+      logger.info(
+        `Overriding '${environment}': apiUrl ${env.apiUrl}${env.appUrl ? `, appUrl ${env.appUrl}` : ''}`
       )
     }
 

--- a/packages/playwright/src/config.test.ts
+++ b/packages/playwright/src/config.test.ts
@@ -1,0 +1,56 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { browserConfigFromEnv } from './config.js'
+
+describe('browserConfigFromEnv', () => {
+  test('an explicit override wins and is reported as one', () => {
+    const config = browserConfigFromEnv(
+      { appUrl: 'https://app.example.com' },
+      { APP_URL: 'https://ignored.example.com' }
+    )
+
+    assert.equal(config.appUrl, 'https://app.example.com')
+    assert.equal(config.appUrlSource, 'override')
+  })
+
+  test('a sandbox hostname known only at run time resolves the app url', () => {
+    const config = browserConfigFromEnv(
+      {},
+      { SANDBOX_HOSTNAME: 'sandbox-a1b2.example.com' }
+    )
+
+    assert.equal(config.appUrl, 'https://sandbox-a1b2.example.com')
+    assert.equal(config.appUrlSource, 'env')
+    assert.equal(config.hostnameOnly, 'sandbox-a1b2.example.com')
+  })
+
+  test('E2E_APP_URL and APP_URL are env resolutions, not defaults', () => {
+    assert.equal(
+      browserConfigFromEnv({}, { E2E_APP_URL: 'https://e2e.example.com' })
+        .appUrlSource,
+      'env'
+    )
+    assert.equal(
+      browserConfigFromEnv({}, { APP_URL: 'https://app.example.com' })
+        .appUrlSource,
+      'env'
+    )
+  })
+
+  test('with nothing to go on the local fallback is marked as the placeholder it is', () => {
+    const config = browserConfigFromEnv({}, {})
+
+    assert.equal(config.appUrl, 'http://localhost:5001')
+    assert.equal(config.appUrlSource, 'default')
+  })
+
+  test('the api url still defaults to the resolved app origin', () => {
+    const config = browserConfigFromEnv(
+      {},
+      { SANDBOX_HOSTNAME: 'sandbox-a1b2.example.com' }
+    )
+
+    assert.equal(config.apiUrl, 'https://sandbox-a1b2.example.com/api')
+  })
+})

--- a/packages/playwright/src/config.ts
+++ b/packages/playwright/src/config.ts
@@ -15,6 +15,12 @@ import { loadElementMap, type ElementMap } from './elements.js'
 export interface BrowserConfig {
   /** Base URL of the running frontend. */
   appUrl: string
+  /**
+   * Where `appUrl` came from. `default` means nothing named a target and the
+   * local dev fallback was used — the scenario runner treats that as a
+   * misconfiguration rather than silently testing localhost.
+   */
+  appUrlSource?: 'override' | 'env' | 'default'
   /** Base URL of the API (default: same origin under /api). */
   apiUrl: string
   /** Per-action Playwright timeout (ms). */
@@ -51,13 +57,12 @@ export function browserConfigFromEnv(
   env: Record<string, string | undefined> = process.env
 ): BrowserConfig {
   const host = env.SANDBOX_HOSTNAME
-  const appUrl =
-    overrides.appUrl ??
-    env.E2E_APP_URL ??
-    env.APP_URL ??
-    (host ? `https://${host}` : 'http://localhost:5001')
+  const envAppUrl =
+    env.E2E_APP_URL ?? env.APP_URL ?? (host ? `https://${host}` : undefined)
+  const appUrl = overrides.appUrl ?? envAppUrl ?? 'http://localhost:5001'
   return {
     appUrl,
+    appUrlSource: overrides.appUrl ? 'override' : envAppUrl ? 'env' : 'default',
     apiUrl:
       overrides.apiUrl ?? env.E2E_API_URL ?? env.API_URL ?? `${appUrl}/api`,
     timeout: overrides.timeout ?? Number(env.E2E_TIMEOUT ?? 30_000),


### PR DESCRIPTION
`pikku scenario run <environment>` read its target from literal strings in `pikku.config.json`, so a suite could not be pointed at something provisioned moments earlier — a freshly deployed sandbox with a unique origin — without writing a config file per run.

## What changed

`--api-url` / `--app-url` override the named environment's URLs for one invocation. The override is applied once, in a new `resolveScenarioEnvironment`, so actors, raw-HTTP steps, the browser driver and a `--spawn`'d server all see the same target. Precedence:

1. `--api-url` / `--app-url`
2. `scenarios.environments.<name>.apiUrl` / `.appUrl`
3. for `appUrl` only, whatever the browser driver resolves from its own environment

The environment is still looked up by name and must exist.

A value that is not an absolute http(s) URL is rejected where it was typed, and `--spawn` with a non-local `--api-url` is refused rather than binding a server to a host this machine does not own (`--spawn --api-url http://localhost:5555`, a legitimate port override, still works).

### The browser guard moves rather than disappears

`scenario-browser.ts` threw eagerly on a missing `appUrl`, before the driver was consulted — which made `@pikku/playwright`'s existing `SANDBOX_HOSTNAME` / `E2E_APP_URL` resolution unreachable. Now a driver may supply the `appUrl`, and reports where it came from: `@pikku/playwright` returns `appUrlSource: 'override' | 'env' | 'default'`, and the CLI fails on `'default'` exactly as it always failed on a missing `appUrl`. `appUrlSource` is optional, so a third-party driver that resolves a URL without classifying it is taken at its word, and a driver with no `browserConfigFromEnv` still hits the old guard.

**Behaviour change worth calling out:** a project that declared no `appUrl` and silently relied on playwright's implicit `http://localhost:5001` now gets an error instead of a silent localhost run.

## Verification

- `packages/cli`: `yarn tsc` clean; `bash run-tests.sh` → **661 pass, 0 fail**
- `packages/playwright`: `yarn tsc` clean; `bash run-tests.sh` → **26 pass, 0 fail**
- `npx changeset status` → patch bumps for `@pikku/cli` and `@pikku/playwright`

New tests: 11 cases in `scenario-environment.test.ts` (override applied, unknown environment still rejected, relative/non-http URLs rejected, both `--spawn` interactions), 4 in `scenario-browser.test.ts` for the moved guard, 5 in `packages/playwright/src/config.test.ts` for `appUrlSource`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
