### PR TITLE
feat(cli): reject camelCase identifiers in migrations

### DIFF
--- a/.changeset/db-migrate-rejects-camelcase-identifiers.md
+++ b/.changeset/db-migrate-rejects-camelcase-identifiers.md
@@ -1,0 +1,11 @@
+---
+'@pikku/cli': patch
+---
+
+`pikku db migrate` now fails when a migration declares a camelCase column or table.
+
+Pikku's Kysely runs with `CamelCasePlugin`, so `priceCents` in TypeScript is `price_cents` in SQL and nothing else. A migration that spells the column `priceCents` half-works, which is what made it expensive: `.selectAll()` compiles to `SELECT *` and never names an identifier, so the table reads back perfectly, while the first query that names the column asks for `price_cents` and gets `no such column`. The plugin looks broken, and the fix looks like a raw `sql` template.
+
+Every `.sql` file in the migrations directory is now parsed before anything is applied, and every camelCase identifier a `CREATE TABLE` column list or an `ALTER TABLE … ADD COLUMN` declares is reported at once with its file, table and snake_case name. Comments, string literals, quoted identifiers and nested parens (`NUMERIC(10,2)`, `CHECK (…)`) are all read as SQL rather than as text, so prose mentioning `createdAt` does not trip it.
+
+There is no exception to opt out of. The generated Better Auth schema is snake_case for the same reason, because Better Auth is handed the app's own Kysely.

