### PR TITLE
fix(create): keep the compatibility_date the Cloudflare template pins

### DIFF
--- a/.changeset/create-keeps-the-template-compat-date.md
+++ b/.changeset/create-keeps-the-template-compat-date.md
@@ -1,0 +1,9 @@
+---
+'create-pikku': patch
+---
+
+Scaffolding a Cloudflare template now keeps the `compatibility_date` the template pins, instead of rewriting it to the day you ran the command.
+
+A compatibility date is a promise about a runtime that already exists. Stamping today's date on a fresh `wrangler.toml` asks workerd for behaviour it does not have yet: the binary bundled with the installed wrangler only supports dates up to the day it was released, so it refuses to boot with `This Worker requires compatibility date "…", but the newest date supported by this server binary is "…"`. Every new project was one wrangler release cycle away from a worker that would not start locally.
+
+Both Cloudflare templates already pin a known-good date, and `@pikku/deploy-cloudflare` pins the same one for the workers it generates. The scaffolder now leaves that value alone; the app name substitution is unchanged.

--- a/packages/create/src/utils.test.ts
+++ b/packages/create/src/utils.test.ts
@@ -251,10 +251,9 @@ describe('Functions Test Suite', () => {
     wranglerChanges(testDir, appName)
 
     const updatedContent = fs.readFileSync(wranglerPath, 'utf-8')
-    const currentDate = new Date().toISOString().split('T')[0]
     assert.ok(
-      updatedContent.includes(`compatibility_date = "${currentDate}"`),
-      'compatibility_date should be updated'
+      updatedContent.includes('compatibility_date = "2020-01-01"'),
+      'compatibility_date should be left at the value the template pins'
     )
     assert.ok(
       updatedContent.includes(appName),

--- a/packages/create/src/utils.ts
+++ b/packages/create/src/utils.ts
@@ -224,12 +224,7 @@ export function wranglerChanges(targetPath: string, appName: string): void {
   if (!fs.existsSync(wranglerFilePath)) return
 
   let wranglerConfig = fs.readFileSync(wranglerFilePath, 'utf-8')
-  const currentDate = new Date().toISOString().split('T')[0]
   wranglerConfig = wranglerConfig
-    .replace(
-      /compatibility_date\s*=\s*"\d{4}-\d{2}-\d{2}"/,
-      `compatibility_date = "${currentDate}"`
-    )
     .replace('pikku-cloudflare-workers', appName)
     .replace('pikku-cloudflare-websockets', appName)
   fs.writeFileSync(wranglerFilePath, wranglerConfig)


### PR DESCRIPTION
## The bug

Both Cloudflare template jobs are red on every branch built today, including #1058:

```
service core:user:test-app: This Worker requires compatibility date "2026-07-30",
but the newest date supported by this server binary is "2026-07-29".
```

workerd then refuses to start, `wrangler dev` never binds, and the harness spends 30s on `Still failing (fetch failed), retrying...` before giving up.

Nothing in #1058 caused it. `wranglerChanges` in `packages/create/src/utils.ts` rewrote the scaffolded `compatibility_date` to `new Date()` — the day the command ran. But a compatibility date names a runtime that already exists: the workerd binary bundled with a given wrangler supports dates only up to its own release day. So the scaffolder was always asking for behaviour one release cycle ahead of the binary, and it only stayed green because CI usually ran on a day wrangler had already shipped. The moment the date rolled past the pinned wrangler 4.115.0's cutoff, every Cloudflare job — and every freshly scaffolded user project — broke at once.

## The fix

Stop rewriting the date. Both templates already pin `2024-12-18`, and `@pikku/deploy-cloudflare` pins that same date for the workers it generates (`wrangler-toml.ts:37`), so the scaffolder was the only place letting it float. A compatibility date is a deliberate, reviewed bump, not a build-time timestamp. The app name substitution is unchanged.

## Verification

`packages/create/src/utils.test.ts` asserts the pinned date survives — red before the change, green after.

Both failing jobs were then reproduced locally end-to-end (scaffold → link → `pikku all --target serverless` → tsc → `wrangler dev` → tests), against this branch's build:

| template | result |
| --- | --- |
| `cloudflare-workers` | exit 0 — `✅ HTTP test passed` |
| `cloudflare-websocket` | exit 0 — `✅ All tests completed successfully.` |

Full `create` unit suite: 19/19.

Unrelated and pre-existing: the `cloudflare-websocket` run logs `Channel not found: /` (403) because `--target serverless` prunes the channel wiring. The test tolerates it and exits 0, matching what CI does on main. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)