### PR TITLE
fix(better-auth): relay the session where third-party cookies are blocked

### DIFF
--- a/.changeset/cors-expose-headers.md
+++ b/.changeset/cors-expose-headers.md
@@ -1,0 +1,13 @@
+---
+'@pikku/core': patch
+---
+
+`cors()` takes an `exposeHeaders` option.
+
+Without `Access-Control-Expose-Headers` a cross-origin caller can read only the
+CORS-safelisted response headers, so any header the client is meant to act on was
+invisible to it. The cross-site session relay in `@pikku/better-auth` is the case that
+surfaced it: the client cannot read `x-pikku-cross-site-set-cookie` off a cross-origin
+response without being told it may.
+
+Defaults to none, so nothing new is exposed unless it is named.

--- a/.changeset/cross-site-session-relay.md
+++ b/.changeset/cross-site-session-relay.md
@@ -1,5 +1,5 @@
 ---
-'@pikku/better-auth': minor
+'@pikku/better-auth': patch
 ---
 
 Keep a cross-site-embedded app signed in on browsers that refuse third-party cookies.
@@ -20,7 +20,9 @@ before reading the session. A real cookie always wins over a relayed one of the 
 name, so a browser that did store it stays authoritative.
 
 Both header names, `crossSiteCookies()` and `mergeRelayedCookies()` are exported for
-clients that implement the browser half.
+clients that implement the browser half. A response carrying the echo header is marked
+`Cache-Control: no-store`: caches along the path know to be careful with `Set-Cookie`
+and nothing about this one, and a stored copy would hand one user's session to the next.
 
 Unchanged for everyone else: the relay is honoured only when `AUTH_COOKIE_CROSS_SITE`
 is set, which only a runtime that embeds its apps cross-site sets. A deployed app keeps

--- a/.changeset/cross-site-session-relay.md
+++ b/.changeset/cross-site-session-relay.md
@@ -1,0 +1,27 @@
+---
+'@pikku/better-auth': minor
+---
+
+Keep a cross-site-embedded app signed in on browsers that refuse third-party cookies.
+
+`AUTH_COOKIE_CROSS_SITE` already rewrote every better-auth cookie to
+`SameSite=None; Secure; Partitioned` so a session survives inside a third-party iframe
+(the Fabric sandbox preview). That is a Chromium answer: `Partitioned` (CHIPS) is not
+implemented in WebKit, which blocks third-party cookie writes outright — and every
+browser on iOS is WebKit. On a phone, sign-in returned 200, the browser dropped the
+cookie, the next request arrived anonymous and the app bounced back to `/login`.
+
+The same flag now also enables a cookie relay, over storage the embedded frame is
+actually allowed to use. The auth handler echoes the cookies it just set in
+`x-pikku-cross-site-set-cookie` (JS can never read `Set-Cookie` itself); the client
+sends them back in `x-pikku-cross-site-cookie`, and `createAuthHandler`,
+`betterAuthSession` and `betterAuthStatelessSession` merge that header into `Cookie`
+before reading the session. A real cookie always wins over a relayed one of the same
+name, so a browser that did store it stays authoritative.
+
+Both header names, `crossSiteCookies()` and `mergeRelayedCookies()` are exported for
+clients that implement the browser half.
+
+Unchanged for everyone else: the relay is honoured only when `AUTH_COOKIE_CROSS_SITE`
+is set, which only a runtime that embeds its apps cross-site sets. A deployed app keeps
+`SameSite=Lax` cookies and ignores the header entirely.

--- a/.changeset/cross-site-session-relay.md
+++ b/.changeset/cross-site-session-relay.md
@@ -14,10 +14,16 @@ cookie, the next request arrived anonymous and the app bounced back to `/login`.
 The same flag now also enables a cookie relay, over storage the embedded frame is
 actually allowed to use. The auth handler echoes the cookies it just set in
 `x-pikku-cross-site-set-cookie` (JS can never read `Set-Cookie` itself); the client
-sends them back in `x-pikku-cross-site-cookie`, and `createAuthHandler`,
-`betterAuthSession` and `betterAuthStatelessSession` merge that header into `Cookie`
-before reading the session. A real cookie always wins over a relayed one of the same
-name, so a browser that did store it stays authoritative.
+sends them back in `x-pikku-cross-site-cookie`, and every place this package hands
+caller headers to better-auth — `createAuthHandler`, `betterAuthSession`,
+`betterAuthStatelessSession`, `getAuthSession` and `callAdminApi` — merges that header
+into `Cookie` before reading the session. A real cookie always wins over a relayed one
+of the same name, so a browser that did store it stays authoritative.
+
+Sign-out becomes partly the client's job: deleting a cookie cannot reach the client's
+own storage, so a client implementing the relay must drop the entries the sign-out
+response expires. Under `betterAuthStatelessSession` a kept-around cache blob otherwise
+keeps verifying until it ages out.
 
 Both header names, `crossSiteCookies()`, `decodeSetCookies()` and
 `mergeRelayedCookies()` are exported for clients that implement the browser half — the

--- a/.changeset/cross-site-session-relay.md
+++ b/.changeset/cross-site-session-relay.md
@@ -19,8 +19,10 @@ sends them back in `x-pikku-cross-site-cookie`, and `createAuthHandler`,
 before reading the session. A real cookie always wins over a relayed one of the same
 name, so a browser that did store it stays authoritative.
 
-Both header names, `crossSiteCookies()` and `mergeRelayedCookies()` are exported for
-clients that implement the browser half. A response carrying the echo header is marked
+Both header names, `crossSiteCookies()`, `decodeSetCookies()` and
+`mergeRelayedCookies()` are exported for clients that implement the browser half — the
+echo header carries a percent-encoded JSON array, so the client needs the decoder to
+read it at all. A response carrying the echo header is marked
 `Cache-Control: no-store`: caches along the path know to be careful with `Set-Cookie`
 and nothing about this one, and a stored copy would hand one user's session to the next.
 

--- a/packages/core/src/middleware/cors.test.ts
+++ b/packages/core/src/middleware/cors.test.ts
@@ -243,6 +243,40 @@ describe('cors', () => {
       )
     })
 
