### PR TITLE
fix(cloudflare)!: require PIKKU_DISPATCH_SECRET on the worker dispatch routes

### DIFF
--- a/.changeset/cloudflare-dispatch-routes-require-secret.md
+++ b/.changeset/cloudflare-dispatch-routes-require-secret.md
@@ -1,0 +1,11 @@
+---
+'@pikku/cloudflare': patch
+---
+
+**Breaking:** the Cloudflare worker's dispatch routes now require `PIKKU_DISPATCH_SECRET`, and reject every request when it is unset.
+
+`POST /__pikku/queue-job` and `POST /__pikku/scheduler-job` are handled ahead of the `includesFetch` gate so a fabric Workers-for-Platforms dispatcher can deliver work to namespace scripts, which cannot bind as CF queue consumers. They had no authentication at all: anyone who could reach the worker URL could run any queue job in the deployment with an attacker-chosen payload, or trigger any scheduled task.
+
+Both routes now require the shared secret in the `x-pikku-dispatch` header, matching the header and env var `@pikku/node-http-server` already uses for the same contract, so one secret covers worker and container dispatch targets. The comparison is a double-HMAC through WebCrypto, which leaks neither the secret's bytes nor its length through timing. A wrong secret and an unconfigured worker both return the same bare 401.
+
+**Every deployment that uses these routes must set `PIKKU_DISPATCH_SECRET`** on the worker (`wrangler secret put PIKKU_DISPATCH_SECRET`) to the value its dispatcher sends. Without it the routes fail closed — queue and scheduler delivery stops — and the worker logs which variable to set. This is deliberate: falling back to unauthenticated execution is what the vulnerability was.

--- a/packages/runtimes/cloudflare/src/dispatch-auth.ts
+++ b/packages/runtimes/cloudflare/src/dispatch-auth.ts
@@ -1,0 +1,72 @@
+import type { CloudflareEnv } from './env.js'
+
+/**
+ * Env var holding the shared secret for the `/__pikku/*-job` dispatch routes.
+ * Matches `@pikku/node-http-server`'s `dispatchSecret`, which the cloudflare
+ * deploy adapter already sources from `PIKKU_DISPATCH_SECRET`, so one secret
+ * covers both worker and container dispatch targets.
+ */
+export const DISPATCH_SECRET_ENV_VAR = 'PIKKU_DISPATCH_SECRET'
+
+export const DISPATCH_SECRET_HEADER = 'x-pikku-dispatch'
+
+const encoder = new TextEncoder()
+
+/**
+ * Double-HMAC comparison. Both values are signed under a key generated freshly
+ * per call, so the digests that actually get compared are fixed-width and
+ * unpredictable to the caller — this leaks neither the secret's bytes nor its
+ * length through timing, which a byte-wise compare with an early length exit
+ * would.
+ */
+export const constantTimeEqual = async (
+  a: string,
+  b: string
+): Promise<boolean> => {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    crypto.getRandomValues(new Uint8Array(32)),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const [digestA, digestB] = await Promise.all([
+    crypto.subtle.sign('HMAC', key, encoder.encode(a)),
+    crypto.subtle.sign('HMAC', key, encoder.encode(b)),
+  ])
+  const bytesA = new Uint8Array(digestA)
+  const bytesB = new Uint8Array(digestB)
+  let difference = bytesA.length ^ bytesB.length
+  for (let i = 0; i < bytesA.length; i++) {
+    difference |= bytesA[i]! ^ bytesB[i]!
+  }
+  return difference === 0
+}
+
+export const isDispatchAuthorized = async (
+  request: Request,
+  env: CloudflareEnv
+): Promise<boolean> => {
+  const expected = env[DISPATCH_SECRET_ENV_VAR]
+  if (typeof expected !== 'string' || expected.length === 0) {
+    console.error(
+      `[DISPATCH] Rejecting dispatch request: ${DISPATCH_SECRET_ENV_VAR} is not set on this worker. Set it (\`wrangler secret put ${DISPATCH_SECRET_ENV_VAR}\`) to the same value the dispatcher sends in the \`${DISPATCH_SECRET_HEADER}\` header.`
+    )
+    return false
+  }
+  const provided = request.headers.get(DISPATCH_SECRET_HEADER)
+  if (provided === null) {
+    return false
+  }
+  return constantTimeEqual(provided, expected)
+}
+
+/**
+ * Deliberately opaque — never distinguishes an unset secret from a mismatched
+ * one, so a prober learns nothing about the deployment's configuration.
+ */
+export const dispatchUnauthorizedResponse = (): Response =>
+  new Response(JSON.stringify({ ok: false, error: 'unauthorized' }), {
+    status: 401,
+    headers: { 'content-type': 'application/json' },
+  })

