### PR TITLE
fix(kysely-sqlite): encode Date and JSON bind args in the libsql web dialect

### DIFF
--- a/.changeset/libsql-web-dialect-encodes-dates-and-json.md
+++ b/.changeset/libsql-web-dialect-encodes-dates-and-json.md
@@ -1,9 +1,12 @@
 ---
 '@pikku/kysely-sqlite': patch
+'@pikku/cli': patch
 ---
 
-`LibsqlWebDialect` now encodes a `Date` bind parameter as an ISO-8601 string and any other plain object or array as JSON, instead of throwing `libsql: unsupported argument type object`.
+`LibsqlWebDialect` now encodes a `Date` bind parameter as an ISO-8601 string and an array or plain record as JSON, instead of throwing `libsql: unsupported argument type object`.
 
-This closes a dev/prod split that broke every write in a deployed libsql app. The CLI's `node:sqlite` dev runtime already coerces dates, booleans and objects before binding them, so a query that stamps a `createdAt` or writes a JSON column passes under `pikku dev` — and then throws on the same code path once the app is deployed to a Worker, where this dialect is the one in use. Reads were unaffected, so the symptom was an app whose every insert and update failed while every list and get worked.
+This closes a dev/prod split that broke every write in a deployed libsql app. The CLI's `node:sqlite` dev runtime already coerced dates and objects before binding them, so a query that stamps a `createdAt` or writes a JSON column passed under `pikku dev` — and then threw on the same code path once the app was deployed to a Worker, where this dialect is the one in use. Reads were unaffected, so the symptom was an app whose every insert and update failed while every list and get worked.
 
-Values still decode as they are stored: a date comes back as its ISO string and a JSON column as its JSON string, matching what the dev runtime writes and reads. Types the dialect genuinely cannot represent (a symbol, say) still throw.
+Both runtimes also stop accepting objects JSON cannot faithfully represent. A `Map`, a `RegExp` or a class instance stringifies to `"{}"` or to a partial view of itself, so binding one used to persist an empty JSON blob where the caller meant something; it now throws. Only arrays and plain records (including null-prototype ones) are JSON-encoded. The two coercions are deliberately identical — a value that binds under `pikku dev` binds the same way once deployed, which is the property whose absence caused the original bug.
+
+Unsupported values now name their constructor — `unsupported argument type Map` rather than `unsupported argument type object`.

--- a/.changeset/libsql-web-dialect-encodes-dates-and-json.md
+++ b/.changeset/libsql-web-dialect-encodes-dates-and-json.md
@@ -1,0 +1,9 @@
+---
+'@pikku/kysely-sqlite': patch
+---
+
+`LibsqlWebDialect` now encodes a `Date` bind parameter as an ISO-8601 string and any other plain object or array as JSON, instead of throwing `libsql: unsupported argument type object`.
+
+This closes a dev/prod split that broke every write in a deployed libsql app. The CLI's `node:sqlite` dev runtime already coerces dates, booleans and objects before binding them, so a query that stamps a `createdAt` or writes a JSON column passes under `pikku dev` — and then throws on the same code path once the app is deployed to a Worker, where this dialect is the one in use. Reads were unaffected, so the symptom was an app whose every insert and update failed while every list and get worked.
+
+Values still decode as they are stored: a date comes back as its ISO string and a JSON column as its JSON string, matching what the dev runtime writes and reads. Types the dialect genuinely cannot represent (a symbol, say) still throw.

--- a/packages/cli/src/functions/db/sqlite/sqlite-kysely.ts
+++ b/packages/cli/src/functions/db/sqlite/sqlite-kysely.ts
@@ -11,12 +11,34 @@ import type {
   SyncSqliteStatement,
 } from './sqlite-runtime.js'
 