--- a/packages/cli/src/functions/db/db-migrator.ts
+++ b/packages/cli/src/functions/db/db-migrator.ts
@@ -2,6 +2,8 @@ import { createHash } from 'node:crypto'
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { assertSnakeCaseIdentifiers } from './migration-identifiers.js'
+
 /**
  * The migrator's own bookkeeping table, which belongs to no dialect and to no
  * project's schema.
@@ -123,10 +125,27 @@ function assertNoDrift(
   }
 }
 
+/**
+ * Every migration on disk, read once.
+ *
+ * The identifier check reads all of them and not just the pending ones, so that
+ * whether a migration is rejected depends on the files alone. A camelCase
+ * column that had already been applied somewhere would otherwise pass on that
+ * machine and fail on a fresh checkout, which is the opposite of deterministic.
+ */
+const readMigrations = (
+  migrationsDir: string
+): Array<{ name: string; sql: string }> =>
+  migrationFiles(migrationsDir).map((name) => ({
+    name,
+    sql: readFileSync(join(migrationsDir, name), 'utf8'),
+  }))
+
 export async function migrate(
   executor: MigrationExecutor,
   migrationsDir: string
 ): Promise<MigrateResult> {
+  assertSnakeCaseIdentifiers(readMigrations(migrationsDir))
   await executor.ensureTrackingTable()
   const applied = await executor.getApplied()
   assertNoDrift(applied, migrationsDir)

--- a/packages/cli/src/functions/db/migration-identifiers.test.ts
+++ b/packages/cli/src/functions/db/migration-identifiers.test.ts
@@ -1,0 +1,142 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  assertSnakeCaseIdentifiers,
+  CamelCaseIdentifierError,
+  findCamelCaseIdentifiers,
+} from './migration-identifiers.js'
+
+test('a snake_case migration declares nothing to complain about', () => {
+  const sql = `CREATE TABLE animal (
+  id TEXT NOT NULL PRIMARY KEY,
+  price_cents INTEGER NOT NULL,
+  weight NUMERIC(10,2),
+  status TEXT CHECK (status IN ('for_sale','sold')) DEFAULT 'for_sale',
+  created_at DATE NOT NULL,
+  CONSTRAINT animal_price_positive CHECK (price_cents > 0),
+  FOREIGN KEY (id) REFERENCES owner (id)
+);
+CREATE INDEX animal_status_idx ON animal (status);`
+
+  assert.deepEqual(findCamelCaseIdentifiers('0001-animal.sql', sql), [])
+})
+
+test('a camelCase column is reported with its snake_case name', () => {
+  const sql = 'CREATE TABLE animal (id TEXT PRIMARY KEY, priceCents INTEGER);'
+
+  assert.deepEqual(findCamelCaseIdentifiers('0001-animal.sql', sql), [
+    {
+      file: '0001-animal.sql',
+      table: 'animal',
+      column: 'priceCents',
+      suggestion: 'price_cents',
+    },
+  ])
+})
+
+test('the Better Auth schema quoting style passes as written', () => {
+  const sql =
+    'create table "user" ("id" text not null primary key, "email_verified" integer not null, "created_at" date not null);'
+
+  assert.deepEqual(findCamelCaseIdentifiers('0001-better-auth.sql', sql), [])
+})
+
+test('quoting a camelCase column does not exempt it', () => {
+  const sql = 'create table "user" ("id" text, "emailVerified" integer);'
+
+  assert.deepEqual(findCamelCaseIdentifiers('0001-better-auth.sql', sql), [
+    {
+      file: '0001-better-auth.sql',
+      table: 'user',
+      column: 'emailVerified',
+      suggestion: 'email_verified',
+    },
+  ])
+})
+
+test('a camelCase table name is reported on its own', () => {
+  const sql = 'CREATE TABLE animalSale (id TEXT PRIMARY KEY);'
+
+  assert.deepEqual(findCamelCaseIdentifiers('0001-sales.sql', sql), [
+    {
+      file: '0001-sales.sql',
+      table: 'animalSale',
+      column: null,
+      suggestion: 'animal_sale',
+    },
+  ])
+})
+
+test('camelCase inside comments and string literals is not a declaration', () => {
+  const sql = `-- priceCents used to live here; renamed for CamelCasePlugin
+/* the createdAt column is a date,
+   not a datetime */
+CREATE TABLE animal (
+  id TEXT PRIMARY KEY, -- was animalId
+  status TEXT NOT NULL DEFAULT 'forSale'
+);`
+
+  assert.deepEqual(findCamelCaseIdentifiers('0001-animal.sql', sql), [])
+})
+
+test('ALTER TABLE ADD COLUMN is a declaration too', () => {
+  const sql = `ALTER TABLE animal ADD COLUMN soldAt DATE;
+ALTER TABLE "animal" ADD priceCents INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE animal ADD COLUMN IF NOT EXISTS ownerId TEXT;`
+
+  assert.deepEqual(
+    findCamelCaseIdentifiers('0002-animal.sql', sql).map((o) => o.column),
+    ['soldAt', 'priceCents', 'ownerId']
+  )
+})
+
+test('an ALTER that adds a constraint declares no column', () => {
+  const sql = `ALTER TABLE animal ADD CONSTRAINT animalPriceCheck CHECK (price_cents > 0);
+ALTER TABLE animal ADD PRIMARY KEY (id);
+ALTER TABLE animal RENAME TO beast;`
+
+  assert.deepEqual(findCamelCaseIdentifiers('0003-animal.sql', sql), [])
+})
+
+test('every offender across every file is reported at once', () => {
+  const migrations = [
+    {
+      name: '0001-animal.sql',
+      sql: 'CREATE TABLE animal (id TEXT, priceCents INTEGER, soldAt DATE);',
+    },
+    {
+      name: '0002-owner.sql',
+      sql: 'ALTER TABLE owner ADD COLUMN displayName TEXT;',
+    },
+  ]
+
+  try {
+    assertSnakeCaseIdentifiers(migrations)
+    assert.fail('expected a CamelCaseIdentifierError')
+  } catch (error) {
+    assert.ok(error instanceof CamelCaseIdentifierError)
+    assert.deepEqual(
+      error.offenders.map((o) => `${o.file}:${o.table}.${o.column}`),
+      [
+        '0001-animal.sql:animal.priceCents',
+        '0001-animal.sql:animal.soldAt',
+        '0002-owner.sql:owner.displayName',
+      ]
+    )
+    assert.match(error.message, /priceCents {2}→ {2}price_cents/)
+    assert.match(error.message, /displayName {2}→ {2}display_name/)
+    assert.match(error.message, /replay your dev\ndatabase from scratch/)
+  }
+})
+
+test('a clean set of migrations passes the assertion', () => {
+  assert.doesNotThrow(() =>
+    assertSnakeCaseIdentifiers([
+      {
+        name: '0001-animal.sql',
+        sql: 'CREATE TABLE animal (price_cents INT);',
+      },
+    ])
+  )
+})

