### PR TITLE
feat(console): let an embedding host own the card and detail panel

### DIFF
--- a/.changeset/console-panel-sibling.md
+++ b/.changeset/console-panel-sibling.md
@@ -1,0 +1,16 @@
+---
+'@pikku/console': patch
+---
+
+Let an embedding host own the console's card and detail panel.
+
+`HostConsoleChrome` marks a console screen as living inside a host that already
+puts every page in its own card and has its own end-edge panel (Fabric). Under
+it, a screen's outermost list surface renders flush instead of painting a second
+card inside the host's one, `ResizablePanelLayout` drops the page padding the
+host already supplies, and it stops docking the detail panel as a column — the
+host mounts `PanelProvider` and renders `PanelContainer` beside the page, so the
+panel opens on the end edge like every other panel in the host.
+
+Nothing changes for the standalone console, which stays on the default `self`
+chrome.

--- a/packages/console/src/components/layout/ResizablePanelLayout.tsx
+++ b/packages/console/src/components/layout/ResizablePanelLayout.tsx
@@ -3,6 +3,7 @@ import { Box } from '@pikku/mantine/core'
 import type { I18nNode } from '@pikku/react'
 import { PanelContainer } from '../panel/PanelContainer'
 import { usePanelContext } from '../../context/PanelContext'
+import { useConsoleChrome } from '../../context/ConsoleChromeContext'
 import classes from '../ui/console.module.css'
 
 const PANEL_WIDTH = 450