+/**
+ * Whether a value is a JSON column's worth of data rather than some other
+ * object that merely happens to be one. A `Map`, a `RegExp` or a class
+ * instance stringifies to `"{}"` or to a partial view of itself, which would
+ * silently persist an empty JSON blob where the caller meant something.
+ *
+ * Kept in lockstep with `isJsonEncodable` in `@pikku/kysely-sqlite`'s
+ * LibsqlWebDialect: whatever binds here under `pikku dev` has to bind the same
+ * way once the app is deployed, or the dev and deployed runtimes disagree
+ * about what a query may do.
+ */
+function isJsonEncodable(v: object): boolean {
+  if (Array.isArray(v)) return true
+  const proto = Object.getPrototypeOf(v)
+  return proto === Object.prototype || proto === null
+}
+
 function coerce(v: unknown): unknown {
   if (v === null || v === undefined) return null
   if (typeof v === 'boolean') return v ? 1 : 0
   if (v instanceof Date) return v.toISOString()
   if (v instanceof Uint8Array) return v
-  if (typeof v === 'object') return JSON.stringify(v)
+  if (typeof v === 'object') {
+    if (isJsonEncodable(v)) return JSON.stringify(v)
+    throw new Error(
+      `sqlite: unsupported argument type ${v.constructor?.name ?? 'object'}`
+    )
+  }
   return v
 }
 

--- a/packages/services/kysely-sqlite/package.json
+++ b/packages/services/kysely-sqlite/package.json
@@ -11,6 +11,9 @@
     "tsc": "tsc",
     "ncu": "npx npm-check-updates",
     "build": "tsc -b",
+    "test": "bash run-tests.sh",
+    "test:watch": "bash run-tests.sh --watch",
+    "test:coverage": "bash run-tests.sh --coverage",
     "prepublishOnly": "yarn build"
   },
   "dependencies": {

--- a/packages/services/kysely-sqlite/run-tests.sh
+++ b/packages/services/kysely-sqlite/run-tests.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Parse command line arguments
+WATCH_MODE=false
+COVERAGE_MODE=false
+
+for arg in "$@"
+do
+    case $arg in
+        --watch)
+        WATCH_MODE=true
+        shift
+        ;;
+        --coverage)
+        COVERAGE_MODE=true
+        shift
+        ;;
+    esac
+done
+
+# Build the command
+CMD="node --import tsx --test --test-force-exit src/**/*.test.ts"
+
+if [ "$WATCH_MODE" = true ]; then
+    CMD="$CMD --watch"
+fi
+
+if [ "$COVERAGE_MODE" = true ]; then
+    CMD="$CMD --experimental-test-coverage"
+fi
+
+# Execute the command
+eval $CMD

--- a/packages/services/kysely-sqlite/src/libsql-web-dialect.test.ts
+++ b/packages/services/kysely-sqlite/src/libsql-web-dialect.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { Kysely } from 'kysely'
+import { LibsqlWebDialect } from './libsql-web-dialect.js'
+
+interface TestDB {
+  entry: {
+    id: string
+    createdAt: string
+    payload: string
+    archived: number
+  }
+}
+
+/** Args of the last `execute` request the dialect put on the wire. */
+let sentArgs: Array<Record<string, unknown>>
+let realFetch: typeof globalThis.fetch
+
+const okResponse = () =>
+  new Response(
+    JSON.stringify({
+      baton: null,
+      base_url: null,
+      results: [
+        {
+          type: 'ok',
+          response: {
+            type: 'execute',
+            result: {
+              cols: [],
+              rows: [],
+              affected_row_count: 1,
+              last_insert_rowid: '1',
+            },
+          },
+        },
+      ],
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } }
+  )
+
+const db = () =>
+  new Kysely<TestDB>({
+    dialect: new LibsqlWebDialect({ url: 'https://example.turso.io' }),
+  })
+
+describe('LibsqlWebDialect bind-parameter encoding', () => {
+  beforeEach(() => {
+    sentArgs = []
+    realFetch = globalThis.fetch
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string)
+      for (const req of body.requests) {
+        if (req.type === 'execute') sentArgs = req.stmt.args
+      }
+      return okResponse()
+    }) as unknown as typeof globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = realFetch
+  })
+
+  test('encodes a Date as an ISO-8601 text value', async () => {
+    const createdAt = new Date('2026-07-29T21:00:00.000Z')
+    await db()
+      .insertInto('entry')
+      .values({ id: 'a', createdAt: createdAt as never } as never)
+      .execute()
+
+    assert.deepEqual(sentArgs[1], {
+      type: 'text',
+      value: '2026-07-29T21:00:00.000Z',
+    })
+  })
+
+  test('encodes a plain object and an array as JSON text', async () => {
+    await db()
+      .insertInto('entry')
+      .values({ id: 'a', payload: { tags: [1, 2] } as never } as never)
+      .execute()
+
+    assert.deepEqual(sentArgs[1], {
+      type: 'text',
+      value: '{"tags":[1,2]}',
+    })
+  })
+
+  test('keeps the primitive encodings intact', async () => {
+    await db()
+      .insertInto('entry')
+      .values({ id: 'a', archived: true as never } as never)
+      .execute()
+
+    assert.deepEqual(sentArgs, [
+      { type: 'text', value: 'a' },
+      { type: 'integer', value: '1' },
+    ])
+  })
+
+  test('still rejects a value it cannot represent', async () => {
+    await assert.rejects(
+      db()
+        .insertInto('entry')
+        .values({ id: 'a', payload: Symbol('nope') as never } as never)
+        .execute(),
+      /unsupported argument type symbol/
+    )
+  })
+})