--- a/packages/cli/src/functions/db/migration-identifiers.ts
+++ b/packages/cli/src/functions/db/migration-identifiers.ts
@@ -1,0 +1,321 @@
+/**
+ * Catching camelCase columns at migrate time, before they can half-work.
+ *
+ * Pikku's Kysely runs with `CamelCasePlugin`, so `priceCents` in TypeScript is
+ * `price_cents` in SQL and nothing else. A migration that declares the column
+ * *as* `priceCents` is not merely unconventional — it is broken in the one way
+ * that hides itself: `.selectAll()` compiles to `SELECT *` and never names an
+ * identifier, so the table reads back perfectly, while the first query that
+ * names the column (`.select(['animal.priceCents'])`) asks for `price_cents`
+ * and gets `no such column`. The usual conclusion is that the plugin is broken,
+ * and the usual response is a raw `sql` template or a retreat to `.selectAll()`
+ * — both of which keep the real cause alive.
+ *
+ * There is no exception to escape. Even the Better Auth schema `db generate`
+ * writes is snake_case (`email_verified`, `user_id`), because Better Auth is
+ * handed the app's own Kysely and its camelCase field names compile the same
+ * way everyone else's do.
+ */
+
+import { splitStatements } from './schema-sql.js'
+
+/** A camelCase identifier a migration declares, and what it should have said. */
+export interface CamelCaseIdentifier {
+  file: string
+  table: string
+  /** `null` when the table name itself is the offender. */
+  column: string | null
+  suggestion: string
+}
+
+export class CamelCaseIdentifierError extends Error {
+  constructor(public readonly offenders: CamelCaseIdentifier[]) {
+    const lines = offenders.map(
+      (o) =>
+        `  ${o.file}  ${o.column === null ? o.table : `${o.table}.${o.column}`}  →  ${o.suggestion}`
+    )
+    super(
+      `[PKU-DB-CAMEL] Migrations declare camelCase identifiers.\n\n` +
+        `Pikku's Kysely runs with CamelCasePlugin, which maps camelCase in TypeScript\n` +
+        `to snake_case in SQL. A camelCase column half-works: \`.selectAll()\` emits\n` +
+        `\`SELECT *\` so the table reads fine, but naming the column compiles it to\n` +
+        `snake_case and the database answers \`no such column\`.\n\n` +
+        `${lines.join('\n')}\n\n` +
+        `Fix the column definition in the migration file itself and replay your dev\n` +
+        `database from scratch. Do not write a RENAME COLUMN migration — that leaves\n` +
+        `the banned identifier in a SQL file forever.`
+    )
+    this.name = 'CamelCaseIdentifierError'
+  }
+}
+
+/**
+ * Strip comments so a word in prose can never be read as an identifier.
+ *
+ * `splitStatements` already skips over comments when it looks for a boundary,
+ * but it hands back the statement with them still in it, and `-- the userId
+ * column` would otherwise be flagged. Quoting rules are honoured for the same
+ * reason they are there: `'a -- b'` is a string, not a comment.
+ */
+export function stripSqlComments(sql: string): string {
+  let out = ''
+  let i = 0
+
+  while (i < sql.length) {
+    const ch = sql[i]!
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const start = i
+      i++
+      while (i < sql.length) {
+        if (sql[i] === '\\' && ch === "'") {
+          i += 2
+          continue
+        }
+        if (sql[i] === ch) {
+          if (sql[i + 1] === ch) {
+            i += 2
+            continue
+          }
+          i++
+          break
+        }
+        i++
+      }
+      out += sql.slice(start, i)
+      continue
+    }
+
+    if (ch === '-' && sql[i + 1] === '-') {
+      const end = sql.indexOf('\n', i)
+      i = end === -1 ? sql.length : end
+      continue
+    }
+
+    if (ch === '/' && sql[i + 1] === '*') {
+      const end = sql.indexOf('*/', i + 2)
+      i = end === -1 ? sql.length : end + 2
+      // A block comment can span lines, and removing it outright would join two
+      // statements onto one line. A space keeps the tokens either side apart.
+      out += ' '
+      continue
+    }
+
+    out += ch
+    i++
+  }
+
+  return out
+}
+
+const IDENTIFIER = String.raw`"[^"]*"|\`[^\`]*\`|\[[^\]]*\]|[A-Za-z_][A-Za-z_0-9$]*`
+
+const CREATE_TABLE = new RegExp(
+  String.raw`^CREATE\s+(?:TEMP(?:ORARY)?\s+|UNLOGGED\s+)*TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+?)\s*\(`,
+  'i'
+)
+
+const ALTER_TABLE = new RegExp(
+  String.raw`^ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?(\S+)`,
+  'i'
+)
+
+const ADD_COLUMN = new RegExp(
+  String.raw`^\s*ADD\s+(?:COLUMN\s+)?(?:IF\s+NOT\s+EXISTS\s+)?(${IDENTIFIER})`,
+  'i'
+)
+
+const COLUMN_NAME = new RegExp(String.raw`^\s*(${IDENTIFIER})`)
+
+/**
+ * The words that open a table-level constraint rather than a column.
+ *
+ * Only consulted for an unquoted first token: `"check"` in quotes is a column
+ * named check, however unwise, and skipping it would let `"checkedAt"`'s
+ * neighbours hide behind it.
+ */
+const CONSTRAINT_KEYWORDS = new Set([
+  'constraint',
+  'primary',
+  'foreign',
+  'unique',
+  'check',
+  'exclude',
+  'index',
+  'key',
+  'like',
+  'period',
+  'fulltext',
+  'spatial',
+])
+
+/** Drop the quoting a dialect happens to use, leaving the identifier itself. */
+const unquote = (name: string): string =>
+  /^["`[]/.test(name) ? name.slice(1, -1) : name
+
+const isCamelCase = (name: string): boolean => /[a-z][A-Z]/.test(name)
+
+const toSnakeCase = (name: string): string =>
+  name.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()
+
+/**
+ * Walk `sql` from `from` and return the offsets just inside and just outside
+ * the parenthesised group that starts there, or `null` if it never closes.
+ *
+ * Quote-aware, because a `)` inside `DEFAULT ')'` closes nothing.
+ */
+function parenSpan(
+  sql: string,
+  from: number
+): { start: number; end: number } | null {
+  let depth = 0
+  let i = from
+
+  while (i < sql.length) {
+    const ch = sql[i]!
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      i++
+      while (i < sql.length && sql[i] !== ch) i++
+      i++
+      continue
+    }
+
+    if (ch === '(') {
+      depth++
+      if (depth === 1) from = i + 1
+    } else if (ch === ')') {
+      depth--
+      if (depth === 0) return { start: from, end: i }
+    }
+
+    i++
+  }
+
+  return null
+}
+
+/**
+ * Split a definition list on the commas that separate its items.
+ *
+ * The commas inside `NUMERIC(10,2)`, a `CHECK (x IN ('a','b'))` or a compound
+ * `PRIMARY KEY (a, b)` belong to those and not to the list, so only depth zero
+ * counts.
+ */
+function splitTopLevel(list: string): string[] {
+  const items: string[] = []
+  let depth = 0
+  let start = 0
+  let i = 0
+
+  while (i < list.length) {
+    const ch = list[i]!
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      i++
+      while (i < list.length && list[i] !== ch) i++
+      i++
+      continue
+    }
+
+    if (ch === '(') depth++
+    else if (ch === ')') depth--
+    else if (ch === ',' && depth === 0) {
+      items.push(list.slice(start, i))
+      start = i + 1
+    }
+
+    i++
+  }
+
+  items.push(list.slice(start))
+  return items.filter((item) => item.trim().length > 0)
+}
+
+/**
+ * Every camelCase identifier one migration file declares.
+ *
+ * Only declarations are read — a `CREATE TABLE` column list and an `ALTER TABLE
+ * … ADD COLUMN`. Everywhere else an identifier merely refers to something that
+ * was declared somewhere, and reporting those would name the same mistake once
+ * per reference while adding nothing to the fix.
+ */
+export function findCamelCaseIdentifiers(
+  file: string,
+  sql: string
+): CamelCaseIdentifier[] {
+  const offenders: CamelCaseIdentifier[] = []
+
+  for (const statement of splitStatements(stripSqlComments(sql))) {
+    const create = CREATE_TABLE.exec(statement)
+    if (create) {
+      const table = unquote(create[1]!.split('.').pop()!)
+      if (isCamelCase(table)) {
+        offenders.push({
+          file,
+          table,
+          column: null,
+          suggestion: toSnakeCase(table),
+        })
+      }
+
+      const span = parenSpan(statement, create.index + create[0]!.length - 1)
+      if (!span) continue
+
+      for (const item of splitTopLevel(statement.slice(span.start, span.end))) {
+        const name = COLUMN_NAME.exec(item)?.[1]
+        if (!name) continue
+        if (CONSTRAINT_KEYWORDS.has(name.toLowerCase())) continue
+        const column = unquote(name)
+        if (isCamelCase(column)) {
+          offenders.push({
+            file,
+            table,
+            column,
+            suggestion: toSnakeCase(column),
+          })
+        }
+      }
+      continue
+    }
+
+    const alter = ALTER_TABLE.exec(statement)
+    if (!alter) continue
+
+    const table = unquote(alter[1]!.split('.').pop()!)
+    // Postgres lets one ALTER carry several actions, and only the ADDs declare.
+    for (const action of splitTopLevel(
+      statement.slice(alter[0]!.length).replace(/;\s*$/, '')
+    )) {
+      const name = ADD_COLUMN.exec(action)?.[1]
+      if (!name) continue
+      if (CONSTRAINT_KEYWORDS.has(name.toLowerCase())) continue
+      const column = unquote(name)
+      if (isCamelCase(column)) {
+        offenders.push({
+          file,
+          table,
+          column,
+          suggestion: toSnakeCase(column),
+        })
+      }
+    }
+  }
+
+  return offenders
+}
+
+/**
+ * Bail unless every migration on disk is snake_case throughout.
+ *
+ * Reports all of them at once: a camelCase column is rarely alone, and a
+ * one-at-a-time failure turns a single edit into one migrate run per column.
+ */
+export function assertSnakeCaseIdentifiers(
+  migrations: Array<{ name: string; sql: string }>
+): void {
+  const offenders = migrations.flatMap(({ name, sql }) =>
+    findCamelCaseIdentifiers(name, sql)
+  )
+  if (offenders.length > 0) throw new CamelCaseIdentifierError(offenders)
+}