+    test('should not expose any headers by default', async () => {
+      const middleware = cors()
+      const request = createMockRequest()
+      const response = createMockResponse()
+
+      await middleware(
+        {} as any,
+        { http: { request, response } } as any,
+        async () => {}
+      )
+
+      assert.strictEqual(
+        response._headers['Access-Control-Expose-Headers'],
+        undefined
+      )
+    })
+
+    test('should set exposed headers', async () => {
+      const middleware = cors({ exposeHeaders: ['X-Custom', 'X-Other'] })
+      const request = createMockRequest()
+      const response = createMockResponse()
+
+      await middleware(
+        {} as any,
+        { http: { request, response } } as any,
+        async () => {}
+      )
+
+      assert.strictEqual(
+        response._headers['Access-Control-Expose-Headers'],
+        'X-Custom, X-Other'
+      )
+    })
+
     test('should not set Vary when origin is string', async () => {
       const middleware = cors({ origin: 'https://example.com' })
       const request = createMockRequest()

--- a/packages/core/src/middleware/cors.ts
+++ b/packages/core/src/middleware/cors.ts
@@ -9,6 +9,7 @@ import { pikkuMiddleware, pikkuMiddlewareFactory } from '../types/core.types.js'
  * @param options.origin - Allowed origin(s). Use `'*'` for any origin, `true` to reflect the request origin, a string for a single origin, or an array for multiple origins. Defaults to `'*'`.
  * @param options.methods - Allowed HTTP methods. Defaults to common methods.
  * @param options.headers - Allowed request headers. Defaults to common headers.
+ * @param options.exposeHeaders - Response headers a cross-origin caller is allowed to read, beyond the CORS-safelisted ones. Defaults to none.
  * @param options.credentials - Whether to allow credentials. Defaults to `false`.
  * @param options.maxAge - Preflight cache duration in seconds. Defaults to `86400` (24 hours).
  *
@@ -39,6 +40,7 @@ export const cors = pikkuMiddlewareFactory<{
   origin?: string | string[] | true
   methods?: string[]
   headers?: string[]
+  exposeHeaders?: string[]
   credentials?: boolean
   maxAge?: number
 }>(
@@ -46,6 +48,7 @@ export const cors = pikkuMiddlewareFactory<{
     origin = '*',
     methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     headers = ['Content-Type', 'Authorization', 'x-api-key'],
+    exposeHeaders = [],
     credentials = false,
     maxAge = 86400,
   } = {}) => {
@@ -82,6 +85,16 @@ export const cors = pikkuMiddlewareFactory<{
         response.header('Access-Control-Allow-Origin', allowedOrigin)
         response.header('Access-Control-Allow-Methods', methods.join(', '))
         response.header('Access-Control-Allow-Headers', headers.join(', '))
+
+        // Without this a cross-origin caller can read only the CORS-safelisted
+        // response headers, so any header the client is meant to act on has to
+        // be named here.
+        if (exposeHeaders.length > 0) {
+          response.header(
+            'Access-Control-Expose-Headers',
+            exposeHeaders.join(', ')
+          )
+        }
 
         if (credentials) {
           response.header('Access-Control-Allow-Credentials', 'true')

--- a/packages/core/src/middleware/cors.ts
+++ b/packages/core/src/middleware/cors.ts
@@ -86,9 +86,6 @@ export const cors = pikkuMiddlewareFactory<{
         response.header('Access-Control-Allow-Methods', methods.join(', '))
         response.header('Access-Control-Allow-Headers', headers.join(', '))
 
-        // Without this a cross-origin caller can read only the CORS-safelisted
-        // response headers, so any header the client is meant to act on has to
-        // be named here.
         if (exposeHeaders.length > 0) {
           response.header(
             'Access-Control-Expose-Headers',

--- a/packages/services/better-auth/README.md
+++ b/packages/services/better-auth/README.md
@@ -20,6 +20,50 @@ const authHandler = createAuthHandler(auth)
 Add `betterAuthSession` to your middleware so Pikku functions see the resolved
 session, and `withResolvedScopes` to attach scopes for authorization.
 
+## Embedding an app cross-site
+
+`AUTH_COOKIE_CROSS_SITE=true` keeps a session alive when the app runs inside a
+third-party iframe, where a `SameSite=Lax` cookie is dropped and sign-in
+"succeeds" into an anonymous next request. Set it only in a runtime that embeds
+its apps cross-site. A deployed app should leave it unset: it keeps `Lax`
+cookies and ignores the relay header entirely.
+
+It turns on two mechanisms, because browsers disagree about which one works:
+
+- every auth cookie becomes `SameSite=None; Secure; Partitioned`, which
+  Chromium honours (CHIPS) and WebKit does not implement;
+- the auth handler echoes the cookies it just set in
+  `x-pikku-cross-site-set-cookie`, and accepts them back in
+  `x-pikku-cross-site-cookie` — over storage a third-party frame is allowed to
+  use on every engine, including WebKit. `createAuthHandler`,
+  `betterAuthSession` and `betterAuthStatelessSession` merge that header into
+  `Cookie` before reading the session.
+
+A real cookie always wins over a relayed one of the same name, so a browser
+that did store it stays authoritative. Implement the browser half with
+`CROSS_SITE_COOKIE_HEADER`, `CROSS_SITE_SET_COOKIE_HEADER` and
+`decodeSetCookies` — the echo is a percent-encoded JSON array.
+
+### What it costs, and two rules
+
+In the embedded frame the session lives in JS-readable storage: no `HttpOnly`,
+so an XSS is account takeover. That is a fair trade for a development preview
+and a real decision for anything else. Weigh it before embedding a production
+app in someone else's page.
+
+**Never add `x-pikku-cross-site-cookie` to a permissive CORS allowlist.** A
+custom header cannot be sent cross-origin unless the server permits it, which
+is the only reason the relay is not a CSRF vector — better-auth's own origin
+checks still run, since the merge happens before its handler.
+
+**Add both header names to your log and APM redaction lists.** Every redactor
+knows about `Cookie` and `Authorization`; none of them know about these, and
+they carry the same credential.
+
+Responses carrying the echo are already sent `Cache-Control: no-store` — caches
+special-case `Set-Cookie` and nothing else, and a stored copy would hand one
+user's session to the next.
+
 ## Docs
 
 https://pikku.dev/docs

--- a/packages/services/better-auth/README.md
+++ b/packages/services/better-auth/README.md
@@ -35,26 +35,60 @@ It turns on two mechanisms, because browsers disagree about which one works:
 - the auth handler echoes the cookies it just set in
   `x-pikku-cross-site-set-cookie`, and accepts them back in
   `x-pikku-cross-site-cookie` — over storage a third-party frame is allowed to
-  use on every engine, including WebKit. `createAuthHandler`,
-  `betterAuthSession` and `betterAuthStatelessSession` merge that header into
-  `Cookie` before reading the session.
+  use on every engine, including WebKit. Every place this package hands caller
+  headers to better-auth merges that header into `Cookie` first:
+  `createAuthHandler`, `betterAuthSession`, `betterAuthStatelessSession`,
+  `getAuthSession` and `callAdminApi`.
 
 A real cookie always wins over a relayed one of the same name, so a browser
 that did store it stays authoritative. Implement the browser half with
 `CROSS_SITE_COOKIE_HEADER`, `CROSS_SITE_SET_COOKIE_HEADER` and
 `decodeSetCookies` — the echo is a percent-encoded JSON array.
 
-### What it costs, and two rules
+### Same-origin API, third-party frame
+
+The supported shape is an app whose API is on its _own_ origin, embedded in
+someone else's page: cross-**site** relative to the top-level document, which is
+what `SameSite` reacts to, but same-origin for the app's own `fetch` calls, so
+CORS never enters it.
+
+If the embedded app instead calls an API on another origin, the relay needs both
+halves of CORS opened deliberately: `x-pikku-cross-site-cookie` in
+`Access-Control-Allow-Headers` (or the preflight fails) and
+`x-pikku-cross-site-set-cookie` in `Access-Control-Expose-Headers` (or the
+client cannot read the echo at all). `cors()` from `@pikku/core/middleware`
+takes both:
+
+```typescript
+cors({
+  origin: ['https://preview.example.com'],
+  credentials: true,
+  headers: ['Content-Type', 'Authorization', 'x-pikku-cross-site-cookie'],
+  exposeHeaders: ['x-pikku-cross-site-set-cookie'],
+})
+```
+
+Name the origins. Reflecting whatever asked (`origin: true`) hands the relay to
+any page that wants it.
+
+### What it costs, and three rules
 
 In the embedded frame the session lives in JS-readable storage: no `HttpOnly`,
 so an XSS is account takeover. That is a fair trade for a development preview
 and a real decision for anything else. Weigh it before embedding a production
 app in someone else's page.
 
-**Never add `x-pikku-cross-site-cookie` to a permissive CORS allowlist.** A
-custom header cannot be sent cross-origin unless the server permits it, which
-is the only reason the relay is not a CSRF vector — better-auth's own origin
-checks still run, since the merge happens before its handler.
+**Never widen CORS to fit the relay in.** A forged `x-pikku-cross-site-cookie`
+is inert — it carries no valid signed token, so the relay is not itself a CSRF
+vector — but a permissive allowlist reached for on its account is one, and
+better-auth's origin checks are what stands behind it (they still run: the merge
+happens before its handler).
+
+**Sign-out is the client's to finish.** Deleting a cookie cannot reach the
+client's own storage, so a client implementing the relay must drop the entries
+the sign-out response expires. It matters most under
+`betterAuthStatelessSession`, where a kept-around cache blob keeps verifying
+until it ages out.
 
 **Add both header names to your log and APM redaction lists.** Every redactor
 knows about `Cookie` and `Authorization`; none of them know about these, and

--- a/packages/services/better-auth/src/admin-api.ts
+++ b/packages/services/better-auth/src/admin-api.ts
@@ -49,9 +49,7 @@ export const callAdminApi = async <T>(
     )
   }
 
-  // These endpoints authorize off the session cookie, so they need the same
-  // relayed cookies the session middleware already accepted — otherwise a
-  // caller whose browser refused to store the cookie resolves fine one layer up
-  // and is then rejected here as anonymous (see cross-site-cookies.ts).
+  // Relay too, or a caller resolves fine in the session middleware and is then
+  // rejected here as anonymous — these endpoints re-read the session cookie.
   return call(api, mergeRelayedCookies(new Headers(request.headers())))
 }

--- a/packages/services/better-auth/src/admin-api.ts
+++ b/packages/services/better-auth/src/admin-api.ts
@@ -1,4 +1,5 @@
 import type { BetterAuthInstance } from './define-auth.js'
+import { mergeRelayedCookies } from './cross-site-cookies.js'
 
 /** The subset of the pikku HTTP wire this helper needs. */
 export type AdminApiHttpWire = {
@@ -48,5 +49,9 @@ export const callAdminApi = async <T>(
     )
   }
 
-  return call(api, new Headers(request.headers()))
+  // These endpoints authorize off the session cookie, so they need the same
+  // relayed cookies the session middleware already accepted — otherwise a
+  // caller whose browser refused to store the cookie resolves fine one layer up
+  // and is then rejected here as anonymous (see cross-site-cookies.ts).
+  return call(api, mergeRelayedCookies(new Headers(request.headers())))
 }

--- a/packages/services/better-auth/src/auth-api.ts
+++ b/packages/services/better-auth/src/auth-api.ts
@@ -7,6 +7,7 @@ import type {
   BetterAuthInstance,
   PikkuBetterAuthFactory,
 } from './define-auth.js'
+import { mergeRelayedCookies } from './cross-site-cookies.js'
 
 export const createResolvedAuthGetter = <
   I extends BetterAuthInstance,
@@ -91,6 +92,10 @@ export async function getAuthSession<
     createSingletonServices
   )()
 
-  const headers = request instanceof Headers ? request : new Headers(request.headers)
+  // Always copy before merging the relayed cookies — the caller's Headers is
+  // theirs, and mergeRelayedCookies mutates what it is given.
+  const headers = mergeRelayedCookies(
+    new Headers(request instanceof Headers ? request : request.headers)
+  )
   return await instance.api.getSession({ headers })
 }

--- a/packages/services/better-auth/src/auth-api.ts
+++ b/packages/services/better-auth/src/auth-api.ts
@@ -92,8 +92,8 @@ export async function getAuthSession<
     createSingletonServices
   )()
 
-  // Always copy before merging the relayed cookies — the caller's Headers is
-  // theirs, and mergeRelayedCookies mutates what it is given.
+  // Copy even when handed a Headers: mergeRelayedCookies mutates its argument,
+  // and that one belongs to the caller.
   const headers = mergeRelayedCookies(
     new Headers(request instanceof Headers ? request : request.headers)
   )

--- a/packages/services/better-auth/src/auth-handler.ts
+++ b/packages/services/better-auth/src/auth-handler.ts
@@ -36,12 +36,9 @@ const rewriteSetCookies = (response: Response): Response => {
     headers.append('set-cookie', cookie)
   }
   headers.set(CROSS_SITE_SET_COOKIE_HEADER, encodeSetCookies(rewritten))
-  // The echo carries a session token in an ordinary response header, and every
-  // cache in the path knows to be careful with `Set-Cookie` but nothing about
-  // this one — a CDN that would have refused to store the response (or would
-  // have stripped the cookie first) will happily store this and hand one user's
-  // session to the next. Say so explicitly rather than trusting whatever the
-  // auth route set.
+  // Caches special-case `Set-Cookie` and know nothing about the echo, so one
+  // that would have refused this response will happily store it — and hand one
+  // user's session to the next.
   headers.set('cache-control', 'no-store')
   return new Response(response.body, {
     status: response.status,
@@ -60,9 +57,7 @@ export const createAuthHandler = (): {
     }
     const auth = (await (services as any).auth()) as BetterAuthInstance
     const webRequest = toWebRequest(request)
-    // The relayed cookies stand in for the ones the browser refused to store,
-    // so better-auth must see them as cookies: /get-session, sign-out and
-    // /update-user all read the session off the Cookie header.
+    // /get-session, sign-out and /update-user all read the session off Cookie.
     mergeRelayedCookies(webRequest.headers)
     const basePath = (auth as any).options?.basePath ?? '/api/auth'
     const response = isDevQuickLoginRequest(webRequest, basePath)

--- a/packages/services/better-auth/src/auth-handler.ts
+++ b/packages/services/better-auth/src/auth-handler.ts
@@ -5,50 +5,37 @@ import {
   handleDevQuickLogin,
   isDevQuickLoginRequest,
 } from './dev-quick-login.js'
+import {
+  CROSS_SITE_SET_COOKIE_HEADER,
+  crossSiteCookies,
+  encodeSetCookies,
+  getSetCookies,
+  mergeRelayedCookies,
+  toCrossSite,
+} from './cross-site-cookies.js'
 
 /**
- * When the app runs embedded in a cross-site iframe (e.g. the Fabric sandbox
- * preview, where the top-level page and the app are different sites) a
- * SameSite=Lax session cookie is silently dropped by the browser — sign-in
- * "succeeds" but the next request arrives with no cookie. Setting
- * AUTH_COOKIE_CROSS_SITE makes every better-auth cookie SameSite=None; Secure;
- * Partitioned so it survives the third-party context. Only the embedding runtime
- * (the sandbox) sets the flag; deployed apps never do and keep the tighter Lax
- * default — first-party traffic gets no needless cross-site exposure.
- */
-const crossSiteCookies = (): boolean => {
-  if (typeof process === 'undefined') return false
-  const v = process.env?.AUTH_COOKIE_CROSS_SITE
-  return v === 'true' || v === '1'
-}
-
-const toCrossSite = (cookie: string): string => {
-  let c = cookie.replace(/;\s*SameSite=(Lax|Strict|None)/gi, '')
-  c += '; SameSite=None'
-  if (!/;\s*Secure\b/i.test(c)) c += '; Secure'
-  if (!/;\s*Partitioned\b/i.test(c)) c += '; Partitioned'
-  return c
-}
-
-/**
- * Rewrite every Set-Cookie on the auth handler's response for cross-site use.
+ * Rewrite every Set-Cookie on the auth handler's response for cross-site use,
+ * and echo the rewritten cookies in a JS-readable header so a client whose
+ * browser refuses third-party cookies outright (any WebKit one, i.e. every
+ * browser on iOS) can relay them back itself — see cross-site-cookies.ts.
+ *
  * Read the cookies via getSetCookie() (which keeps them split) BEFORE copying
  * the rest of the headers — copying a Headers merges duplicate Set-Cookie into a
  * single comma-joined value, so we delete and re-append the clean ones.
  */
 const rewriteSetCookies = (response: Response): Response => {
-  const cookies =
-    typeof response.headers.getSetCookie === 'function'
-      ? response.headers.getSetCookie()
-      : ([response.headers.get('set-cookie')].filter(Boolean) as string[])
+  const cookies = getSetCookies(response.headers)
   if (cookies.length === 0) {
     return response
   }
   const headers = new Headers(response.headers)
   headers.delete('set-cookie')
-  for (const cookie of cookies) {
-    headers.append('set-cookie', toCrossSite(cookie))
+  const rewritten = cookies.map(toCrossSite)
+  for (const cookie of rewritten) {
+    headers.append('set-cookie', cookie)
   }
+  headers.set(CROSS_SITE_SET_COOKIE_HEADER, encodeSetCookies(rewritten))
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -66,6 +53,10 @@ export const createAuthHandler = (): {
     }
     const auth = (await (services as any).auth()) as BetterAuthInstance
     const webRequest = toWebRequest(request)
+    // The relayed cookies stand in for the ones the browser refused to store,
+    // so better-auth must see them as cookies: /get-session, sign-out and
+    // /update-user all read the session off the Cookie header.
+    mergeRelayedCookies(webRequest.headers)
     const basePath = (auth as any).options?.basePath ?? '/api/auth'
     const response = isDevQuickLoginRequest(webRequest, basePath)
       ? await handleDevQuickLogin(

--- a/packages/services/better-auth/src/auth-handler.ts
+++ b/packages/services/better-auth/src/auth-handler.ts
@@ -36,6 +36,13 @@ const rewriteSetCookies = (response: Response): Response => {
     headers.append('set-cookie', cookie)
   }
   headers.set(CROSS_SITE_SET_COOKIE_HEADER, encodeSetCookies(rewritten))
+  // The echo carries a session token in an ordinary response header, and every
+  // cache in the path knows to be careful with `Set-Cookie` but nothing about
+  // this one — a CDN that would have refused to store the response (or would
+  // have stripped the cookie first) will happily store this and hand one user's
+  // session to the next. Say so explicitly rather than trusting whatever the
+  // auth route set.
+  headers.set('cache-control', 'no-store')
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/packages/services/better-auth/src/auth-session-stateless.ts
+++ b/packages/services/better-auth/src/auth-session-stateless.ts
@@ -82,9 +82,6 @@ export const betterAuthStatelessSession = (
       // not throw.
       let cached: CachedSession | null
       try {
-        // No-op unless this runtime embeds its apps cross-site; there it folds
-        // the client-relayed cookies back in, for browsers that refuse to store
-        // a third-party cookie at all (see cross-site-cookies.ts).
         const headers = mergeRelayedCookies(new Headers(request.headers()))
         // Cookie is `__Secure-`-prefixed when secure, unprefixed otherwise; try
         // both since NODE_ENV is unreliable in serverless. Only one cookie exists.

--- a/packages/services/better-auth/src/auth-session-stateless.ts
+++ b/packages/services/better-auth/src/auth-session-stateless.ts
@@ -11,6 +11,7 @@ import {
 } from './auth-session-impersonation.js'
 import { stampActorFlag } from './stamp-actor-flag.js'
 import { withResolvedScopes } from './auth-session-scopes.js'
+import { mergeRelayedCookies } from './cross-site-cookies.js'
 
 type CachedSession = { session: any; user: any }
 
@@ -75,7 +76,10 @@ export const betterAuthStatelessSession = (
       // not throw.
       let cached: CachedSession | null
       try {
-        const headers = new Headers(request.headers())
+        // No-op unless this runtime embeds its apps cross-site; there it folds
+        // the client-relayed cookies back in, for browsers that refuse to store
+        // a third-party cookie at all (see cross-site-cookies.ts).
+        const headers = mergeRelayedCookies(new Headers(request.headers()))
         // Cookie is `__Secure-`-prefixed when secure, unprefixed otherwise; try
         // both since NODE_ENV is unreliable in serverless. Only one cookie exists.
         cached =

--- a/packages/services/better-auth/src/auth-session-stateless.ts
+++ b/packages/services/better-auth/src/auth-session-stateless.ts
@@ -38,6 +38,12 @@ export type BetterAuthStatelessSessionOptions = {
  * server-side revocation isn't seen until the cookie cache expires; sign-out is
  * still immediate (it deletes the cookie).
  *
+ * That last part is the browser's to keep under AUTH_COOKIE_CROSS_SITE: a
+ * relayed cookie lives in the client's own storage, so deleting the real cookie
+ * cannot reach it. A client implementing the relay MUST drop the entries the
+ * sign-out response expires; if it does not, the stale cache blob keeps
+ * verifying here until it ages out on its own (see cross-site-cookies.ts).
+ *
  * The one exception to "no DB": if a `ScopeService` is registered, scopes are
  * resolved per request (see {@link withResolvedScopes}), which costs a query.
  * That is the price of grants that take effect immediately; leave the service

--- a/packages/services/better-auth/src/auth-session.ts
+++ b/packages/services/better-auth/src/auth-session.ts
@@ -136,9 +136,6 @@ export const betterAuthSession = (
       // otherwise read the single-use request body just to discard it,
       // starving the route handler that actually needs it.
       result = (await auth.api.getSession({
-        // mergeRelayedCookies is a no-op unless this runtime embeds its apps
-        // cross-site; there it folds the client-relayed cookies back in, for
-        // browsers that refuse to store them at all (cross-site-cookies.ts).
         headers: mergeRelayedCookies(new Headers(request.headers())),
       })) as BetterAuthSessionResult | null
     } catch (e: any) {

--- a/packages/services/better-auth/src/auth-session.ts
+++ b/packages/services/better-auth/src/auth-session.ts
@@ -12,6 +12,7 @@ import {
 } from './auth-session-impersonation.js'
 import { withResolvedScopes } from './auth-session-scopes.js'
 import { syncProjectedAdminRole } from './admin-role-sync.js'
+import { mergeRelayedCookies } from './cross-site-cookies.js'
 
 type BetterAuthSessionResult = { user: any; session: any }
 
@@ -135,7 +136,10 @@ export const betterAuthSession = (
       // otherwise read the single-use request body just to discard it,
       // starving the route handler that actually needs it.
       result = (await auth.api.getSession({
-        headers: new Headers(request.headers()),
+        // mergeRelayedCookies is a no-op unless this runtime embeds its apps
+        // cross-site; there it folds the client-relayed cookies back in, for
+        // browsers that refuse to store them at all (cross-site-cookies.ts).
+        headers: mergeRelayedCookies(new Headers(request.headers())),
       })) as BetterAuthSessionResult | null
     } catch (e: any) {
       services.logger?.error(

--- a/packages/services/better-auth/src/cross-site-cookies.test.ts
+++ b/packages/services/better-auth/src/cross-site-cookies.test.ts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, test } from 'node:test'
+import { createAuthHandler } from './auth-handler.js'
+import {
+  CROSS_SITE_COOKIE_HEADER,
+  CROSS_SITE_SET_COOKIE_HEADER,
+  decodeSetCookies,
+  encodeSetCookies,
+  mergeRelayedCookies,
+  toCrossSite,
+} from './cross-site-cookies.js'
+
+const FLAG = 'AUTH_COOKIE_CROSS_SITE'
+
+const withFlag = (value: string | undefined) => {
+  if (value === undefined) delete process.env[FLAG]
+  else process.env[FLAG] = value
+}
+
+/** Minimal better-auth double: records the request, replies with two cookies. */
+function createFakeAuth() {
+  const seen: Request[] = []
+  const auth = {
+    options: { basePath: '/api/auth' },
+    handler: async (request: Request) => {
+      seen.push(request)
+      const headers = new Headers()
+      headers.append(
+        'set-cookie',
+        '__Secure-better-auth.session_token=tok; Path=/; HttpOnly; Secure; SameSite=Lax'
+      )
+      headers.append(
+        'set-cookie',
+        '__Secure-better-auth.session_data=blob; Path=/; HttpOnly; Secure; SameSite=Lax; Expires=Wed, 09 Jun 2027 10:18:14 GMT'
+      )
+      return new Response('{}', { status: 200, headers })
+    },
+    api: {},
+  }
+  return { auth, seen }
+}
+
+function fakeHttpRequest(headers: Record<string, string>) {
+  return {
+    header: (name: string) => headers[name.toLowerCase()],
+    headers: () => headers,
+    path: () => '/api/auth/sign-in/actor',
+    query: () => ({}),
+    method: () => 'POST',
+    arrayBuffer: async () => new ArrayBuffer(0),
+    json: async () => ({}),
+  }
+}
+
+async function runHandler(headers: Record<string, string> = {}) {
+  const { auth, seen } = createFakeAuth()
+  const { func } = createAuthHandler()
+  const services: any = {
+    logger: { info() {}, warn() {}, error() {} },
+    auth: async () => auth,
+  }
+  const response = (await func(
+    services,
+    {},
+    { http: { request: fakeHttpRequest({ host: 'app.dev', ...headers }) } } as any
+  )) as Response
+  return { response, seen }
+}
+
+describe('cross-site cookies', () => {
+  afterEach(() => withFlag(undefined))
+
+  test('toCrossSite replaces SameSite and adds Secure/Partitioned once', () => {
+    const rewritten = toCrossSite('a=b; Path=/; HttpOnly; SameSite=Lax')
+    assert.equal(
+      rewritten,
+      'a=b; Path=/; HttpOnly; SameSite=None; Secure; Partitioned'
+    )
+    // Re-running never accumulates duplicates (attribute order may shift, the
+    // set may not) — a browser given two SameSite attributes drops the cookie.
+    const again = toCrossSite(rewritten)
+    for (const attribute of [/SameSite=None/g, /Secure/g, /Partitioned/g]) {
+      assert.equal(again.match(attribute)?.length, 1, again)
+    }
+    // An attribute that is already there is left where it is, not duplicated.
+    assert.equal(
+      toCrossSite('a=b; Secure; SameSite=Lax'),
+      'a=b; Secure; SameSite=None; Partitioned'
+    )
+  })
+
+  test('set-cookie encoding survives the commas in an Expires attribute', () => {
+    const cookies = [
+      'a=b; Expires=Wed, 09 Jun 2027 10:18:14 GMT',
+      'c=d; Path=/',
+    ]
+    assert.deepEqual(decodeSetCookies(encodeSetCookies(cookies)), cookies)
+  })
+
+  test('relayed cookies are ignored unless the runtime opts in', () => {
+    const headers = new Headers({ [CROSS_SITE_COOKIE_HEADER]: 'a=relayed' })
+    assert.equal(mergeRelayedCookies(headers).get('cookie'), null)
+  })
+
+  test('relayed cookies are merged in when the runtime opts in', () => {
+    withFlag('true')
+    const headers = new Headers({ [CROSS_SITE_COOKIE_HEADER]: 'a=relayed' })
+    assert.equal(mergeRelayedCookies(headers).get('cookie'), 'a=relayed')
+  })
+
+  test('a real cookie always wins over the relayed copy of the same name', () => {
+    withFlag('1')
+    const headers = new Headers({
+      cookie: 'a=real; b=real',
+      [CROSS_SITE_COOKIE_HEADER]: 'a=stale; c=relayed',
+    })
+    assert.equal(
+      mergeRelayedCookies(headers).get('cookie'),
+      'a=real; b=real; c=relayed'
+    )
+  })
+
+  test('the handler echoes the rewritten cookies for the client to relay', async () => {
+    withFlag('true')
+    const { response } = await runHandler()
+    const echoed = decodeSetCookies(
+      response.headers.get(CROSS_SITE_SET_COOKIE_HEADER)!
+    )
+    assert.equal(echoed.length, 2)
+    for (const cookie of echoed) {
+      assert.match(cookie, /;\s*SameSite=None\b/)
+      assert.match(cookie, /;\s*Secure\b/)
+      assert.match(cookie, /;\s*Partitioned\b/)
+      assert.doesNotMatch(cookie, /SameSite=Lax/)
+    }
+    // The echo mirrors what actually went out — not a separately built copy.
+    assert.deepEqual(response.headers.getSetCookie(), echoed)
+  })
+
+  test('the handler stays cookie-only when the runtime has not opted in', async () => {
+    const { response } = await runHandler()
+    assert.equal(response.headers.get(CROSS_SITE_SET_COOKIE_HEADER), null)
+    assert.match(response.headers.getSetCookie()[0]!, /SameSite=Lax/)
+  })
+
+  test('better-auth sees the relayed cookies as ordinary cookies', async () => {
+    withFlag('true')
+    const { seen } = await runHandler({
+      [CROSS_SITE_COOKIE_HEADER]: '__Secure-better-auth.session_token=tok',
+    })
+    assert.equal(
+      seen[0]!.headers.get('cookie'),
+      '__Secure-better-auth.session_token=tok'
+    )
+  })
+})

--- a/packages/services/better-auth/src/cross-site-cookies.test.ts
+++ b/packages/services/better-auth/src/cross-site-cookies.test.ts
@@ -131,8 +131,6 @@ describe('cross-site cookies', () => {
   })
 
   test('a mangled echo header decodes to nothing rather than throwing', () => {
-    // The client half runs this on whatever a response happened to carry: a
-    // proxy that rewrote the header must not blow up the caller's fetch.
     assert.deepEqual(decodeSetCookies('not-json'), [])
     assert.deepEqual(decodeSetCookies('%E0%A4%A'), [])
     assert.deepEqual(decodeSetCookies(encodeURIComponent('{"a":1}')), [])
@@ -183,9 +181,8 @@ describe('cross-site cookies', () => {
     )
   })
 
-  // Every other place this package hands caller headers to better-auth has to
-  // relay too: resolving the session in middleware and then losing it one call
-  // later is the confusing half-authenticated failure this exists to avoid.
+  // Resolving the session in middleware and losing it one call later is the
+  // half-authenticated failure these two exist to prevent.
 
   test('callAdminApi forwards the relayed cookies', async () => {
     withFlag('true')

--- a/packages/services/better-auth/src/cross-site-cookies.test.ts
+++ b/packages/services/better-auth/src/cross-site-cookies.test.ts
@@ -120,6 +120,14 @@ describe('cross-site cookies', () => {
     )
   })
 
+  test('an echoed response is never cacheable', async () => {
+    withFlag('true')
+    const { response } = await runHandler()
+    // A cache that knows to be careful with Set-Cookie knows nothing about the
+    // echo header, and would serve one user's session to the next.
+    assert.equal(response.headers.get('cache-control'), 'no-store')
+  })
+
   test('the handler echoes the rewritten cookies for the client to relay', async () => {
     withFlag('true')
     const { response } = await runHandler()

--- a/packages/services/better-auth/src/cross-site-cookies.test.ts
+++ b/packages/services/better-auth/src/cross-site-cookies.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict'
 import { afterEach, describe, test } from 'node:test'
 import { createAuthHandler } from './auth-handler.js'
+import { callAdminApi } from './admin-api.js'
+import { getAuthSession } from './auth-api.js'
+import type { BetterAuthInstance } from './define-auth.js'
 import {
   CROSS_SITE_COOKIE_HEADER,
   CROSS_SITE_SET_COOKIE_HEADER,
@@ -59,11 +62,9 @@ async function runHandler(headers: Record<string, string> = {}) {
     logger: { info() {}, warn() {}, error() {} },
     auth: async () => auth,
   }
-  const response = (await func(
-    services,
-    {},
-    { http: { request: fakeHttpRequest({ host: 'app.dev', ...headers }) } } as any
-  )) as Response
+  const response = (await func(services, {}, {
+    http: { request: fakeHttpRequest({ host: 'app.dev', ...headers }) },
+  } as any)) as Response
   return { response, seen }
 }
 
@@ -120,6 +121,26 @@ describe('cross-site cookies', () => {
     )
   })
 
+  test('a name repeated inside the relay header is taken once', () => {
+    withFlag('true')
+    const headers = new Headers({
+      [CROSS_SITE_COOKIE_HEADER]: 'a=first; a=second; b=only',
+    })
+    // Both copies reaching a parser leaves which one wins up to the parser.
+    assert.equal(mergeRelayedCookies(headers).get('cookie'), 'a=first; b=only')
+  })
+
+  test('a mangled echo header decodes to nothing rather than throwing', () => {
+    // The client half runs this on whatever a response happened to carry: a
+    // proxy that rewrote the header must not blow up the caller's fetch.
+    assert.deepEqual(decodeSetCookies('not-json'), [])
+    assert.deepEqual(decodeSetCookies('%E0%A4%A'), [])
+    assert.deepEqual(decodeSetCookies(encodeURIComponent('{"a":1}')), [])
+    assert.deepEqual(decodeSetCookies(encodeURIComponent('["a=b", 7, null]')), [
+      'a=b',
+    ])
+  })
+
   test('an echoed response is never cacheable', async () => {
     withFlag('true')
     const { response } = await runHandler()
@@ -160,5 +181,61 @@ describe('cross-site cookies', () => {
       seen[0]!.headers.get('cookie'),
       '__Secure-better-auth.session_token=tok'
     )
+  })
+
+  // Every other place this package hands caller headers to better-auth has to
+  // relay too: resolving the session in middleware and then losing it one call
+  // later is the confusing half-authenticated failure this exists to avoid.
+
+  test('callAdminApi forwards the relayed cookies', async () => {
+    withFlag('true')
+    const auth = async () =>
+      ({ api: { banUser: async () => ({}) } }) as unknown as BetterAuthInstance
+    const http = {
+      request: {
+        headers: () => ({
+          [CROSS_SITE_COOKIE_HEADER]: '__Secure-better-auth.session_token=tok',
+        }),
+      },
+    }
+    const forwarded = await callAdminApi(auth, http, async (_api, headers) =>
+      headers.get('cookie')
+    )
+    assert.equal(forwarded, '__Secure-better-auth.session_token=tok')
+  })
+
+  test('getAuthSession forwards the relayed cookies', async () => {
+    withFlag('true')
+    const session = await getAuthSession(
+      {
+        handler: async () => new Response(null, { status: 204 }),
+        api: {
+          getSession: async ({ headers }: { headers: Headers }) => ({
+            cookie: headers.get('cookie'),
+          }),
+        },
+      } as any,
+      new Request('https://example.com/me', {
+        headers: {
+          [CROSS_SITE_COOKIE_HEADER]: 'better-auth.session_token=abc',
+        },
+      })
+    )
+    assert.deepEqual(session, { cookie: 'better-auth.session_token=abc' })
+  })
+
+  test('getAuthSession never mutates a Headers the caller still owns', async () => {
+    withFlag('true')
+    const caller = new Headers({
+      [CROSS_SITE_COOKIE_HEADER]: 'better-auth.session_token=abc',
+    })
+    await getAuthSession(
+      {
+        handler: async () => new Response(null, { status: 204 }),
+        api: { getSession: async () => null },
+      } as any,
+      caller
+    )
+    assert.equal(caller.get('cookie'), null)
   })
 })

--- a/packages/services/better-auth/src/cross-site-cookies.ts
+++ b/packages/services/better-auth/src/cross-site-cookies.ts
@@ -22,6 +22,14 @@
  * sandbox) sets AUTH_COOKIE_CROSS_SITE. A deployed app both keeps the tighter
  * Lax cookies AND ignores the relay header, so a session token can never be
  * carried in JS-readable storage outside the preview.
+ *
+ * Why not better-auth's `bearer()` plugin, which is this same echo-and-relay
+ * shape and signature-verifies on the way in: it carries only `session_token`,
+ * and `betterAuthStatelessSession` reads `session_data` — the signed blob that
+ * lets it resolve a session without bundling the better-auth server. Bearer
+ * would force those apps onto `betterAuthSession`, which is the bundle weight
+ * serverless targets cannot take. Relaying the whole jar is what keeps preview
+ * and production on the same middleware.
  */
 
 /** Request header carrying the relayed `name=value; name=value` cookie pairs. */
@@ -62,10 +70,8 @@ export const encodeSetCookies = (cookies: string[]): string =>
   encodeURIComponent(JSON.stringify(cookies))
 
 /**
- * Never throws: this is the client's half of the relay, called on whatever the
- * response happened to carry. A proxy that mangled the header, or a stale
- * client reading a header it does not understand, must degrade to "no relayed
- * cookies" rather than blowing up the caller's fetch wrapper.
+ * Never throws — the client half runs this on whatever a response carried, and
+ * a mangled header must degrade to "no cookies" rather than break its fetch.
  */
 export const decodeSetCookies = (encoded: string): string[] => {
   let parsed: unknown
@@ -102,8 +108,7 @@ export const mergeRelayedCookies = (headers: Headers): Headers => {
   if (!relayed) return headers
   const existing = headers.get('cookie') ?? ''
   // Grows as pairs are accepted, so a name repeated inside the relay header
-  // itself resolves the same way a repeated real cookie would — first wins —
-  // instead of both copies reaching a parser that may disagree about which one.
+  // itself resolves first-wins instead of reaching a parser twice.
   const taken = cookieNames(existing)
   const added: string[] = []
   for (const pair of relayed.split(';').map((p) => p.trim())) {

--- a/packages/services/better-auth/src/cross-site-cookies.ts
+++ b/packages/services/better-auth/src/cross-site-cookies.ts
@@ -1,0 +1,102 @@
+/**
+ * Cross-site session support for apps rendered inside a third-party iframe
+ * (the Fabric sandbox preview: the console is the top-level site, the app is
+ * another one).
+ *
+ * A SameSite=Lax cookie is dropped outright in that context, so
+ * AUTH_COOKIE_CROSS_SITE rewrites every better-auth cookie to
+ * `SameSite=None; Secure; Partitioned`. That is enough for Chromium — but
+ * `Partitioned` (CHIPS) is a Chromium feature: WebKit does not implement it and
+ * blocks third-party cookie writes outright, and every browser on iOS is
+ * WebKit. Sign-in returns 200, the cookie is discarded, the next request is
+ * anonymous, and the app bounces back to /login.
+ *
+ * So the same flag also enables a cookie RELAY. The auth handler echoes the
+ * cookies it just set in a readable response header (JS can never read
+ * `Set-Cookie`, even same-origin); the embedded client keeps them in
+ * partitioned `localStorage` — which WebKit does allow in a third-party frame —
+ * and sends them back on every request in {@link CROSS_SITE_COOKIE_HEADER},
+ * which the session middlewares merge back into `Cookie` before reading it.
+ *
+ * The relay is strictly opt-in per runtime: only an embedding host (the
+ * sandbox) sets AUTH_COOKIE_CROSS_SITE. A deployed app both keeps the tighter
+ * Lax cookies AND ignores the relay header, so a session token can never be
+ * carried in JS-readable storage outside the preview.
+ */
+
+/** Request header carrying the relayed `name=value; name=value` cookie pairs. */
+export const CROSS_SITE_COOKIE_HEADER = 'x-pikku-cross-site-cookie'
+
+/**
+ * Response header echoing the `Set-Cookie` values of a response, as a
+ * percent-encoded JSON array. Encoded rather than sent raw because a Set-Cookie
+ * string contains commas (`Expires=Wed, 09 Jun 2021 ...`), so no plain-text
+ * separator is safe — and because a header value must be ASCII with no control
+ * characters, which `encodeURIComponent` guarantees.
+ */
+export const CROSS_SITE_SET_COOKIE_HEADER = 'x-pikku-cross-site-set-cookie'
+
+/** True when this runtime embeds its apps in a cross-site iframe. */
+export const crossSiteCookies = (): boolean => {
+  if (typeof process === 'undefined') return false
+  const v = process.env?.AUTH_COOKIE_CROSS_SITE
+  return v === 'true' || v === '1'
+}
+
+/** Rewrite one Set-Cookie for a third-party context. */
+export const toCrossSite = (cookie: string): string => {
+  let c = cookie.replace(/;\s*SameSite=(Lax|Strict|None)/gi, '')
+  c += '; SameSite=None'
+  if (!/;\s*Secure\b/i.test(c)) c += '; Secure'
+  if (!/;\s*Partitioned\b/i.test(c)) c += '; Partitioned'
+  return c
+}
+
+/** Read a response's Set-Cookie values without merging them into one string. */
+export const getSetCookies = (headers: Headers): string[] =>
+  typeof headers.getSetCookie === 'function'
+    ? headers.getSetCookie()
+    : ([headers.get('set-cookie')].filter(Boolean) as string[])
+
+export const encodeSetCookies = (cookies: string[]): string =>
+  encodeURIComponent(JSON.stringify(cookies))
+
+export const decodeSetCookies = (encoded: string): string[] => {
+  const parsed = JSON.parse(decodeURIComponent(encoded))
+  return Array.isArray(parsed) ? parsed.filter((c) => typeof c === 'string') : []
+}
+
+const cookieNames = (cookieHeader: string): Set<string> => {
+  const names = new Set<string>()
+  for (const pair of cookieHeader.split(';')) {
+    const name = pair.split('=')[0]?.trim()
+    if (name) names.add(name)
+  }
+  return names
+}
+
+/**
+ * Merge the relayed cookies into the request's own `Cookie` header. Real
+ * cookies win: a browser that did store them (Chromium) is authoritative, and
+ * the relayed copy may be a stale duplicate. Mutates and returns `headers`.
+ *
+ * A no-op unless {@link crossSiteCookies} — the header is untrusted input, and
+ * outside an embedding runtime it must never be able to stand in for a cookie.
+ */
+export const mergeRelayedCookies = (headers: Headers): Headers => {
+  if (!crossSiteCookies()) return headers
+  const relayed = headers.get(CROSS_SITE_COOKIE_HEADER)
+  if (!relayed) return headers
+  const existing = headers.get('cookie') ?? ''
+  const taken = cookieNames(existing)
+  const added = relayed
+    .split(';')
+    .map((pair) => pair.trim())
+    .filter((pair) => {
+      const name = pair.split('=')[0]?.trim()
+      return !!name && pair.includes('=') && !taken.has(name)
+    })
+  if (added.length === 0) return headers
+  headers.set('cookie', [existing, ...added].filter(Boolean).join('; '))
+  return headers
+}

--- a/packages/services/better-auth/src/cross-site-cookies.ts
+++ b/packages/services/better-auth/src/cross-site-cookies.ts
@@ -61,9 +61,22 @@ export const getSetCookies = (headers: Headers): string[] =>
 export const encodeSetCookies = (cookies: string[]): string =>
   encodeURIComponent(JSON.stringify(cookies))
 
+/**
+ * Never throws: this is the client's half of the relay, called on whatever the
+ * response happened to carry. A proxy that mangled the header, or a stale
+ * client reading a header it does not understand, must degrade to "no relayed
+ * cookies" rather than blowing up the caller's fetch wrapper.
+ */
 export const decodeSetCookies = (encoded: string): string[] => {
-  const parsed = JSON.parse(decodeURIComponent(encoded))
-  return Array.isArray(parsed) ? parsed.filter((c) => typeof c === 'string') : []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(decodeURIComponent(encoded))
+  } catch {
+    return []
+  }
+  return Array.isArray(parsed)
+    ? parsed.filter((c) => typeof c === 'string')
+    : []
 }
 
 const cookieNames = (cookieHeader: string): Set<string> => {
@@ -88,14 +101,17 @@ export const mergeRelayedCookies = (headers: Headers): Headers => {
   const relayed = headers.get(CROSS_SITE_COOKIE_HEADER)
   if (!relayed) return headers
   const existing = headers.get('cookie') ?? ''
+  // Grows as pairs are accepted, so a name repeated inside the relay header
+  // itself resolves the same way a repeated real cookie would — first wins —
+  // instead of both copies reaching a parser that may disagree about which one.
   const taken = cookieNames(existing)
-  const added = relayed
-    .split(';')
-    .map((pair) => pair.trim())
-    .filter((pair) => {
-      const name = pair.split('=')[0]?.trim()
-      return !!name && pair.includes('=') && !taken.has(name)
-    })
+  const added: string[] = []
+  for (const pair of relayed.split(';').map((p) => p.trim())) {
+    const name = pair.split('=')[0]?.trim()
+    if (!name || !pair.includes('=') || taken.has(name)) continue
+    taken.add(name)
+    added.push(pair)
+  }
   if (added.length === 0) return headers
   headers.set('cookie', [existing, ...added].filter(Boolean).join('; '))
   return headers

--- a/packages/services/better-auth/src/index.ts
+++ b/packages/services/better-auth/src/index.ts
@@ -3,6 +3,7 @@ export {
   CROSS_SITE_COOKIE_HEADER,
   CROSS_SITE_SET_COOKIE_HEADER,
   crossSiteCookies,
+  decodeSetCookies,
   mergeRelayedCookies,
 } from './cross-site-cookies.js'
 export {

--- a/packages/services/better-auth/src/index.ts
+++ b/packages/services/better-auth/src/index.ts
@@ -1,5 +1,11 @@
 export { createAuthHandler } from './auth-handler.js'
 export {
+  CROSS_SITE_COOKIE_HEADER,
+  CROSS_SITE_SET_COOKIE_HEADER,
+  crossSiteCookies,
+  mergeRelayedCookies,
+} from './cross-site-cookies.js'
+export {
   DEV_QUICK_LOGIN_USER,
   DEV_QUICK_LOGIN_SUBPATH,
   devQuickLoginEnabled,


### PR DESCRIPTION
## The bug

Signing in inside a cross-site preview iframe works on desktop and fails on any iPhone: the request returns 200, the app comes straight back to `/login`.

`AUTH_COOKIE_CROSS_SITE` already rewrote every better-auth cookie to `SameSite=None; Secure; Partitioned`. That is a Chromium answer — `Partitioned` (CHIPS) is not implemented in WebKit, which blocks third-party cookie writes outright, and every browser on iOS is WebKit. The browser discards the cookie, the next request is anonymous.

## The fix

The same flag now also enables a cookie relay, over storage an embedded frame is actually allowed to use (partitioned `localStorage`, which WebKit does permit in a third-party frame):

- `createAuthHandler` echoes the cookies it just set in `x-pikku-cross-site-set-cookie` — JS can never read `Set-Cookie` itself, even same-origin. Percent-encoded JSON, because a `Set-Cookie` string contains commas in `Expires`.
- The client sends them back in `x-pikku-cross-site-cookie`.
- `createAuthHandler`, `betterAuthSession` and `betterAuthStatelessSession` merge that header into `Cookie` before reading the session. The stateless one matters most — it is what generated app middleware uses.

A real cookie always wins over a relayed one of the same name, so a browser that did store it stays authoritative.

## Blast radius

`mergeRelayedCookies` returns immediately unless `AUTH_COOKIE_CROSS_SITE` is set, which only a runtime that embeds its apps cross-site does. A deployed app keeps `SameSite=Lax` cookies and ignores the header entirely, so a forged relay header is inert there. That gate is the whole safety argument: a session token in JS-readable storage is a trade only an embedding preview should make, and it is a real trade — inside such a preview, XSS becomes session theft.

Both header names plus `crossSiteCookies()` / `mergeRelayedCookies()` are exported for clients implementing the browser half.

## Testing

- New `cross-site-cookies.test.ts`; package suite 106/106 green, `tsc -b` clean.
- Browser half verified separately against a stub API (Playwright, 11/11): sign-in populates the jar, the session rides subsequent calls, expired entries are pruned, cross-origin calls carry no relay header, sign-out empties it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in cross-site session support for embedded applications when third-party cookies are unavailable.
  * Sessions can be relayed through request and response headers, with existing browser cookies taking precedence.
  * Added public helpers for detecting and handling cross-site cookie relays.
  * Existing same-site cookie behavior remains unchanged.

* **Bug Fixes**
  * Improved relayed-cookie handling for regular and stateless sessions.
  * Prevented relayed authentication responses from being cached.

* **Documentation**
  * Added setup, security, CORS, and caching guidance for cross-site authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->