--- a/packages/services/kysely-sqlite/src/libsql-web-dialect.test.ts
+++ b/packages/services/kysely-sqlite/src/libsql-web-dialect.test.ts
@@ -74,7 +74,7 @@ describe('LibsqlWebDialect bind-parameter encoding', () => {
     })
   })
 
-  test('encodes a plain object and an array as JSON text', async () => {
+  test('encodes a plain object as JSON text', async () => {
     await db()
       .insertInto('entry')
       .values({ id: 'a', payload: { tags: [1, 2] } as never } as never)
@@ -84,6 +84,25 @@ describe('LibsqlWebDialect bind-parameter encoding', () => {
       type: 'text',
       value: '{"tags":[1,2]}',
     })
+  })
+
+  test('encodes an array bound directly as JSON text', async () => {
+    await db()
+      .insertInto('entry')
+      .values({ id: 'a', payload: [1, 2] as never } as never)
+      .execute()
+
+    assert.deepEqual(sentArgs[1], { type: 'text', value: '[1,2]' })
+  })
+
+  test('encodes a null-prototype record as JSON text', async () => {
+    const payload = Object.assign(Object.create(null), { tags: [1] })
+    await db()
+      .insertInto('entry')
+      .values({ id: 'a', payload: payload as never } as never)
+      .execute()
+
+    assert.deepEqual(sentArgs[1], { type: 'text', value: '{"tags":[1]}' })
   })
 
   test('keeps the primitive encodings intact', async () => {
@@ -106,5 +125,27 @@ describe('LibsqlWebDialect bind-parameter encoding', () => {
         .execute(),
       /unsupported argument type symbol/
     )
+  })
+
+  // A Map or a class instance stringifies to "{}" or to a partial view of
+  // itself, so it must fail loudly rather than persist an empty JSON blob.
+  test('rejects an object JSON cannot faithfully represent', async () => {
+    class Money {
+      constructor(public cents: number) {}
+    }
+
+    for (const [value, expected] of [
+      [new Map([['a', 1]]), /unsupported argument type Map/],
+      [/abc/i, /unsupported argument type RegExp/],
+      [new Money(100), /unsupported argument type Money/],
+    ] as const) {
+      await assert.rejects(
+        db()
+          .insertInto('entry')
+          .values({ id: 'a', payload: value as never } as never)
+          .execute(),
+        expected
+      )
+    }
   })
 })

--- a/packages/services/kysely-sqlite/src/libsql-web-dialect.ts
+++ b/packages/services/kysely-sqlite/src/libsql-web-dialect.ts
@@ -189,6 +189,16 @@ class LibsqlWebConnection implements DatabaseConnection {
   }
 }
 