--- a/packages/runtimes/cloudflare/src/handler-factories.test.ts
+++ b/packages/runtimes/cloudflare/src/handler-factories.test.ts
@@ -1,0 +1,160 @@
+import { test, describe, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { registerHooks } from 'node:module'
+import { constantTimeEqual } from './dispatch-auth.js'
+// Type-only, so it is erased before runtime and does not load the module ahead
+// of the `cloudflare:workers` stub registered below.
+import type { createCloudflareHandler as CreateCloudflareHandler } from './handler-factories.js'
+
+// `cloudflare:workers` only exists inside the workerd runtime. The handler
+// factories import `WorkerEntrypoint` from it at module scope, so stub the
+// specifier before the module graph is loaded to exercise the real fetch()
+// routing under `node --test`.
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === 'cloudflare:workers') {
+      return {
+        url: 'data:text/javascript,export class WorkerEntrypoint { constructor(ctx, env) { this.ctx = ctx; this.env = env } }',
+        shortCircuit: true,
+      }
+    }
+    return nextResolve(specifier, context)
+  },
+})
+
+type CreateHandler = typeof CreateCloudflareHandler
+
+let createCloudflareHandler: CreateHandler
+
+const factories = {
+  createConfig: async () => ({}),
+  createSingletonServices: async () =>
+    ({
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+    }) as any,
+}
+
+const dispatchRequest = async (
+  env: Record<string, unknown>,
+  pathname: string,
+  headers: Record<string, string> = {}
+) => {
+  const Handler = createCloudflareHandler(factories, ['queue', 'scheduled'])
+  const handler = new Handler({} as any, env as any)
+  return handler.fetch(
+    new Request(`https://unit.example.com${pathname}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify({
+        queueName: 'no-such-queue',
+        data: {},
+        taskName: 'no-such-task',
+      }),
+    })
+  )
+}
+
+describe('constantTimeEqual', () => {
+  test('matches identical values', async () => {
+    assert.equal(
+      await constantTimeEqual('correct-horse', 'correct-horse'),
+      true
+    )
+  })
+
+  test('matches empty values', async () => {
+    assert.equal(await constantTimeEqual('', ''), true)
+  })
+
+  test('rejects values differing in a single byte', async () => {
+    assert.equal(
+      await constantTimeEqual('correct-horse', 'correct-horsE'),
+      false
+    )
+  })
+
+  test('rejects values differing only in length', async () => {
+    assert.equal(
+      await constantTimeEqual('correct-horse', 'correct-horse '),
+      false
+    )
+  })
+
+  test('rejects a prefix of the expected value', async () => {
+    assert.equal(await constantTimeEqual('correct', 'correct-horse'), false)
+  })
+
+  test('handles multi-byte characters', async () => {
+    assert.equal(await constantTimeEqual('sécret-🔐', 'sécret-🔐'), true)
+    assert.equal(await constantTimeEqual('sécret-🔐', 'secret-🔐'), false)
+  })
+})
+
+describe('cloudflare dispatch routes', () => {
+  before(async () => {
+    ;({ createCloudflareHandler } = await import('./handler-factories.js'))
+  })
+
+  // Status the route reports once past auth for a job/task that has no
+  // generated meta — proof the request reached the handler body.
+  const unknownJobStatus = {
+    '/__pikku/queue-job': 422,
+    '/__pikku/scheduler-job': 503,
+  }
+
+  for (const [pathname, pastAuthStatus] of Object.entries(unknownJobStatus)) {
+    describe(pathname, () => {
+      test('rejects when no dispatch secret is configured', async () => {
+        const response = await dispatchRequest({}, pathname)
+        assert.equal(response.status, 401)
+      })
+
+      test('rejects when the dispatch secret is configured but absent', async () => {
+        const response = await dispatchRequest(
+          { PIKKU_DISPATCH_SECRET: 'correct-horse' },
+          pathname
+        )
+        assert.equal(response.status, 401)
+      })
+
+      test('rejects a wrong dispatch secret', async () => {
+        const response = await dispatchRequest(
+          { PIKKU_DISPATCH_SECRET: 'correct-horse' },
+          pathname,
+          { 'x-pikku-dispatch': 'battery-staple' }
+        )
+        assert.equal(response.status, 401)
+      })
+
+      test('rejects a dispatch secret of the wrong length', async () => {
+        const response = await dispatchRequest(
+          { PIKKU_DISPATCH_SECRET: 'correct-horse' },
+          pathname,
+          { 'x-pikku-dispatch': 'correct-horse-battery' }
+        )
+        assert.equal(response.status, 401)
+      })
+
+      test('reveals nothing about why the request was rejected', async () => {
+        const response = await dispatchRequest({}, pathname)
+        const body = await response.text()
+        assert.equal(body.includes('PIKKU_DISPATCH_SECRET'), false)
+        assert.equal(/unset|missing|mismatch/i.test(body), false)
+      })
+
+      test('proceeds past auth with the correct dispatch secret', async () => {
+        const response = await dispatchRequest(
+          { PIKKU_DISPATCH_SECRET: 'correct-horse' },
+          pathname,
+          { 'x-pikku-dispatch': 'correct-horse' }
+        )
+        assert.equal(response.status, pastAuthStatus)
+      })
+    })
+  }
+})

--- a/packages/runtimes/cloudflare/src/handler-factories.ts
+++ b/packages/runtimes/cloudflare/src/handler-factories.ts
@@ -17,6 +17,10 @@ import {
   getCloudflareEnv,
   setCloudflareEnv,
 } from './env.js'
+import {
+  dispatchUnauthorizedResponse,
+  isDispatchAuthorized,
+} from './dispatch-auth.js'
 
 export { getCloudflareEnv, type CloudflareEnv }
 
@@ -166,13 +170,18 @@ export function createCloudflareHandler(
       // via real CF Queues — namespace scripts can't bind as queue consumers).
       // Body: { queueName, data, jobId, traceId }. Status codes: 204 = ack,
       // 422 = ack-no-retry (PikkuMissingMetaError, QueueJobDiscardedError),
-      // 503 = retry (other thrown errors). The fabric dispatcher + pg-boss
-      // worker map these onto pg-boss outcomes.
+      // 503 = retry (other thrown errors), 401 = bad/missing dispatch secret.
+      // The fabric dispatcher + pg-boss worker map these onto pg-boss
+      // outcomes. Because it runs ahead of every other route it is gated on
+      // the PIKKU_DISPATCH_SECRET shared secret and fails closed when unset.
       const reqUrl = new URL(request.url)
       if (
         reqUrl.pathname === '/__pikku/queue-job' &&
         request.method === 'POST'
       ) {
+        if (!(await isDispatchAuthorized(request, this.env))) {
+          return dispatchUnauthorizedResponse()
+        }
         try {
           await setupServices(this.env, factories)
           const body = (await request.json()) as {
@@ -232,11 +241,15 @@ export function createCloudflareHandler(
       // `/__pikku/scheduler-job` is the fabric WfP scheduler-delivery route.
       // Mirrors `/__pikku/queue-job` for schedule-triggered units that have no
       // public HTTP surface. Body: { taskName }. Status codes: 204 = ok,
-      // 422 = no-retry, 503 = retry (transient).
+      // 422 = no-retry, 503 = retry (transient), 401 = bad/missing dispatch
+      // secret. Gated on PIKKU_DISPATCH_SECRET exactly like `/__pikku/queue-job`.
       if (
         reqUrl.pathname === '/__pikku/scheduler-job' &&
         request.method === 'POST'
       ) {
+        if (!(await isDispatchAuthorized(request, this.env))) {
+          return dispatchUnauthorizedResponse()
+        }
         try {
           await setupServices(this.env, factories)
           const body = (await request.json()) as { taskName: string }


### PR DESCRIPTION
**Breaking:** the Cloudflare worker's dispatch routes now require `PIKKU_DISPATCH_SECRET`, and reject every request when it is unset.

`POST /__pikku/queue-job` and `POST /__pikku/scheduler-job` are handled ahead of the `includesFetch` gate so a fabric Workers-for-Platforms dispatcher can deliver work to namespace scripts, which cannot bind as CF queue consumers. They had no authentication at all: anyone who could reach the worker URL could run any queue job in the deployment with an attacker-chosen payload, or trigger any scheduled task.

Both routes now require the shared secret in the `x-pikku-dispatch` header, matching the header and env var `@pikku/node-http-server` already uses for the same contract, so one secret covers worker and container dispatch targets. The comparison is a double-HMAC through WebCrypto, which leaks neither the secret's bytes nor its length through timing. A wrong secret and an unconfigured worker both return the same bare 401.

### Migration

**Every deployment that uses these routes must set `PIKKU_DISPATCH_SECRET`** on the worker:

```
wrangler secret put PIKKU_DISPATCH_SECRET
```

to the value its dispatcher sends. Without it the routes fail closed — queue and scheduler delivery stops — and the worker logs which variable to set. This is deliberate: falling back to unauthenticated execution is what the vulnerability was.

18 tests cover the routing, the timing-safe comparison, and that a rejection reveals nothing about why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)