@@ -25,36 +26,60 @@ export const ResizablePanelLayout: React.FC<ResizablePanelLayoutProps> = ({
   hidePanel = false,
 }) => {
   const { panels } = usePanelContext()
-  const rightOpen = !hidePanel && panels.size > 0
+  // An embedded host renders the detail panel as its own card beside the page
+  // and supplies the page's padding, so the inner column here would be a second
+  // panel for the same selection inside a card that already has a gutter.
+  const ownsChrome = useConsoleChrome() === 'self'
+  const rightOpen = ownsChrome && !hidePanel && panels.size > 0
 
   return (
     <Box className={classes.flexColumn} style={{ flex: 1, minHeight: 0 }}>
       {/* header renders as a full-bleed bar; the panel area below stays padded */}
       {header}
-      <Box className={classes.flexColumn} px="xl" py="md" style={{ flex: 1, minHeight: 0, gap: 'var(--mantine-spacing-md)' }}>
-      <Box style={{ flex: 1, display: 'flex', minHeight: 0 }}>
-        {leftDrawer && (
-          <Box style={{ width: leftDrawerWidth, flexShrink: 0, overflow: 'hidden', marginRight: 'var(--mantine-spacing-md)' }}>
-            {leftDrawer}
-          </Box>
-        )}
-        <Box className={`${classes.flexColumn} ${classes.overflowAuto}`} style={{ flex: 1, minWidth: 0 }}>
-          {children}
-        </Box>
-        {!hidePanel && (
-          <Box style={{
-            width: rightOpen ? PANEL_WIDTH : 0,
-            marginLeft: rightOpen ? 'var(--mantine-spacing-md)' : 0,
-            flexShrink: 0,
-            overflow: 'hidden',
-            transition: 'width 180ms ease, margin-left 180ms ease',
-          }}>
-            <Box className={classes.listSurfaceCard} style={{ width: PANEL_WIDTH, height: '100%' }}>
-              <PanelContainer emptyMessage={emptyPanelMessage} />
+      <Box
+        className={classes.flexColumn}
+        px={ownsChrome ? 'xl' : 0}
+        py={ownsChrome ? 'md' : 0}
+        style={{ flex: 1, minHeight: 0, gap: 'var(--mantine-spacing-md)' }}
+      >
+        <Box style={{ flex: 1, display: 'flex', minHeight: 0 }}>
+          {leftDrawer && (
+            <Box
+              style={{
+                width: leftDrawerWidth,
+                flexShrink: 0,
+                overflow: 'hidden',
+                marginRight: 'var(--mantine-spacing-md)',
+              }}
+            >
+              {leftDrawer}
             </Box>
+          )}
+          <Box
+            className={`${classes.flexColumn} ${classes.overflowAuto}`}
+            style={{ flex: 1, minWidth: 0 }}
+          >
+            {children}
           </Box>
-        )}
-      </Box>
+          {ownsChrome && !hidePanel && (
+            <Box
+              style={{
+                width: rightOpen ? PANEL_WIDTH : 0,
+                marginLeft: rightOpen ? 'var(--mantine-spacing-md)' : 0,
+                flexShrink: 0,
+                overflow: 'hidden',
+                transition: 'width 180ms ease, margin-left 180ms ease',
+              }}
+            >
+              <Box
+                className={classes.listSurfaceCard}
+                style={{ width: PANEL_WIDTH, height: '100%' }}
+              >
+                <PanelContainer emptyMessage={emptyPanelMessage} />
+              </Box>
+            </Box>
+          )}
+        </Box>
       </Box>
     </Box>
   )

--- a/packages/console/src/components/layout/TableListPage.tsx
+++ b/packages/console/src/components/layout/TableListPage.tsx
@@ -15,6 +15,7 @@ import { useLocale } from '@/i18n/config'
 import { Search } from 'lucide-react'
 import { EmptyStatePlaceholder } from './EmptyStatePlaceholder'
 import { usePageGate } from '../../context/PageGateContext'
+import { useListSurfaceClass } from '../../context/ConsoleChromeContext'
 import classes from '../ui/console.module.css'
 
 interface Column<T> {
@@ -74,6 +75,7 @@ export const TableListPage = <T,>({
   headerRight,
 }: TableListPageProps<T>) => {
   const gate = usePageGate()
+  const surfaceClass = useListSurfaceClass()
   useLocale()
   const [internalSearch, setInternalSearch] = useState('')
   const searchQuery =
@@ -91,7 +93,7 @@ export const TableListPage = <T,>({
 
   if (loading) {
     return (
-      <Box className={classes.listSurfaceCard}>
+      <Box className={surfaceClass}>
         <Center h="100%">
           <Loader />
         </Center>
@@ -114,7 +116,7 @@ export const TableListPage = <T,>({
   }
 
   return (
-    <Box className={classes.listSurfaceCard}>
+    <Box className={surfaceClass}>
       <Stack gap={0} className={classes.flexColumn}>
         {description && (
           <Box

--- a/packages/console/src/components/ui/console.module.css
+++ b/packages/console/src/components/ui/console.module.css
@@ -372,6 +372,19 @@
   overflow: hidden;
 }
 
+/* The same list surface with no chrome of its own, for a host that already put
+   the screen in a page card (see ConsoleChromeContext) — there the surface IS
+   that card's content, and keeping its border would read as a card in a card.
+   Only the screen's outermost surface swaps to this: the panes inside a
+   two-pane layout still need their borders to read as separate panes. */
+.listSurfaceFlush {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
 /* ── Badge variants ── */
 
 .tagBadge {

--- a/packages/console/src/context/ConsoleChromeContext.tsx
+++ b/packages/console/src/context/ConsoleChromeContext.tsx
@@ -1,0 +1,58 @@
+import { createContext, useContext } from 'react'
+import type { ReactNode } from 'react'
+import classes from '../components/ui/console.module.css'
+
+/**
+ * Who draws the chrome around a console screen.
+ *
+ * `self` (the default) is the standalone console: each screen paints its own
+ * list surface and docks the detail panel as a column inside itself.
+ *
+ * `host` is an embedded console — a platform such as Fabric that already puts
+ * every screen inside its own page card and has its own end-edge panel. There,
+ * the screen's surfaces are that card's CONTENT, so they drop their border,
+ * radius, background and page padding, and the layout leaves the detail panel
+ * to the host: the host mounts the panel context and renders `PanelContainer`
+ * beside the page rather than welded inside it.
+ */
+export type ConsoleChrome = 'self' | 'host'
+
+export const ConsoleChromeContext = createContext<ConsoleChrome>('self')
+
+export function useConsoleChrome(): ConsoleChrome {
+  return useContext(ConsoleChromeContext)
+}
+
+/**
+ * The class for a screen's OUTERMOST list surface — a card of its own when the
+ * console draws its own chrome, flush when the host already drew that card.
+ *
+ * Only for the outermost surface: the panes inside a two-pane layout are
+ * siblings that read as separate panes because of their borders, so they keep
+ * `listSurfaceCard` in both modes.
+ */
+export function useListSurfaceClass(): string {
+  return useConsoleChrome() === 'host'
+    ? classes.listSurfaceFlush
+    : classes.listSurfaceCard
+}
+
+/**
+ * Declares that the host owns the card and the detail panel.
+ *
+ * The data attribute is not read by the console itself — it is a hook for the
+ * host's own stylesheet, which may need to reach inside the embedded screen.
+ */
+export function HostConsoleChrome({ children }: { children: ReactNode }) {
+  return (
+    <ConsoleChromeContext.Provider value="host">
+      <div
+        data-console-chrome="host"
+        className={classes.flexColumn}
+        style={{ flex: 1, minWidth: 0, minHeight: 0 }}
+      >
+        {children}
+      </div>
+    </ConsoleChromeContext.Provider>
+  )
+}

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -229,6 +229,18 @@ export { ConsoleInspectorPanel } from './components/console/ConsoleInspectorPane
 export type { ConsoleInspectorPanelProps } from './components/console/ConsoleInspectorPanel'
 export { usePanelContextSafe } from './context/PanelContext'
 
+// A host that already cards its screens and has its own end-edge panel wraps the
+// console page in `HostConsoleChrome`: the page's surfaces then render flush
+// inside the host's card, and the layout stops docking its own panel column, so
+// the host can render `PanelContainer` beside the page instead of inside it.
+export {
+  ConsoleChromeContext,
+  HostConsoleChrome,
+  useConsoleChrome,
+  useListSurfaceClass,
+} from './context/ConsoleChromeContext'
+export type { ConsoleChrome } from './context/ConsoleChromeContext'
+
 // The shell behind the console's tabbed pages. `activeTab`/`onTabChange` are
 // optional: supply them to drive tabs from a host router, omit them to keep the
 // OSS `?tab=` search-param behaviour.

--- a/packages/console/src/pages/ChangesPage.tsx
+++ b/packages/console/src/pages/ChangesPage.tsx
@@ -21,6 +21,7 @@ import { useLocale } from '@/i18n/config'
 import { EmptyStatePlaceholder } from '../components/layout/EmptyStatePlaceholder'
 import { useSearchParams } from '../router'
 import { PanelProvider } from '../context/PanelContext'
+import { useListSurfaceClass } from '../context/ConsoleChromeContext'
 import { ResizablePanelLayout } from '../components/layout/ResizablePanelLayout'
 import { ListPageHeader } from '../components/layout/PageLayout'
 import {
@@ -292,7 +293,9 @@ const FieldDiff: React.FC<{
             wrap="nowrap"
             style={{
               borderBottom: '1px solid var(--app-row-border)',
-              background: equal ? 'transparent' : 'var(--mantine-color-default-hover)',
+              background: equal
+                ? 'transparent'
+                : 'var(--mantine-color-default-hover)',
             }}
           >
             <Text
@@ -318,7 +321,8 @@ const FieldDiff: React.FC<{
                 style={{
                   background: 'transparent',
                   fontSize: 11,
-                  color: b === undefined ? 'var(--mantine-color-dimmed)' : undefined,
+                  color:
+                    b === undefined ? 'var(--mantine-color-dimmed)' : undefined,
                 }}
               >
                 {b === undefined ? '—' : JSON.stringify(b)}
@@ -339,7 +343,8 @@ const FieldDiff: React.FC<{
                 style={{
                   background: 'transparent',
                   fontSize: 11,
-                  color: o === undefined ? 'var(--mantine-color-dimmed)' : undefined,
+                  color:
+                    o === undefined ? 'var(--mantine-color-dimmed)' : undefined,
                 }}
               >
                 {o === undefined ? '—' : JSON.stringify(o)}
@@ -566,6 +571,7 @@ const DiffView: React.FC<{ diff: StateDiff }> = ({ diff }) => {
 
 export const ChangesPage: React.FC = () => {
   useLocale()
+  const surfaceClass = useListSurfaceClass()
   const [searchParams] = useSearchParams()
   const queryBase = searchParams.get('base')
   const queryOurs = searchParams.get('ours')
@@ -630,7 +636,11 @@ export const ChangesPage: React.FC = () => {
                   onChange={(e) => setDraftPath(e.currentTarget.value)}
                   onKeyDown={(e) => e.key === 'Enter' && apply()}
                   rightSection={
-                    <ActionIcon variant="subtle" size="sm" onClick={() => fileInputRef.current?.click()}>
+                    <ActionIcon
+                      variant="subtle"
+                      size="sm"
+                      onClick={() => fileInputRef.current?.click()}
+                    >
                       <FolderOpen size={14} />
                     </ActionIcon>
                   }
@@ -657,8 +667,13 @@ export const ChangesPage: React.FC = () => {
         }
       >
         <Box
-          className={classes.listSurfaceCard}
-          style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}
+          className={surfaceClass}
+          style={{
+            flex: 1,
+            minHeight: 0,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
         >
           {!activePath && (
             <EmptyStatePlaceholder
@@ -683,7 +698,8 @@ export const ChangesPage: React.FC = () => {
           {activePath && diff && !diff.baseExists && (
             <Center p="xl">
               <Text size="sm" c="red">
-                {asI18n('Base path does not exist: ')}<Code>{diff.basePath}</Code>
+                {asI18n('Base path does not exist: ')}
+                <Code>{diff.basePath}</Code>
               </Text>
             </Center>
           )}

--- a/packages/console/src/pages/DatabasePage.tsx
+++ b/packages/console/src/pages/DatabasePage.tsx
@@ -1,8 +1,19 @@
 import React, { useState, useEffect, useRef, memo } from 'react'
 import { m } from '@/i18n/messages'
 import { useLocale } from '@/i18n/config'
-import { Box, Center, ActionIcon, Loader, Text, Group, Tooltip, SegmentedControl, TextInput, useMantineColorScheme } from '@pikku/mantine/core'
-import { PanelProvider } from '../context/PanelContext'
+import {
+  Box,
+  Center,
+  ActionIcon,
+  Loader,
+  Text,
+  Group,
+  Tooltip,
+  SegmentedControl,
+  TextInput,
+  useMantineColorScheme,
+} from '@pikku/mantine/core'
+import { ConsoleSurface } from '../components/console/ConsoleSurface'
 import { ResizablePanelLayout } from '../components/layout/ResizablePanelLayout'
 import ReactFlow, {
   ReactFlowProvider,
@@ -19,9 +30,21 @@ import ReactFlow, {
 import type { NodeProps, Node, Edge, ReactFlowInstance } from 'reactflow'
 import { useQuery } from '@tanstack/react-query'
 import ELK from 'elkjs/lib/elk.bundled.js'
-import { Database as DatabaseIcon, Key, Link, RefreshCw, Globe, Shield, LockKeyhole, UserCheck, Table2, Search } from 'lucide-react'
+import {
+  Database as DatabaseIcon,
+  Key,
+  Link,
+  RefreshCw,
+  Globe,
+  Shield,
+  LockKeyhole,
+  UserCheck,
+  Table2,
+  Search,
+} from 'lucide-react'
 import { usePikkuRPC } from '../context/PikkuRpcProvider'
 import { usePanelContext } from '../context/PanelContext'
+import { useListSurfaceClass } from '../context/ConsoleChromeContext'
 import { ListPageHeader } from '../components/layout/PageLayout'
 import { PikkuToggle } from '../components/ui/PikkuToggle'
 import { EmptyStatePlaceholder } from '../components/layout/EmptyStatePlaceholder'
@@ -97,7 +120,9 @@ const DatabaseSchemaNode = memo(function DatabaseSchemaNode({
   const isDark = colorScheme === 'dark'
 
   const border = 'transparent'
-  const headerBg = isDark ? 'var(--mantine-color-dark-5)' : 'var(--mantine-color-blue-0, #e7f5ff)'
+  const headerBg = isDark
+    ? 'var(--mantine-color-dark-5)'
+    : 'var(--mantine-color-blue-0, #e7f5ff)'
   const badgeBg = isDark ? 'var(--mantine-color-dark-4)' : '#f0f0f0'
   const badgeColor = isDark ? 'var(--mantine-color-dark-1)' : '#888'
   const rowBorder = 'transparent'
@@ -121,7 +146,9 @@ const DatabaseSchemaNode = memo(function DatabaseSchemaNode({
         border: `1px solid ${border}`,
         borderRadius: 8,
         backgroundColor: 'var(--mantine-color-body)',
-        boxShadow: isDark ? '0 1px 4px rgba(0,0,0,.4)' : '0 1px 4px rgba(0,0,0,.08)',
+        boxShadow: isDark
+          ? '0 1px 4px rgba(0,0,0,.4)'
+          : '0 1px 4px rgba(0,0,0,.08)',
       }}
     >
       <div
@@ -221,13 +248,18 @@ const DatabaseSchemaNode = memo(function DatabaseSchemaNode({
             </span>
 
             {col.nullable && (
-              <span style={{ fontSize: 11, color: nullableColor, flexShrink: 0 }}>?</span>
+              <span
+                style={{ fontSize: 11, color: nullableColor, flexShrink: 0 }}
+              >
+                ?
+              </span>
             )}
 
-            <span style={{ flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+            <span
+              style={{ flexShrink: 0, display: 'flex', alignItems: 'center' }}
+            >
               {CLASSIFICATION_ICON[col.classification]}
             </span>
-
           </div>
         ))}
       </div>
@@ -248,7 +280,9 @@ const EnumSchemaNode = memo(function EnumSchemaNode({
   const isDark = colorScheme === 'dark'
 
   const border = 'transparent'
-  const headerBg = isDark ? 'var(--mantine-color-violet-9)' : 'var(--mantine-color-violet-1)'
+  const headerBg = isDark
+    ? 'var(--mantine-color-violet-9)'
+    : 'var(--mantine-color-violet-1)'
   const rowBorder = 'transparent'
   const valueColor = isDark ? 'var(--mantine-color-dark-1)' : '#555'
 
@@ -259,7 +293,9 @@ const EnumSchemaNode = memo(function EnumSchemaNode({
         border: `1px solid ${border}`,
         borderRadius: 8,
         backgroundColor: 'var(--mantine-color-body)',
-        boxShadow: isDark ? '0 1px 4px rgba(0,0,0,.4)' : '0 1px 4px rgba(0,0,0,.08)',
+        boxShadow: isDark
+          ? '0 1px 4px rgba(0,0,0,.4)'
+          : '0 1px 4px rgba(0,0,0,.08)',
       }}
     >
       <div
@@ -272,7 +308,14 @@ const EnumSchemaNode = memo(function EnumSchemaNode({
           gap: 8,
         }}
       >
-        <span style={{ fontSize: 10, fontWeight: 700, color: 'var(--mantine-color-violet-5)', letterSpacing: 1 }}>
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            color: 'var(--mantine-color-violet-5)',
+            letterSpacing: 1,
+          }}
+        >
           ENUM
         </span>
         <span
@@ -309,7 +352,14 @@ const EnumSchemaNode = memo(function EnumSchemaNode({
       <Handle
         type="target"
         position={Position.Left}
-        style={{ opacity: 0, pointerEvents: 'none', width: 8, height: 8, minWidth: 0, minHeight: 0 }}
+        style={{
+          opacity: 0,
+          pointerEvents: 'none',
+          width: 8,
+          height: 8,
+          minWidth: 0,
+          minHeight: 0,
+        }}
       />
     </div>
   )
@@ -364,7 +414,8 @@ async function schemaToFlow(schema: DbSchema): Promise<{
 }> {
   const edges: Edge[] = []
   const edgeIds = new Set<string>()
-  const elkEdges: Array<{ id: string; sources: string[]; targets: string[] }> = []
+  const elkEdges: Array<{ id: string; sources: string[]; targets: string[] }> =
+    []
 
   const tableNodeIds = new Set(schema.tables.map((t) => t.name))
 
@@ -425,7 +476,8 @@ async function schemaToFlow(schema: DbSchema): Promise<{
     const nodes: Node[] = schema.tables.map((table, i) => ({
       id: table.name,
       type: 'databaseSchema',
-      position: posById.get(table.name) ?? tableNodes[i]?.position ?? { x: 0, y: 0 },
+      position: posById.get(table.name) ??
+        tableNodes[i]?.position ?? { x: 0, y: 0 },
       data: { label: table.name, columns: sortedColumns(table.columns) },
     }))
 
@@ -507,6 +559,7 @@ function DatabaseCanvas({
   search: string
 }) {
   useLocale()
+  const surfaceClass = useListSurfaceClass()
   const { colorScheme } = useMantineColorScheme()
   const isDark = colorScheme === 'dark'
   const [nodes, setNodes, onNodesChange] = useNodesState([])
@@ -529,13 +582,32 @@ function DatabaseCanvas({
       const filtered = schema.tables
         .filter((t) => {
           if (!shouldShowTable(t, hideInternal, hasProvenance)) return false
-          if (classificationFilter !== 'all' && !t.columns.some((col) => col.classification === classificationFilter)) return false
-          if (q && !t.name.toLowerCase().includes(q) && !t.columns.some((col) => col.name.toLowerCase().includes(q))) return false
+          if (
+            classificationFilter !== 'all' &&
+            !t.columns.some(
+              (col) => col.classification === classificationFilter
+            )
+          )
+            return false
+          if (
+            q &&
+            !t.name.toLowerCase().includes(q) &&
+            !t.columns.some((col) => col.name.toLowerCase().includes(q))
+          )
+            return false
           return true
         })
         .map((t) => {
-          const byClass = classificationFilter === 'all' ? t.columns : t.columns.filter((col) => col.classification === classificationFilter)
-          const cols = q && !t.name.toLowerCase().includes(q) ? byClass.filter((col) => col.name.toLowerCase().includes(q)) : byClass
+          const byClass =
+            classificationFilter === 'all'
+              ? t.columns
+              : t.columns.filter(
+                  (col) => col.classification === classificationFilter
+                )
+          const cols =
+            q && !t.name.toLowerCase().includes(q)
+              ? byClass.filter((col) => col.name.toLowerCase().includes(q))
+              : byClass
           return { ...t, columns: cols }
         })
       if (!filtered.length) {
@@ -546,12 +618,20 @@ function DatabaseCanvas({
 
       setLayouting(true)
       try {
-        const flow = await schemaToFlow({ tables: filtered, enums: schema.enums ?? [] })
+        const flow = await schemaToFlow({
+          tables: filtered,
+          enums: schema.enums ?? [],
+        })
         if (cancelled) return
         setNodes(flow.nodes)
         setEdges(flow.edges)
         setTimeout(() => {
-          if (!cancelled) flowRef.current?.fitView({ padding: 0.15, duration: 300, minZoom: 0.4 })
+          if (!cancelled)
+            flowRef.current?.fitView({
+              padding: 0.15,
+              duration: 300,
+              minZoom: 0.4,
+            })
         }, 50)
       } catch {
         if (!cancelled) {
@@ -592,15 +672,21 @@ function DatabaseCanvas({
     return (
       <EmptyStatePlaceholder
         icon={DatabaseIcon}
-        title={hideInternal ? m.database_no_visible_tables() : m.database_no_tables_found()}
-        description={hideInternal ? m.database_no_visible_tables_description() : undefined}
+        title={
+          hideInternal
+            ? m.database_no_visible_tables()
+            : m.database_no_tables_found()
+        }
+        description={
+          hideInternal ? m.database_no_visible_tables_description() : undefined
+        }
         docsHref="https://pikku.dev/docs/core-features/database"
       />
     )
   }
 
   return (
-    <Box className={classes.listSurfaceCard} style={{ flex: 1, minHeight: 0 }}>
+    <Box className={surfaceClass} style={{ flex: 1, minHeight: 0 }}>
       <ReactFlow
         onInit={(instance) => {
           flowRef.current = instance
@@ -622,15 +708,29 @@ function DatabaseCanvas({
           variant={BackgroundVariant.Dots}
           gap={20}
           size={1}
-          color={isDark ? 'var(--mantine-color-dark-4)' : 'var(--mantine-color-gray-4)'}
+          color={
+            isDark
+              ? 'var(--mantine-color-dark-4)'
+              : 'var(--mantine-color-gray-4)'
+          }
         />
         <Controls
-          style={{
-            '--xy-controls-button-background-color': isDark ? 'var(--mantine-color-dark-6)' : '#fff',
-            '--xy-controls-button-background-color-hover': isDark ? 'var(--mantine-color-dark-5)' : '#f4f4f5',
-            '--xy-controls-button-color': isDark ? 'var(--mantine-color-dark-0)' : '#333',
-            '--xy-controls-button-border-color': isDark ? 'var(--mantine-color-dark-4)' : '#d1d5db',
-          } as React.CSSProperties}
+          style={
+            {
+              '--xy-controls-button-background-color': isDark
+                ? 'var(--mantine-color-dark-6)'
+                : '#fff',
+              '--xy-controls-button-background-color-hover': isDark
+                ? 'var(--mantine-color-dark-5)'
+                : '#f4f4f5',
+              '--xy-controls-button-color': isDark
+                ? 'var(--mantine-color-dark-0)'
+                : '#333',
+              '--xy-controls-button-border-color': isDark
+                ? 'var(--mantine-color-dark-4)'
+                : '#d1d5db',
+            } as React.CSSProperties
+          }
         />
         <MiniMap
           nodeColor={isDark ? 'var(--mantine-color-dark-3)' : '#ccc'}
@@ -647,10 +747,12 @@ function DatabaseCanvas({
 
 // ── Legend ────────────────────────────────────────────────────────────────────
 
-
 // ── Page ──────────────────────────────────────────────────────────────────────
 
-const DatabasePageLayout: React.FC<{ header: React.ReactNode; children: React.ReactNode }> = ({ header, children }) => {
+const DatabasePageLayout: React.FC<{
+  header: React.ReactNode
+  children: React.ReactNode
+}> = ({ header, children }) => {
   const { activePanel } = usePanelContext()
   return (
     <ResizablePanelLayout hidePanel={!activePanel} header={header}>
@@ -663,14 +765,20 @@ function DatabasePageInner() {
   useLocale()
   const rpc = usePikkuRPC()
   const [hideInternal, setHideInternal] = useState(true)
-  const [classificationFilter, setClassificationFilter] = useState<ClassificationFilter>('all')
+  const [classificationFilter, setClassificationFilter] =
+    useState<ClassificationFilter>('all')
   const [search, setSearch] = useState('')
 
-  const { data: schema, isLoading, isFetching, error, refetch } = useQuery<
-    DbSchema | null
-  >({
+  const {
+    data: schema,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
+  } = useQuery<DbSchema | null>({
     queryKey: ['console:getDbSchema'],
-    queryFn: () => rpc.invoke('console:getDbSchema') as Promise<DbSchema | null>,
+    queryFn: () =>
+      rpc.invoke('console:getDbSchema') as Promise<DbSchema | null>,
   })
 
   const header = (
@@ -693,10 +801,45 @@ function DatabasePageInner() {
             onChange={(v) => setClassificationFilter(v as ClassificationFilter)}
             data={[
               { label: 'All', value: 'all' },
-              { label: <Group gap={4} wrap="nowrap"><Globe size={14} color="var(--mantine-color-teal-5)" />Public</Group>, value: 'public' },
-              { label: <Group gap={4} wrap="nowrap"><Shield size={14} color="var(--mantine-color-orange-5)" />Private</Group>, value: 'private' },
-              { label: <Group gap={4} wrap="nowrap"><UserCheck size={14} color="var(--mantine-color-violet-5)" />PII</Group>, value: 'pii' },
-              { label: <Group gap={4} wrap="nowrap"><LockKeyhole size={14} color="var(--mantine-color-red-5)" />Secret</Group>, value: 'secret' },
+              {
+                label: (
+                  <Group gap={4} wrap="nowrap">
+                    <Globe size={14} color="var(--mantine-color-teal-5)" />
+                    Public
+                  </Group>
+                ),
+                value: 'public',
+              },
+              {
+                label: (
+                  <Group gap={4} wrap="nowrap">
+                    <Shield size={14} color="var(--mantine-color-orange-5)" />
+                    Private
+                  </Group>
+                ),
+                value: 'private',
+              },
+              {
+                label: (
+                  <Group gap={4} wrap="nowrap">
+                    <UserCheck
+                      size={14}
+                      color="var(--mantine-color-violet-5)"
+                    />
+                    PII
+                  </Group>
+                ),
+                value: 'pii',
+              },
+              {
+                label: (
+                  <Group gap={4} wrap="nowrap">
+                    <LockKeyhole size={14} color="var(--mantine-color-red-5)" />
+                    Secret
+                  </Group>
+                ),
+                value: 'secret',
+              },
             ]}
           />
           <PikkuToggle
@@ -721,9 +864,16 @@ function DatabasePageInner() {
   )
 
   return (
-    <PanelProvider>
+    <ConsoleSurface>
       <DatabasePageLayout header={header}>
-        <Box style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+        <Box
+          style={{
+            flex: 1,
+            minHeight: 0,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
           {error ? (
             <EmptyStatePlaceholder
               icon={DatabaseIcon}
@@ -745,7 +895,7 @@ function DatabasePageInner() {
           )}
         </Box>
       </DatabasePageLayout>
-    </PanelProvider>
+    </ConsoleSurface>
   )
 }
 


### PR DESCRIPTION
## Problem

A host that already puts every console screen in its own page card and has its own end-edge panel — Fabric — got two things wrong on every embedded screen:

- a **card inside a card**: the screen painted its own list surface inside the host's page card, and `ResizablePanelLayout` added page padding the host already supplies;
- a **second panel**, docked as a 450px column welded inside that card, instead of opening on the end edge like every other panel in the host.

## Change

`HostConsoleChrome` marks a screen as embedded (`ConsoleChromeContext`, default `self`). Under it:

- a screen's **outermost** list surface renders flush (`useListSurfaceClass`), so it reads as the host card's content;
- `ResizablePanelLayout` drops its `px="xl" py="md"` padding and stops rendering the docked panel column — the host mounts `PanelProvider` and renders `PanelContainer` beside the page.

Deliberately narrow: only the outermost surface flattens. The panes inside `ListDetailLayout` / `ThreePaneLayout` keep `listSurfaceCard` in both modes, because their borders are what makes them read as separate panes.

`DatabasePage` now defers to a host-supplied panel context via `ConsoleSurface` instead of mounting a private `PanelProvider` the host could not reach.

## Compatibility

The standalone console stays on the default `self` chrome — no visual or behavioural change there. Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)