+/**
+ * Encodes one Kysely bind parameter as a Hrana value.
+ *
+ * The Date and plain-object branches exist for parity with the `coerce()` in
+ * the CLI's node:sqlite dev runtime (`db/sqlite/sqlite-kysely.ts`). Without
+ * them a query that binds a timestamp or a JSON column passes under
+ * `pikku dev` and throws `unsupported argument type object` once deployed to
+ * a Worker — so every write in a deployed libsql app fails while the same
+ * code works locally.
+ */
 function encodeArg(v: unknown): HranaValue {
   if (v === null || v === undefined) return { type: 'null' }
   if (typeof v === 'string') return { type: 'text', value: v }
@@ -201,6 +211,9 @@ function encodeArg(v: unknown): HranaValue {
   if (v instanceof ArrayBuffer)
     return { type: 'blob', base64: bytesToBase64(new Uint8Array(v)) }
   if (v instanceof Uint8Array) return { type: 'blob', base64: bytesToBase64(v) }
+  if (v instanceof Date) return { type: 'text', value: v.toISOString() }
+  if (typeof v === 'object')
+    return { type: 'text', value: JSON.stringify(v) }
   throw new Error(`libsql: unsupported argument type ${typeof v}`)
 }
 

--- a/packages/services/kysely-sqlite/src/libsql-web-dialect.ts
+++ b/packages/services/kysely-sqlite/src/libsql-web-dialect.ts
@@ -190,6 +190,22 @@ class LibsqlWebConnection implements DatabaseConnection {
 }
 
 /**
+ * Whether a value is a JSON column's worth of data rather than some other
+ * object that merely happens to be one.
+ *
+ * A `Map`, a `RegExp` or a class instance all stringify to `"{}"` or to a
+ * partial view of themselves, so accepting every object would silently persist
+ * an empty JSON blob where the caller meant something. Those fall through to
+ * the unsupported-type error instead. Kept in lockstep with the `coerce()` in
+ * the CLI's node:sqlite dev runtime (`db/sqlite/sqlite-kysely.ts`).
+ */
+function isJsonEncodable(v: object): boolean {
+  if (Array.isArray(v)) return true
+  const proto = Object.getPrototypeOf(v)
+  return proto === Object.prototype || proto === null
+}
+
+/**
  * Encodes one Kysely bind parameter as a Hrana value.
  *
  * The Date and plain-object branches exist for parity with the `coerce()` in
@@ -212,9 +228,13 @@ function encodeArg(v: unknown): HranaValue {
     return { type: 'blob', base64: bytesToBase64(new Uint8Array(v)) }
   if (v instanceof Uint8Array) return { type: 'blob', base64: bytesToBase64(v) }
   if (v instanceof Date) return { type: 'text', value: v.toISOString() }
-  if (typeof v === 'object')
+  if (typeof v === 'object' && isJsonEncodable(v))
     return { type: 'text', value: JSON.stringify(v) }
-  throw new Error(`libsql: unsupported argument type ${typeof v}`)
+  // Name the constructor for objects: "unsupported argument type object" is
+  // what made the missing Date branch so hard to place in the first place.
+  const kind =
+    typeof v === 'object' ? (v.constructor?.name ?? 'object') : typeof v
+  throw new Error(`libsql: unsupported argument type ${kind}`)
 }
 
 function decodeValue(v: HranaValue): unknown {


### PR DESCRIPTION
## The bug

`LibsqlWebDialect.encodeArg` handles string / number / bigint / boolean / ArrayBuffer / Uint8Array and throws `libsql: unsupported argument type object` on anything else — including a `Date`.

The CLI's `node:sqlite` dev runtime (`db/sqlite/sqlite-kysely.ts`) does not have that gap; its `coerce()` maps `Date -> ISOString`, `boolean -> 0/1` and `object -> JSON.stringify` before binding.

So the two runtimes disagree about what a bind parameter may be, and the disagreement only shows up after deploy: a query that stamps a `createdAt` or writes a JSON column passes under `pikku dev` and throws in a Worker, where this dialect is the one in use. Reads were unaffected, so the symptom is an app where every insert and update fails while every list and get works.

Found on a deployed Fabric app: `createSession`, `createEntry` and a reminder cron were failing 100% with this error, against a stage whose read RPCs were fine.

## The fix

Two branches in `encodeArg`, mirroring `coerce()`: `Date` -> ISO-8601 text, any other plain object or array -> JSON text. Values still decode as stored (ISO string / JSON string), matching what the dev runtime writes and reads. A type the dialect genuinely cannot represent still throws.

Adds a test file (and the standard `run-tests.sh` / `test` script the package was missing) covering all four cases through Kysely with a stubbed `fetch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date parameters are now transmitted as ISO-8601 strings.
  * Plain objects (including null-prototype records) and arrays are now transmitted as JSON strings.
  * Non-JSON-encodable values (for example `Map`, `RegExp`, and class instances) are rejected with clearer “unsupported argument type” errors.
  * Primitive value handling remains unchanged.
* **Tests**
  * Expanded and reorganized parameter encoding tests, including additional negative cases.
  * Added test commands and a shared test runner supporting standard, watch, and coverage modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->