### PR TITLE
fix(console): make the E2E Console job green again

### DIFF
--- a/.changeset/addons-page-panel-pane.md
+++ b/.changeset/addons-page-panel-pane.md
@@ -1,0 +1,17 @@
+---
+'@pikku/console': patch
+---
+
+Let the addons page render the panel an addon now opens in.
+
+Addon detail used to be `AddonDetailDrawer`, an overlay that rendered itself
+wherever the page happened to put it, so the addons list correctly asked
+`ResizablePanelLayout` to skip its panel pane — the page had no panels.
+
+Moving addon detail into the panel system left that `hidePanel` behind. The
+pane was never rendered, so clicking a not-yet-installed addon called
+`openPanel` and nothing appeared: no detail, no install form, no way to add an
+addon to a project from the gallery.
+
+The pane is collapsed to zero width until something opens in it, so the
+gallery still gets the full surface when no addon is selected.

--- a/e2e/packages/functions/tests/scenarios/scenarios-console.feature.ts
+++ b/e2e/packages/functions/tests/scenarios/scenarios-console.feature.ts
@@ -215,7 +215,7 @@ export const scenarioCastListedScenario = pikkuScenario<void, { cast: number }>(
       await scenario.then(
         'sees the shopper’s identity',
         'seesTestId',
-        { testId: 'persona-drawer-shopper' },
+        { testId: 'persona-detail-shopper' },
         { actor: actors.admin }
       )
       await scenario.then(
@@ -224,7 +224,7 @@ export const scenarioCastListedScenario = pikkuScenario<void, { cast: number }>(
         {
           testId: 'persona-field-email',
           value: 'shopper@actors.local',
-          within: { testId: 'persona-drawer-shopper' },
+          within: { testId: 'persona-detail-shopper' },
         },
         { actor: actors.admin }
       )

--- a/packages/console/src/components/packages/PackagesListPanel.tsx
+++ b/packages/console/src/components/packages/PackagesListPanel.tsx
@@ -53,7 +53,6 @@ export const PackagesListPanel: React.FC<PackagesListPanelProps> = ({
 
   return (
     <ResizablePanelLayout
-      hidePanel
       header={
         <ListPageHeader
           title={m.packages_title()}


### PR DESCRIPTION
Two unrelated things are failing the **E2E Console** job on `main`. Neither is flaky — both fail on every run, on every branch.

## 1. A test left behind by a rename

`scenarioCastListedScenario` waits 30 seconds for `persona-drawer-shopper`, then fails.

`37105020c` ("open a persona in the panel instead of a drawer") deleted `PersonaDrawer.tsx` and renamed its test id to `` persona-detail-${persona.key} ``, but left this feature file pointing at the old one. Both assertions now use `persona-detail-shopper`.

Nothing else moved in that rename: `persona-field-email` and `` persona-scenario-${flow.name} `` came across unchanged, and `persona-drawer-` has no remaining references anywhere.

**Verified:** this commit alone turns that scenario green in CI — `PASS Scenarios Console Page › scenarioCastListedScenario → {"cast":2}`.

## 2. A real regression the tests caught

With the persona test fixed, `installAddonNameConflictScenario` and `installAddonInvalidNameScenario` fail — both waiting on `addon-install-name` after clicking an addon card.

`aa5f6231d` ("open addons and the canvas catalogue in the panel, not a drawer") moved addon detail out of `AddonDetailDrawer`, an overlay that rendered itself, and into the panel system. But `PackagesListPanel` passes `hidePanel` to `ResizablePanelLayout` — correct when the page had no panels, since the layout then never renders `PanelContainer` at all.

So on `/console/addons`, clicking a not-yet-installed addon calls `openPanel` and **nothing happens**: no detail, no install form, no way to add an addon to a project from the gallery. This is user-facing, not just a test failure.

Dropping `hidePanel` restores it. The pane is already `width: 0` when no panels are open, so the gallery keeps the full surface until an addon is selected.

## Note

`#1077` cannot go green until this merges — its E2E Console failure is #1 above, not anything in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)