### PR DESCRIPTION
## Why

Pikku's Kysely runs with `CamelCasePlugin`, so `priceCents` in TypeScript is `price_cents` in SQL and nothing else. A migration that declares the column *as* `priceCents` half-works, which is exactly what makes it expensive:

- `.selectAll()` compiles to `SELECT *` and never names an identifier, so the table reads back perfectly.
- `.select(['animal.priceCents'])` compiles to `price_cents`, and the database answers `no such column: price_cents`.

The conclusion people reach is that `CamelCasePlugin` is broken, and the workaround they reach for is a raw `sql` template or a retreat to `.selectAll()` — both of which keep the real cause alive. There is no exception to opt out of: the Better Auth schema `pikku db generate` writes is snake_case (`email_verified`, `user_id`, `created_at`) for the same reason, because Better Auth is handed the app's own Kysely.

## What

`migrate()` now validates every `.sql` file in the migrations directory before anything is applied, and throws `CamelCaseIdentifierError` listing **every** offender at once — a camelCase column is rarely alone, and a one-at-a-time failure turns a single edit into one migrate run per column.

```
[PKU-DB-CAMEL] Migrations declare camelCase identifiers.

Pikku's Kysely runs with CamelCasePlugin, which maps camelCase in TypeScript
to snake_case in SQL. A camelCase column half-works: `.selectAll()` emits
`SELECT *` so the table reads fine, but naming the column compiles it to
snake_case and the database answers `no such column`.

  0001-animal.sql  animal.priceCents  →  price_cents
  0001-animal.sql  animal.soldAt  →  sold_at
  0002-owner.sql  owner.displayName  →  display_name

Fix the column definition in the migration file itself and replay your dev
database from scratch. Do not write a RENAME COLUMN migration — that leaves
the banned identifier in a SQL file forever.
```

