### PR TITLE
fix(knowledge): ship the LICENSE file beside the package

### DIFF
--- a/packages/knowledge/LICENSE
+++ b/packages/knowledge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 - present Yasser Fadl and Pikku contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The 0.12.48 publish failed at the first gate:

```
License metadata does not match the LICENSE files:
  packages/knowledge/package.json: no LICENSE file beside it — npm always ships LICENSE, and the root one is not in the tarball
##[error]Publish command exited with code 1
```

`@pikku/knowledge` declares `"license": "MIT"` but has no LICENSE beside it, so `check:licenses` fails and `yarn release` exits before `changeset publish` runs. That blocks the publish of **every** package in the release, not just this one — nothing from 0.12.48 reached npm ([run](https://github.com/pikkujs/pikku/actions/runs/30592888821)).

This adds the MIT LICENSE used by the other MIT packages. `node scripts/check-licenses.mjs` now passes: `✓ 62 publishable packages: license field matches LICENSE file`.

No changeset: the versions are already bumped on `main`, and the release job's "publish any unpublished packages" path picks them up once the gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the MIT License text, including copyright attribution for Yasser Fadl and Pikku contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->