### PR TITLE
fix(cli): write generated files atomically

### DIFF
--- a/.changeset/atomic-generated-writes.md
+++ b/.changeset/atomic-generated-writes.md
@@ -1,0 +1,9 @@
+---
+'@pikku/cli': patch
+---
+
+Generated files are written atomically, and unchanged schemas are not rewritten.
+
+`writeFile` truncates before it writes, so anything reading a generated file during codegen can see it empty. That reader is real: `pikku scenario run --spawn` bundles the registers while the dev server it just spawned is regenerating them, and esbuild fails the entire run with `Unexpected end of file in JSON` on whichever schema it caught mid-write. The scenario schema split made this reachable in practice — a project with hundreds of scenario schemas rewrote every one of them on every run, right as the runner was loading the register that imports them.
+
+Codegen now writes to a temp file and renames it into place, so a concurrent reader gets either the previous complete file or the new one. Schema files whose contents are unchanged are not rewritten at all, which removes the window entirely for the common case and stops file watchers waking on output that did not change.

--- a/packages/cli/src/utils/file-writer.ts
+++ b/packages/cli/src/utils/file-writer.ts
@@ -1,5 +1,5 @@
 import { dirname, join } from 'path'
-import { mkdir, readFile, writeFile, rm } from 'fs/promises'
+import { mkdir, readFile, rename, writeFile, rm } from 'fs/promises'
 import { existsSync } from 'fs'
 import type { CLILogger } from '../services/cli-logger.service.js'
 import { getCLIVersion } from './get-cli-version.js'