All migrations are read, not just the pending ones, so whether a migration is rejected depends on the files alone — a camelCase column that had already been applied on one machine would otherwise pass there and fail on a fresh checkout.

## Parsing

Only *declarations* are read: a `CREATE TABLE` column list (plus the table name itself) and `ALTER TABLE … ADD COLUMN`. Everywhere else an identifier merely refers to something declared elsewhere, so reporting it would name the same mistake once per reference.

`splitStatements` from `schema-sql.ts` is reused for statement boundaries. On top of it:

- **Comments** are stripped first (`stripSqlComments`) — `splitStatements` skips over them when hunting a boundary but hands the statement back with them still in it, so `-- was animalId` would otherwise be flagged. A block comment becomes a space so it cannot join two tokens.
- **String literals** are quote-aware in the stripper, the paren scanner and the comma splitter, so `'a -- b'` is not a comment and `DEFAULT ')'` closes nothing.
- **Quoted identifiers** (`"user"`, `` `x` ``, `[x]`) are parsed as one token and unquoted before the check. Quoting does **not** exempt them: `"emailVerified"` is just as broken, because the plugin still emits `email_verified`.
- **Nested parens** — `NUMERIC(10,2)`, `CHECK (status IN ('a','b'))`, `PRIMARY KEY (a, b)` — only depth-zero commas split the list, and only the first token of each item is read as a name.
- **Table-level constraints** (`CONSTRAINT`, `PRIMARY`, `FOREIGN`, `UNIQUE`, `CHECK`, `LIKE`, …) are skipped, but only when the token was unquoted, so a column genuinely named `"check"` cannot hide its neighbours.

Validated against 264 real `.sql` migration files across this repo's verifiers and a large downstream Pikku project: zero false positives.

## Tests

`migration-identifiers.test.ts` covers a clean snake_case migration passing, a camelCase column failing, the Better Auth quoting style passing as written, a quoted camelCase column still failing, a camelCase table name, comments and string literals containing camelCase words not tripping it, `ALTER TABLE ADD COLUMN` (bare, `COLUMN`, and `IF NOT EXISTS`), an `ALTER … ADD CONSTRAINT` declaring nothing, and multiple offenders across multiple files all being reported.

All 100 tests under `packages/cli/src/functions/db` pass, including the `local-db` suite that drives `migrate()` end-to-end on SQLite and PGlite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