@@ -53,7 +53,18 @@ export const writeFileInDir = async (
   // Only write if content has changed or file doesn't exist
   if (existingContent !== content) {
     await mkdir(dirname(path), { recursive: true })
-    await writeFile(path, content, 'utf-8')
+    // Atomically, because generated files are read while they are generated:
+    // `pikku scenario run --spawn` bundles the registers while the dev server it
+    // spawned is regenerating them, and `writeFile` truncates before it writes —
+    // a reader that lands in that window gets an empty file, not an old one.
+    const tmp = `${path}.${process.pid}.tmp`
+    try {
+      await writeFile(tmp, content, 'utf-8')
+      await rename(tmp, path)
+    } catch (e) {
+      await rm(tmp, { force: true }).catch(() => {})
+      throw e
+    }
     if (TS_FILE_REGEX.test(path)) {
       tsWriteGeneration++
     }

--- a/packages/cli/src/utils/serialize-schemas.test.ts
+++ b/packages/cli/src/utils/serialize-schemas.test.ts
@@ -5,6 +5,7 @@ import {
   readdir,
   readFile,
   rm,
+  stat,
   writeFile,
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -50,6 +51,60 @@ afterEach(async () => {
 })
 
 describe('saveSchemas', () => {
+  test('a byte-identical schema is left untouched, and no temp file survives', async () => {
+    // Generated files are read while they are generated: `pikku scenario run
+    // --spawn` bundles the registers while the dev server it spawned regenerates
+    // them. A rewrite is a window in which a reader can see a truncated file, so
+    // an unchanged schema must not be rewritten at all — and the rewrite that
+    // does happen goes through a temp file that must never be left behind for
+    // the register (or the prune) to trip over.
+    const parent = await makeDir()
+    const schema = { KeptInput: { type: 'object', properties: {} } }
+
+    await saveSchemas(noopLogger, parent, schema, new Set(['KeptInput']), true)
+    const first = await stat(join(parent, 'schemas', 'KeptInput.schema.json'))
+
+    await saveSchemas(noopLogger, parent, schema, new Set(['KeptInput']), true)
+    const second = await stat(join(parent, 'schemas', 'KeptInput.schema.json'))
+
+    assert.equal(
+      second.mtimeMs,
+      first.mtimeMs,
+      'unchanged schema was rewritten'
+    )
+    assert.deepEqual(await listSchemaFiles(parent), ['KeptInput.schema.json'])
+  })
+
+  test('a changed schema is replaced, leaving no temp file', async () => {
+    const parent = await makeDir()
+
+    await saveSchemas(
+      noopLogger,
+      parent,
+      { KeptInput: { type: 'object', properties: {} } },
+      new Set(['KeptInput']),
+      true
+    )
+    await saveSchemas(
+      noopLogger,
+      parent,
+      {
+        KeptInput: {
+          type: 'object',
+          properties: { title: { type: 'string' } },
+        },
+      },
+      new Set(['KeptInput']),
+      true
+    )
+
+    assert.deepEqual(await listSchemaFiles(parent), ['KeptInput.schema.json'])
+    const written = JSON.parse(
+      await readFile(join(parent, 'schemas', 'KeptInput.schema.json'), 'utf-8')
+    )
+    assert.deepEqual(Object.keys(written.properties), ['title'])
+  })
+
   test('removes schema files that are no longer required', async () => {
     const parent = await makeDir()
     await seedExistingSchema(parent, 'CreateClassInput')

--- a/packages/cli/src/utils/serialize-schemas.ts
+++ b/packages/cli/src/utils/serialize-schemas.ts
@@ -1,9 +1,48 @@
 import { writeFileInDir } from './file-writer.js'
-import { mkdir, readdir, unlink, writeFile } from 'fs/promises'
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from 'fs/promises'
 import type { JSONValue } from '@pikku/core'
 import type { CLILogger } from '../services/cli-logger.service.js'
 
 const SCHEMA_FILE_SUFFIX = '.schema.json'
+
+/**
+ * Write a schema file without ever exposing a half-written one.
+ *
+ * `writeFile` truncates and then writes, so a reader that opens the path in
+ * between sees an empty file. That reader is real: `pikku scenario run --spawn`
+ * bundles the register while the dev server it just spawned is running codegen,
+ * and esbuild fails the whole run with "Unexpected end of file in JSON" on
+ * whichever schema it happened to catch mid-write. A rename is atomic, so a
+ * reader gets either the previous complete file or the new one.
+ *
+ * Unchanged content is not rewritten at all. Most runs regenerate hundreds of
+ * byte-identical schemas, and every one of those is a window that does not need
+ * to exist — it also stops file watchers waking on output that did not change.
+ */
+async function writeSchemaFile(path: string, contents: string) {
+  try {
+    if ((await readFile(path, 'utf-8')) === contents) {
+      return
+    }
+  } catch {
+    // Unreadable or absent — fall through and write it.
+  }
+  const tmp = `${path}.${process.pid}.tmp`
+  try {
+    await writeFile(tmp, contents, 'utf-8')
+    await rename(tmp, path)
+  } catch (e) {
+    await unlink(tmp).catch(() => {})
+    throw e
+  }
+}
 
 function toValidIdentifier(name: string): string {
   let result = name.replace(/[-./: ]/g, '_')
@@ -98,10 +137,9 @@ export async function saveSchemas(
   await Promise.all(
     Object.entries(schemas).map(async ([schemaName, schema]) => {
       if (requiredSchemas.has(schemaName)) {
-        await writeFile(
+        await writeSchemaFile(
           `${schemaParentDir}/schemas/${schemaName}.schema.json`,
-          JSON.stringify(schema),
-          'utf-8'
+          JSON.stringify(schema)
         )
       }
     })


### PR DESCRIPTION
Fixes main's `E2E Agent (deterministic)` failure introduced by #1059:

```
e2e/.pikku/scenarios/schemas/schemas/SignsMessageInput.schema.json:1:0:
ERROR: Unexpected end of file in JSON
```

## Cause

`writeFile` truncates before it writes, so anything reading a generated file during codegen can see it **empty** rather than stale. That reader is real: `pikku scenario run --spawn` bundles the registers with esbuild while the dev server it just spawned is running codegen.

This was latent before — the scenario schema split is what made it reachable. The e2e project now writes 471 scenario schemas into `.pikku/scenarios/schemas/`, rewriting every one on every run, precisely while the runner is loading the register that imports them. One unlucky file empties the whole run.

## Fix

- Generated files are written to a temp file and `rename`d into place. A rename is atomic, so a concurrent reader gets either the previous complete file or the new one — never a half-written one. This covers `register.gen.ts` and every schema JSON alongside it.
- A schema whose contents are byte-identical is not rewritten at all. That removes the window entirely for the common case (most runs regenerate hundreds of identical schemas) and stops file watchers waking on output that did not change.

## Verification

- Against the real `e2e/` project: a reader parsing every scenario schema in a tight loop across two full `pikku all` runs — including the first, after `rm -rf`, which writes all 471 — completed **5,168,970 reads, 0 truncated**. All 471 registered schemas parse, no temp file left behind.
- Two new tests: an unchanged schema keeps its mtime and is not rewritten; a changed one is replaced with no stray temp file.
- `@pikku/cli` 684 tests pass, `tsc` clean, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)