### PR TITLE
Voice agents: cooperative interrupt, @pikku/voice-agents, and store-backed converse assertions

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -32,6 +32,7 @@
     "@pikku/addon-hmac-signer": "workspace:*",
     "@pikku/addon-mailgun": "0.1.2",
     "@pikku/addon-mandrill": "0.1.2",
+    "@pikku/ai-deepinfra": "workspace:*",
     "@pikku/ai-vercel": "workspace:*",
     "@pikku/better-auth": "workspace:*",
     "@pikku/core": "workspace:*",
@@ -57,6 +58,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@ai-sdk/openai-compatible": "^2.0.63",
     "@pikku/cli": "workspace:*",
     "@pikku/playwright": "workspace:*",
     "@playwright/test": "^1.50.0",

--- a/e2e/packages/functions/package.json
+++ b/e2e/packages/functions/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@ai-sdk/provider": "^3.0.0",
     "@pikku/better-auth": "workspace:*",
+    "@pikku/voice-agents": "workspace:*",
     "ai": "^6.0.105",
     "better-auth": "^1.6.19",
     "zod": "*"

--- a/e2e/packages/functions/src/agents/voice-assistant.agent.ts
+++ b/e2e/packages/functions/src/agents/voice-assistant.agent.ts
@@ -1,0 +1,154 @@
+import { pikkuAIAgent } from '#pikku/agent/pikku-agent-types.gen.js'
+import { ref } from '#pikku/pikku-types.gen.js'
+import { voiceInput, voiceOutput } from '@pikku/core/ai-agent'
+
+/**
+ * A todo assistant you hold a spoken conversation with.
+ *
+ * Where `voiceInputAgent` only transcribes a question, this one is the whole
+ * loop: it listens, answers out loud, runs tools, and can be talked over
+ * mid-sentence. Its tools are picked to exercise the interrupt path rather
+ * than to be interesting — reads that are cheap to redo, writes that are not,
+ * and one deliberately slow tool that will still be running when the user
+ * cuts in.
+ *
+ * The approval wording is the part that matters most here. On a screen a
+ * mis-worded confirmation is still checkable against the button next to it;
+ * spoken aloud it is all the user gets, so the sentence they answer has to be
+ * the sentence the function sanctioned. The goal below therefore forbids the
+ * model from asking for permission itself — `approvalDescription` on
+ * `addTodo`/`deleteTodo` produces the prompt, and the client speaks it
+ * verbatim.
+ */
+export const voiceAssistantAgent = pikkuAIAgent({
+  name: 'voice-assistant-agent',
+  description: 'Holds a spoken conversation about a todo list',
+  goal: [
+    'You are a voice assistant for a todo list. You are being listened to, not read.',
+    '',
+    'Default to a sentence or two, because most answers here are one fact and',
+    'waiting through three sentences for it is worse than reading them. That is',
+    'a default, not a limit: if the user asks for detail, or for you to keep',
+    'talking, give them as much as they asked for and do not explain that you',
+    'were being brief.',
+    '',
+    'Speak plainly — no lists, no markdown, no IDs read out digit by digit.',
+    'Refer to todos by their title.',
+    '',
+    'Never say you did something unless a tool did it. Not "done", not "I',
+    'marked it", not "I just looked it up" — if there was no tool call, there',
+    'was no action, and saying otherwise is the one mistake here the user has',
+    'no way to catch. Spoken, there is no tool-call log next to your answer;',
+    'your sentence is the only record they get.',
+    '',
+    'If nothing you have does what was asked, say that plainly and say what you',
+    'do have. Do not reach for the closest tool instead — the nearest thing to',
+    'completing a todo is deleting it, and that is not a near miss.',
+    '',
+    'Answering from what you were told earlier is fine, and calling it a fresh',
+    'look is not. "Just now" means this turn. If the list you are reading from',
+    'came from an earlier turn, say so — "from the list you asked for a moment',
+    'ago" — or call the tool again and then it is true.',
+    '',
+    'Never ask for permission to add or delete a todo, and never describe what',
+    'you are about to do to get consent. Those tools stop and ask on their own,',
+    'in wording that has been checked; anything you say instead is unchecked and',
+    'the user cannot see the difference. Just call the tool.',
+    '',
+    'If you are cut off, do not apologise or recap. Answer what was just asked,',
+    'and say nothing about having been interrupted — the user was there.',
+    '',
+    'One exception. A tool result marked "undelivered" is something that changed',
+    'and that the user has not been told about, because your reply describing it',
+    'was cut off. Mention that once, briefly, as an aside, then move on. Nothing',
+    'else counts: if no result says "undelivered", there is nothing to report.',
+  ].join('\n'),
+  model: 'openai/gpt-5-mini',
+  // The reply is listened to, not read, so the pause before the first word is
+  // most of what the interaction feels like, and reasoning is paid entirely
+  // inside that pause.
+  //
+  // Re-measured against `'low'` over an eight-turn transcript of real speech,
+  // after the tool-selection failures that prompted the question turned out to
+  // be a missing tool rather than a thin budget. Both settings picked the
+  // right tool on every turn of every run. `'low'` was 5568ms to first token
+  // against 3775ms here — 1.8s of silence per turn, bought for nothing
+  // measurable. (An earlier note here claimed 2.5s against 0.9s; that was a
+  // smaller goal and half these tools, and it no longer holds.)
+  providerOptions: { openai: { reasoningEffort: 'minimal' } },
+  tools: [
+    // Cheap to redo, so an interrupt discards them rather than explaining them.
+    ref('todos:listTodos'),
+    ref('todos:getTodo'),
+    // Was missing, and the gap did not surface as a refusal. Asked to mark a
+    // todo done, the model first claimed it had — "Okay, marking get lunch
+    // done. Done." with no tool call behind it — and then, on a later run,
+    // reached for the nearest write it did have and tried to *delete* the
+    // item. Only `deleteTodo`'s approval gate stopped that. An agent with no
+    // tool for the request does not report the gap, it fills it.
+    ref('todos:completeTodo'),
+    // Gated by `approvalRequired`, and the source of the spoken prompt.
+    ref('todos:addTodo'),
+    ref('todos:deleteTodo'),
+    // Slow on purpose: long enough that a barge-in lands mid-tool.
+    ref('graph:sleep'),
+  ],
+  aiMiddleware: [
+    // This was Nemotron, to stop Whisper answering a pause with stock filler —
+    // "Thank you.", "*sad music*" — appended to what was actually said. That
+    // filler turned out to be provoked by the clip, not the model: turns were
+    // recorded from the moment the previous one ended, so every one of them
+    // opened with seconds of room tone. Clips now come from the speech model
+    // already cut at both ends, and Whisper returns an empty string for
+    // near-silence like everything else.
+    //
+    // What Nemotron does instead is worse, because it is a *streaming* model
+    // handed a whole short clip: it drops the tail. "I said yes" came back as
+    // "I said ye", "okay and can you hear me now" as "okay and can you hear
+    // me". On a spoken approval that is the entire answer — the user says yes,
+    // nothing arrives, and the conversation deadlocks. Whisper was also twice
+    // as fast on every clip (253–667ms against 810–1341ms) at the same price.
+    //
+    // Qwen3-ASR and Voxtral are faster still and read short clips correctly,
+    // but both invent on near-silence — "嗯。" and "Yeah." — and the Chinese one
+    // would swing the reply into `zf_xiaobei` below. Latency is not worth an
+    // agent answering a question nobody asked.
+    //
+    // Under the deterministic suite this never leaves the process — `'*'`
+    // routes every provider name to the scripted provider — so naming the real
+    // model costs nothing and keeps the config honest about production.
+    voiceInput({ model: 'deepinfra/openai/whisper-large-v3-turbo' }),
+    // Speech is synthesized a sentence at a time as the model writes, so the
+    // first one is playing while the rest is still being generated. A reply
+    // that waited for the whole text before making any sound would leave a
+    // silence long enough that the user starts talking into it.
+    //
+    // Left on under the mock provider too — it has a speech model, so the
+    // deterministic suite carries the audio path rather than routing around it.
+    // Kokoro is 32x cheaper per character than the multilingual alternatives
+    // (0.000062c against Qwen3-TTS's 0.002c — 1.5c an hour of conversation
+    // against 48c), which is worth keeping for the languages it does handle.
+    //
+    // What it must not do is try the ones it does not. Handed Arabic — which it
+    // has no voice for — it neither fails nor stays quiet: it reads out the
+    // letter names, 24 seconds of "Arabic meem, Arabic ra" for a one-line
+    // sentence. So its range is declared, and anything outside it is left
+    // unspoken and said so.
+    //
+    // The voice per script is not decoration. Kokoro's voices are per-language,
+    // and the default American-English one does that same letter-name reading
+    // to Chinese: 9.9 seconds for a sentence `zf_xiaobei` speaks in 3.5, and
+    // Nemotron reads the result back as "Chinese letter, Chinese letter".
+    voiceOutput({
+      model: 'deepinfra/hexgrad/Kokoro-82M',
+      speakableScripts: {
+        han: 'zf_xiaobei',
+        kana: 'jf_alpha',
+        devanagari: 'hf_alpha',
+        latin: 'af_bella',
+      },
+    }),
+  ],
+  maxSteps: 10,
+  toolChoice: 'auto',
+})

--- a/e2e/packages/functions/src/agents/voice.agent.ts
+++ b/e2e/packages/functions/src/agents/voice.agent.ts
@@ -6,7 +6,11 @@ export const voiceInputAgent = pikkuAIAgent({
   description: 'Transcribes spoken audio attachments before answering',
   goal: 'You answer questions the user speaks aloud.',
   model: 'openai/gpt-5-mini',
-  aiMiddleware: [voiceInput({ model: 'mock/whisper' })],
+  aiMiddleware: [
+    voiceInput({
+      model: 'deepinfra/nvidia/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b',
+    }),
+  ],
   maxSteps: 3,
   toolChoice: 'auto',
 })

--- a/e2e/packages/functions/src/functions/voice-demo.function.ts
+++ b/e2e/packages/functions/src/functions/voice-demo.function.ts
@@ -1,0 +1,893 @@
+/**
+ * A page you can actually hold the conversation on.
+ *
+ * The loop only really exists once there is a microphone at one end of it.
+ * Silence detection, barge-in, and the ordering between "stop talking" and
+ * "stop generating" are timing behaviour that unit tests can state but not
+ * exercise — this serves the smallest surface that closes it.
+ *
+ * The page loads `@pikku/voice-agents` straight from the package's ESM build
+ * rather than reimplementing the loop inline, so what it demonstrates is the
+ * shipped package and not a parallel copy of it. The React hook is deliberately
+ * out of reach — it is the one module with an import a browser cannot resolve
+ * unbundled — so the page drives the framework-free primitives itself, which is
+ * also the honest way to show they are usable without React.
+ *
+ * Needs two real keys, because the voice and the words come from different
+ * vendors: `DEEPINFRA_API_KEY` for transcription and speech, `OPENAI_API_KEY`
+ * for the agent's own model. Run it with `PIKKU_MOCK_LLM` unset or `0` — the
+ * scripted provider the deterministic suite uses answers instantly and in
+ * fixed text, which is exactly wrong for judging a conversation.
+ *
+ * Every turn is currently transcribed twice — once by the model that drives the
+ * conversation and once by Whisper — and both transcripts are shown under a
+ * playable copy of the clip. That is temporary, and it is here because two
+ * earlier attempts to fix Whisper's invented filler were reasoned from
+ * synthetic audio and both were wrong. Synthetic noise is stationary; the
+ * things that actually provoke Whisper are breath, lip-smack and keyboards. So
+ * the comparison runs on real recordings instead of on an argument.
+ */
+import { readFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { z } from 'zod'
+import { pikkuSessionlessFunc } from '#pikku/pikku-types.gen.js'
+import { unspeakableScripts, voiceForText } from '@pikku/core/ai-agent'
+
+/**
+ * The published build directory of an installed package.
+ *
+ * `import.meta.resolve` rather than `createRequire`, because `@pikku/voice-agents`
+ * offers `import` and `require` conditions and only the former points at the
+ * ESM build the browser can use.
+ */
+const distOf = (specifier: string) =>
+  dirname(fileURLToPath(import.meta.resolve(specifier)))
+
+/**
+ * Files the page may load, and which package each comes from.
+ *
+ * An allow-list rather than path sanitising: this route reads from disk under a
+ * name that arrives in a URL, and the set of files a demo needs is small,
+ * known, and never user-supplied.
+ *
+ * The first group is the voice package itself, imported as modules —
+ * `voice-session.js` pulls in the two detectors by relative import, so they
+ * have to be here too. The rest exist only for the Silero turn detector, which
+ * is opt-in on the page and served locally rather than from the library's CDN
+ * so it can be tried offline and so the ~2MB model download is visible in the
+ * network tab where it belongs.
+ *
+ * `@ricky0123/vad-web`'s browser bundle is UMD expecting a global `ort`, which
+ * is why onnxruntime's classic-script build is here rather than its ESM one.
+ * Its `.mjs`/`.wasm` pairs are fetched by onnxruntime itself at runtime, not by
+ * the page — which variant depends on what the browser supports, so all of
+ * them are listed.
+ */
+const SERVABLE = new Map<string, string>([
+  ...(
+    [
+      'voice-session.js',
+      'silence-detector.js',
+      'speech-detector.js',
+      'audio-playback-queue.js',
+      'spoken-approval.js',
+    ] as const
+  ).map((file) => [file, '@pikku/voice-agents'] as [string, string]),
+  ...(
+    [
+      'bundle.min.js',
+      'vad.worklet.bundle.min.js',
+      'silero_vad_v5.onnx',
+    ] as const
+  ).map((file) => [file, '@ricky0123/vad-web'] as [string, string]),
+  ...(
+    [
+      'ort.wasm.min.js',
+      'ort-wasm-simd-threaded.mjs',
+      'ort-wasm-simd-threaded.wasm',
+      'ort-wasm-simd-threaded.jsep.mjs',
+      'ort-wasm-simd-threaded.jsep.wasm',
+    ] as const
+  ).map((file) => [file, 'onnxruntime-web'] as [string, string]),
+])
+
+/** The model and the WASM runtime are not text, and a browser will refuse the
+ *  runtime outright if it is not served as `application/wasm`. */
+const contentTypeFor = (file: string): string =>
+  file.endsWith('.wasm')
+    ? 'application/wasm'
+    : file.endsWith('.onnx')
+      ? 'application/octet-stream'
+      : 'text/javascript; charset=utf-8'
+
+/** No caching anywhere: the point of the page is to reload it after an edit. */
+const NO_STORE = 'no-store'
+
+export const VoiceDemoModuleInput = z.object({
+  file: z.string(),
+})
+
+export const voiceDemoModule = pikkuSessionlessFunc({
+  description: 'Serves one demo asset — a voice-agents module, or a VAD asset',
+  readonly: true,
+  input: VoiceDemoModuleInput,
+  func: async (_services, { file }) => {
+    const from = SERVABLE.get(file)
+    if (!from) {
+      return new Response(`Not a demo module: ${file}`, { status: 404 })
+    }
+    // Read as bytes rather than text: the same route now serves an ONNX model
+    // and a WASM binary, and decoding either as UTF-8 corrupts it silently.
+    const bytes = await readFile(resolve(join(distOf(from), file)))
+    return new Response(bytes, {
+      headers: {
+        'content-type': contentTypeFor(file),
+        'cache-control': NO_STORE,
+      },
+    })
+  },
+})
+
+export const voiceDemoPage = pikkuSessionlessFunc({
+  description: 'Serves the voice conversation demo page',
+  readonly: true,
+  func: async () =>
+    new Response(PAGE, {
+      headers: {
+        'content-type': 'text/html; charset=utf-8',
+        'cache-control': NO_STORE,
+      },
+    }),
+})
+
+export const VoiceDemoTranscribeInput = z.object({
+  /** The recorded turn, base64. JSON rather than a raw body so the route needs
+   *  no binary handling on either side; a few seconds of Opus is small. */
+  audio: z.string(),
+})
+
+/** Drives the conversation. See the note in `voice-assistant.agent.ts`. */
+const ASR_MODEL = 'deepinfra/openai/whisper-large-v3-turbo'
+
+/**
+ * Run side by side purely so the two can be compared on real audio.
+ *
+ * The one this replaced, so the swap keeps being checked rather than being
+ * decided once on a bench of five clips. What to watch for: Nemotron dropping
+ * the last word of a short turn, and Whisper opening one with a greeting
+ * nobody said.
+ */
+const COMPARISON_MODEL =
+  'deepinfra/nvidia/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b'
+
+/** Kept in step with the agent's own `voiceOutput`, so one voice is heard. */
+const TTS_MODEL = 'deepinfra/hexgrad/Kokoro-82M'
+
+/**
+ * Kokoro's voices are per-language, and the wrong one is not merely accented:
+ * its default American-English voice reads Chinese out character-name by
+ * character-name, 9.9 seconds for a sentence `zf_xiaobei` speaks in 3.5.
+ * Scripts absent here — Arabic, Cyrillic, Hangul — it has no voice for at all.
+ */
+const SPEAKABLE_SCRIPTS = {
+  han: 'zf_xiaobei',
+  kana: 'jf_alpha',
+  devanagari: 'hf_alpha',
+  latin: 'af_bella',
+}
+
+export const VoiceDemoTranscribeOutput = z.object({
+  /** What the conversation acts on. */
+  text: z.string(),
+  /** Round-trip milliseconds, so latency stops being a guess. */
+  asrMs: z.number(),
+})
+
+/**
+ * Transcribe one turn.
+ *
+ * The agent could do this itself — `voiceInput` transcribes an audio attachment
+ * server-side — but the browser needs the text too: it is what the user sees
+ * to check whether they were heard correctly, and it is what an answer to a
+ * spoken approval has to be read out of before anything is approved.
+ */
+export const voiceDemoTranscribe = pikkuSessionlessFunc({
+  description: 'Transcribes a recorded turn for the voice demo page',
+  readonly: true,
+  input: VoiceDemoTranscribeInput,
+  output: VoiceDemoTranscribeOutput,
+  func: async ({ aiAgentRunner }, { audio }) => {
+    if (!aiAgentRunner.transcribe) {
+      throw new Error('The configured aiAgentRunner cannot transcribe')
+    }
+    const startedAt = Date.now()
+    const result = await aiAgentRunner.transcribe({
+      model: ASR_MODEL,
+      audio: Buffer.from(audio, 'base64'),
+    })
+
+    return { text: result.text, asrMs: Date.now() - startedAt }
+  },
+})
+
+export const VoiceDemoCompareInput = VoiceDemoTranscribeInput
+export const VoiceDemoCompareOutput = z.object({
+  comparison: z.string(),
+  comparisonMs: z.number(),
+})
+
+/**
+ * The same clip through Whisper, for comparison only.
+ *
+ * A separate route rather than a second transcription inside the one above,
+ * because the turn must not wait for it. Running both together made every turn
+ * cost `max(nemotron, whisper)` and the diagnostic became a latency tax — the
+ * page fires this after the turn is already moving and fills the numbers in
+ * when they land. Delete both this and its caller once the comparison has been
+ * watched for a session or two.
+ */
+export const voiceDemoCompare = pikkuSessionlessFunc({
+  description: 'Transcribes a turn with Whisper, for side-by-side comparison',
+  readonly: true,
+  input: VoiceDemoCompareInput,
+  output: VoiceDemoCompareOutput,
+  func: async ({ aiAgentRunner }, { audio }) => {
+    if (!aiAgentRunner.transcribe) {
+      throw new Error('The configured aiAgentRunner cannot transcribe')
+    }
+    const startedAt = Date.now()
+    const result = await aiAgentRunner.transcribe({
+      model: COMPARISON_MODEL,
+      audio: Buffer.from(audio, 'base64'),
+    })
+    return { comparison: result.text, comparisonMs: Date.now() - startedAt }
+  },
+})
+
+export const VoiceDemoSpeakInput = z.object({
+  text: z.string(),
+})
+
+export const VoiceDemoSpeakOutput = z.object({
+  audio: z.string(),
+  format: z.string(),
+  /**
+   * Scripts the speech model cannot pronounce, when there are any. Empty audio
+   * with a reason on it, rather than silence the caller has to explain — an
+   * approval question that cannot be spoken has to be visibly unspoken, since
+   * the whole point of it is that the user answers the sentence they were read.
+   */
+  unspeakable: z.array(z.string()),
+})
+
+/**
+ * Speak text the model did not write.
+ *
+ * Only the approval question goes through here. It is synthesized with the same
+ * model as the agent's own speech so the user cannot tell the sanctioned
+ * sentence apart from the reply around it by voice — the wording is checked,
+ * and it should not sound like a different speaker reading a disclaimer.
+ */
+export const voiceDemoSpeak = pikkuSessionlessFunc({
+  description: 'Synthesizes an utterance for the voice demo page',
+  readonly: true,
+  input: VoiceDemoSpeakInput,
+  output: VoiceDemoSpeakOutput,
+  func: async ({ aiAgentRunner }, { text }) => {
+    if (!aiAgentRunner.generateSpeech) {
+      throw new Error('The configured aiAgentRunner cannot generate speech')
+    }
+    // Must stay the same model the agent speaks with — see above.
+    const unspeakable = unspeakableScripts(text, SPEAKABLE_SCRIPTS)
+    if (unspeakable.length > 0) {
+      return { audio: '', format: '', unspeakable }
+    }
+    const result = await aiAgentRunner.generateSpeech({
+      model: TTS_MODEL,
+      text,
+      voice: voiceForText(text, SPEAKABLE_SCRIPTS),
+    })
+    return {
+      audio: result.audio.base64,
+      format: result.audio.format,
+      unspeakable: [],
+    }
+  },
+})
+
+export const VoiceDemoInterruptInput = z.object({
+  runId: z.string(),
+  reason: z.enum(['speech', 'user', 'timeout']).optional(),
+})
+
+/**
+ * Stop the agent talking.
+ *
+ * This is what `agentInterrupt()` wraps, written out because the inspector
+ * reads `func` statically and cannot see through a spread. `rpc.agent.interrupt`
+ * checks the run belongs to the caller before stopping it, and resolves
+ * `stopped: false` when there was nothing left to stop — racing a run that
+ * finishes on its own is the normal case here, not an error.
+ */
+export const voiceDemoInterrupt = pikkuSessionlessFunc({
+  description: 'Interrupts the run the demo page is currently listening to',
+  input: VoiceDemoInterruptInput,
+  func: async (_services, { runId, reason }, { rpc }) =>
+    rpc.agent.interrupt(runId, reason),
+})
+
+const PAGE = /* html */ `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Pikku voice agent</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    font: 15px/1.55 ui-sans-serif, system-ui, sans-serif;
+    max-width: 44rem; margin: 0 auto; padding: 2rem 1.25rem 4rem;
+  }
+  h1 { font-size: 1.25rem; margin: 0 0 .25rem; }
+  p.sub { margin: 0 0 1.5rem; opacity: .7; }
+  button {
+    font: inherit; padding: .5rem 1rem; border-radius: .5rem;
+    border: 1px solid currentColor; background: transparent; cursor: pointer;
+  }
+  button[disabled] { opacity: .4; cursor: default; }
+  .bar { display: flex; gap: .75rem; align-items: center; margin-bottom: 1rem; }
+  .state { opacity: .7; font-size: .85rem; }
+  #log { display: flex; flex-direction: column; gap: .5rem; }
+  .msg { padding: .5rem .75rem; border-radius: .5rem; border: 1px solid; white-space: pre-wrap; }
+  .user { border-color: #8884; }
+  .agent { border-color: #4a94ff88; }
+  .approval { border-color: #d4913a; }
+  .note { border-color: #8884; opacity: .7; font-size: .85rem; }
+  .clip { border-color: #8884; font-size: .8rem; opacity: .75; font-family: ui-monospace, monospace; white-space: pre; overflow-x: auto; }
+  .clip.differs { border-color: #d4913a; opacity: 1; }
+  .seg.mismatch { color: #d4913a; }
+  .clip audio { width: 100%; height: 32px; margin-top: .4rem; }
+  .cut { opacity: .6; font-style: italic; }
+  code { font-size: .85em; }
+</style>
+</head>
+<body>
+<h1>Pikku voice agent</h1>
+<p class="sub">
+  Talk to <code>voice-assistant-agent</code> about the todo list. Talk over it
+  to cut it off. Adding and deleting ask permission out loud.
+</p>
+
+<div class="bar">
+  <button id="talk">Start talking</button>
+  <span class="state" id="state">idle</span>
+  <label class="state" style="margin-left:auto">
+    <input type="checkbox" id="use-vad" /> Silero VAD
+  </label>
+</div>
+
+<div id="log"></div>
+
+<script type="module">
+import { VoiceSession } from './voice-demo/lib/voice-session.js'
+import { AudioPlaybackQueue } from './voice-demo/lib/audio-playback-queue.js'
+import { spokenApproval, interpretConsent } from './voice-demo/lib/spoken-approval.js'
+
+const AGENT = 'voiceAssistantAgent'
+const threadId = crypto.randomUUID()
+const resourceId = 'voice-demo'
+
+const $log = document.getElementById('log')
+const $state = document.getElementById('state')
+const $talk = document.getElementById('talk')
+// Not id="vad": an element id becomes a global, and \`window.vad\` is the name
+// the VAD bundle publishes itself under. The checkbox got there first, the
+// "already loaded?" check saw it and skipped loading, and the detector failed
+// with "Cannot read properties of undefined (reading 'new')".
+const $vad = document.getElementById('use-vad')
+
+const setState = (text) => { $state.textContent = text }
+
+const say = (kind, text) => {
+  const el = document.createElement('div')
+  el.className = 'msg ' + kind
+  el.textContent = text
+  $log.append(el)
+  el.scrollIntoView({ block: 'nearest' })
+  return el
+}
+
+/**
+ * The captured turn, playable, with what each model made of it.
+ *
+ * Object URLs are never revoked: the point of the page is to scroll back and
+ * listen again, and a session ends by closing the tab. Revoking them on append
+ * would be tidier and would break the only feature this adds.
+ */
+/** Whitespace-insensitive, because Whisper pads with leading/doubled spaces. */
+const words = (text) => text.trim().replace(/\\s+/g, ' ')
+
+const attachClip = (turn, result, base64) => {
+  const el = document.createElement('div')
+  el.className = 'msg clip'
+
+  const label = document.createElement('div')
+  label.textContent =
+    (turn.durationMs / 1000).toFixed(1) + 's audio · asr ' + result.asrMs + 'ms'
+  el.append(label)
+
+  const asrRow = document.createElement('div')
+  asrRow.className = 'seg'
+  asrRow.textContent = '     asr  ' + (result.text.trim() || '(nothing)')
+  el.append(asrRow)
+
+  // Deliberately after the turn has already been handed on. This is a
+  // diagnostic, and a diagnostic that delays the reply is worse than no
+  // diagnostic — so it lands late and edits the row in place.
+  const whisperRow = document.createElement('div')
+  whisperRow.className = 'seg'
+  whisperRow.textContent = ' whisper  …'
+  el.append(whisperRow)
+
+  post('/voice-demo/compare', { audio: base64 })
+    .then((other) => {
+      const differs = words(other.comparison) !== words(result.text)
+      if (differs) el.classList.add('differs')
+      whisperRow.className = 'seg' + (differs ? ' mismatch' : '')
+      whisperRow.textContent =
+        ' whisper  ' + (other.comparison.trim() || '(nothing)') +
+        '   [' + other.comparisonMs + 'ms]'
+    })
+    .catch(() => whisperRow.remove())
+
+  const player = document.createElement('audio')
+  player.controls = true
+  player.src = URL.createObjectURL(turn.audio)
+  el.append(player)
+
+  $log.append(el)
+  el.scrollIntoView({ block: 'nearest' })
+}
+
+const post = async (path, body) => {
+  const response = await fetch(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) throw new Error(path + ' -> ' + response.status)
+  return response.json()
+}
+
+const toBase64 = async (blob) => {
+  const bytes = new Uint8Array(await blob.arrayBuffer())
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
+  return btoa(binary)
+}
+
+const fromBase64 = (data) => {
+  const binary = atob(data)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes.buffer
+}
+
+let session = null
+let playback = null
+/** The run currently streaming, so barge-in knows what to stop. */
+let runId = null
+/** Whether this turn started over the agent's voice. Read when it ends. */
+let bargedIn = false
+/** The approval we are waiting to hear an answer to. */
+let awaiting = null
+/** Unclear answers to the approval currently being asked. Reset by \`ask\`. */
+let unclearAnswers = 0
+/** Two tries, then the action is denied rather than asked about forever. */
+const MAX_UNCLEAR_ANSWERS = 2
+
+/** Speech for text the model did not write — only the approval question. */
+const speak = async (text) => {
+  const { audio, unspeakable } = await post('/voice-demo/speak', { text })
+  if (unspeakable && unspeakable.length) {
+    // Worth saying loudly here. This helper only ever speaks the approval
+    // question, and an approval the user was never read is one they answer
+    // from memory of what they asked for rather than from what was
+    // sanctioned — which is the exact thing the verbatim wording exists to
+    // prevent. Unspoken and visibly so is the only safe state.
+    say('note', 'not spoken aloud yet (' + unspeakable.join(', ') + ') — read it above before answering')
+    return false
+  }
+  await playback.enqueue({ text, audio: fromBase64(audio) })
+  return true
+}
+
+/**
+ * Read one SSE body, rendering text as it arrives and queueing audio behind it.
+ * Returns how the turn ended so the caller knows what to ask next.
+ *
+ * The wire format is AG-UI, so pikku's own events arrive as \`CUSTOM\` under a
+ * \`pikku:\` name — that is where speech, approvals and interruption live, since
+ * AG-UI itself has no event for any of them.
+ */
+const consume = async (response) => {
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let bubble = null
+  const approvals = []
+  let interrupted = false
+
+  const handle = (event) => {
+    switch (event.type) {
+      case 'RUN_STARTED':
+        runId = event.runId
+        return
+      case 'TEXT_MESSAGE_CONTENT':
+        if (!bubble) bubble = say('agent', '')
+        bubble.textContent += event.delta
+        return
+      case 'TOOL_CALL_START':
+        say('note', 'calling ' + event.toolCallName)
+        return
+      case 'RUN_ERROR':
+        say('note', 'error: ' + event.message)
+        return
+      case 'CUSTOM':
+        break
+      default:
+        return
+    }
+
+    switch (event.name) {
+      case 'pikku:audio-delta':
+        // Queued, never awaited: the rest of the stream has to keep arriving
+        // while this sentence is being spoken. A chunk that will not decode is
+        // reported and skipped — one silent sentence beats a dead stream.
+        playback
+          .enqueue({ text: '', audio: fromBase64(event.value.data) })
+          .catch(() => say('note', 'could not decode a sentence of speech'))
+        return
+      case 'pikku:voice-unsupported':
+        // The reply is on screen either way. What this says is that the part
+        // of it in this script was not read out — otherwise the silence looks
+        // like the speech failed, and the user waits for audio that is not
+        // coming.
+        say(
+          'note',
+          'not spoken aloud yet: ' + event.value.scripts.join(', ')
+        )
+        return
+      case 'pikku:approval-request':
+        runId = event.value.runId ?? runId
+        approvals.push(event.value)
+        return
+      case 'pikku:interrupted':
+        // Guarded: a new run may already have announced itself while the
+        // interrupted one was still shutting down, and clearing that would
+        // leave the next reply with nothing to stop.
+        if (runId === event.value.runId) runId = null
+        if (bubble) bubble.classList.add('cut')
+        interrupted = true
+        return
+    }
+  }
+
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+
+    let index
+    while ((index = buffer.indexOf('\\n\\n')) !== -1) {
+      const frame = buffer.slice(0, index)
+      buffer = buffer.slice(index + 2)
+      const line = frame.split('\\n').find((l) => l.startsWith('data:'))
+      if (!line) continue
+      try { handle(JSON.parse(line.slice(5).trim())) } catch {}
+    }
+  }
+  return { approvals, interrupted }
+}
+
+const stream = async (path, body) => {
+  const response = await fetch(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'text/event-stream' },
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) {
+    say('note', path + ' -> ' + response.status)
+    return { approvals: [], interrupted: false }
+  }
+  return consume(response)
+}
+
+/**
+ * Ask for one approval out loud, in the function's own words.
+ *
+ * The sentence is never composed here and never comes from the model: it is
+ * whatever \`approvalDescription\` produced, carried through untouched. On a
+ * screen a wrong word is checkable against the button beside it; spoken, it is
+ * the whole interface.
+ */
+const ask = async (approval) => {
+  const prompt = spokenApproval(approval)
+  say('approval', prompt.text)
+  if (prompt.undescribed) {
+    say('note', 'This tool supplied no approvalDescription.')
+  }
+  awaiting = prompt
+  unclearAnswers = 0
+  setState('waiting for yes or no')
+  await speak(prompt.text)
+}
+
+const askAll = async (approvals) => {
+  // Only the first is asked now. The server keeps a run suspended until every
+  // pending approval is answered, so the rest are picked up as each resume
+  // replies, and the user is never read two questions before answering one.
+  if (approvals.length > 0) await ask(approvals[0])
+}
+
+const answer = async (transcript) => {
+  const prompt = awaiting
+  const consent = interpretConsent(transcript)
+
+  if (consent === 'unclear') {
+    unclearAnswers += 1
+
+    // Asking again is the right response to one unclear answer and the wrong
+    // response to every unclear answer: whatever is producing them — a bad
+    // microphone, a room, a person who has walked away — is still producing
+    // them on the next pass, and the question repeats until something breaks.
+    // Giving up denies, because the only safe reading of "no answer" for an
+    // action awaiting consent is that consent was not given.
+    if (unclearAnswers >= MAX_UNCLEAR_ANSWERS) {
+      awaiting = null
+      say('note', 'No clear answer after ' + MAX_UNCLEAR_ANSWERS + ' tries — treating that as no.')
+      await speak('I could not tell whether that was a yes, so I have not done it.')
+      const declined = await stream('/rpc/agent/' + AGENT + '/resume', {
+        agentName: AGENT,
+        runId,
+        toolCallId: prompt.toolCallId,
+        approved: false,
+      })
+      await askAll(declined.approvals)
+      return
+    }
+
+    // Never resolved on a guess. The same question is asked again, unchanged —
+    // rewording it would mean the user answers a sentence the function never
+    // sanctioned. Only the note beside it says which of the two happened,
+    // because "I didn't hear you" and "that wasn't a yes" are different things
+    // to fix and the user is the one who can fix them.
+    say(
+      'note',
+      transcript
+        ? 'Not a clear yes or no, so nothing was decided.'
+        : 'Nothing was transcribed, so nothing was decided.'
+    )
+    await speak(prompt.text)
+    return
+  }
+
+  awaiting = null
+  say('note', consent === 'granted' ? 'approved' : 'denied')
+  const outcome = await stream('/rpc/agent/' + AGENT + '/resume', {
+    agentName: AGENT,
+    runId,
+    toolCallId: prompt.toolCallId,
+    approved: consent === 'granted',
+  })
+  await askAll(outcome.approvals)
+}
+
+const handleTurn = async (turn, heard) => {
+  setState('transcribing')
+  let transcript = ''
+  let result = null
+  const base64 = await toBase64(turn.audio)
+  try {
+    result = await post('/voice-demo/transcribe', { audio: base64 })
+    transcript = result.text.trim()
+  } catch (error) {
+    say('note', String(error.message))
+  }
+
+  // Every turn gets a playable clip and the transcript it produced, whether or
+  // not anything was heard — a turn that came back empty is the interesting
+  // one, because it is the only way to hear what the model was actually given.
+  if (result) attachClip(turn, result, base64)
+
+  // An empty transcript is nothing to act on — unless something is waiting to
+  // be answered, in which case dropping it is what leaves the conversation
+  // hung: the user says yes, the model returns nothing, and the question is
+  // never asked again. Silence is not consent, but it is an answer that has to
+  // be handled rather than ignored, so it goes through the same unclear path
+  // as "maybe" — asked again, and denied once the retries run out.
+  if (!transcript && !awaiting) {
+    setState('listening')
+    return
+  }
+  if (transcript) say('user', transcript)
+
+  if (awaiting) {
+    await answer(transcript)
+    setState('listening')
+    return
+  }
+
+  setState('thinking')
+  // What the user actually heard before cutting in, folded into the message
+  // rather than sent as context: the model has to see where its last reply
+  // stopped, or it answers as though the whole sentence landed.
+  const message = heard && !heard.complete
+    ? transcript + '\\n\\n(You were cut off. All I heard was: "' + heard.text + '")'
+    : transcript
+
+  const outcome = await stream('/rpc/agent/' + AGENT + '/stream', {
+    agentName: AGENT,
+    message,
+    threadId,
+    resourceId,
+  })
+  await askAll(outcome.approvals)
+  if (!awaiting) setState('listening')
+}
+
+/**
+ * Stop the run now. Fires on the first audible frame — before the turn is over
+ * and long before there is a transcript — because stopping the bill should not
+ * wait for either.
+ */
+const interruptRun = async () => {
+  if (!runId) return
+  try {
+    const { stopped, inFlightTools } = await post('/voice-demo/interrupt', {
+      runId,
+      reason: 'speech',
+    })
+    if (stopped && inFlightTools.length > 0) {
+      // Named, not offered to undo — it has already happened.
+      say('note', 'still finishing: ' + inFlightTools.join(', '))
+    }
+  } catch (error) {
+    say('note', String(error.message))
+  }
+}
+
+const script = (src) =>
+  new Promise((resolve, reject) => {
+    const el = document.createElement('script')
+    el.src = src
+    el.onload = resolve
+    el.onerror = () => reject(new Error('failed to load ' + src))
+    document.head.append(el)
+  })
+
+/**
+ * Two classic scripts, in order, because \`@ricky0123/vad-web\`'s browser build
+ * is UMD and closes over a global \`ort\` that onnxruntime has to have defined
+ * first. Not \`import()\`: the ESM builds of both resolve bare specifiers a
+ * browser cannot, which is the same reason this page loads the voice package
+ * from a route rather than from node_modules.
+ */
+let vadModule = null
+const loadVad = () => {
+  // Cached as the promise, not as a global lookup: the module publishes itself
+  // on \`window\`, and asking \`window\` whether it is loaded is how this broke.
+  vadModule ??= (async () => {
+    await script('/voice-demo/lib/ort.wasm.min.js')
+    await script('/voice-demo/lib/bundle.min.js')
+    if (!window.vad?.MicVAD) throw new Error('vad bundle loaded without MicVAD')
+    return window.vad
+  })()
+  return vadModule
+}
+
+/**
+ * The Silero option. Assets come from this server rather than the library's
+ * CDN, and \`redemptionMs\` matches the energy detector's 700ms rather than the
+ * library's 1400 — comparing them is the point, so the only difference that
+ * should show up is how the end of a turn is decided.
+ */
+const speechOptions = () => ({
+  load: loadVad,
+  baseAssetPath: '/voice-demo/lib/',
+  onnxWASMBasePath: '/voice-demo/lib/',
+  model: 'v5',
+  redemptionMs: 700,
+  // Below "yes". The library's 400 drops it, and this demo asks yes-or-no
+  // questions out loud, so that is the one turn it cannot afford to lose.
+  minSpeechMs: 200,
+  onDiagnostics: (d) =>
+    say(
+      'note',
+      'vad · ' + d.processor + ' · load ' + Math.round(d.loadMs) + 'ms · ' +
+      'frame ' + d.meanFrameIntervalMs.toFixed(1) + 'ms · ' +
+      Math.round(d.sampleRate / 1000) + 'kHz'
+    ),
+})
+
+const startSession = async () => {
+  // Both AudioContexts are constructed inside the click handler. On iOS Safari
+  // a context created outside a user gesture starts suspended and stays that
+  // way, so the agent would be silent with nothing in the console to say why.
+  playback = new AudioPlaybackQueue()
+  playback.onIdle = () => { if (!awaiting) setState('listening') }
+
+  session = new VoiceSession({
+    ...($vad.checked ? { speech: speechOptions() } : {}),
+    onSpeechStart: () => {
+      // The only sign of life on the VAD path: it decides a turn is over
+      // rather than counting down to it, so onSilenceProgress never fires and
+      // the state would otherwise read 'listening' through the whole turn.
+      if (!playback.playing) {
+        setState('hearing you')
+        return
+      }
+      bargedIn = true
+      void playback.pause()
+      void interruptRun()
+    },
+    onSilenceProgress: (percentage) => {
+      if (percentage > 0) setState('…')
+    },
+    onTurn: (turn) => {
+      const heard = bargedIn ? playback.interrupt() : null
+      bargedIn = false
+      void handleTurn(turn, heard).catch((error) =>
+        say('note', String(error.message))
+      )
+    },
+    onTurnDiscarded: () => {
+      // Too short to be speech. The agent was only paused, so it picks up where
+      // it was — a cough must not end a reply.
+      if (!awaiting && !playback.playing) setState('listening')
+      if (!bargedIn) return
+      bargedIn = false
+      void playback.resume()
+    },
+    onError: (error) => say('note', String(error.message)),
+  })
+  await session.start()
+}
+
+$talk.addEventListener('click', async () => {
+  if (session) {
+    session.stop()
+    void session.destroy()
+    void playback.destroy()
+    session = null
+    playback = null
+    $talk.textContent = 'Start talking'
+    $vad.disabled = false
+    setState('idle')
+    return
+  }
+
+  $talk.disabled = true
+  // Fixed for the life of the session: the detector is chosen once, in
+  // \`start()\`, because loading the model is not something to do mid-sentence.
+  $vad.disabled = true
+  try {
+    if ($vad.checked) setState('loading vad…')
+    await startSession()
+    $talk.textContent = 'Stop'
+    setState('listening')
+  } catch (error) {
+    say('note', 'microphone unavailable: ' + error.message)
+    session = null
+    playback = null
+    $vad.disabled = false
+    setState('idle')
+  } finally {
+    $talk.disabled = false
+  }
+})
+</script>
+</body>
+</html>
+`

--- a/e2e/packages/functions/src/wirings/voice-demo.wirings.ts
+++ b/e2e/packages/functions/src/wirings/voice-demo.wirings.ts
@@ -1,0 +1,57 @@
+import { defineHTTPRoutes, wireHTTPRoutes } from '#pikku/pikku-types.gen.js'
+import {
+  voiceDemoCompare,
+  voiceDemoInterrupt,
+  voiceDemoModule,
+  voiceDemoPage,
+  voiceDemoSpeak,
+  voiceDemoTranscribe,
+} from '../functions/voice-demo.function.js'
+
+/**
+ * The demo page and the three calls it makes that the generated agent routes do
+ * not already cover: transcription, speech for the approval question, and
+ * interruption — there is no generated interrupt route because interrupting
+ * ends a stream rather than continuing one.
+ *
+ * Unauthenticated, like the rest of the e2e HTTP surface. It reads and writes
+ * the same seeded todo list every other e2e scenario uses.
+ */
+export const voiceDemoRoutes = defineHTTPRoutes({
+  auth: false,
+  routes: {
+    page: {
+      route: '/voice-demo',
+      method: 'get',
+      func: voiceDemoPage,
+    },
+    module: {
+      route: '/voice-demo/lib/:file',
+      method: 'get',
+      func: voiceDemoModule,
+    },
+    transcribe: {
+      route: '/voice-demo/transcribe',
+      method: 'post',
+      func: voiceDemoTranscribe,
+    },
+    // Diagnostic only, and off the turn's critical path — see voiceDemoCompare.
+    compare: {
+      route: '/voice-demo/compare',
+      method: 'post',
+      func: voiceDemoCompare,
+    },
+    speak: {
+      route: '/voice-demo/speak',
+      method: 'post',
+      func: voiceDemoSpeak,
+    },
+    interrupt: {
+      route: '/voice-demo/interrupt',
+      method: 'post',
+      func: voiceDemoInterrupt,
+    },
+  },
+})
+
+wireHTTPRoutes({ routes: { voiceDemo: voiceDemoRoutes } })

--- a/e2e/packages/functions/tests/scenarios/agent-assert.steps.ts
+++ b/e2e/packages/functions/tests/scenarios/agent-assert.steps.ts
@@ -414,13 +414,23 @@ export const expectsApprovalState = pikkuScenarioStep<
     suspended: boolean
     count?: number
     reasonContains?: string
+    /**
+     * The whole reason, character for character. Worth asserting rather than
+     * `reasonContains` when the wording is what is being consented to — a voice
+     * client reads this string out and the user answers it, so a stray prefix
+     * is a different question than the one the function sanctioned.
+     */
+    reasonEquals?: string
   },
   { pending: number }
 >({
   name: 'expectsApprovalState',
   description: 'expects the run to be suspended for approval, or resumed',
   template: 'expects suspended={suspended}',
-  default: async (_services, { run, suspended, count, reasonContains }) => {
+  default: async (
+    _services,
+    { run, suspended, count, reasonContains, reasonEquals }
+  ) => {
     const isSuspended = run.runStatus === 'suspended'
     if (isSuspended !== suspended) {
       throw new Error(
@@ -442,6 +452,14 @@ export const expectsApprovalState = pikkuScenarioStep<
       if (!reasons.some((reason) => reason.includes(reasonContains))) {
         throw new Error(
           `No pending approval reason contains ${describeValue(reasonContains)}, got ${describeValue(reasons)}`
+        )
+      }
+    }
+    if (reasonEquals !== undefined) {
+      const reasons = run.pendingApprovals.map((approval) => approval.reason)
+      if (!reasons.some((reason) => reason === reasonEquals)) {
+        throw new Error(
+          `No pending approval reason is exactly ${describeValue(reasonEquals)}, got ${describeValue(reasons)}`
         )
       }
     }

--- a/e2e/packages/functions/tests/scenarios/converse.steps.ts
+++ b/e2e/packages/functions/tests/scenarios/converse.steps.ts
@@ -101,3 +101,65 @@ export const expectsTodoTitled = pikkuScenarioStep<
     return { titles }
   },
 })
+
+/**
+ * The same check one state further on: the todo is there *and* it is done.
+ *
+ * Worth its own step rather than a flag on {@link expectsTodoTitled}, because
+ * the two ways it fails are different bugs and reading them apart is the whole
+ * value. A todo that is present but not completed is an agent that said "done"
+ * without calling anything. A todo that is gone is an agent that had no
+ * `completeTodo` and reached for `deleteTodo` instead. Both answer the user
+ * with a sentence that sounds identical, and only the store tells them apart —
+ * which is why this asserts on the store and not on which tools ran. What
+ * matters is that the world changed the way the user was told it did; the call
+ * that got it there is an implementation detail.
+ */
+export const expectsTodoCompleted = pikkuScenarioStep<
+  { title: string },
+  { completed: boolean }
+>({
+  name: 'expectsTodoCompleted',
+  description: 'expects the todo store to hold a completed todo with a title',
+  template: 'expects the store to hold a completed todo titled {title}',
+  default: async (_services, { title }, { scenarioStep }) => {
+    const actor = requireActor(scenarioStep)
+    const { todos } = (await actor.invoke(
+      'todos:listTodos' as never,
+      {} as never
+    )) as { todos: Array<{ title: string; completed: boolean }> }
+    const needle = title.toLowerCase()
+    const matches = todos.filter((todo) =>
+      todo.title.toLowerCase().includes(needle)
+    )
+    if (matches.length === 0) {
+      throw new Error(
+        `No todo titled "${title}" in the store — it was never added, or it was deleted instead of completed. Got: ${JSON.stringify(
+          todos
+        )}`
+      )
+    }
+    // Uniqueness is part of the assertion, not pedantry about it. Asked to
+    // complete a todo, the agent has been observed adding a second one with the
+    // same title and completing *that*, leaving the original open. Every
+    // looser reading passes that: "some todo with this title is done" is true,
+    // and so is the actor's verdict, because the agent truthfully said it
+    // marked one done. Only counting catches it.
+    if (matches.length > 1) {
+      const open = matches.filter((todo) => !todo.completed).length
+      throw new Error(
+        `Expected one todo titled "${title}", found ${matches.length} (${open} still open) — the agent added a duplicate instead of completing the one already there. Got: ${JSON.stringify(
+          todos
+        )}`
+      )
+    }
+    if (!matches[0]!.completed) {
+      throw new Error(
+        `Todo "${matches[0]!.title}" is still open, so nothing marked it done. Got: ${JSON.stringify(
+          todos
+        )}`
+      )
+    }
+    return { completed: true }
+  },
+})

--- a/e2e/packages/functions/tests/scenarios/voice-approval.feature.ts
+++ b/e2e/packages/functions/tests/scenarios/voice-approval.feature.ts
@@ -1,0 +1,106 @@
+/**
+ * The wording a voice user is asked to consent to.
+ *
+ * `agent-approval.feature.ts` already proves an approval-gated tool suspends
+ * and carries a reason. What matters here is narrower and stricter: the reason
+ * reaches the client *exactly* as `approvalDescription` wrote it. A voice
+ * client has nothing else to show — it reads this string out and the user
+ * answers it — so a reason that has been prefixed, trimmed or summarised is a
+ * different question than the one the function sanctioned, and nobody can hear
+ * the difference afterwards.
+ *
+ * Hence `reasonEquals` rather than `reasonContains`. The spoken-side half of
+ * this contract (never rewriting the string, refusing to invent one) is
+ * covered by `spokenApproval` in `@pikku/voice-agents`.
+ */
+import {
+  pikkuFeature,
+  pikkuScenario,
+} from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+const AGENT = 'voiceAssistantAgent'
+const RESOURCE_ID = 'voice-approval'
+const ALICE = { userId: 'alice' }
+
+export const voiceApprovalReasonIsVerbatimScenario = pikkuScenario<
+  void,
+  { verbatim: true }
+>({
+  title: 'The spoken approval reason is the function’s wording, untouched',
+  description: 'What the voice client reads out is exactly what was sanctioned',
+  tags: ['scenario', 'agent-protocol', 'voice-approval'],
+  func: async (_services, _data, { scenario }) => {
+    const thread = await scenario.given('opens a thread', 'startsAgentThread')
+    await scenario.given('resets the todo list', 'resetsTodos')
+
+    const run = await scenario.when('runs the voice agent', 'runsAgent', {
+      agent: AGENT,
+      script: 'add-todo-then-text',
+      message: 'add a todo',
+      threadId: thread.threadId,
+      resourceId: RESOURCE_ID,
+      identity: ALICE,
+    })
+
+    await scenario.then(
+      'hears exactly what addTodo wrote',
+      'expectsApprovalState',
+      {
+        run,
+        suspended: true,
+        count: 1,
+        // Character for character. `addTodo` writes this and nothing else.
+        reasonEquals: 'Add a todo called "Write e2e tests"',
+      }
+    )
+    return { verbatim: true }
+  },
+})
+
+export const voiceApprovalReasonNamesTheRecordScenario = pikkuScenario<
+  void,
+  { named: true }
+>({
+  title: 'A spoken delete names the todo, not the tool',
+  description: 'The reason is built from the record the caller would lose',
+  tags: ['scenario', 'agent-protocol', 'voice-approval'],
+  func: async (_services, _data, { scenario }) => {
+    const thread = await scenario.given('opens a thread', 'startsAgentThread')
+    await scenario.given('resets the todo list', 'resetsTodos')
+
+    const run = await scenario.when('runs the voice agent', 'runsAgent', {
+      agent: AGENT,
+      script: 'delete-todo-then-text',
+      message: 'delete that one',
+      threadId: thread.threadId,
+      resourceId: RESOURCE_ID,
+      identity: ALICE,
+    })
+
+    await scenario.then(
+      'hears the todo named, not its id',
+      'expectsApprovalState',
+      {
+        run,
+        suspended: true,
+        count: 1,
+        // `resetsTodos` seeds id '1' as "Buy groceries". The point of the
+        // assertion is that the reason went to the store for the title rather
+        // than reading the id aloud, which no listener could act on.
+        reasonEquals: 'Delete the todo called "Buy groceries"',
+      }
+    )
+    return { named: true }
+  },
+})
+
+export const voiceApprovalFeature = pikkuFeature({
+  name: 'A spoken approval asks the function’s own question',
+  description:
+    'The reason a voice client reads aloud reaches it verbatim, because the sentence is the whole interface',
+  tags: ['agent-protocol', 'voice-approval'],
+  scenarios: [
+    voiceApprovalReasonIsVerbatimScenario,
+    voiceApprovalReasonNamesTheRecordScenario,
+  ],
+})

--- a/e2e/packages/functions/tests/scenarios/voice-assistant-converse.feature.ts
+++ b/e2e/packages/functions/tests/scenarios/voice-assistant-converse.feature.ts
@@ -1,0 +1,101 @@
+/**
+ * The voice assistant, held to what the store says rather than to what it said.
+ *
+ * This exists because of a failure that reads perfectly in a transcript. Asked
+ * to mark a todo done, the agent answered "Okay — marking get lunch done." and
+ * called nothing at all; on a later run it reached for `deleteTodo`, the only
+ * write it had, and would have destroyed the record had the approval gate not
+ * stopped it. Both turns sound like success. Spoken aloud there is no tool-call
+ * log beside the sentence, so the reply *is* the whole interface, and the only
+ * thing that can contradict it is the store.
+ *
+ * So the shape here is deliberate: an LLM actor drives a real conversation and
+ * returns its own verdict, and then the store is asked separately. The verdict
+ * is a model grading a model and catches the conversation going off the rails;
+ * the store assertions are deterministic and catch the two failures above,
+ * which the verdict alone cannot — a persuaded actor and an unchanged database
+ * is exactly the bug.
+ *
+ * Note what is *not* asserted: which tools ran. That was the first instinct and
+ * it is the wrong test. The user asked for a todo to be done, not for
+ * `completeTodo` to be invoked, and an assertion on the call name breaks the
+ * day the agent finds a better route to the same state. Whether the agent's
+ * sentence was *honest* about how it got there is a separate question — a grade
+ * on the run, not a check on the world — and belongs to the judge in #719.
+ *
+ * Two live models and no script, so this is `ai-live`.
+ */
+import {
+  pikkuFeature,
+  pikkuScenario,
+} from '#pikku/workflow/pikku-workflow-types.gen.js'
+
+const AGENT = 'voiceAssistantAgent'
+const TITLE = 'get lunch'
+/** Seeded, open, and nothing in the task refers to it. */
+const BYSTANDER = 'Buy groceries'
+
+export const voiceAssistantCompletesTodoScenario = pikkuScenario<
+  void,
+  { passed: true }
+>({
+  title: 'The voice assistant marks a todo done, and the store agrees',
+  description:
+    'An actor asks for a todo to be added and completed; the store is checked independently',
+  tags: ['scenario', 'voice-assistant-converse', 'ai-live'],
+  func: async (_services, _data, { scenario, actors }) => {
+    await scenario.do(
+      'the todo list is reset',
+      'todos:resetTodos',
+      {},
+      { actor: actors.shopper }
+    )
+
+    const verdict = await scenario.when(
+      'the shopper adds a todo and then asks for it to be completed',
+      'conversesWithAgent',
+      {
+        agent: AGENT,
+        // Two requests in one task, in this order, because the failure needed
+        // both: the completion has to be asked of a todo the agent itself just
+        // created, in the same conversation it could answer from memory.
+        task: `Ask the assistant to add a todo titled exactly "${TITLE}". Once it confirms, ask it to mark "${TITLE}" as done. When it asks permission to run a tool, allow it.`,
+        evaluate: `A todo titled "${TITLE}" was added, and then marked as done.`,
+      },
+      { actor: actors.shopper }
+    )
+
+    await scenario.then(
+      'the actor concludes the task succeeded',
+      'expectsActorVerdict',
+      { verdict, passed: true },
+      { actor: actors.shopper }
+    )
+    // The assertion the transcript cannot make. Absent means it was deleted
+    // instead of completed; present-but-open means nothing was called at all.
+    await scenario.then(
+      'the store holds the todo, completed',
+      'expectsTodoCompleted',
+      { title: TITLE },
+      { actor: actors.shopper }
+    )
+    // Nothing asked for this one to be touched. A destructive tool reached for
+    // by mistake lands somewhere, and it is not always on the todo named.
+    await scenario.then(
+      'the todo nobody mentioned is still there',
+      'expectsTodoTitled',
+      { title: BYSTANDER },
+      { actor: actors.shopper }
+    )
+
+    return { passed: true }
+  },
+})
+
+export const voiceAssistantConverseFeature = pikkuFeature({
+  name: 'The voice assistant is judged by the store, not by its own sentence',
+  description:
+    'A persona-driven conversation with the voice agent, checked against the records it claims to have changed',
+  tags: ['voice-assistant-converse', 'ai-live'],
+  scenarios: [voiceAssistantCompletesTodoScenario],
+})

--- a/e2e/packages/todos/src/functions/getTodo.function.ts
+++ b/e2e/packages/todos/src/functions/getTodo.function.ts
@@ -14,6 +14,7 @@ export const GetTodoOutput = z.object({
 
 export const getTodo = pikkuSessionlessFunc({
   description: 'Returns a single todo by ID',
+  readonly: true,
   input: GetTodoInput,
   output: GetTodoOutput,
   func: async ({ todoStore }, { id }) => {

--- a/e2e/packages/todos/src/functions/listTodos.function.ts
+++ b/e2e/packages/todos/src/functions/listTodos.function.ts
@@ -16,6 +16,7 @@ export const ListTodosOutput = z.object({
 
 export const listTodos = pikkuSessionlessFunc({
   description: 'Lists all todos',
+  readonly: true,
   expose: true,
   input: ListTodosInput,
   output: ListTodosOutput,

--- a/e2e/pikku.config.json
+++ b/e2e/pikku.config.json
@@ -98,6 +98,7 @@
         "appUrl": "http://localhost:4077",
         "signInPath": "/api/auth/sign-in/actor"
       }
-    }
+    },
+    "actorModel": "openai/gpt-4.1-mini"
   }
 }

--- a/e2e/src/services.ts
+++ b/e2e/src/services.ts
@@ -14,6 +14,7 @@ import { BetterAuthCredentialService } from '@pikku/better-auth'
 import { CREDENTIAL_OAUTH2_CONFIGS } from '#pikku/credentials/pikku-credentials.gen.js'
 import { CFWorkerSchemaService } from '@pikku/schema-cfworker'
 import { VercelAIAgentRunner } from '@pikku/ai-vercel'
+import { createDeepInfra } from '@pikku/ai-deepinfra'
 import { JoseJWTService } from '@pikku/jose'
 import { createOpenAI } from '@ai-sdk/openai'
 import type { KyselyPikkuDB } from '@pikku/kysely'
@@ -49,13 +50,23 @@ export const createSingletonServices = pikkuServices(
     const mockLlm = process.env.PIKKU_MOCK_LLM === '1'
     const aiAgentRunner = new VercelAIAgentRunner(
       mockLlm
-        ? await (async () => {
-            const { createMockLlmProvider } =
+        ? {
+            // '*' seals the runner: every provider name resolves to the
+            // scripted provider, so no model string can reach a real endpoint
+            // — including ones added long after this line was written. Naming
+            // the providers instead is how the suite used to break whenever an
+            // agent started using one nobody had listed here.
+            '*': (
               await import('../packages/functions/src/mock-llm/provider.js')
-            const provider = createMockLlmProvider()
-            return { mock: provider, openai: provider }
-          })()
-        : { openai: createOpenAI() }
+            ).createMockLlmProvider(),
+          }
+        : {
+            openai: createOpenAI(),
+            // DeepInfra serves the audio models. `@ai-sdk/deepinfra` covers its
+            // language models but not transcription or speech, and its audio
+            // API is not OpenAI-shaped, so this provider is the only way in.
+            deepinfra: createDeepInfra(),
+          }
     )
 
     const backend = process.env.DB_BACKEND ?? 'sqlite'

--- a/packages/cli/src/functions/commands/dev-ai-runner.ts
+++ b/packages/cli/src/functions/commands/dev-ai-runner.ts
@@ -4,20 +4,6 @@ import { pathToFileURL } from 'url'
 import type { Logger, VariablesService } from '@pikku/core/services'
 import type { AIAgentRunnerService } from '@pikku/core/services'
 
-// Provider prefixes a fabric/proxy baseURL fronts. Models are written as
-// `openai/gpt-4o-mini`, `openai/deepseek-v4-flash`, etc. — the runner splits on
-// the first `/`, so the prefix only selects the provider entry and the bare
-// model name is forwarded to the OpenAI-compatible proxy, which routes it.
-const PROXY_PROVIDER_NAMES = [
-  'openai',
-  'anthropic',
-  'google',
-  'gemini',
-  'deepseek',
-  'xai',
-  'litellm',
-]
-
 /**
  * Build the AI agent runner for `pikku dev` from env.
  *
@@ -25,10 +11,18 @@ const PROXY_PROVIDER_NAMES = [
  * has no equivalent, so agents 503 with AIProviderNotConfiguredError unless we
  * construct one here. When an OpenAI-compatible base URL + key are present
  * (fabric injects LITELLM_PROXY_URL/LITELLM_API_KEY; the standard OPENAI_*
- * vars are also honored) we point a single openai-compatible provider at it and
- * register it under every common provider prefix. Returns undefined when no AI
+ * vars are also honored) we point one provider at it and register it under
+ * `'*'`, so every provider prefix resolves to it. Returns undefined when no AI
  * env is configured (agents stay disabled, with the clear downstream error) or
  * when the AI SDK packages aren't installed in the project.
+ *
+ * Audio does not work here: `@ai-sdk/openai-compatible` exposes only
+ * language/embedding/image models, so a voice agent under `pikku dev` throws
+ * `Provider does not support transcription models`. Fixing that means the full
+ * `@ai-sdk/openai` provider, which assumes OpenAI's own request specifics — a
+ * bad default for a path whose entire purpose is fronting arbitrary gateways.
+ * If it becomes worth it, delegate just `transcription`/`speech` to the full
+ * provider and leave everything else on this one.
  */
 export async function createDevAIAgentRunner({
   logger,
@@ -84,14 +78,26 @@ export async function createDevAIAgentRunner({
     return undefined
   }
 
-  const buildProviders = (key: string): Record<string, unknown> => {
-    const provider = createOpenAICompatible({
+  // One provider under '*', so every prefix a model might name resolves to the
+  // proxy — including ones nobody thought to list. This was a hardcoded array
+  // of seven names, which silently excluded everything else.
+  //
+  // `supportsStructuredOutputs` defaults to false, and the default fails in the
+  // worst available way: an `outputSchema` is dropped, the call degrades to
+  // bare `json_object`, and the model returns well-formed JSON with whatever
+  // keys it felt like. Nothing errors — the caller reads `undefined` off every
+  // field it asked for and behaves as though the model said nothing. Anything
+  // fronting this URL that is worth calling speaks `json_schema`; the ones that
+  // do not now fail loudly on the first schema'd call, which is the outcome we
+  // want over silently ignoring the schema.
+  const buildProviders = (key: string): Record<string, unknown> => ({
+    '*': createOpenAICompatible({
       name: 'pikku-dev',
       baseURL,
       apiKey: key,
-    })
-    return Object.fromEntries(PROXY_PROVIDER_NAMES.map((name) => [name, provider]))
-  }
+      supportsStructuredOutputs: true,
+    }),
+  })
 
   logger.info(`pikku dev: AI agent runner wired to ${baseURL}`)
   return new VercelAIAgentRunner(buildProviders(apiKey), buildProviders)

--- a/packages/cli/src/functions/commands/scenario.ts
+++ b/packages/cli/src/functions/commands/scenario.ts
@@ -36,6 +36,7 @@ import { spawnDevServer } from '../../server/spawn-dev-server.js'
 import { buildScenarioPlan } from './scenario-plan.js'
 import type { ScenarioPlanGroup } from './scenario-plan.js'
 import { resolveScenarioEnvironment } from './scenario-environment.js'
+import { createDevAIAgentRunner } from './dev-ai-runner.js'
 
 const isScenario = (wf: any) => wf?.scenario === true
 
@@ -273,6 +274,7 @@ export const scenarioRun = pikkuSessionlessFunc<
       actors: scenarioActors,
       signInPath: env.signInPath,
       rpcPath: env.rpcPath,
+      model: config.scenarios?.actorModel,
     })
 
     const functionsMeta = state.functions?.meta ?? {}
@@ -352,10 +354,28 @@ export const scenarioRun = pikkuSessionlessFunc<
       appUrl: env.appUrl,
     })
     scenarioService.setRunSurface(effectiveSurface)
+
+    // Scenario steps run here, not on the target — everything they touch of the
+    // app goes over HTTP through an actor, which is what `guardRpc` below
+    // enforces. `actor.converse` is the exception, and the reason this is not
+    // just the three services above: the persona's own turns are LLM calls made
+    // in this process, and without a runner every conversing scenario fails
+    // before it says anything. Built the same way `pikku dev` builds its own,
+    // and only when the project declares agents, so a project with no agents
+    // does not have to have AI env set to run scenarios.
+    const aiAgentRunner =
+      Object.keys(state.agents?.agentsMeta ?? {}).length > 0
+        ? await createDevAIAgentRunner({
+            logger,
+            projectRoot: config.rootDir,
+            variables,
+          })
+        : undefined
     pikkuState(null, 'package', 'singletonServices', {
       logger,
       workflowService,
       workflowRunService: workflowService,
+      ...(aiAgentRunner ? { aiAgentRunner } : {}),
     } as any)
     const guardRpc = {
       rpcWithWire: async (rpcName: string) => {

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -428,6 +428,14 @@ export type PikkuCLIInput = {
      * particular browser tool. Defaults to `@pikku/playwright`.
      */
     browserDriver?: string
+    /**
+     * The model an actor thinks with in `actor.converse(...)` — its own turns,
+     * its approval decisions and its closing verdict. Not the model under test:
+     * that one belongs to the agent being conversed with, and the whole point
+     * of the exercise is that the two are different. A step can override it per
+     * conversation; with neither set, `converse` refuses rather than guessing.
+     */
+    actorModel?: string
   }
 
   scaffold?: {

--- a/packages/core/src/function/abort-scope.test.ts
+++ b/packages/core/src/function/abort-scope.test.ts
@@ -1,0 +1,97 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  AbandonedError,
+  beginChanges,
+  getAbortScope,
+  runInAbortScope,
+  type AbortScope,
+} from './abort-scope.js'
+
+describe('beginChanges', () => {
+  test('is a no-op outside a scope, so a function need not know how it was called', async () => {
+    await beginChanges()
+    assert.equal(getAbortScope(), undefined)
+  })
+
+  test('lets the mutation proceed while the caller is still there', async () => {
+    let declared = false
+    const scope: AbortScope = {
+      abandoned: false,
+      onBeginChanges: () => {
+        declared = true
+      },
+    }
+
+    let mutated = false
+    await runInAbortScope(scope, async () => {
+      await beginChanges()
+      mutated = true
+    })
+
+    assert.equal(mutated, true)
+    assert.equal(declared, true)
+  })
+
+  test('stops the mutation when the caller has gone, and reports why', async () => {
+    let mutated = false
+    const scope: AbortScope = { abandoned: true, reason: 'speech' }
+
+    await assert.rejects(
+      () =>
+        runInAbortScope(scope, async () => {
+          await beginChanges()
+          mutated = true
+        }),
+      (error: unknown) => {
+        assert.ok(error instanceof AbandonedError)
+        assert.match(error.message, /speech/)
+        return true
+      }
+    )
+
+    // The whole point: the irreversible line never ran.
+    assert.equal(mutated, false)
+  })
+
+  test('survives the await boundaries a real function has', async () => {
+    // AsyncLocalStorage is the reason this works — the checkpoint is usually
+    // several awaits deep inside helpers that never took the scope as an
+    // argument.
+    const scope: AbortScope = { abandoned: true }
+    const nestedHelper = async () => {
+      await new Promise((resolve) => setImmediate(resolve))
+      await beginChanges()
+    }
+
+    await assert.rejects(
+      () =>
+        runInAbortScope(scope, async () => {
+          await new Promise((resolve) => setImmediate(resolve))
+          return nestedHelper()
+        }),
+      AbandonedError
+    )
+  })
+
+  test('reads the scope live, so an interrupt mid-function is still caught', async () => {
+    let aborted = false
+    const scope: AbortScope = {
+      get abandoned() {
+        return aborted
+      },
+    }
+
+    await assert.rejects(
+      () =>
+        runInAbortScope(scope, async () => {
+          // Plenty of interruptible work happens before the checkpoint.
+          await new Promise((resolve) => setImmediate(resolve))
+          aborted = true
+          await beginChanges()
+        }),
+      AbandonedError
+    )
+  })
+})

--- a/packages/core/src/function/abort-scope.ts
+++ b/packages/core/src/function/abort-scope.ts
@@ -1,0 +1,80 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+/**
+ * Raised by {@link beginChanges} when the caller has gone away before anything
+ * was changed. Distinct from a failure: nothing happened, so there is nothing
+ * to report, retry or apologise for.
+ */
+export class AbandonedError extends Error {
+  constructor(reason?: string) {
+    super(
+      reason
+        ? `Aborted before making changes: ${reason}`
+        : 'Aborted before making changes'
+    )
+    this.name = 'AbandonedError'
+  }
+}
+
+export interface AbortScope {
+  /** Whether whatever asked for this work has gone away. */
+  readonly abandoned: boolean
+  /** Why, when known — an interrupt reason, a disconnect, a cancellation. */
+  readonly reason?: string
+  /** Called by `beginChanges()` once a function commits to mutating. */
+  onBeginChanges?: () => void
+}
+
+/**
+ * The ambient "is my caller still there?" signal.
+ *
+ * Ambient rather than a parameter because the question is the same one for
+ * every wiring — an agent run that was interrupted, an HTTP request whose
+ * client disconnected, a cancelled workflow — and threading it through every
+ * signature would mean changing every function that merely sits between the
+ * wiring and the mutation.
+ */
+const scopeStorage = new AsyncLocalStorage<AbortScope>()
+
+/** Run `fn` with an abort scope that `beginChanges()` will observe. */
+export const runInAbortScope = <T>(scope: AbortScope, fn: () => T): T =>
+  scopeStorage.run(scope, fn)
+
+/** The current scope, if the caller is running inside one. */
+export const getAbortScope = (): AbortScope | undefined =>
+  scopeStorage.getStore()
+
+/**
+ * Declare that everything after this line changes something.
+ *
+ * ```ts
+ * const plan = await computePlan(input)   // interruptible, costs nothing to redo
+ * await beginChanges()
+ * await db.deleteProject(input.projectId) // past the point of no return
+ * ```
+ *
+ * Two things happen here. If the caller has already gone away it throws, so the
+ * mutation never runs and the interrupt is clean — nothing happened, and the
+ * user is told nothing because there is nothing to tell. If the caller is still
+ * there it marks this call as mutating, so an interrupt landing *after* this
+ * point produces an `undelivered` note on the thread rather than silently
+ * discarding work that did happen.
+ *
+ * It throws rather than returning a boolean on purpose: `if (await ...)` invites
+ * ignoring the answer, and the failure mode of ignoring it is a mutation nobody
+ * asked for.
+ *
+ * Entirely cooperative, and safe to call anywhere — outside a scope it is a
+ * no-op, so a function does not need to know how it was invoked. A function
+ * that never calls it keeps the conservative default: if it is not marked
+ * `readonly`, an interrupt assumes it changed something and says so. The tool
+ * that forgot to call this is exactly the one that cannot be assumed harmless.
+ */
+export const beginChanges = async (): Promise<void> => {
+  const scope = scopeStorage.getStore()
+  if (!scope) return
+  if (scope.abandoned) {
+    throw new AbandonedError(scope.reason)
+  }
+  scope.onBeginChanges?.()
+}

--- a/packages/core/src/function/function-runner.ts
+++ b/packages/core/src/function/function-runner.ts
@@ -1,3 +1,4 @@
+import { beginChanges } from './abort-scope.js'
 import { runMiddleware, combineMiddleware } from '../middleware-runner.js'
 import {
   combineChannelMiddleware,
@@ -288,6 +289,13 @@ export const runPikkuFunc = async <In = any, Out = any>(
 
     if ((session as any)?.readonly && !funcMeta.readonly) {
       throw new ReadonlySessionError()
+    }
+
+    // Only mutating functions get a checkpoint. A read has nothing to declare,
+    // and offering it there would invite the contradiction of a `readonly`
+    // function announcing where its changes begin.
+    if (!funcMeta.readonly) {
+      invocationWire.beginChanges = beginChanges
     }
 
     // Scopes gate before the data is evaluated: they depend only on the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,6 +89,13 @@ export {
   parseVersionedId,
 } from './version.js'
 export { runPikkuFunc } from './function/function-runner.js'
+export {
+  AbandonedError,
+  beginChanges,
+  getAbortScope,
+  runInAbortScope,
+  type AbortScope,
+} from './function/abort-scope.js'
 export { runCLICommand, pikkuCLIRender } from './wirings/cli/cli-runner.js'
 export { fetch } from './wirings/http/http-runner.js'
 export {

--- a/packages/core/src/services/ai-agent-runner-service.ts
+++ b/packages/core/src/services/ai-agent-runner-service.ts
@@ -19,6 +19,26 @@ export type AIAgentRunnerParams = {
   /** Pikku agent function name — forwarded to the LLM proxy (LiteLLM) as
    *  request-level metadata so usage can be broken down per agent. */
   agentId?: string
+  /**
+   * Cancels the model call itself, not just delivery of its output. Set by
+   * `streamAIAgent` from the run's interrupt handle so a voice barge-in stops
+   * generation upstream rather than leaving tokens being billed into a stream
+   * nobody reads. A runner that ignores it degrades to "the caller stops
+   * listening", which is the behaviour before this field existed.
+   */
+  abortSignal?: AbortSignal
+  /**
+   * Per-provider settings passed to the model untouched — the escape hatch for
+   * anything the shared params above cannot express because only one vendor
+   * has it.
+   *
+   * The setting that motivated it is `reasoningEffort`. A voice turn is heard
+   * rather than read, so the wait before the first word is most of the
+   * experience: `{ openai: { reasoningEffort: 'minimal' } }` on gpt-5-mini
+   * measured 0.9s to first token against 2.5s at the default, and 1.6s of
+   * silence is a long time to sit through having just finished speaking.
+   */
+  providerOptions?: AIProviderOptions
 }
 
 export type AIAgentRunnerResult = {

--- a/packages/core/src/types/core.types.ts
+++ b/packages/core/src/types/core.types.ts
@@ -475,6 +475,20 @@ export type PikkuWire<
   audit: {
     durability: AuditDurability
   }
+  /**
+   * Declare that everything after this line changes something.
+   *
+   * Present only on functions that are not `readonly` — a read has nothing to
+   * declare. Throws `AbandonedError` if whatever asked for this work has
+   * already gone away (an interrupted agent run, a disconnected client), so the
+   * mutation never runs and the abort is clean. Otherwise it marks the call as
+   * mutating, so an interrupt landing after this point is reported rather than
+   * silently discarded.
+   *
+   * Cooperative: a function that never calls it is assumed to have changed
+   * something, which is the safe default.
+   */
+  beginChanges: () => Promise<void>
 }>
 
 /**

--- a/packages/core/src/wirings/actor-flow/run-conversation.ts
+++ b/packages/core/src/wirings/actor-flow/run-conversation.ts
@@ -119,6 +119,13 @@ function actorInstructions(actor: ScenarioActorConfig, task: string): string {
       : '',
     `Your goal in this conversation: ${task}.`,
     `Send one message at a time. Set "done" to true only once your goal is clearly accomplished, or clearly impossible.`,
+    // Every call the actor makes wants a schema'd object back, and a gateway
+    // that cannot take a JSON *schema* degrades to OpenAI's `json_object`
+    // mode — which refuses the request outright unless the word "json" appears
+    // somewhere in the prompt. Saying it once here covers all three call sites
+    // (turn, approvals, verdict), since each builds on these instructions, and
+    // it costs nothing on providers that never needed telling.
+    `Reply with json matching the schema you are given, and nothing else.`,
   ]
     .filter(Boolean)
     .join('\n')

--- a/packages/core/src/wirings/ai-agent/ai-agent-agui.test.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-agui.test.ts
@@ -562,8 +562,8 @@ describe('wrapChannelWithAGUI — Pikku CUSTOM events', () => {
   })
 })
 
-describe('wrapChannelWithAGUI — silently dropped events', () => {
-  it('drops audio-delta without emitting anything', () => {
+describe('wrapChannelWithAGUI — speech', () => {
+  it('forwards audio-delta as a CUSTOM event', () => {
     const { channel, events } = makeChannel()
     const wrapped = wrapChannelWithAGUI(channel)
 
@@ -573,16 +573,41 @@ describe('wrapChannelWithAGUI — silently dropped events', () => {
       format: 'mp3',
     } as AIStreamEvent)
 
-    assert.equal(events.length, 0)
+    // AG-UI has no speech event, but dropping it makes a voice agent reached
+    // over HTTP inaudible: every sentence is synthesized and billed, then
+    // thrown away here.
+    const custom = find(events, 'CUSTOM', 'pikku:audio-delta')
+    assert.ok(custom)
+    assert.deepEqual(custom.value, { data: 'base64abc', format: 'mp3' })
   })
 
-  it('drops audio-done without emitting anything', () => {
+  it('forwards audio-done as a CUSTOM event', () => {
     const { channel, events } = makeChannel()
     const wrapped = wrapChannelWithAGUI(channel)
 
     wrapped.send({ type: 'audio-done' } as AIStreamEvent)
 
-    assert.equal(events.length, 0)
+    assert.ok(find(events, 'CUSTOM', 'pikku:audio-done'))
+  })
+
+  it('leaves an open text message open, so speech cannot split a reply', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel)
+
+    wrapped.send({ type: 'text-delta', text: 'hello' } as AIStreamEvent)
+    wrapped.send({
+      type: 'audio-delta',
+      data: 'abc',
+      format: 'mp3',
+    } as AIStreamEvent)
+    wrapped.send({ type: 'text-delta', text: ' there' } as AIStreamEvent)
+
+    // Audio arrives interleaved with the text it is saying. Ending the message
+    // around it would render one reply as several.
+    const starts = events.filter(
+      (event: any) => event.type === 'TEXT_MESSAGE_START'
+    )
+    assert.equal(starts.length, 1)
   })
 })
 
@@ -1107,5 +1132,50 @@ describe('wrapChannelWithAGUI — late-bound runId', () => {
     const started = find(fallback.events, 'RUN_STARTED')
     assert.ok(started.runId)
     assert.equal(started.runId, find(fallback.events, 'RUN_FINISHED').runId)
+  })
+})
+
+describe('wrapChannelWithAGUI — interruption', () => {
+  it('closes the open text message and forwards the fragment as a custom event', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel, { threadId: 't', runId: 'r' })
+
+    wrapped.send({
+      type: 'text-delta',
+      text: 'I will delete the ',
+    } as AIStreamEvent)
+    wrapped.send({
+      type: 'interrupted',
+      runId: 'r',
+      text: 'I will delete the ',
+      reason: 'speech',
+    } as AIStreamEvent)
+
+    // Leaving TEXT_MESSAGE_END unsent would strand the assistant bubble in a
+    // streaming state that never resolves.
+    assert.ok(types(events).includes('TEXT_MESSAGE_END'))
+    const custom = find(events, 'CUSTOM', 'pikku:interrupted')
+    assert.deepEqual(custom.value, {
+      runId: 'r',
+      text: 'I will delete the ',
+      reason: 'speech',
+    })
+  })
+
+  it('still ends the run exactly once, so an interrupted run is not terminal on its own', () => {
+    const { channel, events } = makeChannel()
+    const wrapped = wrapChannelWithAGUI(channel, { threadId: 't', runId: 'r' })
+
+    wrapped.send({ type: 'text-delta', text: 'partial' } as AIStreamEvent)
+    wrapped.send({
+      type: 'interrupted',
+      runId: 'r',
+      text: 'partial',
+      reason: 'speech',
+    } as AIStreamEvent)
+    wrapped.send({ type: 'done' } as AIStreamEvent)
+
+    assert.equal(events.filter((e: any) => e.type === 'RUN_FINISHED').length, 1)
+    assert.equal(events.filter((e: any) => e.type === 'RUN_ERROR').length, 0)
   })
 })

--- a/packages/core/src/wirings/ai-agent/ai-agent-agui.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-agui.ts
@@ -371,9 +371,40 @@ export function wrapChannelWithAGUI(
           break
         }
 
-        case 'audio-delta':
-        case 'audio-done':
+        case 'interrupted': {
+          endTextMessage()
+          endThinkingMessage()
+          endStep()
+          send({
+            type: 'CUSTOM',
+            name: 'pikku:interrupted',
+            value: {
+              runId: event.runId,
+              text: event.text,
+              reason: event.reason,
+            },
+          })
           break
+        }
+
+        // AG-UI has no event for speech, so it travels as CUSTOM like the other
+        // pikku-specific ones. Dropping it instead — which is what this did —
+        // means a voice agent reached over HTTP is inaudible: `voiceOutput`
+        // synthesizes every sentence, the provider bills for it, and nothing
+        // gets past the mapper.
+        case 'audio-delta': {
+          send({
+            type: 'CUSTOM',
+            name: 'pikku:audio-delta',
+            value: { data: event.data, format: event.format },
+          })
+          break
+        }
+
+        case 'audio-done': {
+          send({ type: 'CUSTOM', name: 'pikku:audio-done', value: {} })
+          break
+        }
       }
     },
   }

--- a/packages/core/src/wirings/ai-agent/ai-agent-helpers.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-helpers.ts
@@ -1,3 +1,5 @@
+import type { AgentInterruptResult } from './ai-agent-interrupt.js'
+
 export function agent<TAgentMap extends Record<string, { output: any }>>(
   agentName: string & keyof TAgentMap
 ): { func: (services: any, data: any, wire: any) => Promise<any> } {
@@ -45,6 +47,24 @@ export function agentResume(): {
         toolCallId: data.toolCallId,
         approved: data.approved,
       })
+    },
+  }
+}
+
+export function agentInterrupt(): {
+  func: (
+    services: any,
+    data: { runId: string; reason?: 'speech' | 'user' | 'timeout' },
+    wire: any
+  ) => Promise<AgentInterruptResult>
+} {
+  return {
+    func: async (
+      _services: any,
+      data: { runId: string; reason?: 'speech' | 'user' | 'timeout' },
+      { rpc }: any
+    ) => {
+      return rpc.agent.interrupt(data.runId, data.reason)
     },
   }
 }

--- a/packages/core/src/wirings/ai-agent/ai-agent-interrupt.test.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-interrupt.test.ts
@@ -1,0 +1,837 @@
+import { beforeEach, describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { resetPikkuState, pikkuState } from '../../pikku-state.js'
+import {
+  interruptAIAgent,
+  resumeAIAgent,
+  streamAIAgent,
+} from './ai-agent-stream.js'
+import { runAIAgent, resumeAIAgentSync } from './ai-agent-runner.js'
+import {
+  AgentInterruptedError,
+  awaitPendingInterruptNote,
+  getInFlightTools,
+  isAbortError,
+  isRunInterruptible,
+  registerInterruptibleRun,
+  signalRunInterrupt,
+  trackToolExecution,
+} from './ai-agent-interrupt.js'
+import { AbandonedError, beginChanges } from '../../function/abort-scope.js'
+import type {
+  AgentRunState,
+  AIMessage,
+  AIStreamEvent,
+  CoreAIAgent,
+} from './ai-agent.types.js'
+import type {
+  AIAgentRunnerParams,
+  AIAgentStepResult,
+} from '../../services/ai-agent-runner-service.js'
+
+beforeEach(() => {
+  resetPikkuState()
+})
+
+const addTestAgent = (agentName: string) => {
+  const agent: CoreAIAgent = {
+    name: agentName,
+    description: 'test agent',
+    goal: 'be helpful',
+    model: 'test/test-model',
+  }
+  pikkuState(null, 'agent', 'agentsMeta')[agentName] = {
+    ...agent,
+    inputSchema: null,
+    outputSchema: null,
+    workingMemorySchema: null,
+  }
+  pikkuState(null, 'agent', 'agents').set(agentName, agent)
+}
+
+const abortError = () => {
+  const error = new Error('The operation was aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+/**
+ * A runner that emits one delta, has the user talk over it, and then rejects
+ * the way a fetch-based provider rejects on cancellation.
+ */
+const interruptingRunner = (getRunId: () => string | undefined) => ({
+  stream: async (
+    params: AIAgentRunnerParams,
+    channel: { send: (event: AIStreamEvent) => void }
+  ): Promise<AIAgentStepResult> => {
+    channel.send({ type: 'text-delta', text: 'I will delete the staging ' })
+    const runId = getRunId()
+    assert.ok(runId, 'run should exist before the model call')
+    assert.ok(params.abortSignal, 'the runner must receive an abort signal')
+    assert.equal(signalRunInterrupt(runId, { reason: 'speech' }), true)
+    assert.equal(params.abortSignal.aborted, true)
+    throw abortError()
+  },
+})
+
+describe('agent interruption', () => {
+  test('marks the run interrupted and reports the truncated text', async () => {
+    addTestAgent('interrupted-agent')
+
+    const updates: Array<{ runId: string; patch: unknown }> = []
+    const events: AIStreamEvent[] = []
+    let runId: string | undefined
+
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      aiAgentRunner: interruptingRunner(() => runId),
+      aiRunState: {
+        createRun: async () => 'run-interrupted',
+        updateRun: async (id: string, patch: unknown) => {
+          updates.push({ runId: id, patch })
+        },
+      },
+    } as any)
+
+    const text = await streamAIAgent(
+      'interrupted-agent',
+      {
+        message: 'delete staging',
+        threadId: 'thread-int',
+        resourceId: 'resource-int',
+      },
+      {
+        channelId: 'channel-int',
+        openingData: undefined,
+        state: 'open',
+        send: (event: AIStreamEvent) => events.push(event),
+        close: () => {},
+      } as any,
+      {},
+      undefined,
+      { onRunCreated: (id: string) => (runId = id) }
+    )
+
+    assert.equal(text, 'I will delete the staging ')
+    assert.deepEqual(updates, [
+      { runId: 'run-interrupted', patch: { status: 'interrupted' } },
+    ])
+
+    const interrupted = events.find((event) => event.type === 'interrupted')
+    assert.ok(interrupted, 'an interrupted event should reach the client')
+    assert.deepEqual(interrupted, {
+      type: 'interrupted',
+      runId: 'run-interrupted',
+      text: 'I will delete the staging ',
+      reason: 'speech',
+    })
+
+    // The client must still see exactly one terminal event, so an interrupted
+    // run closes down the same path as a clean one.
+    assert.equal(events.filter((event) => event.type === 'done').length, 1)
+    assert.equal(
+      events.some((event) => event.type === 'error'),
+      false
+    )
+  })
+
+  test('persists the truncated reply marked as interrupted', async () => {
+    addTestAgent('interrupted-persisting-agent')
+
+    const saved: AIMessage[] = []
+    let runId: string | undefined
+
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      aiAgentRunner: interruptingRunner(() => runId),
+      aiRunState: {
+        createRun: async () => 'run-persist-int',
+        updateRun: async () => {},
+      },
+      aiStorage: {
+        createThread: async () => {},
+        getMessages: async () => [],
+        saveMessages: async (_threadId: string, messages: AIMessage[]) => {
+          saved.push(...messages)
+        },
+      },
+    } as any)
+
+    await streamAIAgent(
+      'interrupted-persisting-agent',
+      {
+        message: 'delete staging',
+        threadId: 'thread-persist-int',
+        resourceId: 'resource-persist-int',
+      },
+      {
+        channelId: 'channel-persist-int',
+        openingData: undefined,
+        state: 'open',
+        send: () => {},
+        close: () => {},
+      } as any,
+      {},
+      undefined,
+      { onRunCreated: (id: string) => (runId = id) }
+    )
+
+    const assistant = saved.find((message) => message.role === 'assistant')
+    assert.ok(assistant, 'the partial reply should be persisted, not dropped')
+    assert.equal(assistant.content, 'I will delete the staging ')
+    assert.equal(
+      assistant.interrupted,
+      true,
+      'the fragment must be marked so the next turn can tell it apart from a finished reply'
+    )
+  })
+
+  test('releases the run once it ends, so a late interrupt is a no-op', async () => {
+    addTestAgent('released-agent')
+
+    let runId: string | undefined
+
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      aiAgentRunner: {
+        stream: async (): Promise<AIAgentStepResult> => ({
+          text: 'done',
+          toolCalls: [],
+          toolResults: [],
+          usage: { inputTokens: 0, outputTokens: 0 },
+          finishReason: 'stop',
+        }),
+      },
+      aiRunState: {
+        createRun: async () => 'run-released',
+        updateRun: async () => {},
+      },
+    } as any)
+
+    await streamAIAgent(
+      'released-agent',
+      { message: 'hi', threadId: 't', resourceId: 'r' },
+      {
+        channelId: 'c',
+        openingData: undefined,
+        state: 'open',
+        send: () => {},
+        close: () => {},
+      } as any,
+      {},
+      undefined,
+      { onRunCreated: (id: string) => (runId = id) }
+    )
+
+    assert.ok(runId)
+    assert.equal(isRunInterruptible(runId), false)
+    // Racing a run that finishes on its own is the normal case in voice, so it
+    // must report "nothing to interrupt" rather than throw.
+    assert.equal(signalRunInterrupt(runId), false)
+  })
+
+  test('recognises provider cancellation errors as aborts, not failures', () => {
+    assert.equal(isAbortError(abortError()), true)
+    assert.equal(isAbortError(new Error('stream failed')), false)
+  })
+})
+
+/** Register a pikku function so an agent can call it by name as a tool. */
+const addTestTool = (
+  agentName: string,
+  toolName: string,
+  func: () => Promise<unknown>
+) => {
+  pikkuState(null, 'function', 'functions').set(toolName, { func })
+  pikkuState(null, 'function', 'meta')[toolName] = {
+    pikkuFuncName: toolName,
+    description: `${toolName} tool`,
+    services: [],
+    // The tool runs as an RPC, which refuses a sessionful function without a
+    // session; this test is about interruption, not auth.
+    sessionless: true,
+  } as any
+  // Unnamespaced tools resolve name → funcId through the RPC registry first;
+  // without this the tool is silently dropped as a missing RPC.
+  pikkuState(null, 'rpc', 'meta')[toolName] = toolName
+  const tools = [toolName]
+  pikkuState(null, 'agent', 'agents').get(agentName)!.tools = tools
+  pikkuState(null, 'agent', 'agentsMeta')[agentName]!.tools = tools
+}
+
+describe('tool results that outlive an interrupt', () => {
+  test('a tool still running when the user cuts in is kept, not dropped', async () => {
+    addTestAgent('tool-interrupt-agent')
+
+    const saved: AIMessage[] = []
+    let runId: string | undefined
+    let releaseTool: (value: string) => void
+    const toolFinished = new Promise<string>((resolve) => {
+      releaseTool = resolve
+    })
+    addTestTool('tool-interrupt-agent', 'deploy', () => toolFinished)
+
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      aiAgentRunner: {
+        stream: async (
+          params: AIAgentRunnerParams,
+          channel: { send: (event: AIStreamEvent) => void }
+        ): Promise<AIAgentStepResult> => {
+          // The agent kicks off a deploy and starts narrating it; the user talks
+          // over the narration while the deploy is still running.
+          const tool = params.tools[0]
+          assert.ok(tool, 'the agent should expose its deploy tool')
+          const call = tool.execute({ env: 'staging' })
+          channel.send({ type: 'text-delta', text: 'Deploying to ' })
+          assert.equal(signalRunInterrupt(runId!, { reason: 'speech' }), true)
+          releaseTool('deployed 3 services')
+          await call
+          throw abortError()
+        },
+      },
+      aiRunState: {
+        createRun: async () => 'run-tool-int',
+        updateRun: async () => {},
+      },
+      aiStorage: {
+        createThread: async () => {},
+        getMessages: async () => [],
+        saveMessages: async (_threadId: string, messages: AIMessage[]) => {
+          saved.push(...messages)
+        },
+      },
+    } as any)
+
+    await streamAIAgent(
+      'tool-interrupt-agent',
+      { message: 'deploy staging', threadId: 'thread-tool', resourceId: 'r' },
+      {
+        channelId: 'c',
+        openingData: undefined,
+        state: 'open',
+        send: () => {},
+        close: () => {},
+      } as any,
+      {},
+      undefined,
+      { onRunCreated: (id: string) => (runId = id) }
+    )
+
+    // The stream deliberately does not await the write, so the next run on this
+    // thread is what waits for it — exercise that path rather than sleeping.
+    await awaitPendingInterruptNote('thread-tool')
+
+    const note = saved.find((message) => message.role === 'tool')
+    assert.ok(note, 'the settled tool result must reach the thread')
+    assert.equal(
+      note.undelivered,
+      true,
+      'the model never described this result, and the next turn has to know that'
+    )
+    assert.equal(note.toolResults?.[0]?.name, 'deploy')
+    assert.match(String(note.toolResults?.[0]?.result), /deployed 3 services/)
+  })
+
+  test('reports what is in flight without offering to undo it', async () => {
+    const handle = registerInterruptibleRun('run-inflight')
+    let finish: () => void
+    const running = new Promise<void>((resolve) => {
+      finish = resolve
+    })
+    const tracked = handle.trackTool('deploy', 'tc-1', () => running)
+
+    assert.deepEqual(getInFlightTools('run-inflight'), ['deploy'])
+    signalRunInterrupt('run-inflight', { reason: 'speech' })
+    finish!()
+    await tracked
+
+    assert.deepEqual(await handle.settle(), [
+      { toolCallId: 'tc-1', toolName: 'deploy', result: undefined },
+    ])
+    assert.deepEqual(getInFlightTools('run-inflight'), [])
+    handle.release()
+  })
+
+  test('a tool that bails at its own checkpoint leaves nothing to report', async () => {
+    const handle = registerInterruptibleRun('run-declared')
+    const tools = trackToolExecution(
+      [
+        {
+          name: 'deploy',
+          execute: async () => {
+            // Interruptible work first, then the point of no return.
+            await new Promise((resolve) => setImmediate(resolve))
+            await beginChanges()
+            return 'deployed'
+          },
+        },
+      ],
+      handle
+    )
+
+    signalRunInterrupt('run-declared', { reason: 'speech' })
+    await assert.rejects(() => tools[0]!.execute({}), AbandonedError)
+
+    // Nothing was changed, so there is nothing to tell the user — reporting
+    // "it aborted" is exactly the noise the checkpoint exists to remove.
+    assert.deepEqual(await handle.settle(), [])
+    handle.release()
+  })
+
+  test('a mutating tool with no checkpoint is still reported', async () => {
+    const handle = registerInterruptibleRun('run-undeclared')
+    let finish: (value: string) => void
+    const work = new Promise<string>((resolve) => {
+      finish = resolve
+    })
+    const tools = trackToolExecution(
+      [{ name: 'deploy', execute: () => work }],
+      handle
+    )
+
+    const call = tools[0]!.execute({})
+    signalRunInterrupt('run-undeclared', { reason: 'speech' })
+    finish!('deployed 3 services')
+    await call
+
+    // The tool that never declared a checkpoint is the one that cannot be
+    // assumed harmless, so the default has to fail toward telling the user.
+    const orphaned = await handle.settle()
+    assert.equal(orphaned.length, 1)
+    assert.equal(orphaned[0]!.toolName, 'deploy')
+    assert.equal(orphaned[0]!.result, 'deployed 3 services')
+    handle.release()
+  })
+
+  test('an interrupted read is discarded rather than reported', async () => {
+    const handle = registerInterruptibleRun('run-read')
+    let finish: (value: string) => void
+    const reading = new Promise<string>((resolve) => {
+      finish = resolve
+    })
+    const tracked = handle.trackTool('lookup', 'tc-3', () => reading, {
+      collectResult: false,
+    })
+
+    signalRunInterrupt('run-read', { reason: 'speech' })
+    finish!('weather: sunny')
+    await tracked
+
+    // Nothing changed, so there is nothing to tell the user about — and by the
+    // next turn this answer may be wrong anyway.
+    assert.deepEqual(await handle.settle(), [])
+    handle.release()
+  })
+
+  test('a tool that settles before the interrupt is not orphaned', async () => {
+    const handle = registerInterruptibleRun('run-quick')
+    await handle.trackTool('lookup', 'tc-2', async () => 'done')
+    signalRunInterrupt('run-quick', { reason: 'speech' })
+
+    assert.deepEqual(await handle.settle(), [])
+    handle.release()
+  })
+})
+
+/**
+ * The non-streaming path (`rpc.agent.run` / `rpc.agent.approve`) creates runs
+ * through the same `aiRunState`, so `interruptAIAgent` resolves and authorizes
+ * them either way. If it did not also register an abort controller, that call
+ * would pass the ownership check, fail to stop anything, and — because the run
+ * is still marked `running` — report it as executing on another instance.
+ */
+describe('non-streaming agent interruption', () => {
+  const logger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }
+
+  const interruptingSyncRunner = (runId: string) => ({
+    run: async (params: AIAgentRunnerParams): Promise<AIAgentStepResult> => {
+      assert.ok(params.abortSignal, 'the runner must receive an abort signal')
+      assert.equal(
+        isRunInterruptible(runId),
+        true,
+        'the run must be reachable by runId while the model call is in flight'
+      )
+      assert.equal(signalRunInterrupt(runId, { reason: 'speech' }), true)
+      assert.equal(params.abortSignal.aborted, true)
+      throw abortError()
+    },
+  })
+
+  test('runAIAgent reports an interrupt as an interrupt, not a failure', async () => {
+    addTestAgent('sync-agent')
+
+    const updates: unknown[] = []
+    pikkuState(null, 'package', 'singletonServices', {
+      logger,
+      aiAgentRunner: interruptingSyncRunner('run-sync-int'),
+      aiRunState: {
+        createRun: async () => 'run-sync-int',
+        updateRun: async (_runId: string, patch: unknown) => {
+          updates.push(patch)
+        },
+      },
+    } as any)
+
+    await assert.rejects(
+      () =>
+        runAIAgent(
+          'sync-agent',
+          { message: 'delete staging', threadId: 't', resourceId: 'r' },
+          {}
+        ),
+      (error: unknown) => {
+        assert.ok(error instanceof AgentInterruptedError)
+        assert.equal(error.runId, 'run-sync-int')
+        assert.deepEqual(error.interruption, { reason: 'speech' })
+        return true
+      }
+    )
+
+    // No `failed` and no `errorMessage`: a cancelled run is not an outage, and
+    // anything reading run history to page someone must be able to tell.
+    assert.deepEqual(updates, [{ status: 'interrupted' }])
+    assert.equal(isRunInterruptible('run-sync-int'), false)
+  })
+
+  test('releases a clean non-streaming run', async () => {
+    addTestAgent('sync-clean-agent')
+
+    pikkuState(null, 'package', 'singletonServices', {
+      logger,
+      aiAgentRunner: {
+        run: async (): Promise<AIAgentStepResult> => ({
+          text: 'done',
+          toolCalls: [],
+          toolResults: [],
+          usage: { inputTokens: 0, outputTokens: 0 },
+          finishReason: 'stop',
+        }),
+      },
+      aiRunState: {
+        createRun: async () => 'run-sync-clean',
+        updateRun: async () => {},
+      },
+    } as any)
+
+    await runAIAgent(
+      'sync-clean-agent',
+      { message: 'hi', threadId: 't', resourceId: 'r' },
+      {}
+    )
+    assert.equal(isRunInterruptible('run-sync-clean'), false)
+  })
+
+  test('a resumed run is interruptible on its own terms', async () => {
+    addTestAgent('sync-resume-agent')
+
+    const run: AgentRunState = {
+      runId: 'run-sync-resume',
+      agentName: 'sync-resume-agent',
+      threadId: 'thread-sync-resume',
+      resourceId: 'resource-sync-resume',
+      status: 'suspended',
+      suspendReason: 'approval',
+      pendingApprovals: [],
+      usage: { inputTokens: 0, outputTokens: 0, model: 'test/test-model' },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+
+    const updates: unknown[] = []
+    pikkuState(null, 'package', 'singletonServices', {
+      logger,
+      aiAgentRunner: interruptingSyncRunner('run-sync-resume'),
+      aiRunState: {
+        getRun: async () => run,
+        createRun: async () => 'unused',
+        updateRun: async (_runId: string, patch: unknown) => {
+          updates.push(patch)
+        },
+        resolveApproval: async () => {},
+      },
+    } as any)
+
+    await assert.rejects(
+      () => resumeAIAgentSync('run-sync-resume', [], {}),
+      (error: unknown) => error instanceof AgentInterruptedError
+    )
+
+    // `running` is set on the way in; the interrupt is the last word.
+    assert.deepEqual(updates.at(-1), { status: 'interrupted' })
+    assert.equal(isRunInterruptible('run-sync-resume'), false)
+  })
+})
+
+describe('streaming resume interruption', () => {
+  /**
+   * The turn after an approval is where a voice agent does most of its
+   * talking — "done, I deleted it, and while I was there…" — so it is at least
+   * as likely to be talked over as the first one. It went unregistered for a
+   * while, which made it silently uninterruptible: the interrupt call found no
+   * handle and reported nothing to stop.
+   */
+  test('a resumed stream can be talked over like any other', async () => {
+    addTestAgent('resume-stream-agent')
+    // The resume path validates the approved call against the agent's tools.
+    addTestTool('resume-stream-agent', 'deleteTodo', async () => ({
+      success: true,
+    }))
+
+    const run: AgentRunState = {
+      runId: 'run-stream-resume',
+      agentName: 'resume-stream-agent',
+      threadId: 'thread-stream-resume',
+      resourceId: 'resource-stream-resume',
+      status: 'suspended',
+      suspendReason: 'approval',
+      pendingApprovals: [
+        {
+          toolCallId: 'call-1',
+          toolName: 'deleteTodo',
+          args: {},
+          reason: 'Delete the todo called "Buy milk"',
+        } as any,
+      ],
+      usage: { inputTokens: 0, outputTokens: 0, model: 'test/test-model' },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+
+    const updates: unknown[] = []
+    const events: AIStreamEvent[] = []
+
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      aiAgentRunner: interruptingRunner(() => run.runId),
+      aiRunState: {
+        getRun: async () => run,
+        createRun: async () => run.runId,
+        updateRun: async (_runId: string, patch: unknown) => {
+          updates.push(patch)
+        },
+        // Clearing it is what lets the resume continue rather than sit waiting
+        // for approvals that have already been given.
+        resolveApproval: async () => {
+          run.pendingApprovals = []
+        },
+      },
+    } as any)
+
+    await resumeAIAgent(
+      { runId: run.runId, toolCallId: 'call-1', approved: true },
+      {
+        channelId: 'channel-resume',
+        openingData: undefined,
+        state: 'open',
+        send: (event: AIStreamEvent) => events.push(event),
+        close: () => {},
+      } as any,
+      {}
+    )
+
+    // Recorded as interrupted, not failed: nothing went wrong.
+    assert.deepEqual(updates.at(-1), { status: 'interrupted' })
+
+    const interrupted = events.find((event) => event.type === 'interrupted')
+    assert.ok(interrupted, 'the resumed stream should report the interrupt')
+    assert.equal((interrupted as any).reason, 'speech')
+    assert.equal((interrupted as any).text, 'I will delete the staging ')
+
+    // No `error` event — that would send the client down the failure path for
+    // something the user did on purpose.
+    assert.equal(
+      events.some((event) => event.type === 'error'),
+      false
+    )
+    assert.equal(isRunInterruptible(run.runId), false)
+  })
+})
+
+describe('interruptAIAgent authorization', () => {
+  const withRun = (run: Record<string, unknown> | null) => {
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      aiRunState: { getRun: async () => run },
+    } as any)
+  }
+
+  const session = (userId: string) => ({
+    sessionService: { get: () => ({ userId }) },
+  })
+
+  test('refuses a run owned by someone else', async () => {
+    addTestAgent('owned-agent')
+    withRun({
+      runId: 'run-alice',
+      agentName: 'owned-agent',
+      resourceId: 'alice:thread-1',
+      status: 'running',
+    })
+
+    const handle = registerInterruptibleRun('run-alice')
+    await assert.rejects(
+      () => interruptAIAgent({ runId: 'run-alice' }, session('mallory') as any),
+      /Not authorized to access this run/
+    )
+    // The gate has to hold before the abort, not after it.
+    assert.equal(handle.signal.aborted, false)
+    handle.release()
+  })
+
+  test('refuses a lookalike principal rather than prefix-matching it', async () => {
+    addTestAgent('lookalike-agent')
+    withRun({
+      runId: 'run-alice-2',
+      agentName: 'lookalike-agent',
+      resourceId: 'alice-evil:thread-1',
+      status: 'running',
+    })
+
+    const handle = registerInterruptibleRun('run-alice-2')
+    await assert.rejects(
+      () => interruptAIAgent({ runId: 'run-alice-2' }, session('alice') as any),
+      /Not authorized to access this run/
+    )
+    assert.equal(handle.signal.aborted, false)
+    handle.release()
+  })
+
+  test('stops a run the caller owns', async () => {
+    addTestAgent('mine-agent')
+    withRun({
+      runId: 'run-mine',
+      agentName: 'mine-agent',
+      resourceId: 'alice:thread-1',
+      status: 'running',
+    })
+
+    const handle = registerInterruptibleRun('run-mine')
+    const result = await interruptAIAgent(
+      { runId: 'run-mine', reason: 'speech' },
+      session('alice') as any
+    )
+    assert.deepEqual(result, { stopped: true, inFlightTools: [] })
+    assert.equal(handle.signal.aborted, true)
+    assert.deepEqual(handle.interruption, { reason: 'speech' })
+    handle.release()
+  })
+
+  test('reports false rather than throwing when the run already finished', async () => {
+    addTestAgent('finished-agent')
+    withRun({
+      runId: 'run-finished',
+      agentName: 'finished-agent',
+      resourceId: 'alice:thread-1',
+      status: 'completed',
+    })
+
+    assert.deepEqual(
+      await interruptAIAgent(
+        { runId: 'run-finished' },
+        session('alice') as any
+      ),
+      { stopped: false, inFlightTools: [] }
+    )
+  })
+
+  test('warns instead of failing silently when the run is on another instance', async () => {
+    addTestAgent('remote-agent')
+    const warnings: string[] = []
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: {
+        info: () => {},
+        warn: (message: string) => warnings.push(message),
+        error: () => {},
+        debug: () => {},
+      },
+      aiRunState: {
+        getRun: async () => ({
+          runId: 'run-elsewhere',
+          agentName: 'remote-agent',
+          resourceId: 'alice:thread-1',
+          // Still running, but never registered here — i.e. another process.
+          status: 'running',
+        }),
+      },
+    } as any)
+
+    assert.deepEqual(
+      await interruptAIAgent(
+        { runId: 'run-elsewhere' },
+        session('alice') as any
+      ),
+      { stopped: false, inFlightTools: [] }
+    )
+    assert.equal(warnings.length, 1)
+    assert.match(warnings[0]!, /running in another process/)
+  })
+
+  test('stays quiet when the run simply finished', async () => {
+    addTestAgent('done-agent')
+    const warnings: string[] = []
+    pikkuState(null, 'package', 'singletonServices', {
+      logger: {
+        info: () => {},
+        warn: (message: string) => warnings.push(message),
+        error: () => {},
+        debug: () => {},
+      },
+      aiRunState: {
+        getRun: async () => ({
+          runId: 'run-done',
+          agentName: 'done-agent',
+          resourceId: 'alice:thread-1',
+          status: 'completed',
+        }),
+      },
+    } as any)
+
+    await interruptAIAgent({ runId: 'run-done' }, session('alice') as any)
+    assert.deepEqual(warnings, [])
+  })
+
+  test('rejects an unknown runId', async () => {
+    withRun(null)
+    await assert.rejects(
+      () => interruptAIAgent({ runId: 'nope' }, session('alice') as any),
+      /No run found for runId nope/
+    )
+  })
+})

--- a/packages/core/src/wirings/ai-agent/ai-agent-interrupt.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-interrupt.ts
@@ -1,0 +1,399 @@
+import { randomUUID } from './ai-agent-utils.js'
+import {
+  AbandonedError,
+  runInAbortScope,
+  type AbortScope,
+} from '../../function/abort-scope.js'
+import type { AIStorageService } from '../../services/ai-storage-service.js'
+
+/**
+ * Why an in-flight agent run was cut short.
+ *
+ * Deliberately carries no interjection text. A voice interruption is not a
+ * cancel button — it is the user starting to talk — but what they said arrives
+ * a second later as an ordinary next turn on the same thread, and that turn
+ * already has a working path through `streamAIAgent`. The model then sees its
+ * own truncated message (marked `interrupted`) followed by the interjection and
+ * decides for itself whether to resume, correct itself or drop the thread.
+ * Nothing here classifies the interjection; a second delivery path for the same
+ * text would only give the two ways to disagree about ordering.
+ */
+export interface AgentInterruption {
+  /** `'speech'` — the user started talking over the agent (voice barge-in).
+   *  `'user'` — an explicit stop (a button). `'timeout'` — a caller-side deadline. */
+  reason: 'speech' | 'user' | 'timeout'
+}
+
+/**
+ * Thrown out of the step loop when a run is interrupted, so an interruption is
+ * distinguishable from a genuine failure at the one `catch` that would
+ * otherwise mark the run `failed`.
+ */
+export class AgentInterruptedError extends Error {
+  constructor(
+    public readonly runId: string,
+    public readonly interruption: AgentInterruption
+  ) {
+    super(`Agent run ${runId} interrupted (${interruption.reason})`)
+    this.name = 'AgentInterruptedError'
+  }
+}
+
+/**
+ * A tool call that settled after its run was interrupted, so its result never
+ * reached the model.
+ *
+ * These are not failures, and they are only ever mutations. The tool ran, its
+ * side effect happened, and the only thing the interrupt cost was the reply
+ * describing it — so the result is worth mentioning on the next turn. Reads are
+ * excluded at the call site: nothing changed, so there is nothing to account
+ * for, and a stale answer is worse than re-reading.
+ */
+export interface OrphanedToolResult {
+  toolCallId: string
+  toolName: string
+  result: unknown
+  /** Set instead of `result` when the tool threw after the interrupt. */
+  error?: string
+}
+
+/** What an authorized interrupt actually achieved. */
+export interface AgentInterruptResult {
+  /**
+   * Whether a generating run was stopped. `false` is routine, not an error:
+   * racing a run that finishes on its own is the normal case in voice.
+   */
+  stopped: boolean
+  /**
+   * Tools that were still executing when the interrupt landed. Their side
+   * effects have already happened and cannot be undone from here — this is for
+   * saying something true ("the deploy is still going"), not for offering to
+   * roll it back. Each will surface as an `undelivered` tool message on the
+   * thread once it settles.
+   */
+  inFlightTools: string[]
+}
+
+export interface InterruptibleRunHandle {
+  readonly signal: AbortSignal
+  /** Set at the moment the run is interrupted; `undefined` on a clean run. */
+  readonly interruption: AgentInterruption | undefined
+  /** Names of tools executing right now — what an interrupt would talk over. */
+  readonly inFlightTools: string[]
+  /**
+   * Wrap a tool execution so it survives an interrupt. Before the interrupt
+   * this is a pass-through; after one, the settled value is collected as an
+   * {@link OrphanedToolResult} rather than vanishing with the aborted stream.
+   */
+  trackTool<T>(
+    toolName: string,
+    toolCallId: string,
+    exec: () => Promise<T>,
+    opts?: { collectResult?: boolean }
+  ): Promise<T>
+  /**
+   * Resolves once every tool still running at the moment of the interrupt has
+   * settled, with the results the model never got to see.
+   *
+   * Deliberately not awaited before the stream closes: barge-in has to stop the
+   * agent talking immediately, and a tool holding that up for its own duration
+   * is the one thing voice cannot tolerate.
+   */
+  settle(timeoutMs?: number): Promise<OrphanedToolResult[]>
+  release(): void
+}
+
+type Entry = {
+  controller: AbortController
+  interruption?: AgentInterruption
+  inFlight: Map<string, string>
+  orphaned: OrphanedToolResult[]
+  pending: Set<Promise<void>>
+}
+
+/**
+ * Live runs, keyed by runId.
+ *
+ * Module-level rather than `pikkuState` because the value is an
+ * `AbortController` — a process-local object that cannot be serialised or
+ * shared. That is also this registry's limit: an interrupt only reaches a run
+ * executing in the same process. Single-process and channel-attached callers
+ * (where the interrupt arrives on the socket already carrying the run) are
+ * covered; a horizontally-scaled deployment interrupting over a *separate* HTTP
+ * request needs the interrupt fanned out over `eventHub` to every instance
+ * first, with each instance calling `signalRunInterrupt` locally.
+ */
+const runs = new Map<string, Entry>()
+
+/**
+ * Make a run interruptible for the duration of its stream. The returned signal
+ * is threaded into the model call, so an interrupt cancels the upstream HTTP
+ * request rather than merely stopping delivery of tokens we are still paying
+ * for.
+ */
+export const registerInterruptibleRun = (
+  runId: string
+): InterruptibleRunHandle => {
+  const entry: Entry = {
+    controller: new AbortController(),
+    inFlight: new Map(),
+    orphaned: [],
+    pending: new Set(),
+  }
+  runs.set(runId, entry)
+  return {
+    signal: entry.controller.signal,
+    get interruption() {
+      return entry.interruption
+    },
+    get inFlightTools() {
+      return [...entry.inFlight.values()]
+    },
+    trackTool: async <T>(
+      toolName: string,
+      toolCallId: string,
+      exec: () => Promise<T>,
+      opts?: { collectResult?: boolean }
+    ): Promise<T> => {
+      entry.inFlight.set(toolCallId, toolName)
+      const call = exec()
+      // Tracked separately from the returned promise so an interrupt can wait
+      // on the tool without the caller's rejection becoming an unhandled one.
+      const tracked = call.then(
+        (result) => {
+          entry.inFlight.delete(toolCallId)
+          // Read now rather than at call time: a tool that uses
+          // `beginChanges()` only reveals partway through whether it mutated.
+          if (
+            (opts?.collectResult ?? true) &&
+            entry.controller.signal.aborted
+          ) {
+            entry.orphaned.push({ toolCallId, toolName, result })
+          }
+        },
+        (err: unknown) => {
+          entry.inFlight.delete(toolCallId)
+          // A tool that stopped *at* its own checkpoint changed nothing by
+          // construction, so it never files a note — reporting "it aborted"
+          // is exactly the noise `beginChanges()` exists to remove.
+          if (err instanceof AbandonedError) return
+          if (
+            (opts?.collectResult ?? true) &&
+            entry.controller.signal.aborted
+          ) {
+            entry.orphaned.push({
+              toolCallId,
+              toolName,
+              result: undefined,
+              error: err instanceof Error ? err.message : String(err),
+            })
+          }
+        }
+      )
+      entry.pending.add(tracked)
+      void tracked.finally(() => entry.pending.delete(tracked))
+      return call
+    },
+    settle: async (timeoutMs = 30_000): Promise<OrphanedToolResult[]> => {
+      if (entry.pending.size > 0) {
+        // A tool that never settles must not strand the note forever; whatever
+        // has landed by the deadline is what gets reported.
+        let timer: ReturnType<typeof setTimeout> | undefined
+        await Promise.race([
+          Promise.all([...entry.pending]),
+          new Promise<void>((resolve) => {
+            timer = setTimeout(resolve, timeoutMs)
+          }),
+        ])
+        if (timer) clearTimeout(timer)
+      }
+      return entry.orphaned
+    },
+    release: () => {
+      if (runs.get(runId) === entry) runs.delete(runId)
+    },
+  }
+}
+
+/**
+ * Stop a run that is generating right now.
+ *
+ * Plumbing: this performs NO authorization, so anyone holding a runId can stop
+ * it. Reach for {@link interruptAIAgent} instead unless the caller has already
+ * established that the run belongs to the session — which in practice means
+ * only the runner itself and code already inside an authorized run.
+ *
+ * Returns `false` when the run is not in flight in this process — already
+ * finished, never started, or running elsewhere — which callers should treat as
+ * "nothing to interrupt", not as an error: racing a run that finishes on its own
+ * is the normal case in voice.
+ */
+export const signalRunInterrupt = (
+  runId: string,
+  interruption: AgentInterruption = { reason: 'user' }
+): boolean => {
+  const entry = runs.get(runId)
+  if (!entry || entry.controller.signal.aborted) return false
+  entry.interruption = interruption
+  entry.controller.abort()
+  return true
+}
+
+/** Whether a run is currently interruptible in this process. */
+export const isRunInterruptible = (runId: string): boolean => runs.has(runId)
+
+/**
+ * Tools executing in a run right now. Empty for a run that is merely
+ * generating, or one this process does not hold.
+ *
+ * Callers use this to say something true about work that outlives the reply —
+ * "that deploy is still going" — rather than to offer to stop it. By the time a
+ * tool is executing its side effect has already happened, and pikku functions
+ * receive no abort signal, so there is nothing left to cancel.
+ */
+export const getInFlightTools = (runId: string): string[] => {
+  const entry = runs.get(runId)
+  return entry ? [...entry.inFlight.values()] : []
+}
+
+/**
+ * Wrap tool definitions so their results survive an interrupt.
+ *
+ * Applied by the runner after the handle exists rather than in `buildToolDefs`,
+ * which builds tools before there is a runId to attach them to.
+ */
+export const trackToolExecution = <
+  T extends {
+    name: string
+    readonly?: boolean
+    execute: (input: any) => Promise<any>
+  },
+>(
+  tools: T[],
+  handle: InterruptibleRunHandle
+): T[] =>
+  tools.map((tool) => {
+    // Reads run outside the scope entirely: they never produce a note and have
+    // nothing to declare, so `beginChanges()` inside one is a no-op rather than
+    // a contradiction to resolve.
+    if (tool.readonly) {
+      return {
+        ...tool,
+        execute: (input: unknown) =>
+          handle.trackTool(tool.name, randomUUID(), () => tool.execute(input), {
+            collectResult: false,
+          }),
+      }
+    }
+
+    return {
+      ...tool,
+      execute: (input: unknown) => {
+        // Assumed to have changed something unless it says otherwise — the tool
+        // that never declares its checkpoint is the one that cannot be assumed
+        // harmless. `beginChanges()` can only ever make this more precise.
+        const call = { mutating: true }
+        const scope: AbortScope = {
+          get abandoned() {
+            return handle.signal.aborted
+          },
+          get reason() {
+            return handle.interruption?.reason
+          },
+          onBeginChanges: () => {
+            call.mutating = true
+          },
+        }
+        return handle.trackTool(
+          tool.name,
+          randomUUID(),
+          () => runInAbortScope(scope, () => tool.execute(input)),
+          {
+            get collectResult() {
+              return call.mutating
+            },
+          }
+        )
+      },
+    }
+  })
+
+/**
+ * Threads with an interrupted tool call still settling.
+ *
+ * The note describing that result has to be in the thread before the turn that
+ * ought to mention it loads its context, and the user's next sentence usually
+ * arrives well inside a slow tool. Runs await this for their own thread first,
+ * so the ordering holds without the interrupt itself blocking on anything.
+ */
+const pendingNotes = new Map<string, Promise<void>>()
+
+export const trackInterruptNote = (
+  threadId: string,
+  write: Promise<void>
+): void => {
+  const done = write.finally(() => {
+    if (pendingNotes.get(threadId) === done) pendingNotes.delete(threadId)
+  })
+  pendingNotes.set(threadId, done)
+}
+
+/** Await an interrupted tool result still being written to this thread. */
+export const awaitPendingInterruptNote = async (
+  threadId: string
+): Promise<void> => {
+  await pendingNotes.get(threadId)
+}
+
+/**
+ * Write the results of tools that were still running when a run was cut off.
+ *
+ * Saved as an ordinary tool message so it reaches the model through the same
+ * context load as everything else — there is no separate "notes" channel to
+ * keep in sync, and storage that drops the `undelivered` flag still keeps the
+ * result itself.
+ *
+ * Callers should hand this to {@link trackInterruptNote} rather than awaiting
+ * it: an interrupt has to end the reply immediately, and a slow tool must not
+ * hold that up.
+ */
+export const persistOrphanedToolResults = async (
+  handle: InterruptibleRunHandle,
+  storage: AIStorageService,
+  threadId: string
+): Promise<void> => {
+  let orphaned: OrphanedToolResult[]
+  try {
+    orphaned = await handle.settle()
+  } finally {
+    handle.release()
+  }
+  if (orphaned.length === 0) return
+  await storage.saveMessages(threadId, [
+    {
+      id: randomUUID(),
+      role: 'tool',
+      toolResults: orphaned.map((entry) => ({
+        id: entry.toolCallId,
+        name: entry.toolName,
+        result: entry.error
+          ? `Error: ${entry.error}`
+          : typeof entry.result === 'string'
+            ? entry.result
+            : JSON.stringify(entry.result),
+      })),
+      undelivered: true,
+      createdAt: new Date(),
+    },
+  ])
+}
+
+/**
+ * Whether a thrown value is an abort rather than a failure. The AI SDK
+ * surfaces cancellation as a DOMException/Error named `AbortError`, so the
+ * name is the only portable signal — there is no shared error class to
+ * `instanceof` against across fetch, undici and the provider SDKs.
+ */
+export const isAbortError = (err: unknown): boolean =>
+  err instanceof Error &&
+  (err.name === 'AbortError' || err.name === 'TimeoutError')

--- a/packages/core/src/wirings/ai-agent/ai-agent-prepare.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-prepare.ts
@@ -20,6 +20,7 @@ import { pikkuState, getSingletonServices } from '../../pikku-state.js'
 import { createMiddlewareSessionWireProps } from '../../services/user-session-service.js'
 import type { SessionService } from '../../services/user-session-service.js'
 import { randomUUID } from './ai-agent-utils.js'
+import { awaitPendingInterruptNote } from './ai-agent-interrupt.js'
 import { streamAIAgent } from './ai-agent-stream.js'
 import { runAIAgent } from './ai-agent-runner.js'
 import {
@@ -663,6 +664,7 @@ export async function buildToolDefs(
         inputSchema,
         needsApproval: needsApproval || undefined,
         approvalDescriptionFn,
+        readonly: fnMeta?.readonly || undefined,
         execute: async (toolInput: unknown) => {
           const wire: PikkuRawWire = params.sessionService
             ? { ...createMiddlewareSessionWireProps(params.sessionService) }
@@ -1022,6 +1024,11 @@ export async function prepareAgentRun(
 
   let messages: AIMessage[] = []
   if (storage) {
+    // A tool whose run was interrupted may still be writing its result to this
+    // thread. In voice the next turn lands within a second or two, so without
+    // this the model would load context that is missing the very thing it is
+    // about to be asked about.
+    await awaitPendingInterruptNote(threadId)
     messages = await storage.getMessages(threadId, {
       lastN: memoryConfig?.lastMessages ?? 20,
     })
@@ -1102,6 +1109,7 @@ export async function prepareAgentRun(
     tools,
     maxSteps: 1,
     toolChoice: agent.toolChoice ?? 'auto',
+    providerOptions: agent.providerOptions,
     outputSchema,
   }
 

--- a/packages/core/src/wirings/ai-agent/ai-agent-runner.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-runner.ts
@@ -34,6 +34,14 @@ import {
   type RunAIAgentParams,
 } from './ai-agent-prepare.js'
 import { checkForApprovals, appendStepMessages } from './ai-agent-stream.js'
+import {
+  AgentInterruptedError,
+  isAbortError,
+  persistOrphanedToolResults,
+  registerInterruptibleRun,
+  trackInterruptNote,
+  trackToolExecution,
+} from './ai-agent-interrupt.js'
 import { pikkuState, getSingletonServices } from '../../pikku-state.js'
 import { resolveModelConfig } from './ai-agent-model-config.js'
 import { AIProviderNotConfiguredError } from '../../errors/errors.js'
@@ -160,6 +168,14 @@ export async function runAIAgent(
     createdAt: new Date(),
     updatedAt: new Date(),
   })
+
+  // Registered on the same terms as `streamAIAgent`. A run created here is
+  // visible to `interruptAIAgent` through `aiRunState` either way, so skipping
+  // this would leave that call finding the run, passing the ownership check and
+  // then failing to stop it — reported as if it were running on another host.
+  const interruptHandle = registerInterruptibleRun(runId)
+  runnerParams.abortSignal = interruptHandle.signal
+  runnerParams.tools = trackToolExecution(runnerParams.tools, interruptHandle)
 
   try {
     const accumulatedSteps: AIAgentStep[] = []
@@ -363,6 +379,21 @@ export async function runAIAgent(
       usage: totalUsage,
     }
   } catch (error) {
+    // An interrupt is not a failure, so it skips the `onError` hooks and never
+    // becomes an `errorMessage`. Unlike the streaming path there is no partial
+    // reply to hand back — nothing was delivered — so the caller gets a typed
+    // throw it can tell apart from a provider outage instead of a result.
+    const interruption = interruptHandle.interruption
+    if (interruption || isAbortError(error)) {
+      await aiRunState.updateRun(runId, { status: 'interrupted' })
+      if (storage) {
+        trackInterruptNote(
+          threadId,
+          persistOrphanedToolResults(interruptHandle, storage, threadId)
+        )
+      }
+      throw new AgentInterruptedError(runId, interruption ?? { reason: 'user' })
+    }
     for (const mw of aiMiddlewares) {
       if (mw.onError) {
         try {
@@ -381,6 +412,8 @@ export async function runAIAgent(
       errorMessage: error instanceof Error ? error.message : String(error),
     })
     throw error
+  } finally {
+    interruptHandle.release()
   }
 }
 
@@ -624,11 +657,19 @@ async function continueAfterToolResultSync(
     tools: resumeTools,
     maxSteps: 1,
     toolChoice: (agent.toolChoice ?? 'auto') as 'auto' | 'required' | 'none',
+    providerOptions: agent.providerOptions,
     outputSchema: meta?.outputSchema
       ? pikkuState(packageName, 'misc', 'schemas').get(meta.outputSchema)
       : undefined,
     agentId: run.agentName,
   }
+
+  // A resumed run keeps its original runId, so the handle registered for the
+  // first leg is long gone — an approval that kicks off more generation has to
+  // be interruptible on its own terms.
+  const interruptHandle = registerInterruptibleRun(run.runId)
+  runnerParams.abortSignal = interruptHandle.signal
+  runnerParams.tools = trackToolExecution(runnerParams.tools, interruptHandle)
 
   try {
     const accumulatedSteps: AIAgentStep[] = []
@@ -817,6 +858,20 @@ async function continueAfterToolResultSync(
       usage: totalUsage,
     }
   } catch (error) {
+    const interruption = interruptHandle.interruption
+    if (interruption || isAbortError(error)) {
+      await aiRunState.updateRun(run.runId, { status: 'interrupted' })
+      if (storage) {
+        trackInterruptNote(
+          run.threadId,
+          persistOrphanedToolResults(interruptHandle, storage, run.threadId)
+        )
+      }
+      throw new AgentInterruptedError(
+        run.runId,
+        interruption ?? { reason: 'user' }
+      )
+    }
     for (const mw of aiMiddlewares) {
       if (mw.onError) {
         try {
@@ -835,5 +890,7 @@ async function continueAfterToolResultSync(
       errorMessage: error instanceof Error ? error.message : String(error),
     })
     throw error
+  } finally {
+    interruptHandle.release()
   }
 }

--- a/packages/core/src/wirings/ai-agent/ai-agent-stream.test.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-stream.test.ts
@@ -1087,7 +1087,10 @@ describe('streamAIAgent', () => {
 
     assert.equal(result, 'Hello')
     assert.ok(events.some((event) => event.type === 'reasoning-delta'))
-    assert.deepEqual(middlewareStateSnapshots, [1, 2, 3, 4])
+    // Five, not four: the terminal `done` goes through the middleware too. It
+    // is the only signal a buffering hook gets that the reply is over, so a
+    // hook that never sees it can never flush what it is holding.
+    assert.deepEqual(middlewareStateSnapshots, [1, 2, 3, 4, 5])
     assert.equal(savedMessages[0].messages[0].role, 'user')
     assert.equal(savedMessages[1].messages[0].role, 'assistant')
     assert.equal(savedMessages[1].messages[1].role, 'tool')

--- a/packages/core/src/wirings/ai-agent/ai-agent-stream.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent-stream.ts
@@ -48,10 +48,21 @@ import {
 import { resolveModelConfig } from './ai-agent-model-config.js'
 import type { AIRunStateService } from '../../services/ai-run-state-service.js'
 import type { AIAgentRunnerService } from '../../services/ai-agent-runner-service.js'
+import {
+  getInFlightTools,
+  isAbortError,
+  persistOrphanedToolResults,
+  registerInterruptibleRun,
+  signalRunInterrupt,
+  trackInterruptNote,
+  trackToolExecution,
+  type AgentInterruption,
+  type AgentInterruptResult,
+} from './ai-agent-interrupt.js'
 
 type PersistingChannel = AIStreamChannel & {
   fullText: string
-  flush: () => Promise<void>
+  flush: (opts?: { interrupted?: boolean }) => Promise<void>
   totalUsage: { inputTokens: number; outputTokens: number; model?: string }
 }
 
@@ -75,7 +86,7 @@ function createPersistingChannel(
     outputTokens: 0,
   }
 
-  const flushStep = async () => {
+  const flushStep = async (opts?: { interrupted?: boolean }) => {
     if (!storage) return
     const text = stepText
     const generativeUI = stepGenerativeUI
@@ -97,6 +108,7 @@ function createPersistingChannel(
               ]
             : text || undefined,
         toolCalls: calls.length > 0 ? calls : undefined,
+        ...(opts?.interrupted ? { interrupted: true } : {}),
         createdAt: new Date(),
       }
       const messages: AIMessage[] = [assistantMsg]
@@ -145,11 +157,14 @@ function createPersistingChannel(
     close: () => parent.close(),
     sendBinary: (data) => parent.sendBinary(data),
     send: (event: AIStreamEvent) => {
+      // Accumulated whether or not storage is configured: `fullText` is what
+      // the client was streamed, and an interrupted run has to be able to
+      // report the fragment it got through even with persistence turned off.
+      if (event.type === 'text-delta') fullText += event.text
       if (storage) {
         switch (event.type) {
           case 'text-delta':
             stepText += event.text
-            fullText += event.text
             break
           case 'tool-call':
             stepToolCalls.push({
@@ -711,6 +726,13 @@ export async function streamAIAgent(
   })
   options?.onRunCreated?.(runId)
 
+  // Registered before the first model call and released in `finally`, so the
+  // window in which an interrupt can land is exactly the window in which there
+  // is something to interrupt.
+  const interruptHandle = registerInterruptibleRun(runId)
+  runnerParams.abortSignal = interruptHandle.signal
+  runnerParams.tools = trackToolExecution(runnerParams.tools, interruptHandle)
+
   if (storage) {
     await storage.saveMessages(threadId, [userMessage])
   }
@@ -726,6 +748,10 @@ export async function streamAIAgent(
           event,
           allEvents,
           state,
+          // Sends downstream directly, so a hook can hand back the fast event
+          // now and push the slow one when it is ready.
+          emit: next,
+          signal: interruptHandle.signal,
         })
         if (result == null) return
         if (Array.isArray(result)) {
@@ -772,6 +798,10 @@ export async function streamAIAgent(
   // unresulted is what lets the client resume it after connecting.
   const credentialFilteredChannel: AIStreamChannel = {
     ...wrappedChannel,
+    // Returns what the inner send returns. Middleware runs asynchronously, so
+    // swallowing the promise here makes every `await channel.send(...)` upstream
+    // a no-op — including the one that waits for a buffering hook to flush
+    // before the channel closes.
     send: (event: AIStreamEvent) => {
       if (
         event.type === 'tool-result' &&
@@ -781,7 +811,7 @@ export async function streamAIAgent(
       ) {
         return
       }
-      wrappedChannel.send(event)
+      return wrappedChannel.send(event)
     },
   }
 
@@ -803,7 +833,7 @@ export async function streamAIAgent(
             (event.type === 'text-delta' || event.type === 'reasoning-delta')
           )
             return
-          credentialFilteredChannel.send(event)
+          return credentialFilteredChannel.send(event)
         },
         delegateState,
       }
@@ -853,10 +883,41 @@ export async function streamAIAgent(
       runId
     )
 
-    channel.send({ type: 'done' })
+    // Through the middleware rather than straight at the channel, and awaited.
+    // `done` is the only signal a stream hook gets that the reply is over, and
+    // the ones that buffer need it: `voiceOutput` speaks a trailing fragment
+    // that never reached a full stop, and waits for audio it has already paid
+    // to synthesize. Sent raw, that work is discarded by the `close()` below.
+    await outputChannel.send({ type: 'done' })
     channel.close()
     return persistingChannel.fullText
   } catch (err) {
+    // An interrupt is not a failure: the truncated text is real output the user
+    // already heard part of, so it is persisted and marked rather than dropped.
+    const interruption = interruptHandle.interruption
+    if (interruption || isAbortError(err)) {
+      await persistingChannel.flush({ interrupted: true })
+      await aiRunState.updateRun(runId, { status: 'interrupted' })
+      // Deliberately not awaited. A tool still running must not hold the stream
+      // open — the whole point of barge-in is that the agent stops now — so the
+      // note lands later and the next run on this thread waits for it instead.
+      if (storage) {
+        trackInterruptNote(
+          threadId,
+          persistOrphanedToolResults(interruptHandle, storage, threadId)
+        )
+      }
+      channel.send({
+        type: 'interrupted',
+        runId,
+        text: persistingChannel.fullText,
+        reason: interruption?.reason ?? 'user',
+      })
+      channel.send({ type: 'done' })
+      channel.close()
+      return persistingChannel.fullText
+    }
+
     for (const mw of aiMiddlewares) {
       if (mw.onError) {
         try {
@@ -881,7 +942,72 @@ export async function streamAIAgent(
     channel.send({ type: 'done' })
     channel.close()
     return persistingChannel.fullText
+  } finally {
+    interruptHandle.release()
   }
+}
+
+/**
+ * Stop an in-flight run on behalf of a caller, after checking the run is theirs.
+ *
+ * Unlike {@link resumeAIAgent} this needs no channel: it does not continue the
+ * stream, it ends one. The `interrupted` event and the truncated message are
+ * emitted by the original {@link streamAIAgent} call on its own channel, so this
+ * can be reached over a plain RPC while the stream is held open elsewhere —
+ * which is exactly the shape a voice barge-in needs.
+ *
+ * Ownership is the whole gate, deliberately without {@link assertAgentAuthorized}.
+ * Resuming re-enters the agent and approves a tool call, so a revoked grant must
+ * block it; stopping is the opposite — if a caller's access to an agent was
+ * revoked mid-run, being able to stop their own run is harmless and arguably
+ * what you want.
+ *
+ * Returns `false` when there was nothing to stop. Racing a run that finishes on
+ * its own is the normal case in voice, so it is not an error.
+ */
+export async function interruptAIAgent(
+  input: { runId: string; reason?: AgentInterruption['reason'] },
+  params: RunAIAgentParams
+): Promise<AgentInterruptResult> {
+  const { aiRunState, logger } = getSingletonServices()
+  if (!aiRunState) {
+    throw new Error('AIRunStateService not available in singletonServices')
+  }
+
+  const run = await aiRunState.getRun(input.runId)
+  if (!run) {
+    throw new Error(`No run found for runId ${input.runId}`)
+  }
+  assertResourceOwner(
+    resolveOwnerResourceId(
+      params,
+      agentSessionScope(run.agentName),
+      run.resourceId
+    ),
+    run.resourceId,
+    'run'
+  )
+
+  const stopped = signalRunInterrupt(input.runId, {
+    reason: input.reason ?? 'user',
+  })
+
+  // A run still marked `running` that this process cannot abort is executing on
+  // another instance. Returning a bare `false` there is indistinguishable from
+  // "it already finished", so the one deployment shape this registry does not
+  // cover fails silently — an agent that simply refuses to shut up, with nothing
+  // in the logs. Say so instead. See `signalRunInterrupt` for the fix (fan the
+  // interrupt out over eventHub so every instance tries locally).
+  if (!stopped && run.status === 'running') {
+    logger?.warn(
+      `Could not interrupt run ${input.runId}: it is running in another process. ` +
+        'Interrupts are process-local; fan them out over eventHub to support multiple instances.'
+    )
+  }
+
+  // Reported after the abort so it names what is *still* running: aborting the
+  // model call does nothing to a tool already executing.
+  return { stopped, inFlightTools: getInFlightTools(input.runId) }
 }
 
 export async function resumeAIAgent(
@@ -1225,6 +1351,12 @@ async function continueAfterToolResult(
     }
   }
 
+  // Resuming is as interruptible as the first turn. It is the same person
+  // listening to the same voice, and after an approval it is where most of the
+  // reply actually gets spoken — an approved delete is followed by the agent
+  // talking about it, and that is a normal thing to talk over.
+  const interruptHandle = registerInterruptibleRun(run.runId)
+
   const streamMiddleware = aiMiddlewares
     .filter((mw) => mw.modifyOutputStream)
     .map((mw) => {
@@ -1236,6 +1368,10 @@ async function continueAfterToolResult(
           event,
           allEvents,
           state,
+          // Sends downstream directly, so a hook can hand back the fast event
+          // now and push the slow one when it is ready.
+          emit: next,
+          signal: interruptHandle.signal,
         })
         if (result == null) return
         if (Array.isArray(result)) {
@@ -1298,10 +1434,14 @@ async function continueAfterToolResult(
     tools: resumeTools,
     maxSteps: 1,
     toolChoice: (agent.toolChoice ?? 'auto') as 'auto' | 'required' | 'none',
+    providerOptions: agent.providerOptions,
     outputSchema: meta?.outputSchema
       ? pikkuState(packageName, 'misc', 'schemas').get(meta.outputSchema)
       : undefined,
   }
+
+  runnerParams.abortSignal = interruptHandle.signal
+  runnerParams.tools = trackToolExecution(runnerParams.tools, interruptHandle)
 
   try {
     const loopResult = await runStreamStepLoop({
@@ -1347,9 +1487,36 @@ async function continueAfterToolResult(
       run.runId
     )
 
-    channel.send({ type: 'done' })
+    // Through the middleware, for the same reason as the first turn — and it
+    // matters more here. After an approval, most of what gets spoken is the
+    // agent talking about what it just did, so this is the half of the reply a
+    // dropped flush would silence.
+    await wrappedChannel.send({ type: 'done' })
     channel.close()
   } catch (err) {
+    // Same reasoning as the first turn: an interrupt is not a failure, and the
+    // part of the reply the user already heard is real output.
+    const interruption = interruptHandle.interruption
+    if (interruption || isAbortError(err)) {
+      await persistingChannel.flush({ interrupted: true })
+      await aiRunState.updateRun(run.runId, { status: 'interrupted' })
+      if (storage) {
+        trackInterruptNote(
+          run.threadId,
+          persistOrphanedToolResults(interruptHandle, storage, run.threadId)
+        )
+      }
+      channel.send({
+        type: 'interrupted',
+        runId: run.runId,
+        text: persistingChannel.fullText,
+        reason: interruption?.reason ?? 'user',
+      })
+      channel.send({ type: 'done' })
+      channel.close()
+      return
+    }
+
     for (const mw of aiMiddlewares) {
       if (mw.onError) {
         try {
@@ -1373,5 +1540,7 @@ async function continueAfterToolResult(
     })
     channel.send({ type: 'done' })
     channel.close()
+  } finally {
+    interruptHandle.release()
   }
 }

--- a/packages/core/src/wirings/ai-agent/ai-agent.types.ts
+++ b/packages/core/src/wirings/ai-agent/ai-agent.types.ts
@@ -7,6 +7,7 @@ import type {
   MiddlewareMetadata,
   PermissionMetadata,
 } from '../../types/core.types.js'
+import type { AIProviderOptions } from '../../services/ai-agent-runner-service.js'
 import type { PikkuChannel } from '../channel/channel.types.js'
 import type { CorePikkuChannelMiddleware } from '../channel/channel.types.js'
 import type { ApprovalPolicy } from '../channel/channel-rpc.js'
@@ -59,6 +60,23 @@ export interface AIMessage {
   toolCalls?: AIToolCall[]
   toolResults?: AIToolResult[]
   reasoningContent?: string
+  /**
+   * Set on an assistant message whose generation was cut short by
+   * an interrupt — the text is a mid-sentence fragment, not a reply.
+   * Carried into the next turn's context so the model can see it said only
+   * this much before being talked over, and decide for itself whether to
+   * resume, restate or move on. Storage that drops unknown fields loses the
+   * marker but keeps the fragment, which degrades to a truncated reply.
+   */
+  interrupted?: boolean
+  /**
+   * Set on a tool message whose result arrived after the run was interrupted,
+   * so the model never got to describe it. The work happened; only the reply
+   * about it was lost. It is ordinary thread context on the next turn — the
+   * model raises it unprompted ("that deploy did go through") rather than the
+   * result being silently dropped or replayed as a fresh tool call.
+   */
+  undelivered?: boolean
   createdAt: Date
 }
 
@@ -131,6 +149,13 @@ export interface AIAgentToolDef extends Partial<ApprovalPolicy> {
   inputSchema: Record<string, unknown>
   execute: (input: unknown) => Promise<unknown>
   /**
+   * Mirrors the pikku function's `readonly` flag. A read that gets interrupted
+   * is discarded rather than reported: nothing changed, and by the next turn
+   * the data may be stale anyway — re-reading is cheaper than explaining a
+   * result the user never asked to hear about.
+   */
+  readonly?: boolean
+  /**
    * Set only by the framework on sub-agent delegating tools. Such a tool may
    * legitimately return an `__approvalRequired` marker to forward a nested
    * sub-agent approval. The marker is honored ONLY from a tool with this flag —
@@ -157,6 +182,27 @@ export interface PikkuAIMiddlewareHooks<
       event: AIStreamEvent
       allEvents: readonly AIStreamEvent[]
       state: State
+      /**
+       * Push an event into the stream *after* this call has returned.
+       *
+       * Returning events blocks the stream until the hook resolves, which is
+       * right for anything derived from the event and wrong for anything slow.
+       * Speech is the motivating case: awaiting a text-to-speech call before
+       * returning the text delta stalls the reader at every full stop and
+       * serialises synthesis behind playback. Return the text immediately,
+       * start the slow work, and `emit` its result when it lands.
+       *
+       * Ordering among emitted events is the caller's problem — chain them if
+       * it matters — and a hook that emits must make sure anything still
+       * outstanding has landed before it lets `done` through.
+       */
+      emit: (event: AIStreamEvent) => Promise<void>
+      /**
+       * Aborts when the run is interrupted. Pass it to any provider call the
+       * hook makes: work started for a reply the user has already talked over
+       * is billed but never heard.
+       */
+      signal?: AbortSignal
     }
   ) =>
     | Promise<AIStreamEvent | AIStreamEvent[] | null>
@@ -262,6 +308,16 @@ export type CoreAIAgent<
   memory?: AIAgentMemoryConfig
   maxSteps?: number
   toolChoice?: 'auto' | 'required' | 'none'
+  /**
+   * Per-provider model settings, keyed by provider id and passed through
+   * untouched — for anything only one vendor offers, which the fields above
+   * deliberately do not try to unify.
+   *
+   * `{ openai: { reasoningEffort: 'minimal' } }` is the one that matters for
+   * voice: on gpt-5-mini it measured 0.9s to first token against 2.5s at the
+   * default, and a spoken reply is waited through rather than skimmed.
+   */
+  providerOptions?: AIProviderOptions
   input?: unknown
   output?: unknown
   tags?: string[]
@@ -384,6 +440,15 @@ export type AIStreamEvent =
       reason: 'rpc-missing'
       missingRpcs: string[]
     }
+  | {
+      type: 'interrupted'
+      runId: string
+      /** The truncated assistant text at the moment generation stopped. */
+      text: string
+      reason: 'speech' | 'user' | 'timeout'
+      agent?: string
+      session?: string
+    }
   | { type: 'done' }
 
 export interface AIStreamChannel extends PikkuChannel<unknown, AIStreamEvent> {}
@@ -418,7 +483,7 @@ export interface AgentRunState {
   agentName: string
   threadId: string
   resourceId: string
-  status: 'running' | 'suspended' | 'completed' | 'failed'
+  status: 'running' | 'suspended' | 'completed' | 'failed' | 'interrupted'
   errorMessage?: string
   suspendReason?: 'approval' | 'credential' | 'rpc-missing'
   missingRpcs?: string[]

--- a/packages/core/src/wirings/ai-agent/index.ts
+++ b/packages/core/src/wirings/ai-agent/index.ts
@@ -3,12 +3,44 @@ export {
   agentStream,
   agentResume,
   agentApprove,
+  agentInterrupt,
 } from './ai-agent-helpers.js'
 export { wrapChannelWithAGUI, type AGUIEvent } from './ai-agent-agui.js'
 export { runAIAgent, resumeAIAgentSync } from './ai-agent-runner.js'
-export { streamAIAgent, resumeAIAgent } from './ai-agent-stream.js'
-export { voiceInput } from './voice-input.js'
-export { voiceOutput } from './voice-output.js'
+export {
+  streamAIAgent,
+  resumeAIAgent,
+  interruptAIAgent,
+} from './ai-agent-stream.js'
+export {
+  voiceInput,
+  readsAsNonSpeech,
+  NoSpeechDetectedError,
+} from './voice-input.js'
+export {
+  voiceOutput,
+  unspeakableScripts,
+  voiceForText,
+  type SpeakableScripts,
+} from './voice-output.js'
+export {
+  AgentInterruptedError,
+  awaitPendingInterruptNote,
+  getInFlightTools,
+  isAbortError,
+  isRunInterruptible,
+  persistOrphanedToolResults,
+  registerInterruptibleRun,
+  signalRunInterrupt,
+  trackInterruptNote,
+  trackToolExecution,
+} from './ai-agent-interrupt.js'
+export type {
+  AgentInterruption,
+  AgentInterruptResult,
+  InterruptibleRunHandle,
+  OrphanedToolResult,
+} from './ai-agent-interrupt.js'
 export {
   type RunAIAgentParams,
   type StreamAIAgentOptions,

--- a/packages/core/src/wirings/ai-agent/voice-input.test.ts
+++ b/packages/core/src/wirings/ai-agent/voice-input.test.ts
@@ -1,7 +1,11 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { voiceInput } from './voice-input.js'
+import {
+  voiceInput,
+  readsAsNonSpeech,
+  NoSpeechDetectedError,
+} from './voice-input.js'
 import type { AIContentPart, AIMessage } from './ai-agent.types.js'
 
 /**
@@ -86,5 +90,72 @@ describe('voiceInput', () => {
         }),
       /voiceInput requires a transcription model/
     )
+  })
+
+  test('a turn with no speech in it never reaches the model', async () => {
+    // The failure this prevents: the user says nothing, the model answers
+    // anyway, and what it answers is a guess about audio it could not hear.
+    // An ASR that returns '' on non-speech is what makes this checkable — see
+    // readsAsNonSpeech for why nothing subtler than '' survived contact.
+    const silent = {
+      async transcribe() {
+        return { text: '', segments: [], warnings: [] }
+      },
+    }
+    const mw = voiceInput({
+      model: 'deepinfra/nvidia/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b',
+    })
+
+    await assert.rejects(
+      () =>
+        mw.modifyInput!({ aiAgentRunner: silent } as any, {
+          messages: [audioMessage()],
+          instructions: 'sys',
+        }),
+      NoSpeechDetectedError
+    )
+  })
+
+  test('a transcript is passed through exactly as the provider wrote it', async () => {
+    // No reassembly, no trimming, no filtering — whatever the model heard is
+    // what the agent is asked about.
+    const spaced = {
+      async transcribe() {
+        return {
+          text: '  spacing   the provider chose  ',
+          segments: [],
+          warnings: [],
+        }
+      },
+    }
+    const mw = voiceInput({ model: 'mock/asr' })
+
+    const result = await mw.modifyInput!({ aiAgentRunner: spaced } as any, {
+      messages: [audioMessage()],
+      instructions: 'sys',
+    })
+
+    const parts = result.messages.at(-1)!.content as AIContentPart[]
+    assert.equal(
+      (parts[0] as { text: string }).text,
+      '  spacing   the provider chose  '
+    )
+  })
+})
+
+describe('readsAsNonSpeech', () => {
+  test('only an empty transcript counts as nothing said', () => {
+    assert.equal(readsAsNonSpeech({ text: '' }), true)
+    assert.equal(readsAsNonSpeech({ text: '   ' }), true)
+    assert.equal(readsAsNonSpeech({}), true)
+    assert.equal(readsAsNonSpeech({ text: 'add milk to the list' }), false)
+  })
+
+  test('a short or low-confidence-looking transcript is still speech', () => {
+    // The gate that used to live here would have been tempted by these. "Yes"
+    // is the single most important word in an approval flow, and dropping it
+    // because it is brief or quiet is far worse than keeping a stray one.
+    assert.equal(readsAsNonSpeech({ text: 'yes' }), false)
+    assert.equal(readsAsNonSpeech({ text: 'Thank you.' }), false)
   })
 })

--- a/packages/core/src/wirings/ai-agent/voice-input.ts
+++ b/packages/core/src/wirings/ai-agent/voice-input.ts
@@ -14,6 +14,46 @@ function base64ToUint8Array(base64: string): Uint8Array {
 
 const MAX_AUDIO_SIZE = 50 * 1024 * 1024
 
+/**
+ * Raised when every audio part in a turn turned out to be non-speech.
+ *
+ * Distinct from a transcription failure, because the response is different: a
+ * failure is worth reporting, whereas this is the microphone doing its job on a
+ * pause. A voice loop should catch it and go back to listening without running
+ * the agent — answering a hallucinated sentence is worse than answering nothing.
+ */
+export class NoSpeechDetectedError extends Error {
+  constructor() {
+    super('No speech was detected in the audio.')
+    this.name = 'NoSpeechDetectedError'
+  }
+}
+
+/**
+ * Whether nothing usable was said — an empty transcript, and nothing cleverer
+ * than that.
+ *
+ * There was a confidence gate here once, and it is worth recording why it is
+ * gone. Whisper is trained on subtitles, so audio it cannot parse comes back
+ * not as nothing but as stock filler appended to real speech: "Hello, my name
+ * is Yasir. Thank you." where only the first sentence was spoken. The obvious
+ * defence is to drop low-confidence segments, and it does not work. Measured on
+ * a real turn, the invented "Thank you." scored `avg_logprob` -0.52 against
+ * -0.30 for the genuine sentence beside it, and `no_speech_prob` read 0.000 for
+ * both. Whisper is *confident* when it invents, because the text it invents is
+ * high-probability text. No threshold separates those two numbers, and one set
+ * low enough to try would take real quiet speech with it.
+ *
+ * The fix belongs at the model, not behind it: an ASR that is not a
+ * subtitle-trained autoregressive decoder returns an empty string on non-speech
+ * and there is nothing left to filter. Hence this reduces to asking whether
+ * anything came back at all — which is a property every provider reports
+ * honestly, unlike per-segment confidence (Nemotron, for one, hardcodes
+ * `avg_logprob` to 0.0).
+ */
+export const readsAsNonSpeech = (result: { text?: string }): boolean =>
+  !(result.text ?? '').trim()
+
 async function fetchAsUint8Array(
   url: string,
   allowedAudioHosts?: string[]
@@ -87,8 +127,16 @@ export const voiceInput = (config?: {
               }
             : {}),
         })
+        // Dropped when nothing was said: an empty text part is still a turn the
+        // model will answer, and what it answers is a guess about what it could
+        // not hear.
+        if (readsAsNonSpeech(result)) continue
         updatedContent.push({ type: 'text' as const, text: result.text })
       }
+
+      // Every part was audio, and none of it was speech. There is nothing left
+      // to send, and a message with no content is not a question.
+      if (updatedContent.length === 0) throw new NoSpeechDetectedError()
 
       return {
         messages: [

--- a/packages/core/src/wirings/ai-agent/voice-output.test.ts
+++ b/packages/core/src/wirings/ai-agent/voice-output.test.ts
@@ -1,0 +1,422 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  voiceOutput,
+  unspeakableScripts,
+  voiceForText,
+} from './voice-output.js'
+import type { AIStreamEvent } from './ai-agent.types.js'
+
+const KOKORO_SCRIPTS = ['latin', 'devanagari', 'han', 'kana']
+
+/** The same four, as the voice each one has to be spoken in. */
+const KOKORO_VOICES = {
+  han: 'zf_xiaobei',
+  kana: 'jf_alpha',
+  devanagari: 'hf_alpha',
+  latin: 'af_bella',
+}
+
+const deferred = () => {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+/**
+ * Drives the hook exactly as `ai-agent-stream` does, so `out` is the order the
+ * client actually sees — returned events and `emit`ed ones interleaved on the
+ * one channel.
+ */
+const createStream = (
+  mw: ReturnType<typeof voiceOutput>,
+  services: unknown
+) => {
+  const state: Record<string, unknown> = {}
+  const allEvents: AIStreamEvent[] = []
+  const out: AIStreamEvent[] = []
+  const next = async (event: AIStreamEvent) => {
+    out.push(event)
+  }
+  return {
+    out,
+    types: () => out.map((event) => event.type),
+    spoken: () =>
+      out
+        .filter((event) => event.type === 'audio-delta')
+        .map((event) => atob((event as { data: string }).data)),
+    send: async (event: AIStreamEvent) => {
+      allEvents.push(event)
+      const result = await mw.modifyOutputStream!(services as any, {
+        event,
+        allEvents,
+        state,
+        emit: next,
+      })
+      if (result == null) return
+      if (Array.isArray(result)) {
+        for (const r of result) await next(r)
+      } else {
+        await next(result)
+      }
+    },
+  }
+}
+
+/** Labels the audio with the text it came from so order is checkable. */
+const speechFor = (text: string) => ({
+  audio: { uint8Array: new TextEncoder().encode(text.trim()), format: 'mp3' },
+})
+
+describe('voiceOutput', () => {
+  test('lets the text through while the speech is still being generated', async () => {
+    // The regression this guards: awaiting synthesis inside the hook stalls
+    // the reader at every full stop, and the stall is as long as the speech
+    // provider takes.
+    const gate = deferred()
+    const services = {
+      aiAgentRunner: {
+        generateSpeech: async ({ text }: { text: string }) => {
+          await gate.promise
+          return speechFor(text)
+        },
+      },
+    }
+
+    const stream = createStream(voiceOutput({ model: 'mock/tts' }), services)
+    await stream.send({ type: 'text-delta', text: 'Hello there.' } as any)
+
+    assert.deepEqual(stream.types(), ['text-delta'])
+    gate.resolve()
+  })
+
+  test('speaks sentences in order even when the later one is ready first', async () => {
+    const slow = deferred()
+    const services = {
+      aiAgentRunner: {
+        generateSpeech: async ({ text }: { text: string }) => {
+          // A short sentence after a long one routinely finishes first.
+          if (text.includes('first')) await slow.promise
+          return speechFor(text)
+        },
+      },
+    }
+
+    const stream = createStream(voiceOutput({ model: 'mock/tts' }), services)
+    await stream.send({ type: 'text-delta', text: 'The first one.' } as any)
+    await stream.send({ type: 'text-delta', text: ' Second.' } as any)
+    slow.resolve()
+    await stream.send({ type: 'done' } as any)
+
+    assert.deepEqual(stream.spoken(), ['The first one.', 'Second.'])
+  })
+
+  test('holds done until everything queued has been spoken', async () => {
+    const gate = deferred()
+    const services = {
+      aiAgentRunner: {
+        generateSpeech: async ({ text }: { text: string }) => {
+          await gate.promise
+          return speechFor(text)
+        },
+      },
+    }
+
+    const stream = createStream(voiceOutput({ model: 'mock/tts' }), services)
+    await stream.send({ type: 'text-delta', text: 'All done.' } as any)
+
+    const finished = stream.send({ type: 'done' } as any)
+    assert.deepEqual(stream.types(), ['text-delta'])
+
+    gate.resolve()
+    await finished
+
+    // audio-done has to mean it, so the chunk precedes it.
+    assert.deepEqual(stream.types(), [
+      'text-delta',
+      'audio-delta',
+      'audio-done',
+      'done',
+    ])
+  })
+
+  test('speaks a trailing fragment the model never punctuated', async () => {
+    const services = {
+      aiAgentRunner: {
+        generateSpeech: async ({ text }: { text: string }) => speechFor(text),
+      },
+    }
+
+    const stream = createStream(voiceOutput({ model: 'mock/tts' }), services)
+    await stream.send({ type: 'text-delta', text: 'no full stop here' } as any)
+    await stream.send({ type: 'done' } as any)
+
+    assert.deepEqual(stream.spoken(), ['no full stop here'])
+  })
+
+  test('says nothing extra when the reply ended on a boundary', async () => {
+    const services = {
+      aiAgentRunner: {
+        generateSpeech: async ({ text }: { text: string }) => speechFor(text),
+      },
+    }
+
+    const stream = createStream(voiceOutput({ model: 'mock/tts' }), services)
+    await stream.send({ type: 'text-delta', text: 'Complete.' } as any)
+    await stream.send({ type: 'done' } as any)
+
+    assert.deepEqual(stream.spoken(), ['Complete.'])
+  })
+
+  test('carries on after a sentence fails to synthesize, and says why', async () => {
+    const errors: string[] = []
+    const services = {
+      logger: { error: (message: string) => errors.push(message) },
+      aiAgentRunner: {
+        generateSpeech: async ({ text }: { text: string }) => {
+          if (text.includes('boom')) throw new Error('provider exploded')
+          return speechFor(text)
+        },
+      },
+    }
+
+    const stream = createStream(voiceOutput({ model: 'mock/tts' }), services)
+    await stream.send({ type: 'text-delta', text: 'This is boom.' } as any)
+    await stream.send({ type: 'text-delta', text: ' This survives.' } as any)
+    await stream.send({ type: 'done' } as any)
+
+    // One sentence going unspoken beats the rest of the reply never arriving.
+    assert.deepEqual(stream.spoken(), ['This survives.'])
+    assert.equal(errors.length, 1)
+    assert.match(errors[0]!, /provider exploded/)
+    assert.ok(stream.types().includes('done'))
+  })
+
+  test('stays out of the way when the runner cannot speak at all', async () => {
+    const stream = createStream(voiceOutput({ model: 'mock/tts' }), {
+      aiAgentRunner: {},
+    })
+    await stream.send({ type: 'text-delta', text: 'Hello.' } as any)
+    await stream.send({ type: 'done' } as any)
+
+    // No audio events, and crucially no `audio-done` promising audio that is
+    // never coming.
+    assert.deepEqual(stream.types(), ['text-delta', 'done'])
+  })
+
+  test('a script the model cannot pronounce is reported, not mangled', async () => {
+    // Kokoro handed Arabic does not fail and does not stay quiet — it reads out
+    // the letter names for twenty-odd seconds. Sending it nothing and saying so
+    // is the only honest option.
+    const asked: string[] = []
+    const services = {
+      aiAgentRunner: {
+        generateSpeech: async ({ text }: { text: string }) => {
+          asked.push(text)
+          return speechFor(text)
+        },
+      },
+    }
+    const stream = createStream(
+      voiceOutput({ model: 'mock/tts', speakableScripts: KOKORO_SCRIPTS }),
+      services
+    )
+
+    await stream.send({ type: 'text-delta', text: 'مرحبا بك.' })
+    await stream.send({ type: 'done' })
+
+    assert.deepEqual(asked, [], 'nothing should have been sent for synthesis')
+    const notice = stream.out.find((event) => event.type === 'data') as
+      | { name: string; data: { scripts: string[] } }
+      | undefined
+    assert.equal(notice?.name, 'voice-unsupported')
+    assert.deepEqual(notice?.data.scripts, ['arabic'])
+  })
+
+  test('a reply says it once, however many sentences it is', async () => {
+    const services = {
+      aiAgentRunner: {
+        generateSpeech: async ({ text }: { text: string }) => speechFor(text),
+      },
+    }
+    const stream = createStream(
+      voiceOutput({ model: 'mock/tts', speakableScripts: KOKORO_SCRIPTS }),
+      services
+    )
+
+    await stream.send({ type: 'text-delta', text: 'مرحبا.' })
+    await stream.send({ type: 'text-delta', text: 'كيف حالك؟' })
+    await stream.send({ type: 'done' })
+
+    assert.equal(
+      stream.out.filter((event) => event.type === 'data').length,
+      1,
+      'the notice belongs to the reply, not to each sentence'
+    )
+  })
+
+  test('a bilingual reply still speaks the half it can', async () => {
+    const asked: string[] = []
+    const services = {
+      aiAgentRunner: {
+        generateSpeech: async ({ text }: { text: string }) => {
+          asked.push(text.trim())
+          return speechFor(text)
+        },
+      },
+    }
+    const stream = createStream(
+      voiceOutput({ model: 'mock/tts', speakableScripts: KOKORO_SCRIPTS }),
+      services
+    )
+
+    await stream.send({ type: 'text-delta', text: 'Added it.' })
+    await stream.send({ type: 'text-delta', text: ' تمت الإضافة.' })
+    await stream.send({ type: 'done' })
+
+    assert.deepEqual(asked, ['Added it.'])
+  })
+
+  test('each sentence is spoken in the voice its own script needs', async () => {
+    // The bug this guards is silent and expensive to find by ear: Kokoro handed
+    // Chinese in its default English voice does not fail, it spells the
+    // characters out for three times the duration.
+    const asked: Array<{ text: string; voice?: string }> = []
+    const services = {
+      aiAgentRunner: {
+        generateSpeech: async ({
+          text,
+          voice,
+        }: {
+          text: string
+          voice?: string
+        }) => {
+          asked.push({ text: text.trim(), voice })
+          return speechFor(text)
+        },
+      },
+    }
+    const stream = createStream(
+      voiceOutput({ model: 'mock/tts', speakableScripts: KOKORO_VOICES }),
+      services
+    )
+
+    await stream.send({ type: 'text-delta', text: 'Added it.' })
+    await stream.send({ type: 'text-delta', text: ' 已添加。' })
+    await stream.send({ type: 'done' })
+
+    assert.deepEqual(asked, [
+      { text: 'Added it.', voice: 'af_bella' },
+      { text: '已添加。', voice: 'zf_xiaobei' },
+    ])
+  })
+
+  test('a script with no voice mapped is still refused, not mis-voiced', async () => {
+    const asked: string[] = []
+    const services = {
+      aiAgentRunner: {
+        generateSpeech: async ({ text }: { text: string }) => {
+          asked.push(text)
+          return speechFor(text)
+        },
+      },
+    }
+    const stream = createStream(
+      voiceOutput({ model: 'mock/tts', speakableScripts: KOKORO_VOICES }),
+      services
+    )
+
+    await stream.send({ type: 'text-delta', text: 'مرحبا بك.' })
+    await stream.send({ type: 'done' })
+
+    assert.deepEqual(asked, [])
+    const notice = stream.out.find((event) => event.type === 'data') as
+      | { name: string; data: { scripts: string[] } }
+      | undefined
+    assert.deepEqual(notice?.data.scripts, ['arabic'])
+  })
+
+  test('no declared scripts means every model is trusted with everything', async () => {
+    const asked: string[] = []
+    const services = {
+      aiAgentRunner: {
+        generateSpeech: async ({ text }: { text: string }) => {
+          asked.push(text.trim())
+          return speechFor(text)
+        },
+      },
+    }
+    const stream = createStream(voiceOutput({ model: 'mock/tts' }), services)
+
+    await stream.send({ type: 'text-delta', text: 'مرحبا بك.' })
+    await stream.send({ type: 'done' })
+
+    assert.deepEqual(asked, ['مرحبا بك.'])
+  })
+})
+
+describe('unspeakableScripts', () => {
+  test('names the scripts present that the model was not given', () => {
+    assert.deepEqual(unspeakableScripts('مرحبا', KOKORO_SCRIPTS), ['arabic'])
+    assert.deepEqual(unspeakableScripts('Привет', KOKORO_SCRIPTS), ['cyrillic'])
+    assert.deepEqual(unspeakableScripts('안녕하세요', KOKORO_SCRIPTS), [
+      'hangul',
+    ])
+  })
+
+  test('the seven Kokoro handles are all one Latin test, plus three', () => {
+    // Spanish, French, Italian and Brazilian Portuguese are not separable from
+    // English by script, and do not need to be — the model speaks all of them.
+    for (const text of [
+      'Hello.',
+      'Añadido.',
+      'Ajouté.',
+      'Aggiunto.',
+      'Adicionado.',
+    ]) {
+      assert.deepEqual(unspeakableScripts(text, KOKORO_SCRIPTS), [], text)
+    }
+    assert.deepEqual(unspeakableScripts('जोड़ा गया', KOKORO_SCRIPTS), [])
+    assert.deepEqual(unspeakableScripts('已添加', KOKORO_SCRIPTS), [])
+    assert.deepEqual(unspeakableScripts('追加しました', KOKORO_SCRIPTS), [])
+  })
+
+  test('punctuation and digits are not a script anyone has to support', () => {
+    assert.deepEqual(
+      unspeakableScripts('42 — "ok"? (yes!)', KOKORO_SCRIPTS),
+      []
+    )
+  })
+
+  test('the voice map declares the same scripts the array form does', () => {
+    assert.deepEqual(unspeakableScripts('مرحبا', KOKORO_VOICES), ['arabic'])
+    assert.deepEqual(unspeakableScripts('已添加', KOKORO_VOICES), [])
+  })
+})
+
+describe('voiceForText', () => {
+  test('picks the voice belonging to the script in front of it', () => {
+    assert.equal(voiceForText('已添加', KOKORO_VOICES), 'zf_xiaobei')
+    assert.equal(voiceForText('追加しました', KOKORO_VOICES), 'jf_alpha')
+    assert.equal(voiceForText('जोड़ा गया', KOKORO_VOICES), 'hf_alpha')
+    assert.equal(voiceForText('Added it.', KOKORO_VOICES), 'af_bella')
+  })
+
+  test('a mixed sentence takes the voice of the script that needs one', () => {
+    // A Chinese voice reading an English word is accented; an English voice
+    // reading Chinese spells it out. Only one of those is recoverable.
+    assert.equal(
+      voiceForText('The title is 清单.', KOKORO_VOICES),
+      'zf_xiaobei'
+    )
+  })
+
+  test('falls back when nothing mapped appears, and when nothing is mapped', () => {
+    assert.equal(voiceForText('42!', KOKORO_VOICES, 'af_heart'), 'af_heart')
+    // The array form declares no voices at all, so the configured one stands.
+    assert.equal(voiceForText('已添加', KOKORO_SCRIPTS, 'af_heart'), 'af_heart')
+  })
+})

--- a/packages/core/src/wirings/ai-agent/voice-output.ts
+++ b/packages/core/src/wirings/ai-agent/voice-output.ts
@@ -3,6 +3,18 @@ import { pikkuAIMiddleware } from '../../types/core.types.js'
 
 type VoiceOutputState = {
   textBuffer?: string
+  /**
+   * The audio emitted so far, as a chain.
+   *
+   * Synthesis for every finished sentence starts immediately, so the second
+   * sentence is being generated while the first is still being spoken. That
+   * also means the second can finish first — a short sentence after a long one
+   * routinely does. Chaining the *emissions* keeps the client receiving audio
+   * in the order it was written while leaving the generation overlapped.
+   */
+  tail?: Promise<void>
+  /** Whether this reply has already said it cannot be spoken aloud. */
+  reportedUnspeakable?: boolean
 }
 
 function bufferToBase64(data: Uint8Array): string {
@@ -19,6 +31,102 @@ function isSentenceBoundary(text: string): boolean {
   return SENTENCE_BOUNDARY.test(text)
 }
 
+/**
+ * Scripts a speech model can pronounce, as named by {@link voiceOutput}'s
+ * `speakableScripts`.
+ *
+ * Script rather than language because script is what is decidable from the text
+ * alone. Spanish, French and English are one test, not three — and the models
+ * that handle one Latin-script language generally handle the others. What a
+ * model cannot do is invent a phoneme set it was never given.
+ */
+const SCRIPT_RANGES: Record<string, RegExp> = {
+  latin: /[A-ɏ]/,
+  devanagari: /[ऀ-ॿ]/,
+  han: /[㐀-鿿]/,
+  kana: /[぀-ヿ]/,
+  arabic: /[؀-ۿݐ-ݿ]/,
+  cyrillic: /[Ѐ-ӿ]/,
+  hangul: /[가-힯ᄀ-ᇿ]/,
+  hebrew: /[֐-׿]/,
+  greek: /[Ͱ-Ͽ]/,
+  thai: /[฀-๿]/,
+}
+
+/**
+ * The scripts a model can pronounce, and optionally the voice each one needs.
+ *
+ * The array form is for a model whose voice is the same whatever the script.
+ * The record form exists because that is not the common case: Kokoro speaks
+ * Mandarin, Japanese and Hindi well, but only through a voice belonging to that
+ * language. Asked for Chinese in its default American-English voice it spells
+ * the characters out — 9.9 seconds of "Chinese letter, Chinese letter" for a
+ * sentence the right voice says in 3.5. Same model, same text, same price.
+ */
+export type SpeakableScripts = string[] | Record<string, string>
+
+/**
+ * Which script decides the voice when a sentence contains several.
+ *
+ * The ordering is by how much a script narrows down the language, not by
+ * preference. Kana appears only in Japanese, so a sentence holding any settles
+ * it — while Han is written in both Chinese and Japanese and so cannot, which
+ * matters because ordinary Japanese is mostly kanji. Latin comes last for the
+ * same reason from the other end: it turns up inside sentences in every other
+ * script, and it is the one whose voice is least often the one that counts. A
+ * Chinese voice reading an English word is accented; an English voice reading
+ * Chinese spells it out.
+ *
+ * Everything else — Han included — sits between the two in config order.
+ */
+const SCRIPT_PRECEDENCE: Record<string, number> = { kana: -1, latin: 1 }
+
+const scriptRank = (name: string): number => SCRIPT_PRECEDENCE[name] ?? 0
+
+const scriptNames = (speakable: SpeakableScripts): string[] =>
+  Array.isArray(speakable) ? speakable : Object.keys(speakable)
+
+/**
+ * The scripts present in `text` that the model was not said to handle.
+ *
+ * Silence would be the wrong answer here and so would a best effort. Handed
+ * Arabic — which it has no voice for at all — Kokoro does not fail and does not
+ * stay quiet: it reads out the *letter names*, twenty-four seconds of "Arabic
+ * meem, Arabic ra" for a one-line sentence, which is worse than either. Naming
+ * the gap lets the caller say so instead.
+ */
+export const unspeakableScripts = (
+  text: string,
+  speakable: SpeakableScripts
+): string[] => {
+  const allowed = new Set(scriptNames(speakable))
+  return Object.entries(SCRIPT_RANGES)
+    .filter(([name, range]) => !allowed.has(name) && range.test(text))
+    .map(([name]) => name)
+}
+
+/**
+ * The voice to speak `text` in, or `fallback` if no mapped script appears.
+ *
+ * A sentence is regularly in more than one script, so which one decides is
+ * settled by {@link SCRIPT_PRECEDENCE} rather than by the order the config
+ * happens to be written in.
+ */
+export const voiceForText = (
+  text: string,
+  speakable: SpeakableScripts,
+  fallback?: string
+): string | undefined => {
+  if (Array.isArray(speakable)) return fallback
+  const mapped = Object.entries(speakable).sort(
+    ([a], [b]) => scriptRank(a) - scriptRank(b)
+  )
+  for (const [name, voice] of mapped) {
+    if (SCRIPT_RANGES[name]?.test(text)) return voice
+  }
+  return fallback
+}
+
 async function synthesizeAudio(
   aiAgentRunner: AIAgentRunnerService,
   input: {
@@ -29,6 +137,7 @@ async function synthesizeAudio(
     instructions?: string
     speed?: number
     language?: string
+    abortSignal?: AbortSignal
   }
 ): Promise<{ bytes: Uint8Array; format: string }> {
   const result = await aiAgentRunner.generateSpeech?.({
@@ -39,6 +148,7 @@ async function synthesizeAudio(
     instructions: input.instructions,
     speed: input.speed,
     language: input.language,
+    abortSignal: input.abortSignal,
   })
   if (!result) {
     throw new Error(
@@ -60,77 +170,127 @@ export const voiceOutput = (config?: {
   instructions?: string
   speed?: number
   language?: string
+  /**
+   * Scripts the configured model can actually pronounce, and the voice each
+   * needs — see {@link SpeakableScripts}. Anything written in another script is
+   * left unspoken and reported once, as a `voice-unsupported` data event,
+   * rather than sent to a model that will mangle it.
+   *
+   * Omitted means no check: every model is trusted with every script, which is
+   * the right default for a provider that genuinely is multilingual.
+   */
+  speakableScripts?: SpeakableScripts
 }) =>
   pikkuAIMiddleware<VoiceOutputState>({
-    modifyOutputStream: async (services, { event, state }) => {
-      const aiAgentRunner = (
-        services as {
-          aiAgentRunner?: AIAgentRunnerService
-        }
-      ).aiAgentRunner
+    modifyOutputStream: async (services, { event, state, emit, signal }) => {
+      const { aiAgentRunner, logger } = services as {
+        aiAgentRunner?: AIAgentRunnerService
+        logger?: { error: (message: string) => void }
+      }
       if (!aiAgentRunner?.generateSpeech) return event
+
+      /**
+       * Queue a finished sentence for speech.
+       *
+       * Nothing here is awaited by the caller. Synthesis is kicked off at once
+       * and its emission is chained behind the previous sentence, which is
+       * what keeps the text flowing at the speed the model writes it instead
+       * of the speed the speech provider answers.
+       */
+      const speak = (text: string) => {
+        if (!config?.model) {
+          throw new Error(
+            'voiceOutput requires a speech model (e.g. openai/tts-1)'
+          )
+        }
+
+        // Checked per sentence but announced once per reply: a bilingual answer
+        // should still speak the half it can, and repeating the notice for
+        // every sentence of a long one would bury the reply itself.
+        //
+        // Per sentence is also what makes the voice right. A reply that answers
+        // in English and then quotes a Chinese title is two sentences in two
+        // scripts, and each is synthesized in the voice its own script needs.
+        let voice = config.voice
+        if (config.speakableScripts) {
+          const unspeakable = unspeakableScripts(text, config.speakableScripts)
+          voice = voiceForText(text, config.speakableScripts, config.voice)
+          if (unspeakable.length > 0) {
+            if (!state.reportedUnspeakable) {
+              state.reportedUnspeakable = true
+              state.tail = (state.tail ?? Promise.resolve()).then(() =>
+                emit({
+                  type: 'data',
+                  name: 'voice-unsupported',
+                  data: { model: config.model, scripts: unspeakable },
+                })
+              )
+            }
+            return
+          }
+        }
+        // Settled into a value rather than left as a rejectable promise: it
+        // sits unobserved until the chain reaches it, and an unhandled
+        // rejection in that window would take the process down.
+        const synthesis = synthesizeAudio(aiAgentRunner, {
+          model: config.model,
+          text,
+          voice,
+          format: config?.format,
+          instructions: config?.instructions,
+          speed: config?.speed,
+          language: config?.language,
+          // Barge-in should stop the bill, not just the playback. Without this
+          // every sentence already in flight is synthesized in full and paid
+          // for after the user has stopped listening.
+          abortSignal: signal,
+        }).then(
+          (audio) => ({ ok: true as const, audio }),
+          (error: unknown) => ({ ok: false as const, error })
+        )
+
+        state.tail = (state.tail ?? Promise.resolve()).then(async () => {
+          const result = await synthesis
+          if (!result.ok) {
+            // One sentence going unspoken is better than the rest of the reply
+            // never arriving, so the chain carries on.
+            logger?.error(
+              `voiceOutput could not synthesize a sentence: ${String(result.error)}`
+            )
+            return
+          }
+          await emit({
+            type: 'audio-delta',
+            data: bufferToBase64(result.audio.bytes),
+            format: result.audio.format,
+          })
+        })
+      }
 
       if (event.type === 'done') {
         const remaining = state.textBuffer ?? ''
-        if (remaining) {
-          state.textBuffer = ''
-          if (!config?.model) {
-            throw new Error(
-              'voiceOutput requires a speech model (e.g. openai/tts-1)'
-            )
-          }
-          const audio = await synthesizeAudio(aiAgentRunner, {
-            model: config.model,
-            text: remaining,
-            voice: config?.voice,
-            format: config?.format,
-            instructions: config?.instructions,
-            speed: config?.speed,
-            language: config?.language,
-          })
-          return [
-            {
-              type: 'audio-delta' as const,
-              data: bufferToBase64(audio.bytes),
-              format: audio.format,
-            },
-            { type: 'audio-done' as const },
-            event,
-          ]
+        state.textBuffer = ''
+        if (remaining.trim()) {
+          speak(remaining)
         }
+        // The only place this hook waits. The reply is already over, so the
+        // wait costs the reader nothing, and it is what makes `audio-done`
+        // mean what it says rather than racing the last chunk.
+        await state.tail
+        state.tail = undefined
         return [{ type: 'audio-done' as const }, event]
       }
 
       if (event.type !== 'text-delta') return event
 
       state.textBuffer = `${state.textBuffer ?? ''}${event.text}`
-      if (!isSentenceBoundary(state.textBuffer)) return event
-
-      const text = state.textBuffer
-      state.textBuffer = ''
-
-      if (!config?.model) {
-        throw new Error(
-          'voiceOutput requires a speech model (e.g. openai/tts-1)'
-        )
+      if (isSentenceBoundary(state.textBuffer)) {
+        const text = state.textBuffer
+        state.textBuffer = ''
+        speak(text)
       }
-      const audio = await synthesizeAudio(aiAgentRunner, {
-        model: config.model,
-        text,
-        voice: config?.voice,
-        format: config?.format,
-        instructions: config?.instructions,
-        speed: config?.speed,
-        language: config?.language,
-      })
 
-      return [
-        event,
-        {
-          type: 'audio-delta' as const,
-          data: bufferToBase64(audio.bytes),
-          format: audio.format,
-        },
-      ]
+      // Returned without waiting for any audio — the entire point.
+      return event
     },
   })

--- a/packages/core/src/wirings/http/http.types.ts
+++ b/packages/core/src/wirings/http/http.types.ts
@@ -274,7 +274,9 @@ export interface PikkuHTTPResponse<Out = unknown> {
       | ReadableStream
   ): this
   json(data: Out): this
-  send?(data: string | ArrayBuffer | Buffer): this
+  /** `ArrayBufferView` covers `Buffer` and `Uint8Array`, which is how a body
+   *  that is not text reaches here without being decoded on the way. */
+  send?(data: string | ArrayBuffer | ArrayBufferView): this
   redirect(location: string, status?: number): this
   close?: () => void
   setMode?: (mode: 'stream') => void

--- a/packages/core/src/wirings/http/web-request.test.ts
+++ b/packages/core/src/wirings/http/web-request.test.ts
@@ -34,7 +34,7 @@ const createMockResponse = () => {
   const state = {
     statusCode: 0,
     headers: {} as Record<string, string | string[]>,
-    body: null as string | null,
+    body: null as string | Uint8Array | null,
     redirectUrl: null as string | null,
     redirectStatus: null as number | null,
   }
@@ -55,7 +55,9 @@ const createMockResponse = () => {
       return res
     },
     arrayBuffer(data: any) {
-      state.body = typeof data === 'string' ? data : null
+      // Recorded as given. Coercing a non-string to null here would have hidden
+      // a body that arrived as bytes, which is the case worth testing.
+      state.body = data ?? null
       return res
     },
     redirect(location: string, status?: number) {
@@ -347,5 +349,34 @@ describe('applyWebResponse', () => {
     assert.equal(state.headers['x-custom'], 'ok')
     assert.equal(state.headers['content-length'], undefined)
     assert.equal(state.headers['transfer-encoding'], undefined)
+  })
+
+  test('passes a binary body through byte for byte', async () => {
+    // Reading a body as text is lossy for anything that is not valid UTF-8:
+    // 0x8e is not, and decoding it produces U+FFFD, which re-encodes to three
+    // bytes. A WASM module or a model file goes over the wire bigger than it
+    // started and no longer parses, with a 200 and nothing logged either side.
+    const { res, state } = createMockResponse()
+    const bytes = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x8e, 0xff])
+    const webRes = new Response(bytes, {
+      status: 200,
+      headers: { 'content-type': 'application/wasm' },
+    })
+
+    await applyWebResponse(res, webRes)
+
+    assert.deepEqual(new Uint8Array(state.body as Uint8Array), bytes)
+  })
+
+  test('still writes a JSON body as text', async () => {
+    const { res, state } = createMockResponse()
+    const webRes = new Response('{"ok":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    })
+
+    await applyWebResponse(res, webRes)
+
+    assert.equal(state.body, '{"ok":true}')
   })
 })

--- a/packages/core/src/wirings/http/web-request.ts
+++ b/packages/core/src/wirings/http/web-request.ts
@@ -108,6 +108,35 @@ function collectSetCookieHeaders(webResponse: Response): string[] {
 }
 
 /**
+ * Content types whose bodies are text. Everything else is bytes.
+ *
+ * The distinction matters because reading a body as text is lossy for anything
+ * that is not valid UTF-8: every byte that does not decode becomes U+FFFD, and
+ * re-encoding turns each of those into three bytes. A WASM module or an ONNX
+ * model served that way arrives larger than it left and no longer parses, with
+ * a 200 and no error anywhere to say why.
+ */
+const TEXTUAL_CONTENT_TYPE =
+  /^(text\/|application\/(json|javascript|ecmascript|xml|x-www-form-urlencoded)|[^;]*\+(json|xml)\b)/i
+
+/**
+ * Read a response body as text where that is meaningful, and as bytes
+ * otherwise. An absent content type is treated as text, which is what a body
+ * built from a string gets by default and so preserves existing behaviour.
+ */
+async function readBody(
+  webResponse: Response
+): Promise<string | Uint8Array | null> {
+  const contentType = webResponse.headers.get('content-type')
+  if (contentType === null || TEXTUAL_CONTENT_TYPE.test(contentType)) {
+    const text = await webResponse.text()
+    return text === '' ? null : text
+  }
+  const bytes = new Uint8Array(await webResponse.arrayBuffer())
+  return bytes.byteLength === 0 ? null : bytes
+}
+
+/**
  * Applies a Web API Response to a PikkuHTTPResponse.
  * Copies status, headers (including Set-Cookie), redirects, and body.
  */
@@ -138,8 +167,8 @@ export async function applyWebResponse(
     res.header('Set-Cookie', setCookieValues)
   }
 
-  const body = await webResponse.text()
-  if (body) {
+  const body = await readBody(webResponse)
+  if (body !== null) {
     if (res.send) {
       res.send(body)
     } else {

--- a/packages/core/src/wirings/rpc/rpc-runner.ts
+++ b/packages/core/src/wirings/rpc/rpc-runner.ts
@@ -61,7 +61,11 @@ import type { AIAgentInput } from '../ai-agent/ai-agent.types.js'
 import type { AIStreamChannel } from '../ai-agent/ai-agent.types.js'
 import type { StreamAIAgentOptions } from '../ai-agent/ai-agent-prepare.js'
 import { runAIAgent, resumeAIAgentSync } from '../ai-agent/ai-agent-runner.js'
-import { streamAIAgent, resumeAIAgent } from '../ai-agent/ai-agent-stream.js'
+import {
+  streamAIAgent,
+  resumeAIAgent,
+  interruptAIAgent,
+} from '../ai-agent/ai-agent-stream.js'
 import { wrapChannelWithAGUI } from '../ai-agent/ai-agent-agui.js'
 
 /**
@@ -517,6 +521,15 @@ export class ContextAwareRPCService {
             getCredential: this.wire.getCredential?.bind(this.wire),
           },
           options
+        )
+      },
+      interrupt: async (
+        runId: string,
+        reason?: 'speech' | 'user' | 'timeout'
+      ) => {
+        return interruptAIAgent(
+          { runId, ...(reason ? { reason } : {}) },
+          { sessionService: this.options.sessionService }
         )
       },
       approve: async (

--- a/packages/core/src/wirings/rpc/rpc-types.ts
+++ b/packages/core/src/wirings/rpc/rpc-types.ts
@@ -1,3 +1,5 @@
+import type { AgentInterruptResult } from '../ai-agent/ai-agent-interrupt.js'
+
 export type PikkuRPC<
   Invoke extends (...args: any[]) => any = (...args: any[]) => any,
   Remote extends (...args: any[]) => any = (...args: any[]) => any,
@@ -24,6 +26,15 @@ export type PikkuRPC<
       approvals: { toolCallId: string; approved: boolean }[],
       expectedAgentName?: string
     ) => Promise<any>
+    /** Stop an in-flight run. Needs no channel — it ends a stream rather than
+     *  continuing one — so it is reachable over a plain RPC while the stream
+     *  itself is held open elsewhere. Resolves `stopped: false` when there was
+     *  nothing left to stop, and names any tools still executing — their side
+     *  effects have already happened and are not undone by interrupting. */
+    interrupt: (
+      runId: string,
+      reason?: 'speech' | 'user' | 'timeout'
+    ) => Promise<AgentInterruptResult>
   }
 }
 

--- a/packages/services/ai-deepinfra/LICENSE
+++ b/packages/services/ai-deepinfra/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 - present Yasser Fadl and Pikku contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/services/ai-deepinfra/README.md
+++ b/packages/services/ai-deepinfra/README.md
@@ -1,0 +1,87 @@
+# @pikku/ai-deepinfra
+
+DeepInfra transcription and speech models for the Vercel AI SDK.
+
+`@ai-sdk/deepinfra` covers DeepInfra's language, embedding and image models. It
+does not cover audio, and `@ai-sdk/openai-compatible` cannot be pointed at
+DeepInfra's audio endpoints either: they are not OpenAI-shaped. Everything at
+DeepInfra — chat, ASR, TTS alike — is `POST /v1/inference/{model}`, and ASR takes
+its upload under a part named `audio` rather than OpenAI's `file`. This package
+is that gap, and nothing else.
+
+## Install
+
+```bash
+npm install @pikku/ai-deepinfra
+```
+
+## Usage
+
+```typescript
+import { createDeepInfra } from '@pikku/ai-deepinfra'
+import { VercelAIAgentRunner } from '@pikku/ai-vercel'
+
+const aiAgentRunner = new VercelAIAgentRunner({
+  deepinfra: createDeepInfra(), // reads DEEPINFRA_API_KEY
+})
+```
+
+Then name models the way the runner parses them — provider, slash, model id:
+
+```typescript
+voiceInput({ model: 'deepinfra/openai/whisper-large-v3-turbo' })
+voiceOutput({ model: 'deepinfra/hexgrad/Kokoro-82M' })
+```
+
+The runner splits on the *first* slash only, so the rest reaches DeepInfra
+intact. The `openai/` in that id is the org that published the weights on
+HuggingFace, not the vendor serving them — this is Whisper running on DeepInfra,
+with no OpenAI account involved.
+
+For language models, keep `@ai-sdk/deepinfra` alongside this one; the two are
+independent.
+
+## Options
+
+```typescript
+createDeepInfra({
+  apiKey,   // defaults to process.env.DEEPINFRA_API_KEY
+  baseURL,  // defaults to https://api.deepinfra.com/v1/inference
+  headers,  // merged into every request
+  fetch,    // injectable, so tests need neither a key nor a network
+})
+```
+
+The key is read per request rather than at construction, so a provider can be
+built before the environment is loaded — the error lands on the call that
+needed it.
+
+Per-model knobs ride through `providerOptions`:
+
+```typescript
+await transcribe({
+  model: deepinfra.transcription('openai/whisper-large-v3-turbo'),
+  audio,
+  providerOptions: { deepinfra: { chunk_level: 'word' } },
+})
+```
+
+## Models
+
+Anything DeepInfra serves; the model id is opaque to this package. Current
+audio options include:
+
+| Model                                    | Kind | Price                    |
+| ---------------------------------------- | ---- | ------------------------ |
+| `openai/whisper-large-v3-turbo`          | ASR  | $0.00020/min             |
+| `openai/whisper-large-v3`                | ASR  | $0.00045/min             |
+| `Qwen/Qwen3-ASR-0.6B`                    | ASR  | $0.00020/min             |
+| `Voxtral-Mini-3B`                        | ASR  | $0.00100/min             |
+| `hexgrad/Kokoro-82M`                     | TTS  | $0.80/M chars            |
+
+DeepInfra serves streaming-capable ASR models in batch mode only, so their
+streaming modes are not reachable through this API.
+
+## Docs
+
+https://pikku.dev/docs

--- a/packages/services/ai-deepinfra/package.json
+++ b/packages/services/ai-deepinfra/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@pikku/ai-deepinfra",
+  "version": "0.12.0",
+  "description": "DeepInfra transcription and speech models for the Vercel AI SDK",
+  "author": "yasser.fadl@gmail.com",
+  "license": "MIT",
+  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "tsc": "tsc",
+    "ncu": "npx npm-check-updates",
+    "build": "tsc -b",
+    "test": "bash run-tests.sh",
+    "test:coverage": "bash run-tests.sh --coverage",
+    "release": "npm run build && npm test",
+    "prepublishOnly": "yarn build"
+  },
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "peerDependencies": {
+    "@ai-sdk/provider": "^3.0.0"
+  },
+  "devDependencies": {
+    "@ai-sdk/provider": "^3.0.14",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/services/ai-deepinfra/run-tests.sh
+++ b/packages/services/ai-deepinfra/run-tests.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir" || exit 1
+
+# Enable nullglob to handle cases where no files match the pattern
+shopt -s nullglob
+
+# Initialize variables for options
+watch_mode=false
+coverage_mode=false
+
+# Parse command-line options
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --watch)
+      watch_mode=true
+      shift
+      ;;
+    --coverage)
+      coverage_mode=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Define the pattern to match your test files
+pattern="src/**/*.test.ts"
+
+# Expand the pattern into an array of files
+files=($(find src -type f -name "*.test.ts"))
+
+# Check if any files matched the pattern
+if [ ${#files[@]} -eq 0 ]; then
+  echo "No test files found matching pattern: $pattern"
+  if [ "${STRICT_TEST_DISCOVERY}" = "1" ]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+# Construct the node command
+node_cmd=(node --import tsx --test)
+
+# Append options based on flags
+if [ "$watch_mode" = true ]; then
+  node_cmd+=(--watch)
+fi
+
+if [ "$coverage_mode" = true ]; then
+  node_cmd+=(--test-coverage-include="src/**/*.{ts,js}" --test-coverage-exclude="**/dist/**" --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info)
+fi
+
+# Execute the node command with the expanded list of files
+"${node_cmd[@]}" "${files[@]}"

--- a/packages/services/ai-deepinfra/src/deepinfra-config.ts
+++ b/packages/services/ai-deepinfra/src/deepinfra-config.ts
@@ -1,0 +1,91 @@
+/**
+ * DeepInfra serves every model — chat, ASR, TTS alike — from one endpoint
+ * shape: `POST {baseURL}/{modelId}`, with the model id as a path segment.
+ *
+ * That is why this package needs no per-model code: the id is opaque, so
+ * `openai/whisper-large-v3-turbo` and `hexgrad/Kokoro-82M` differ only in the
+ * string. Model ids contain slashes, which is fine here — nothing splits them.
+ */
+export const DEEPINFRA_BASE_URL = 'https://api.deepinfra.com/v1/inference'
+
+export type DeepInfraFetch = typeof globalThis.fetch
+
+export type DeepInfraProviderSettings = {
+  /** Falls back to `DEEPINFRA_API_KEY`. */
+  apiKey?: string
+  /** Override for a proxy or a self-hosted deployment of the same API. */
+  baseURL?: string
+  /** Merged into every request. */
+  headers?: Record<string, string>
+  /** Injectable so tests need neither a key nor a network. */
+  fetch?: DeepInfraFetch
+}
+
+export type DeepInfraConfig = {
+  baseURL: string
+  /**
+   * Built per request rather than once, so a provider can be constructed
+   * before the key exists — the throw lands on the call that needed it, where
+   * the stack says which model was being reached for.
+   */
+  headers: () => Record<string, string>
+  fetch: DeepInfraFetch
+}
+
+export const resolveConfig = (
+  settings: DeepInfraProviderSettings
+): DeepInfraConfig => ({
+  baseURL: (settings.baseURL ?? DEEPINFRA_BASE_URL).replace(/\/+$/, ''),
+  headers: () => {
+    const apiKey = settings.apiKey ?? process.env.DEEPINFRA_API_KEY
+    if (!apiKey) {
+      throw new Error(
+        'DeepInfra API key is missing. Pass `apiKey` to createDeepInfra(), or set DEEPINFRA_API_KEY.'
+      )
+    }
+    return { authorization: `Bearer ${apiKey}`, ...settings.headers }
+  },
+  fetch: settings.fetch ?? globalThis.fetch,
+})
+
+/**
+ * Turns a failed response into an error that names the model and carries the
+ * body. DeepInfra puts the useful part (`detail`) in the body, so a bare status
+ * code would throw away the only sentence explaining what was wrong.
+ */
+export const failedResponseError = async (
+  modelId: string,
+  response: Response
+): Promise<Error> => {
+  let detail = ''
+  try {
+    detail = (await response.text()).slice(0, 500)
+  } catch {
+    // A body that cannot be read is not worth failing differently over — the
+    // status is still the story.
+  }
+  return new Error(
+    `DeepInfra request for '${modelId}' failed with ${response.status} ${response.statusText}${
+      detail ? `: ${detail}` : ''
+    }`
+  )
+}
+
+/**
+ * Per-call header overrides, minus the `undefined` values the V3 call options
+ * permit — `fetch` rejects a record that can hold them.
+ */
+export const definedHeaders = (
+  headers: Record<string, string | undefined> | undefined
+): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(headers ?? {}).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined
+    )
+  )
+
+/** Provider-specific extras, e.g. `{ deepinfra: { chunk_level: 'word' } }`. */
+export const providerExtras = (
+  providerOptions: Record<string, unknown> | undefined
+): Record<string, unknown> =>
+  (providerOptions?.['deepinfra'] as Record<string, unknown> | undefined) ?? {}

--- a/packages/services/ai-deepinfra/src/index.ts
+++ b/packages/services/ai-deepinfra/src/index.ts
@@ -1,0 +1,67 @@
+import type { SpeechModelV3, TranscriptionModelV3 } from '@ai-sdk/provider'
+import {
+  resolveConfig,
+  type DeepInfraProviderSettings,
+} from './deepinfra-config.js'
+import { DeepInfraSpeechModel } from './speech-model.js'
+import { DeepInfraTranscriptionModel } from './transcription-model.js'
+
+export type {
+  DeepInfraConfig,
+  DeepInfraFetch,
+  DeepInfraProviderSettings,
+} from './deepinfra-config.js'
+export { DEEPINFRA_BASE_URL } from './deepinfra-config.js'
+export { DeepInfraSpeechModel } from './speech-model.js'
+export { DeepInfraTranscriptionModel } from './transcription-model.js'
+
+export type DeepInfraProvider = {
+  transcription(modelId: string): TranscriptionModelV3
+  speech(modelId: string): SpeechModelV3
+  /**
+   * Same objects under the alternative names. Runners probe for one or the
+   * other — pikku's checks `transcription|transcriptionModel` — and which one
+   * a given version looks for is not worth a support thread.
+   */
+  transcriptionModel(modelId: string): TranscriptionModelV3
+  speechModel(modelId: string): SpeechModelV3
+}
+
+/**
+ * Transcription and speech models served by DeepInfra.
+ *
+ * Model ids are DeepInfra's own and contain a slash — the HuggingFace org that
+ * published the weights, then the model:
+ *
+ * ```ts
+ * const deepinfra = createDeepInfra()
+ * deepinfra.transcription('openai/whisper-large-v3-turbo')
+ * deepinfra.speech('hexgrad/Kokoro-82M')
+ * ```
+ *
+ * `openai/` there names who trained it, not who is serving it. Under pikku the
+ * full string gains a provider prefix — `deepinfra/openai/whisper-large-v3-turbo`
+ * — and only the first slash is significant.
+ *
+ * Deliberately no language models: `@ai-sdk/deepinfra` already covers those,
+ * and only audio is missing.
+ */
+export const createDeepInfra = (
+  settings: DeepInfraProviderSettings = {}
+): DeepInfraProvider => {
+  const config = resolveConfig(settings)
+
+  const transcription = (modelId: string) =>
+    new DeepInfraTranscriptionModel(modelId, config)
+  const speech = (modelId: string) => new DeepInfraSpeechModel(modelId, config)
+
+  return {
+    transcription,
+    speech,
+    transcriptionModel: transcription,
+    speechModel: speech,
+  }
+}
+
+/** Default instance, reading `DEEPINFRA_API_KEY` when first called. */
+export const deepinfra = createDeepInfra()

--- a/packages/services/ai-deepinfra/src/speech-model.test.ts
+++ b/packages/services/ai-deepinfra/src/speech-model.test.ts
@@ -1,0 +1,154 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createDeepInfra } from './index.js'
+
+const stubFetch = (
+  body: unknown,
+  init: { status?: number; contentType?: string } = {}
+) => {
+  const calls: Array<{ url: string; init: RequestInit }> = []
+  const fetch = (async (url: string, requestInit: RequestInit) => {
+    calls.push({ url, init: requestInit })
+    const payload =
+      body instanceof Uint8Array
+        ? body
+        : typeof body === 'string'
+          ? body
+          : JSON.stringify(body ?? {})
+    return new Response(payload as BodyInit, {
+      status: init.status ?? 200,
+      headers: { 'content-type': init.contentType ?? 'application/json' },
+    })
+  }) as unknown as typeof globalThis.fetch
+  return { fetch, calls }
+}
+
+const wavDataUri = 'data:audio/wav;base64,UklGRiQ='
+
+describe('DeepInfraSpeechModel', () => {
+  test('posts JSON to the model path with the standard options mapped', async () => {
+    const { fetch, calls } = stubFetch({ audio: wavDataUri })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).speech(
+      'hexgrad/Kokoro-82M'
+    )
+
+    await model.doGenerate({
+      text: 'hello there',
+      voice: 'af_bella',
+      speed: 1.1,
+      outputFormat: 'wav',
+      language: 'en',
+    })
+
+    assert.equal(
+      calls[0]!.url,
+      'https://api.deepinfra.com/v1/inference/hexgrad/Kokoro-82M'
+    )
+    assert.deepEqual(JSON.parse(calls[0]!.init.body as string), {
+      // Both names, because the models disagree on which they want: Kokoro
+      // requires `text`, Qwen3-TTS requires `input` and rejects a body without
+      // it. Each tolerates the other as an extra, so one body serves both.
+      text: 'hello there',
+      input: 'hello there',
+      preset_voice: 'af_bella',
+      speed: 1.1,
+      output_format: 'wav',
+      language: 'en',
+    })
+  })
+
+  test('strips the data URI prefix but does not decode the base64', async () => {
+    const { fetch } = stubFetch({ audio: wavDataUri })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).speech('m')
+
+    const result = await model.doGenerate({ text: 'hi' })
+
+    // The V3 contract says base64 comes back as base64 — decoding here would
+    // only be re-encoded a layer up.
+    assert.equal(result.audio, 'UklGRiQ=')
+  })
+
+  test('passes raw bytes through untouched', async () => {
+    const bytes = new Uint8Array([0, 1, 2, 3])
+    const { fetch } = stubFetch(bytes, { contentType: 'audio/wav' })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).speech('m')
+
+    const result = await model.doGenerate({ text: 'hi' })
+
+    assert.ok(result.audio instanceof Uint8Array)
+    assert.deepEqual(result.audio, bytes)
+  })
+
+  test('warns about instructions rather than dropping them silently', async () => {
+    const { fetch } = stubFetch({ audio: wavDataUri })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).speech('m')
+
+    const result = await model.doGenerate({
+      text: 'hi',
+      instructions: 'speak slowly and warmly',
+    })
+
+    // Silently ignoring it is how a caller ends up trusting a setting that
+    // never took effect.
+    assert.equal(result.warnings.length, 1)
+    assert.equal(result.warnings[0]!.type, 'unsupported')
+    assert.equal(
+      (result.warnings[0] as { feature: string }).feature,
+      'instructions'
+    )
+  })
+
+  test('provider options ride through for per-model knobs', async () => {
+    const { fetch, calls } = stubFetch({ audio: wavDataUri })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).speech('m')
+
+    await model.doGenerate({
+      text: 'hi',
+      providerOptions: { deepinfra: { seed: 7 } },
+    })
+
+    assert.equal(JSON.parse(calls[0]!.init.body as string).seed, 7)
+  })
+
+  test('JSON without an audio string fails loudly', async () => {
+    const { fetch } = stubFetch({ detail: 'quota exceeded' })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).speech('m')
+
+    await assert.rejects(
+      () => model.doGenerate({ text: 'hi' }),
+      /returned JSON without an 'audio' string/
+    )
+  })
+
+  test('a failure names the model and keeps the body', async () => {
+    const { fetch } = stubFetch('{"detail":"bad voice"}', { status: 422 })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).speech(
+      'hexgrad/Kokoro-82M'
+    )
+
+    await assert.rejects(
+      () => model.doGenerate({ text: 'hi' }),
+      /'hexgrad\/Kokoro-82M' failed with 422.*bad voice/s
+    )
+  })
+
+  test('omitted options are omitted, not sent as null', async () => {
+    const { fetch, calls } = stubFetch({ audio: wavDataUri })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).speech('m')
+
+    await model.doGenerate({ text: 'hi' })
+
+    const body = calls[0]!.init.body as string
+    assert.deepEqual(JSON.parse(body), { text: 'hi', input: 'hi' })
+  })
+
+  test('both provider method names return a usable model', () => {
+    const provider = createDeepInfra({ apiKey: 'k' })
+
+    // Runners probe for one name or the other; both must work.
+    assert.equal(provider.speech('m').modelId, 'm')
+    assert.equal(provider.speechModel('m').modelId, 'm')
+    assert.equal(provider.transcription('m').specificationVersion, 'v3')
+    assert.equal(provider.transcriptionModel('m').provider, 'deepinfra')
+  })
+})

--- a/packages/services/ai-deepinfra/src/speech-model.ts
+++ b/packages/services/ai-deepinfra/src/speech-model.ts
@@ -1,0 +1,111 @@
+import type {
+  SharedV3Warning,
+  SpeechModelV3,
+  SpeechModelV3CallOptions,
+} from '@ai-sdk/provider'
+import {
+  definedHeaders,
+  failedResponseError,
+  providerExtras,
+  type DeepInfraConfig,
+} from './deepinfra-config.js'
+
+/**
+ * Pulls the payload out of `data:audio/wav;base64,…`.
+ *
+ * DeepInfra's TTS models answer with JSON holding a data URI rather than raw
+ * bytes. The V3 contract says to return base64 as base64 without converting,
+ * so only the prefix comes off — decoding here would mean re-encoding one
+ * layer up.
+ */
+const stripDataUri = (audio: string): string => {
+  const comma = audio.indexOf(',')
+  return audio.startsWith('data:') && comma !== -1
+    ? audio.slice(comma + 1)
+    : audio
+}
+
+export class DeepInfraSpeechModel implements SpeechModelV3 {
+  readonly specificationVersion = 'v3' as const
+  readonly provider = 'deepinfra'
+
+  constructor(
+    readonly modelId: string,
+    private readonly config: DeepInfraConfig
+  ) {}
+
+  async doGenerate(options: SpeechModelV3CallOptions) {
+    const warnings: SharedV3Warning[] = []
+
+    // Surfaced rather than dropped. `voiceOutput` labels every chunk with the
+    // format that came back, and the browser decodes on that label, so a
+    // silently ignored setting turns into an undecodable sentence far from
+    // here. A warning is the difference between a bug and a note.
+    if (options.instructions) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'instructions',
+        details:
+          'DeepInfra speech models take no free-text style instructions; use `voice`.',
+      })
+    }
+
+    const response = await this.config.fetch(
+      `${this.config.baseURL}/${this.modelId}`,
+      {
+        method: 'POST',
+        headers: {
+          ...this.config.headers(),
+          'content-type': 'application/json',
+          ...definedHeaders(options.headers),
+        },
+        body: JSON.stringify({
+          // The same string under both names, because DeepInfra's TTS models do
+          // not agree on one: Kokoro and Orpheus require `text`, Qwen3-TTS
+          // requires `input` and rejects a body without it. Every model tested
+          // accepts the other key as a harmless extra, so sending both is what
+          // keeps one provider from needing a per-model field table.
+          text: options.text,
+          input: options.text,
+          // Voice ids are per-model — Kokoro's are not Orpheus's — so the
+          // value passes through untouched and the model validates it.
+          preset_voice: options.voice,
+          speed: options.speed,
+          output_format: options.outputFormat,
+          language: options.language,
+          ...providerExtras(options.providerOptions),
+        }),
+        signal: options.abortSignal,
+      }
+    )
+
+    if (!response.ok) throw await failedResponseError(this.modelId, response)
+
+    const contentType = response.headers.get('content-type') ?? ''
+    let audio: string | Uint8Array
+
+    if (contentType.includes('application/json')) {
+      const payload = (await response.json()) as { audio?: unknown }
+      if (typeof payload.audio !== 'string') {
+        throw new Error(
+          `DeepInfra speech model '${this.modelId}' returned JSON without an 'audio' string.`
+        )
+      }
+      audio = stripDataUri(payload.audio)
+    } else {
+      // Some deployments answer with the bytes directly. Handing them back
+      // unconverted is what the V3 contract asks for.
+      audio = new Uint8Array(await response.arrayBuffer())
+    }
+
+    return {
+      audio,
+      warnings,
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: Object.fromEntries(response.headers),
+      },
+    }
+  }
+}

--- a/packages/services/ai-deepinfra/src/transcription-model.test.ts
+++ b/packages/services/ai-deepinfra/src/transcription-model.test.ts
@@ -1,0 +1,256 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createDeepInfra } from './index.js'
+
+/** Captures the request and answers with `body`, so no key and no network. */
+const stubFetch = (
+  body: unknown,
+  init: { status?: number; contentType?: string } = {}
+) => {
+  const calls: Array<{ url: string; init: RequestInit }> = []
+  const fetch = (async (url: string, requestInit: RequestInit) => {
+    calls.push({ url, init: requestInit })
+    const payload = typeof body === 'string' ? body : JSON.stringify(body ?? {})
+    return new Response(payload, {
+      status: init.status ?? 200,
+      headers: {
+        'content-type': init.contentType ?? 'application/json',
+      },
+    })
+  }) as unknown as typeof globalThis.fetch
+  return { fetch, calls }
+}
+
+const audio = new Uint8Array([1, 2, 3, 4])
+
+describe('DeepInfraTranscriptionModel', () => {
+  test('posts the model id as a path segment, slashes intact', async () => {
+    const { fetch, calls } = stubFetch({ text: 'hello' })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).transcription(
+      'openai/whisper-large-v3-turbo'
+    )
+
+    await model.doGenerate({ audio, mediaType: 'audio/wav' })
+
+    // The embedded slash is the model id, not a route separator — nothing may
+    // split or escape it.
+    assert.equal(
+      calls[0]!.url,
+      'https://api.deepinfra.com/v1/inference/openai/whisper-large-v3-turbo'
+    )
+  })
+
+  test("sends the audio under 'audio', which is why an OpenAI client cannot be aimed here", async () => {
+    const { fetch, calls } = stubFetch({ text: 'hello' })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).transcription('m')
+
+    await model.doGenerate({ audio, mediaType: 'audio/mpeg' })
+
+    const body = calls[0]!.init.body as FormData
+    assert.ok(body instanceof FormData)
+    assert.ok(body.get('audio'), "expected an 'audio' part")
+    assert.equal(body.get('file'), null, "OpenAI's field name must be absent")
+    assert.equal((body.get('audio') as File).name, 'audio.mp3')
+  })
+
+  test('accepts base64 audio as well as bytes', async () => {
+    const { fetch, calls } = stubFetch({ text: 'hello' })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).transcription('m')
+
+    await model.doGenerate({
+      audio: Buffer.from(audio).toString('base64'),
+      mediaType: 'audio/wav',
+    })
+
+    const part = (calls[0]!.init.body as FormData).get('audio') as File
+    assert.deepEqual(new Uint8Array(await part.arrayBuffer()), audio)
+  })
+
+  test('maps text, language, segments and duration', async () => {
+    const { fetch } = stubFetch({
+      text: 'the transcribed spoken words',
+      language: 'en',
+      input_length_ms: 2500,
+      segments: [{ text: 'the transcribed', start: 0, end: 1.2 }],
+    })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).transcription('m')
+
+    const result = await model.doGenerate({ audio, mediaType: 'audio/wav' })
+
+    assert.equal(result.text, 'the transcribed spoken words')
+    assert.equal(result.language, 'en')
+    assert.equal(result.durationInSeconds, 2.5)
+    assert.deepEqual(result.segments, [
+      { text: 'the transcribed', startSecond: 0, endSecond: 1.2 },
+    ])
+  })
+
+  test('drops unusable segments rather than losing the transcript', async () => {
+    const { fetch } = stubFetch({
+      text: 'still here',
+      segments: [
+        { text: 'good', start: 0, end: 1 },
+        { text: 'no timings' },
+        { start: 1, end: 2 },
+        'not an object',
+        { text: 'nan', start: Number.NaN, end: 2 },
+      ],
+    })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).transcription('m')
+
+    const result = await model.doGenerate({ audio, mediaType: 'audio/wav' })
+
+    // A caller who only wanted the words still gets them.
+    assert.equal(result.text, 'still here')
+    assert.deepEqual(result.segments, [
+      { text: 'good', startSecond: 0, endSecond: 1 },
+    ])
+  })
+
+  test('reports per-segment confidence without acting on it', async () => {
+    // The real measured turn: "Thank you." invented after a genuine question.
+    // Both fields fail to separate them — no_speech is 0.000 either way and the
+    // logprobs are a fifth of a nat apart — which is why the text comes back
+    // whole and the numbers come back as diagnostics.
+    const { fetch } = stubFetch({
+      text: ' Hey, is this working okay?  Thank you.',
+      segments: [
+        {
+          text: ' Hey, is this working okay?',
+          start: 0.3,
+          end: 2.1,
+          no_speech_prob: 0,
+          avg_logprob: -0.3,
+        },
+        {
+          text: ' Thank you.',
+          start: 2.1,
+          end: 2.5,
+          no_speech_prob: 0,
+          avg_logprob: -0.52,
+        },
+      ],
+    })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).transcription('m')
+
+    const result = await model.doGenerate({ audio, mediaType: 'audio/wav' })
+
+    assert.equal(result.text, ' Hey, is this working okay?  Thank you.')
+    assert.deepEqual(result.providerMetadata?.['deepinfra'], {
+      segments: [
+        {
+          text: ' Hey, is this working okay?',
+          startSecond: 0.3,
+          endSecond: 2.1,
+          noSpeechProbability: 0,
+          avgLogProbability: -0.3,
+        },
+        {
+          text: ' Thank you.',
+          startSecond: 2.1,
+          endSecond: 2.5,
+          noSpeechProbability: 0,
+          avgLogProbability: -0.52,
+        },
+      ],
+    })
+  })
+
+  test("'auto' is a detection mode, not a language, so it is not reported as one", async () => {
+    const { fetch } = stubFetch({ text: 'hello', language: 'auto' })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).transcription(
+      'nvidia/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b'
+    )
+
+    const result = await model.doGenerate({ audio, mediaType: 'audio/wav' })
+
+    assert.equal(result.language, undefined)
+  })
+
+  test('non-speech comes back as an empty transcript, not as filler', async () => {
+    // Nemotron's answer to silence, and the property the whole no-speech check
+    // now rests on. Recorded here so a model swap that breaks it is a test
+    // failure rather than a conversation about nothing.
+    const { fetch } = stubFetch({
+      text: '',
+      segments: [],
+      language: 'auto',
+      input_length_ms: 4000,
+    })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).transcription(
+      'nvidia/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b'
+    )
+
+    const result = await model.doGenerate({ audio, mediaType: 'audio/wav' })
+
+    assert.equal(result.text, '')
+    assert.deepEqual(result.segments, [])
+    assert.equal(result.providerMetadata, undefined)
+  })
+
+  test('omits confidence entirely when the provider reports none', async () => {
+    const { fetch } = stubFetch({
+      text: 'hello',
+      segments: [{ text: 'hello', start: 0, end: 1 }],
+    })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).transcription('m')
+
+    const result = await model.doGenerate({ audio, mediaType: 'audio/wav' })
+
+    // Absent, not zero — a fabricated 0 would read as "certainly speech".
+    assert.equal(result.providerMetadata, undefined)
+  })
+
+  test('a missing segments field is empty, not a crash', async () => {
+    const { fetch } = stubFetch({ text: 'hello' })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).transcription('m')
+
+    const result = await model.doGenerate({ audio, mediaType: 'audio/wav' })
+
+    assert.deepEqual(result.segments, [])
+    assert.equal(result.language, undefined)
+    assert.equal(result.durationInSeconds, undefined)
+  })
+
+  test('a failure names the model and keeps the body', async () => {
+    const { fetch } = stubFetch('{"detail":"model not found"}', { status: 404 })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).transcription(
+      'openai/nope'
+    )
+
+    await assert.rejects(
+      () => model.doGenerate({ audio, mediaType: 'audio/wav' }),
+      /'openai\/nope' failed with 404.*model not found/s
+    )
+  })
+
+  test('forwards the abort signal so barge-in cancels work in flight', async () => {
+    const { fetch, calls } = stubFetch({ text: 'hello' })
+    const model = createDeepInfra({ apiKey: 'k', fetch }).transcription('m')
+    const controller = new AbortController()
+
+    await model.doGenerate({
+      audio,
+      mediaType: 'audio/wav',
+      abortSignal: controller.signal,
+    })
+
+    assert.equal(calls[0]!.init.signal, controller.signal)
+  })
+
+  test('the key is demanded at call time, naming the env var', async () => {
+    const { fetch } = stubFetch({ text: 'hello' })
+    const previous = process.env.DEEPINFRA_API_KEY
+    delete process.env.DEEPINFRA_API_KEY
+    try {
+      // Constructing without a key is fine — only the call needs one.
+      const model = createDeepInfra({ fetch }).transcription('m')
+      await assert.rejects(
+        () => model.doGenerate({ audio, mediaType: 'audio/wav' }),
+        /DEEPINFRA_API_KEY/
+      )
+    } finally {
+      if (previous !== undefined) process.env.DEEPINFRA_API_KEY = previous
+    }
+  })
+})

--- a/packages/services/ai-deepinfra/src/transcription-model.ts
+++ b/packages/services/ai-deepinfra/src/transcription-model.ts
@@ -1,0 +1,229 @@
+import type {
+  SharedV3Warning,
+  TranscriptionModelV3,
+  TranscriptionModelV3CallOptions,
+} from '@ai-sdk/provider'
+import {
+  definedHeaders,
+  failedResponseError,
+  providerExtras,
+  type DeepInfraConfig,
+} from './deepinfra-config.js'
+
+/** Extensions DeepInfra's ASR responses are known to use. */
+type DeepInfraTranscriptionResponse = {
+  text?: string
+  language?: string
+  input_length_ms?: number
+  segments?: unknown
+}
+
+/**
+ * Whatever the caller handed us, as bytes. The V3 contract allows a base64
+ * string as well as a `Uint8Array`.
+ */
+const toBytes = (audio: Uint8Array | string): Uint8Array =>
+  typeof audio === 'string'
+    ? Uint8Array.from(Buffer.from(audio, 'base64'))
+    : audio
+
+/**
+ * A filename with a plausible extension.
+ *
+ * Multipart uploads carry the media type on the part, but DeepInfra — like
+ * most Whisper deployments — also sniffs the extension, and a name it cannot
+ * place is a decode failure rather than a fallback.
+ */
+const filenameFor = (mediaType: string): string => {
+  const subtype = mediaType.split('/')[1]?.split(';')[0] ?? 'wav'
+  const extension =
+    subtype === 'mpeg' ? 'mp3' : subtype === 'x-wav' ? 'wav' : subtype
+  return `audio.${extension}`
+}
+
+/**
+ * Segments, defensively.
+ *
+ * Timings are the one part of the response we cannot verify without calling
+ * the real thing, and they are not worth failing a transcript over: a caller
+ * that only wants `text` should still get it if a segment is malformed. So
+ * anything unrecognisable is dropped rather than coerced into a wrong number.
+ */
+const toSegments = (
+  raw: unknown
+): Array<{ text: string; startSecond: number; endSecond: number }> => {
+  if (!Array.isArray(raw)) return []
+
+  const segments: Array<{
+    text: string
+    startSecond: number
+    endSecond: number
+  }> = []
+
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue
+    const record = entry as Record<string, unknown>
+    const start = record['start'] ?? record['startSecond']
+    const end = record['end'] ?? record['endSecond']
+    const text = record['text']
+    if (
+      typeof text !== 'string' ||
+      typeof start !== 'number' ||
+      typeof end !== 'number' ||
+      !Number.isFinite(start) ||
+      !Number.isFinite(end)
+    ) {
+      continue
+    }
+    segments.push({ text, startSecond: start, endSecond: end })
+  }
+
+  return segments
+}
+
+/**
+ * Per-segment confidence, reported for inspection and explicitly not to be
+ * filtered on.
+ *
+ * Whisper was trained on subtitles, so noise it cannot parse does not come back
+ * as nothing — it comes back as stock subtitle filler appended to whatever was
+ * really said. It is tempting to drop the low-confidence segments, and callers
+ * should not, because these numbers do not support it. Measured on a real turn
+ * where "Thank you." was invented after a genuine question:
+ *
+ *     no_speech 0.000  logprob -0.30  "Hey, is this working okay?"   (spoken)
+ *     no_speech 0.000  logprob -0.52  "Thank you."                   (invented)
+ *
+ * Neither field separates them. `no_speech` reads 0.000 for both, and the
+ * logprobs are a fifth of a nat apart — Whisper is confident when it invents,
+ * because the text it invents is high-probability text. A threshold loose
+ * enough to catch -0.52 eats real speech, and one tight enough to spare real
+ * speech never fires.
+ *
+ * Nor are the fields portable: Nemotron returns segments with `avg_logprob`
+ * hardcoded to 0.0, so a filter written against Whisper silently becomes a
+ * no-op — or, worse, a drop-everything — on a different model behind the same
+ * provider. Treat these as diagnostics for a human looking at a waveform.
+ */
+const speechConfidence = (
+  raw: unknown
+):
+  | Array<{
+      text: string
+      startSecond: number
+      endSecond: number
+      noSpeechProbability: number
+      avgLogProbability: number
+    }>
+  | undefined => {
+  if (!Array.isArray(raw) || raw.length === 0) return undefined
+
+  const scored: Array<{
+    text: string
+    startSecond: number
+    endSecond: number
+    noSpeechProbability: number
+    avgLogProbability: number
+  }> = []
+
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue
+    const record = entry as Record<string, unknown>
+    const text = record['text']
+    const start = record['start']
+    const end = record['end']
+    const p = record['no_speech_prob']
+    const lp = record['avg_logprob']
+    if (
+      typeof text !== 'string' ||
+      typeof p !== 'number' ||
+      typeof lp !== 'number'
+    ) {
+      continue
+    }
+    scored.push({
+      text,
+      startSecond: typeof start === 'number' ? start : 0,
+      endSecond: typeof end === 'number' ? end : 0,
+      noSpeechProbability: p,
+      avgLogProbability: lp,
+    })
+  }
+
+  return scored.length > 0 ? scored : undefined
+}
+
+export class DeepInfraTranscriptionModel implements TranscriptionModelV3 {
+  readonly specificationVersion = 'v3' as const
+  readonly provider = 'deepinfra'
+
+  constructor(
+    readonly modelId: string,
+    private readonly config: DeepInfraConfig
+  ) {}
+
+  async doGenerate(options: TranscriptionModelV3CallOptions) {
+    const warnings: SharedV3Warning[] = []
+
+    const body = new FormData()
+    body.append(
+      // DeepInfra names the part `audio`; OpenAI names it `file`. This is the
+      // whole reason the OpenAI-compatible client cannot be pointed here.
+      'audio',
+      new Blob([toBytes(options.audio) as BlobPart], {
+        type: options.mediaType,
+      }),
+      filenameFor(options.mediaType)
+    )
+
+    for (const [key, value] of Object.entries(
+      providerExtras(options.providerOptions)
+    )) {
+      if (value !== undefined && value !== null) body.append(key, String(value))
+    }
+
+    const response = await this.config.fetch(
+      `${this.config.baseURL}/${this.modelId}`,
+      {
+        method: 'POST',
+        // No content-type: fetch sets it, with the multipart boundary.
+        headers: {
+          ...this.config.headers(),
+          ...definedHeaders(options.headers),
+        },
+        body,
+        // Barge-in has to cancel work that is genuinely in flight, not merely
+        // stop reading its result.
+        signal: options.abortSignal,
+      }
+    )
+
+    if (!response.ok) throw await failedResponseError(this.modelId, response)
+
+    const payload = (await response.json()) as DeepInfraTranscriptionResponse
+    const confidence = speechConfidence(payload.segments)
+
+    return {
+      text: payload.text ?? '',
+      segments: toSegments(payload.segments),
+      // Nemotron reports the literal string 'auto' when it was not asked to
+      // detect a language. That is a mode, not a language tag, and passing it
+      // on as one would have callers matching it against BCP-47.
+      language: payload.language === 'auto' ? undefined : payload.language,
+      durationInSeconds:
+        typeof payload.input_length_ms === 'number'
+          ? payload.input_length_ms / 1000
+          : undefined,
+      warnings,
+      ...(confidence
+        ? { providerMetadata: { deepinfra: { segments: confidence } } }
+        : {}),
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: Object.fromEntries(response.headers),
+        body: payload,
+      },
+    }
+  }
+}

--- a/packages/services/ai-deepinfra/tsconfig.json
+++ b/packages/services/ai-deepinfra/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "module": "Node18",
+    "outDir": "dist",
+    "target": "esnext",
+    "declaration": true,
+    "composite": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.test.ts", "node_modules"]
+}

--- a/packages/services/ai-vercel/src/message-converter.test.ts
+++ b/packages/services/ai-vercel/src/message-converter.test.ts
@@ -209,6 +209,34 @@ describe('convertToSDKMessages', () => {
     ])
     assert.equal((out as any).content[0].output.value, 'plain text')
   })
+
+  test('an undelivered result says so, and keeps the result inside it', async () => {
+    // Without this the model cannot tell a result saved after an interrupt
+    // from one it already used, and a model asked to mention the former
+    // announces the latter — reporting a cancelled read as though something
+    // had happened.
+    const [out] = await convertToSDKMessages([
+      msg({
+        role: 'tool',
+        undelivered: true,
+        toolResults: [{ id: 'c1', name: 'deploy', result: '{"shipped":true}' }],
+      }),
+    ])
+    const { value } = (out as any).content[0].output
+    assert.equal(value.undelivered, true)
+    assert.deepEqual(value.result, { shipped: true })
+    assert.match(value.note, /cut off/)
+  })
+
+  test('an ordinary result is not wrapped, so tools read as they were written', async () => {
+    const [out] = await convertToSDKMessages([
+      msg({
+        role: 'tool',
+        toolResults: [{ id: 'c1', name: 'lookup', result: '{"found":true}' }],
+      }),
+    ])
+    assert.deepEqual((out as any).content[0].output.value, { found: true })
+  })
 })
 
 /**

--- a/packages/services/ai-vercel/src/message-converter.ts
+++ b/packages/services/ai-vercel/src/message-converter.ts
@@ -108,7 +108,23 @@ function convertToSDKMessage(msg: AIMessage): ModelMessage {
                 type: 'tool-result' as const,
                 toolCallId: tr.id,
                 toolName: tr.name,
-                output: { type: 'json' as const, value: parsed },
+                // Wrapped rather than passed through, because the difference
+                // matters to the model and is invisible otherwise. A result
+                // saved after its run was cut off looks exactly like one the
+                // model already used, so without this the only way to guess
+                // which is which is the fact that a turn was interrupted — and
+                // a model told to mention undelivered results guesses wrong,
+                // announcing a read that was cancelled and cost nothing.
+                output: msg.undelivered
+                  ? {
+                      type: 'json' as const,
+                      value: {
+                        undelivered: true,
+                        note: 'This finished after the reply was cut off, so it was never reported to the user.',
+                        result: parsed,
+                      },
+                    }
+                  : { type: 'json' as const, value: parsed },
               }
             })
           : [],

--- a/packages/services/ai-vercel/src/vercel-ai-agent-runner.test.ts
+++ b/packages/services/ai-vercel/src/vercel-ai-agent-runner.test.ts
@@ -35,3 +35,92 @@ describe('VercelAIAgentRunner.withApiKey', () => {
     assert.deepEqual(second.providers, { openai: { apiKey: 'key-b' } })
   })
 })
+
+describe('VercelAIAgentRunner provider resolution', () => {
+  /** `getProvider` is private, and the rule it encodes is the unit under test
+   *  — going through `run`/`transcribe` would drag a real AI SDK call in. */
+  const resolve = (providers: Record<string, unknown>, name: string) =>
+    (new VercelAIAgentRunner(providers) as any).getProvider(name)
+
+  test('an exact entry wins over the catch-all', () => {
+    const direct = { name: 'direct' }
+    const gateway = { name: 'gateway' }
+
+    // The shape that makes "everything through the gateway except this one"
+    // expressible — which is the whole point of the precedence.
+    assert.strictEqual(
+      resolve({ deepinfra: direct, '*': gateway }, 'deepinfra'),
+      direct
+    )
+    assert.strictEqual(
+      resolve({ deepinfra: direct, '*': gateway }, 'anthropic'),
+      gateway
+    )
+  })
+
+  test('the catch-all resolves names nobody registered', () => {
+    const scripted = { name: 'scripted' }
+    const providers = { '*': scripted }
+
+    // A scripted suite must stay sealed against model strings written after
+    // it: no name may fall through to a real endpoint.
+    assert.strictEqual(resolve(providers, 'openai'), scripted)
+    assert.strictEqual(resolve(providers, 'deepinfra'), scripted)
+    assert.strictEqual(resolve(providers, 'invented-yesterday'), scripted)
+  })
+
+  test('without a catch-all an unknown provider still throws, naming what exists', () => {
+    assert.throws(
+      () => resolve({ openai: {} }, 'deepinfra'),
+      /Unknown AI provider: 'deepinfra'\. Available: openai/
+    )
+  })
+
+  test('an empty record throws rather than resolving to undefined', () => {
+    assert.throws(() => resolve({}, 'openai'), /Available: none/)
+  })
+})
+
+describe('VercelAIAgentRunner.transcribe on silence', () => {
+  /** A provider whose model transcribes everything to nothing. */
+  const silentProvider = (text: string) => ({
+    transcription: (modelId: string) => ({
+      specificationVersion: 'v3' as const,
+      provider: 'stub',
+      modelId,
+      async doGenerate() {
+        return {
+          text,
+          segments: [],
+          warnings: [],
+          response: { timestamp: new Date(0), modelId, headers: {} },
+        }
+      },
+    }),
+  })
+
+  const runner = (text: string) =>
+    new VercelAIAgentRunner({ stub: silentProvider(text) })
+
+  test('a turn with no speech returns empty text rather than throwing', async () => {
+    // The AI SDK treats an empty transcript as an error, which is right for a
+    // transcription job and wrong at a microphone: a pause is the most ordinary
+    // thing a silence detector can hand us, and it must not fail the run.
+    const result = await runner('').transcribe({
+      model: 'stub/whisper',
+      audio: new Uint8Array([1, 2, 3]),
+    })
+
+    assert.equal(result.text, '')
+    assert.deepEqual(result.segments, [])
+  })
+
+  test('a real transcript still comes through untouched', async () => {
+    const result = await runner('the transcribed spoken words').transcribe({
+      model: 'stub/whisper',
+      audio: new Uint8Array([1, 2, 3]),
+    })
+
+    assert.equal(result.text, 'the transcribed spoken words')
+  })
+})

--- a/packages/services/ai-vercel/src/vercel-ai-agent-runner.ts
+++ b/packages/services/ai-vercel/src/vercel-ai-agent-runner.ts
@@ -6,12 +6,14 @@ import {
   generateImage,
   generateText,
   jsonSchema,
+  NoTranscriptGeneratedError,
   Output,
   rerank,
   stepCountIs,
   streamText,
   tool as aiTool,
 } from 'ai'
+import type { SharedV3ProviderOptions } from '@ai-sdk/provider'
 import { safeDownload } from './safe-download.js'
 import type {
   AIAgentRunnerParams,
@@ -299,8 +301,19 @@ export class VercelAIAgentRunner implements AIAgentRunnerService {
     }
   }
 
+  /**
+   * Resolves a provider name to the object that builds models for it.
+   *
+   * A `'*'` entry catches anything with no exact match. That only makes sense
+   * when whatever sits behind it accepts arbitrary model names — a scripted
+   * provider, or a gateway — so pointing it at a single real vendor is a
+   * mistake: `anthropic/...` reaching OpenAI is not a fallback, it is a bug.
+   *
+   * Exact entries win, which is what makes "everything through the gateway
+   * except this one" expressible as `{ deepinfra: direct, '*': gateway }`.
+   */
   private getProvider(providerName: string) {
-    const provider = this.providers[providerName]
+    const provider = this.providers[providerName] ?? this.providers['*']
     if (!provider) {
       const available = Object.keys(this.providers).join(', ')
       throw new Error(
@@ -371,12 +384,31 @@ export class VercelAIAgentRunner implements AIAgentRunnerService {
     )
   }
 
-  private buildProviderOptions(params: AIAgentRunnerParams) {
-    if (!params.agentId) return undefined
+  private buildProviderOptions(
+    params: AIAgentRunnerParams
+  ): SharedV3ProviderOptions | undefined {
+    const caller = params.providerOptions as SharedV3ProviderOptions | undefined
+    if (!params.agentId) return caller
     const meta = { agent_id: params.agentId }
     // Spread into the request body for every provider so LiteLLM picks up
     // agent_id and includes it in the spend-log / generic_api callback.
-    return { openai: { metadata: meta }, anthropic: { metadata: meta } }
+    const merged: Record<string, Record<string, unknown>> = {
+      openai: { metadata: meta },
+      anthropic: { metadata: meta },
+    }
+    // Merged one provider at a time rather than by top-level key: replacing the
+    // whole `openai` entry with the caller's would drop `metadata` and quietly
+    // end the per-agent billing breakdown, which nothing downstream would
+    // notice. Within a provider the caller still wins on every key it sets.
+    for (const [provider, options] of Object.entries(caller ?? {})) {
+      merged[provider] = { ...merged[provider], ...options }
+    }
+    // Cast because core types these values as `unknown` and the SDK wants
+    // `JSONValue`. Core cannot narrow them without taking a type dependency on
+    // the SDK, and the constraint holds anyway: whatever goes in here ends up
+    // serialized into a request body, so a non-JSON value was never going to
+    // survive the trip regardless of what the type said.
+    return merged as SharedV3ProviderOptions
   }
 
   async stream(
@@ -406,6 +438,7 @@ export class VercelAIAgentRunner implements AIAgentRunnerService {
       stopWhen: stepCountIs(1),
       experimental_download: safeDownload(this.allowedAttachmentHosts),
       toolChoice: params.toolChoice,
+      abortSignal: params.abortSignal,
       ...(params.temperature !== undefined && {
         temperature: params.temperature,
       }),
@@ -563,6 +596,7 @@ export class VercelAIAgentRunner implements AIAgentRunnerService {
       stopWhen: stepCountIs(1),
       experimental_download: safeDownload(this.allowedAttachmentHosts),
       toolChoice: params.toolChoice,
+      abortSignal: params.abortSignal,
       ...(params.temperature !== undefined && {
         temperature: params.temperature,
       }),
@@ -624,17 +658,44 @@ export class VercelAIAgentRunner implements AIAgentRunnerService {
     }
   }
 
+  /**
+   * Silence is an outcome, not a failure.
+   *
+   * The AI SDK throws `AI_NoTranscriptGeneratedError` whenever a model returns
+   * empty text, which is reasonable for a one-shot transcription job and wrong
+   * for a conversation: a turn where the user said nothing is the single most
+   * ordinary thing that can happen at a microphone, and it arrives here every
+   * time a silence detector fires on a pause. Callers get `text: ''` and decide
+   * — which is what they already do for a transcript that comes back blank by
+   * any other route.
+   *
+   * Only that one error is caught. A missing key, a refused request or an
+   * unreachable provider still throw.
+   */
   async transcribe(
     params: AITranscriptionParams
   ): Promise<AITranscriptionResult> {
-    const result = await transcribe({
-      model: this.getModel(params.model, 'transcription'),
-      audio: params.audio,
-      providerOptions: params.providerOptions as any,
-      maxRetries: params.maxRetries,
-      abortSignal: params.abortSignal,
-      headers: params.headers,
-    })
+    let result: Awaited<ReturnType<typeof transcribe>>
+    try {
+      result = await transcribe({
+        model: this.getModel(params.model, 'transcription'),
+        audio: params.audio,
+        providerOptions: params.providerOptions as any,
+        maxRetries: params.maxRetries,
+        abortSignal: params.abortSignal,
+        headers: params.headers,
+      })
+    } catch (error) {
+      if (NoTranscriptGeneratedError.isInstance(error)) {
+        return {
+          text: '',
+          segments: [],
+          warnings: [],
+          responses: error.responses,
+        }
+      }
+      throw error
+    }
 
     return {
       text: result.text,

--- a/packages/services/kysely/src/kysely-tables.ts
+++ b/packages/services/kysely/src/kysely-tables.ts
@@ -131,7 +131,14 @@ export interface AIRunTable {
   agentName: string
   threadId: string
   resourceId: string
-  status: Generated<'running' | 'suspended' | 'completed' | 'failed'>
+  /**
+   * `interrupted` is distinct from `failed`: the run was stopped on purpose,
+   * usually because the user talked over it. Nothing went wrong, so it should
+   * not show up in error reporting.
+   */
+  status: Generated<
+    'running' | 'suspended' | 'completed' | 'failed' | 'interrupted'
+  >
   errorMessage: string | null
   suspendReason: 'approval' | 'credential' | 'rpc-missing' | null
   missingRpcs: string | null

--- a/packages/voice-agents/README.md
+++ b/packages/voice-agents/README.md
@@ -1,0 +1,136 @@
+# @pikku/voice-agents
+
+Headless browser primitives for holding a spoken conversation with a Pikku AI agent.
+
+This package owns the microphone, the speech playback queue, and the ordering between them. It renders nothing, knows nothing about how a turn reaches your backend, and holds no chat state — so it composes with an existing chat surface (`@pikku/assistant-ui`, or your own) rather than replacing it.
+
+## Install
+
+```bash
+yarn add @pikku/voice-agents
+```
+
+## The loop
+
+```tsx
+import { useVoiceConversation } from '@pikku/voice-agents'
+
+const Conversation = ({ runId }: { runId: string | null }) => {
+  const voice = useVoiceConversation({
+    onBargeIn: async () => {
+      // The user started talking over the agent. Stop generating now —
+      // playback is already paused.
+      if (runId) await rpc.invoke('interruptAgent', { runId })
+    },
+    onTurn: async ({ audio }, { interrupted }) => {
+      const text = await rpc.invoke('transcribeAudio', { audio })
+      await rpc.invoke('sendMessage', {
+        text,
+        // What the agent actually got through before it was cut off. Send it
+        // so the model can see where it stopped rather than assuming its last
+        // sentence landed.
+        heardSoFar: interrupted?.text,
+      })
+    },
+  })
+
+  return (
+    <button onClick={voice.listening ? voice.stop : voice.start}>
+      {voice.listening ? 'Stop' : 'Talk'}
+    </button>
+  )
+}
+```
+
+Feed synthesized audio back in as it arrives:
+
+```ts
+voice.speak({ text: sentence, audio: await response.arrayBuffer() })
+```
+
+## What each piece is for
+
+| Export | Purpose |
+| --- | --- |
+| `useVoiceConversation` | The whole loop: listen, detect the end of a turn, play the reply, handle barge-in. |
+| `VoiceSession` | The microphone, framework-free. Acquired once, held across turns. |
+| `AudioPlaybackQueue` | Sequential speech playback that can be stopped mid-word and asked what was heard. |
+| `detectSilence` | Energy-based end-of-turn detection on a live `AudioNode`. |
+
+## Two design decisions worth knowing
+
+**The microphone is acquired once and released only on teardown.** Reacquiring per turn is the obvious implementation and it is the one that makes Bluetooth headsets unusable: each `getUserMedia` renegotiates the device from A2DP to the mono HFP profile, which cuts any music playing, drops output quality audibly, and takes long enough to swallow the first word. Holding it open means the user hears that transition once, at the start of the conversation.
+
+**Barge-in pauses first and commits later.** Playback pauses on the first audible frame so the agent stops talking immediately, but the interruption is only committed once the turn ends and proves long enough to be speech. A cough resumes playback instead of ending the reply.
+
+## Server side
+
+Interrupting the agent itself lives in `@pikku/core`. Wire it like any other agent control RPC:
+
+```ts
+import { agentInterrupt } from '@pikku/core/ai-agent'
+
+wireHTTP({ method: 'post', route: '/agent/interrupt', ...agentInterrupt() })
+```
+
+It checks the run belongs to the caller before stopping it, and needs no channel — it ends a stream rather than continuing one, so it is reachable over a plain RPC while the stream itself is held open elsewhere. It resolves `false` when there was nothing left to stop, because racing a run that finishes on its own is the normal case here, not an error.
+
+Cancelling the model call, persisting the truncated reply marked `interrupted`, and emitting an `interrupted` stream event (`pikku:interrupted` over AG-UI) all happen on the original stream. The next turn then shows the model its own cut-off message followed by whatever the user said, and lets it decide whether to resume, correct itself, or move on.
+
+Non-streaming agents (`rpc.agent.run`, and the resume half of `rpc.agent.approve`) are interruptible through the same call. There is no stream to emit an event on and nothing was delivered to truncate, so the caller gets an `AgentInterruptedError` — distinguishable from a provider failure, and the run is recorded as `interrupted` rather than `failed`.
+
+### Tools that outlive the reply
+
+Interrupting stops the model, not a tool already executing — its side effect has happened. Rather than lose that, the result is written to the thread as a tool message marked `undelivered`, and the model raises it unprompted on the next turn ("that deploy did go through"). The summary costs nothing extra: it falls out of the next turn's ordinary context load.
+
+Only mutations are kept. A `readonly` tool that gets interrupted is discarded — nothing changed, and by the next turn its answer may be stale, so re-reading beats explaining it.
+
+The write is not awaited before the stream closes, because barge-in has to stop the agent talking immediately. The next run on that thread waits for it instead, so the note is always in context before the turn that should mention it.
+
+`interrupt` resolves `{ stopped, inFlightTools }`. `inFlightTools` names what is still executing so the agent can say something true about it — not offer to undo it, which it cannot.
+
+### Where the speech arrives
+
+`voiceOutput` synthesizes on the server, a sentence at a time as the model writes, so the first one is playing while the rest is still being generated. AG-UI has no event for speech, so it reaches the browser as `CUSTOM` alongside the other pikku-specific ones:
+
+```ts
+case 'CUSTOM':
+  if (event.name === 'pikku:audio-delta') {
+    // { data: base64, format: 'mp3' | 'pcm16' | … }
+    voice.speak({ text: '', audio: fromBase64(event.value.data) })
+  }
+```
+
+`pikku:audio-done` follows the last delta and precedes `RUN_FINISHED`. It means every sentence has been synthesized and sent — not that playback has finished, which only the queue knows. Use it to stop showing a "thinking" state; use `AudioPlaybackQueue`'s idle callback to know the agent has stopped talking.
+
+Synthesizing in the browser instead — `voice.speak({ text, audio: await synthesize(text) })` — is the other supported shape, and the one to reach for when the reply is short enough that a single round trip beats streaming, or when the voice is chosen per user at the edge. Do one or the other: with `voiceOutput` wired, the sentences are already paid for and on the wire.
+
+## Asking permission out loud
+
+A tool declared `approvalRequired` suspends the run, and its `approvalDescription` supplies the wording — `Delete the todo called "Buy milk"`. Speak that string, not a summary of it:
+
+```ts
+import { spokenApproval, interpretConsent } from '@pikku/voice-agents'
+
+for (const approval of run.pendingApprovals) {
+  const prompt = spokenApproval(approval)
+  await voice.speak({ text: prompt.text, audio: await synthesize(prompt.text) })
+
+  const answer = await nextTranscript()
+  const consent = interpretConsent(answer)
+  if (consent === 'unclear') continue // ask again; never assume
+  await rpc.invoke('approveAgent', {
+    runId,
+    toolCallId: prompt.toolCallId,
+    approved: consent === 'granted',
+  })
+}
+```
+
+On a screen a badly worded confirmation is still checkable against the tool name and arguments next to the button. Spoken aloud the sentence *is* the whole interface, so it has to be the one the function sanctioned — "delete the production database" and "tidy things up" get the same "yeah, go on". `spokenApproval` therefore copies the reason in untouched and only appends a fixed question; it never builds a description out of the arguments, and when a function supplied none it says so instead of guessing.
+
+Tell the agent to stay out of it. A model that announces the delete before calling the tool has just asked for consent in wording nobody checked, and the user cannot hear the difference:
+
+> Never ask for permission to add or delete a todo. Those tools stop and ask on their own, in wording that has been checked. Just call the tool.
+
+`interpretConsent` returns `'granted' | 'denied' | 'unclear'`, and returns `'unclear'` for anything that is not plainly one or the other — an answer holding both ("yes — no, wait"), a change of subject, silence. Asking again costs a sentence; guessing costs whatever the tool was about to do, and afterwards nobody can tell the two apart.

--- a/packages/voice-agents/package.json
+++ b/packages/voice-agents/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@pikku/voice-agents",
+  "version": "0.0.1",
+  "description": "Headless browser primitives for voice conversations with Pikku AI agents — persistent microphone, silence detection, speech playback and barge-in",
+  "author": "yasser.fadl@gmail.com",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
+  "scripts": {
+    "tsc": "tsc",
+    "test": "bash run-tests.sh",
+    "build:esm": "tsc -b && echo '{\"type\": \"module\"}' > dist/esm/package.json",
+    "build:cjs": "tsc -b tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
+    "build": "yarn build:esm && yarn build:cjs",
+    "prepublishOnly": "yarn build"
+  },
+  "peerDependencies": {
+    "react": "^18 || ^19"
+  },
+  "devDependencies": {
+    "@ricky0123/vad-web": "^0.0.30",
+    "@types/react": "^19",
+    "react": "^19",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/voice-agents/run-tests.sh
+++ b/packages/voice-agents/run-tests.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+# Enable nullglob to handle cases where no files match the pattern
+shopt -s nullglob
+
+# Initialize variables for options
+watch_mode=false
+coverage_mode=false
+
+# Parse command-line options
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --watch)
+      watch_mode=true
+      shift
+      ;;
+    --coverage)
+      coverage_mode=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Define the pattern to match your test files
+pattern="src/*.test.ts"
+
+# Expand the pattern into an array of files
+files=($(find src -type f -name "*.test.ts"))
+
+# Check if any files matched the pattern
+if [ ${#files[@]} -eq 0 ]; then
+  echo "No test files found matching pattern: $pattern"
+  if [ "${STRICT_TEST_DISCOVERY}" = "1" ]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+# Construct the node command
+node_cmd=(node --import tsx --test)
+
+# Append options based on flags
+if [ "$watch_mode" = true ]; then
+  node_cmd+=(--watch)
+fi
+
+if [ "$coverage_mode" = true ]; then
+  node_cmd+=(--test-coverage-include="src/**/*.{ts,js}" --test-coverage-exclude="**/dist/**" --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info)
+  export PIKKU_TEST_COVERAGE=1
+fi
+
+# Execute the node command with the expanded list of files
+"${node_cmd[@]}" "${files[@]}"

--- a/packages/voice-agents/src/audio-playback-queue.test.ts
+++ b/packages/voice-agents/src/audio-playback-queue.test.ts
@@ -1,0 +1,131 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { AudioPlaybackQueue } from './audio-playback-queue.js'
+
+/**
+ * A stand-in for the browser's `AudioContext`, with two properties the real one
+ * has and a naive fake would not: decoding takes time, and how much time
+ * depends on the clip. That is the whole subject of these tests — sentences are
+ * enqueued without being awaited so their decodes overlap, and a fake that
+ * resolves instantly or uniformly cannot tell a queue that preserves order from
+ * one that plays whatever finished first.
+ *
+ * Playback is likewise not instant: `start()` schedules `onended` a tick later,
+ * so a chunk that jumps the queue is observable as an out-of-order `played`.
+ */
+const fakeContext = (decodeMs: (clip: number) => number) => {
+  const played: string[] = []
+  let time = 0
+  const ctx = {
+    state: 'running' as string,
+    get currentTime() {
+      return time
+    },
+    decodeAudioData: (audio: ArrayBuffer) => {
+      const label = (audio as any).label as string
+      const size = new Uint8Array(audio)[0]!
+      return new Promise((resolve) =>
+        setTimeout(() => resolve({ duration: 1, label } as any), decodeMs(size))
+      )
+    },
+    createBufferSource: () => {
+      const source: any = {
+        buffer: null,
+        connect: () => {},
+        onended: null as null | (() => void),
+        start: () => {
+          setTimeout(() => {
+            time += 1
+            played.push(source.buffer.label)
+            source.onended?.()
+          }, 1)
+        },
+        stop: () => {},
+      }
+      return source
+    },
+    suspend: async () => {
+      ctx.state = 'suspended'
+    },
+    resume: async () => {
+      ctx.state = 'running'
+    },
+    close: async () => {},
+  }
+  return { ctx, played }
+}
+
+/** Labels the audio so playback order is checkable. `n` sizes the clip. */
+const clip = (label: string, n: number): ArrayBuffer => {
+  const bytes = new Uint8Array([n])
+  Object.defineProperty(bytes.buffer, 'label', { value: label })
+  return bytes.buffer
+}
+
+const settled = () => new Promise((resolve) => setTimeout(resolve, 60))
+
+describe('AudioPlaybackQueue', () => {
+  test('speaks sentences in the order enqueued, not the order decoded', async () => {
+    // The regression: `enqueue` used to await the decode before taking its
+    // place in the queue. Decode time scales with clip length, so a short
+    // second sentence overtook a long first one and the reply played back
+    // rearranged — which sounds like a plausible reply, just not the one the
+    // model wrote.
+    const { ctx, played } = fakeContext((n) => n * 10)
+    const queue = new AudioPlaybackQueue(ctx as any)
+
+    // Enqueued without awaiting, exactly as the stream handler does.
+    void queue.enqueue({ text: 'first', audio: clip('first', 3) })
+    void queue.enqueue({ text: 'second', audio: clip('second', 1) })
+    await settled()
+
+    assert.deepEqual(played, ['first', 'second'])
+  })
+
+  test('a sentence that will not decode costs that sentence only', async () => {
+    const { ctx, played } = fakeContext((n) => n * 10)
+    ctx.decodeAudioData = ((audio: ArrayBuffer) => {
+      const label = (audio as any).label
+      return label === 'bad'
+        ? Promise.reject(new Error('corrupt'))
+        : Promise.resolve({ duration: 1, label } as any)
+    }) as any
+    const queue = new AudioPlaybackQueue(ctx as any)
+
+    void queue.enqueue({ text: 'ok', audio: clip('ok', 1) })
+    queue.enqueue({ text: 'bad', audio: clip('bad', 1) }).catch(() => {})
+    void queue.enqueue({ text: 'after', audio: clip('after', 1) })
+    await settled()
+
+    assert.deepEqual(played, ['ok', 'after'])
+  })
+
+  test('a decode still in flight when the user cuts in never speaks', async () => {
+    // Barge-in has to stop the agent. A sentence whose decode was outstanding
+    // at that moment belongs to a reply the user has already talked over, and
+    // must not arrive late — least of all after the next reply has begun.
+    const { ctx, played } = fakeContext(() => 20)
+    const queue = new AudioPlaybackQueue(ctx as any)
+
+    void queue.enqueue({ text: 'abandoned', audio: clip('abandoned', 1) })
+    queue.interrupt()
+    void queue.enqueue({ text: 'next turn', audio: clip('next turn', 1) })
+    await settled()
+
+    assert.deepEqual(played, ['next turn'])
+  })
+
+  test('reports what was heard, in order, once the queue drains', async () => {
+    const { ctx } = fakeContext((n) => n * 10)
+    const queue = new AudioPlaybackQueue(ctx as any)
+
+    void queue.enqueue({ text: 'The first one.', audio: clip('a', 3) })
+    void queue.enqueue({ text: 'Second.', audio: clip('b', 1) })
+    await settled()
+
+    const heard = queue.interrupt()
+    assert.equal(heard.text, 'The first one. Second.')
+    assert.equal(heard.complete, true)
+  })
+})

--- a/packages/voice-agents/src/audio-playback-queue.ts
+++ b/packages/voice-agents/src/audio-playback-queue.ts
@@ -1,0 +1,201 @@
+/** One synthesized utterance, paired with the text it was synthesized from. */
+export interface SpeechChunk {
+  /** The text this audio says. Kept alongside the audio so an interruption can
+   *  report what the user actually heard, not what the agent meant to say. */
+  text: string
+  audio: ArrayBuffer
+}
+
+/** What the user had actually heard at the moment playback was cut off. */
+export interface SpokenSoFar {
+  text: string
+  /** `true` when the queue had drained, i.e. nothing was cut off. */
+  complete: boolean
+}
+
+/**
+ * A queued utterance. The buffer is a promise because the slot is claimed
+ * before the decode finishes — see {@link AudioPlaybackQueue.enqueue}.
+ */
+type Pending = { text: string; buffer: Promise<AudioBuffer> }
+
+/**
+ * Sequential playback of synthesized speech, built so it can be stopped
+ * mid-word and asked what it got through.
+ *
+ * That last part is the reason this exists rather than a bare `<audio>` element.
+ * When a user talks over the agent, the next turn is only coherent if the model
+ * is told what the user heard — an agent that was cut off after "I'll delete the
+ * staging database and" must not assume the sentence landed. Playback position
+ * is the only place that information exists.
+ *
+ * Owns its own `AudioContext` so `pause()` can suspend playback without also
+ * freezing the capture graph's analyser — the two run concurrently during
+ * barge-in, and a suspended context is what makes "heard so far" stop advancing
+ * for free while the user talks.
+ */
+export class AudioPlaybackQueue {
+  private readonly ctx: AudioContext
+  private readonly queue: Pending[] = []
+  private spoken: string[] = []
+  private current: {
+    text: string
+    source: AudioBufferSourceNode
+    startedAt: number
+    duration: number
+  } | null = null
+  private draining = false
+  /**
+   * Bumped by {@link interrupt}, so a decode that was in flight when playback
+   * was cut off can tell that it belongs to a conversation that has moved on.
+   * A plain `draining` flag is not enough: a new utterance enqueued straight
+   * after the interrupt sets it back to `true`, and the abandoned chunk would
+   * take that as permission to speak.
+   */
+  private generation = 0
+
+  /** Called when the queue empties and the last chunk has finished playing. */
+  onIdle?: () => void
+
+  constructor(ctx?: AudioContext) {
+    this.ctx = ctx ?? new AudioContext()
+  }
+
+  get playing(): boolean {
+    return this.current !== null
+  }
+
+  get paused(): boolean {
+    return this.ctx.state === 'suspended'
+  }
+
+  /**
+   * Decode and queue an utterance. Decoding happens on enqueue rather than at
+   * play time so the gap between sentences is a buffer swap and not a decode —
+   * a pause of a few hundred milliseconds mid-reply reads as the agent having
+   * finished, and the user starts talking into it.
+   *
+   * The position in the queue is taken synchronously, before the decode is
+   * awaited, and that ordering is the whole point. Callers enqueue without
+   * awaiting so that decoding overlaps, and decode time scales with clip
+   * length — so a short sentence following a long one finishes decoding first
+   * and, if the slot were claimed on completion, would be spoken first. The
+   * reply then plays back in a plausible-sounding but wrong order, which is
+   * far harder to notice than silence.
+   */
+  enqueue(chunk: SpeechChunk): Promise<void> {
+    const buffer = this.ctx.decodeAudioData(chunk.audio)
+    this.queue.push({ text: chunk.text, buffer })
+    if (!this.draining) void this.drain()
+    // Resolves on decode, not on playback — unchanged from when the decode was
+    // awaited here, so a caller awaiting this still means "queued", not "said".
+    return buffer.then(() => undefined)
+  }
+
+  /** Suspend playback, keeping the queue intact. Safe to call when idle. */
+  async pause(): Promise<void> {
+    if (this.ctx.state === 'running') await this.ctx.suspend()
+  }
+
+  /** Resume after {@link pause}. */
+  async resume(): Promise<void> {
+    if (this.ctx.state === 'suspended') await this.ctx.resume()
+  }
+
+  /**
+   * Stop immediately, drop everything queued, and report what was heard.
+   *
+   * The in-flight utterance is reported as a character-proportional prefix of
+   * its text: audio duration maps to characters linearly, which is wrong at the
+   * scale of any individual word and close enough at the scale of a sentence.
+   * A model reading it needs to know roughly where it was cut off, not which
+   * phoneme.
+   */
+  interrupt(): SpokenSoFar {
+    const heard = [...this.spoken]
+    let complete = true
+
+    if (this.current) {
+      const { text, source, startedAt, duration } = this.current
+      complete = false
+      source.onended = null
+      try {
+        source.stop()
+      } catch {
+        // Already stopped by the scheduler; nothing to unwind.
+      }
+      const elapsed = Math.max(0, this.ctx.currentTime - startedAt)
+      const fraction = duration > 0 ? Math.min(1, elapsed / duration) : 0
+      const cut = text.slice(0, Math.round(text.length * fraction)).trimEnd()
+      if (cut) heard.push(cut)
+      this.current = null
+    }
+
+    if (this.queue.length > 0) complete = false
+    this.queue.length = 0
+    this.spoken = []
+    this.draining = false
+    this.generation++
+
+    // Silence comes from the empty queue, not from a suspended context. Barge-in
+    // reaches here via `pause()`, and leaving the context suspended would mean
+    // the *next* reply decodes, queues and starts a source node that plays to
+    // nobody — the conversation goes quiet from the second turn onwards.
+    void this.resume()
+
+    return { text: heard.join(' '), complete }
+  }
+
+  /** Release the audio context. The queue is unusable afterwards. */
+  async destroy(): Promise<void> {
+    this.interrupt()
+    await this.ctx.close()
+  }
+
+  private async drain(): Promise<void> {
+    this.draining = true
+    const generation = this.generation
+    while (this.queue.length > 0) {
+      const next = this.queue.shift()
+      if (!next) break
+      let buffer: AudioBuffer
+      try {
+        buffer = await next.buffer
+      } catch {
+        // One sentence that will not decode should cost that sentence and no
+        // more. Dropping the rest of the queue with it would take the reply
+        // down over a single bad chunk.
+        continue
+      }
+      // Checked after the await: an interrupt landing during the decode has
+      // already emptied the queue, and playing this would be the agent
+      // carrying on after being told to stop.
+      if (this.generation !== generation) return
+      await this.play({ text: next.text, buffer })
+    }
+    this.draining = false
+    if (!this.current) this.onIdle?.()
+  }
+
+  private play(pending: { text: string; buffer: AudioBuffer }): Promise<void> {
+    return new Promise((resolve) => {
+      const source = this.ctx.createBufferSource()
+      source.buffer = pending.buffer
+      source.connect(this.ctx.destination)
+      this.current = {
+        text: pending.text,
+        source,
+        startedAt: this.ctx.currentTime,
+        duration: pending.buffer.duration,
+      }
+      source.onended = () => {
+        // `interrupt()` clears `current` and detaches this handler, so reaching
+        // here means the utterance genuinely finished.
+        this.spoken.push(pending.text)
+        this.current = null
+        resolve()
+      }
+      source.start()
+    })
+  }
+}

--- a/packages/voice-agents/src/index.ts
+++ b/packages/voice-agents/src/index.ts
@@ -1,0 +1,38 @@
+export { detectSilence } from './silence-detector.js'
+export type {
+  SilenceDetectorControl,
+  SilenceDetectorHandlers,
+} from './silence-detector.js'
+
+export { detectSpeech } from './speech-detector.js'
+export type {
+  SpeechDetectorDiagnostics,
+  SpeechDetectorHandlers,
+  SpeechDetectorOptions,
+  VadInstance,
+  VadModule,
+} from './speech-detector.js'
+
+export { VoiceSession } from './voice-session.js'
+export type { VoiceSessionOptions, VoiceTurn } from './voice-session.js'
+
+export { AudioPlaybackQueue } from './audio-playback-queue.js'
+export type { SpeechChunk, SpokenSoFar } from './audio-playback-queue.js'
+
+export {
+  spokenApproval,
+  spokenApprovals,
+  interpretConsent,
+} from './spoken-approval.js'
+export type {
+  Consent,
+  PendingApproval,
+  SpokenApproval,
+  SpokenApprovalOptions,
+} from './spoken-approval.js'
+
+export { useVoiceConversation } from './use-voice-conversation.js'
+export type {
+  VoiceConversation,
+  VoiceConversationOptions,
+} from './use-voice-conversation.js'

--- a/packages/voice-agents/src/silence-detector.ts
+++ b/packages/voice-agents/src/silence-detector.ts
@@ -1,0 +1,118 @@
+/** Tuning for {@link detectSilence}. */
+export interface SilenceDetectorControl {
+  /** Milliseconds of quiet that end a turn. */
+  silenceDelay: number
+  /**
+   * The analyser's noise floor in dBFS. Bins quieter than this read exactly
+   * zero, which is what makes "is anyone talking" a test for a non-zero bin
+   * rather than a threshold on an amplitude average — an average is dominated
+   * by whichever frequencies the room happens to be loud in, so it drifts
+   * between a laptop mic and a headset. `-50` suits close-mic speech.
+   */
+  minDecibels: number
+}
+
+export interface SilenceDetectorHandlers {
+  /** The first frame of a turn in which the user is audible. This is the
+   *  barge-in trigger: it fires while the agent may still be speaking. */
+  onSpeechStart?: () => void
+  /** How far through the trailing pause the turn is, 0–100. Reported in coarse
+   *  steps so a UI can render a countdown without a per-frame re-render. */
+  onSilenceProgress?: (percentage: number) => void
+  /** The pause outlasted `silenceDelay`, so the turn is over. Times are
+   *  `AudioContext.currentTime`-based milliseconds since the detector started. */
+  onSpeechEnd: (turn: { startedAt: number; endedAt: number }) => void
+}
+
+const PROGRESS_STEP = 10
+
+/**
+ * Watch a live microphone stream and call back when the user starts and stops
+ * talking.
+ *
+ * Deliberately energy-based rather than model-based: deciding *when* someone
+ * stopped needs no idea of *what* they said, and a word-level endpointer costs
+ * a network round trip per turn to answer a question the browser can answer for
+ * free in the same frame. The trade is that it cannot tell speech from a slammed
+ * door — acceptable for a push-to-talk-free composer, and the caller can still
+ * discard implausibly short turns.
+ *
+ * Returns a stop function. Stopping does not release the stream: the caller owns
+ * it, because reacquiring a microphone per turn is what makes Bluetooth headsets
+ * audibly renegotiate between A2DP and HFP.
+ */
+export const detectSilence = (
+  ctx: AudioContext,
+  source: AudioNode,
+  handlers: SilenceDetectorHandlers,
+  control: SilenceDetectorControl
+): (() => void) => {
+  const analyser = ctx.createAnalyser()
+  analyser.minDecibels = control.minDecibels
+  analyser.fftSize = 64
+  source.connect(analyser)
+
+  const bins = new Uint8Array(analyser.frequencyBinCount)
+  const startedFrom = ctx.currentTime * 1000
+
+  let speechStart = -1
+  let speechEnd = -1
+  let lastProgress = -1
+  let stopped = false
+  let frame = 0
+
+  const loop = () => {
+    if (stopped) return
+    frame = requestAnimationFrame(loop)
+
+    analyser.getByteFrequencyData(bins)
+    const now = ctx.currentTime * 1000
+    const audible = bins.some((v) => v !== 0)
+
+    if (audible) {
+      if (speechStart === -1) {
+        speechStart = now
+        handlers.onSpeechStart?.()
+      }
+      speechEnd = now
+      if (lastProgress !== 0) {
+        lastProgress = 0
+        handlers.onSilenceProgress?.(0)
+      }
+      return
+    }
+
+    // Silence before the first word is just the user not having started, so
+    // the countdown only arms once there is a turn to end.
+    if (speechStart === -1) return
+
+    const quietFor = now - speechEnd
+    if (quietFor >= control.silenceDelay) {
+      stop()
+      handlers.onSpeechEnd({
+        startedAt: speechStart - startedFrom,
+        endedAt: speechEnd - startedFrom,
+      })
+      return
+    }
+
+    const progress = Math.min(
+      100,
+      Math.round((quietFor / control.silenceDelay) * 100)
+    )
+    if (Math.abs(progress - lastProgress) >= PROGRESS_STEP) {
+      lastProgress = progress
+      handlers.onSilenceProgress?.(progress)
+    }
+  }
+
+  const stop = () => {
+    if (stopped) return
+    stopped = true
+    cancelAnimationFrame(frame)
+    source.disconnect(analyser)
+  }
+
+  frame = requestAnimationFrame(loop)
+  return stop
+}

--- a/packages/voice-agents/src/speech-detector.ts
+++ b/packages/voice-agents/src/speech-detector.ts
@@ -1,0 +1,277 @@
+/**
+ * Turn detection by speech model, as an alternative to {@link detectSilence}.
+ *
+ * The energy detector answers "is anything audible", which is the wrong
+ * question asked cheaply: it cannot tell a word from a door, and it ends a turn
+ * on a fixed timer that has to be long enough for the pause in the middle of a
+ * sentence and short enough not to be felt. This one runs Silero VAD over the
+ * same microphone and answers "is anyone speaking", so the turn ends when the
+ * model stops hearing speech rather than when a stopwatch runs out.
+ *
+ * It is not obviously the better choice, which is why both exist. It costs a
+ * ~2MB model and a WASM runtime on first load, it can be defeated by the same
+ * echo cancellation problem the energy detector has — synthesized speech is
+ * still speech, so an agent heard through a speaker is a turn — and its own
+ * default `redemptionMs` of 1400 is twice the delay it would be replacing.
+ * Which one wins is a question about devices and rooms, so the shape here is
+ * built for measuring rather than for switching over.
+ */
+
+/** The `@ricky0123/vad-web` surface used here, structurally. */
+export interface VadModule {
+  MicVAD: {
+    new: (options: Record<string, unknown>) => Promise<VadInstance>
+  }
+  utils: {
+    encodeWAV: (
+      samples: Float32Array,
+      format?: number,
+      sampleRate?: number,
+      numChannels?: number,
+      bitDepth?: number
+    ) => ArrayBuffer
+  }
+}
+
+export interface VadInstance {
+  start: () => Promise<void>
+  pause: () => Promise<void>
+  destroy: () => Promise<void>
+}
+
+/** What the detector learned about the device it is actually running on. */
+export interface SpeechDetectorDiagnostics {
+  /** The context's real rate. Silero needs 16000 and the library resamples to
+   *  it, so this is the size of the resampling job, not a failure when it is
+   *  not 16k. */
+  sampleRate: number
+  /** Which audio processor the browser could give us. `ScriptProcessor` means
+   *  the deprecated main-thread path — it works, and it competes with rendering
+   *  for the same thread, so a slow device shows up here first. */
+  processor: 'AudioWorklet' | 'ScriptProcessor'
+  /** How long the model and WASM runtime took to become usable. Paid once per
+   *  session, and entirely on the first turn the user waits through. */
+  loadMs: number
+  /**
+   * Mean wall-clock gap between processed frames. Each frame is 32ms of audio,
+   * so a device keeping up sits at ~32 — this measures whether detection is
+   * running behind the conversation, not what inference costs. Well above 32
+   * means turns are being decided late, and on a `ScriptProcessor` device that
+   * is the number that will say so.
+   */
+  meanFrameIntervalMs: number
+  framesProcessed: number
+}
+
+export interface SpeechDetectorHandlers {
+  /** First frame the model calls speech. The barge-in trigger, same as the
+   *  energy detector's — it fires while the agent may still be talking. */
+  onSpeechStart?: () => void
+  /**
+   * The turn ended. Times are milliseconds since the detector started, matching
+   * `detectSilence`'s.
+   *
+   * `audio` is the speech itself — 16kHz mono WAV, trimmed to what the model
+   * called speech plus `preSpeechPadMs` of lead-in, and nothing else. That is
+   * the reason to take the audio from here rather than record the microphone
+   * alongside: a recorder armed when the previous turn ended captures every
+   * second of room between the turns, and transcription models answer leading
+   * silence by inventing filler — "Thank you.", "*sad music*" — and bolting it
+   * onto the front of what was actually said. A clip that begins where the
+   * speech begins gives them nothing to invent from.
+   *
+   * Absent when the model decided the segment was too short to be speech. That
+   * case is still reported rather than swallowed, because a caller that paused
+   * the agent on `onSpeechStart` has to be told something or the agent stays
+   * paused.
+   */
+  onSpeechEnd: (turn: {
+    startedAt: number
+    endedAt: number
+    audio?: Blob
+  }) => void
+  onError?: (error: Error) => void
+}
+
+export interface SpeechDetectorOptions {
+  /**
+   * Loads `@ricky0123/vad-web`. Injected rather than imported so this package
+   * keeps no runtime dependencies and the model stays out of the bundle of
+   * every app that only wants the energy detector — most of them, since this
+   * one is opt-in.
+   */
+  load: () => Promise<VadModule>
+  /** Where `vad.worklet.bundle.min.js` and the `.onnx` are served from.
+   *  Defaults to the library's CDN; set it to serve them yourself. */
+  baseAssetPath?: string
+  /** Where the onnxruntime-web `.wasm` files are served from. Must match the
+   *  onnxruntime-web version the library was built against. */
+  onnxWASMBasePath?: string
+  /** `v5` is the 2024 model; the library still defaults to `legacy`. */
+  model?: 'v5' | 'legacy'
+  /**
+   * Silence after speech before the turn is called over. The library's default
+   * is 1400, which is more than twice the energy detector's 700 — worth setting
+   * deliberately, because leaving it is a latency regression dressed as a
+   * default.
+   */
+  redemptionMs?: number
+  /** Audio kept from before speech was detected, so the turn does not start on
+   *  the second phoneme. */
+  preSpeechPadMs?: number
+  /**
+   * Segments shorter than this are reported as ended but not as speech. The
+   * library defaults to 400, which is longer than the word "yes" — and "yes"
+   * is the entire answer to a spoken approval, so a floor that drops it hangs
+   * the conversation rather than tidying it up. Set it below the shortest
+   * thing the user is allowed to say.
+   */
+  minSpeechMs?: number
+  positiveSpeechThreshold?: number
+  negativeSpeechThreshold?: number
+  /** Called once the first turn completes, with what the device turned out to
+   *  be capable of. The point of running this at all is to find out. */
+  onDiagnostics?: (diagnostics: SpeechDetectorDiagnostics) => void
+}
+
+/** Matches the library's own detection, which does not expose its choice. */
+const processorFor = (ctx: AudioContext): 'AudioWorklet' | 'ScriptProcessor' =>
+  'audioWorklet' in ctx && typeof AudioWorkletNode === 'function'
+    ? 'AudioWorklet'
+    : 'ScriptProcessor'
+
+/**
+ * Watch an already-open microphone and report turns.
+ *
+ * Takes the caller's `stream` and `ctx` rather than opening its own. `MicVAD`
+ * will call `getUserMedia` and tear the tracks down on pause if allowed to, and
+ * both are exactly what a session holding a Bluetooth headset open must not do
+ * — a reacquisition renegotiates the device from A2DP to mono HFP, audibly, and
+ * eats the first word of the turn.
+ *
+ * Loading the model is the expensive part, so the returned handle lives for the
+ * session and reports every turn, rather than being armed per turn like
+ * {@link detectSilence}.
+ */
+export const detectSpeech = async (
+  ctx: AudioContext,
+  stream: MediaStream,
+  handlers: SpeechDetectorHandlers,
+  options: SpeechDetectorOptions
+): Promise<{ stop: () => void }> => {
+  const startedLoadingAt = Date.now()
+  const { MicVAD, utils } = await options.load()
+
+  const redemptionMs = options.redemptionMs ?? 700
+  const startedFrom = ctx.currentTime * 1000
+  let speechStart = -1
+  let frames = 0
+  let frameMsTotal = 0
+  let lastFrameAt = 0
+  let loadedAt = 0
+  let reported = false
+  let stopped = false
+
+  const now = () => ctx.currentTime * 1000
+
+  const endTurn = (samples?: Float32Array) => {
+    // Guarded because a misfire and a real end both arrive here, and because a
+    // segment can end after `stop()` if the model was mid-frame.
+    if (speechStart === -1 || stopped) return
+    const startedAt = speechStart
+    speechStart = -1
+    // The callback arrives once the redemption window has elapsed, so the
+    // clock is already that far past the last speech. Reporting it raw would
+    // inflate every turn by `redemptionMs`, and the caller's minimum-turn
+    // floor — the thing that throws away coughs — would be measuring the
+    // silence after the cough as part of it.
+    handlers.onSpeechEnd({
+      startedAt: startedAt - startedFrom,
+      endedAt: Math.max(startedAt, now() - redemptionMs) - startedFrom,
+      // The model hands back the segment it decided on, already cut at both
+      // ends. `encodeWAV` only wraps it in a header — 16kHz mono, which is what
+      // every speech model resamples to anyway, so nothing is lost by not
+      // shipping the microphone's native rate.
+      //
+      // 16-bit PCM rather than the library's 32-bit float default. Nothing
+      // downstream can hear the difference — the models quantise to 16 on the
+      // way in — and it is four times the bytes over the wire on every turn of
+      // a conversation, which is latency the user does hear.
+      audio: samples
+        ? new Blob([utils.encodeWAV(samples, 1, 16000, 1, 16)], {
+            type: 'audio/wav',
+          })
+        : undefined,
+    })
+    if (!reported && options.onDiagnostics) {
+      reported = true
+      options.onDiagnostics({
+        sampleRate: ctx.sampleRate,
+        processor: processorFor(ctx),
+        loadMs: loadedAt - startedLoadingAt,
+        meanFrameIntervalMs: frames > 0 ? frameMsTotal / frames : 0,
+        framesProcessed: frames,
+      })
+    }
+  }
+
+  const vad = await MicVAD.new({
+    model: options.model ?? 'v5',
+    ...(options.baseAssetPath ? { baseAssetPath: options.baseAssetPath } : {}),
+    ...(options.onnxWASMBasePath
+      ? { onnxWASMBasePath: options.onnxWASMBasePath }
+      : {}),
+    redemptionMs,
+    preSpeechPadMs: options.preSpeechPadMs ?? 800,
+    minSpeechMs: options.minSpeechMs ?? 400,
+    positiveSpeechThreshold: options.positiveSpeechThreshold ?? 0.3,
+    negativeSpeechThreshold: options.negativeSpeechThreshold ?? 0.25,
+
+    // The three injection points that keep the microphone ours. `pauseStream`
+    // defaults to stopping every track, which would release the device.
+    audioContext: ctx,
+    getStream: async () => stream,
+    pauseStream: async () => {},
+    resumeStream: async () => stream,
+
+    // Started explicitly below, after the handlers are known to be wired.
+    startOnLoad: false,
+
+    onSpeechStart: () => {
+      if (stopped) return
+      speechStart = now()
+      handlers.onSpeechStart?.()
+    },
+    onSpeechEnd: (samples: Float32Array) => endTurn(samples),
+    // Too short to be speech. Reported as an ended turn with its real duration
+    // but no audio: the caller's own floor then discards it, and a caller that
+    // paused the agent to listen gets told to carry on.
+    onVADMisfire: () => endTurn(),
+    onFrameProcessed: () => {
+      const at = Date.now()
+      if (lastFrameAt > 0) {
+        frames++
+        frameMsTotal += at - lastFrameAt
+      }
+      lastFrameAt = at
+    },
+  })
+
+  loadedAt = Date.now()
+
+  try {
+    await vad.start()
+  } catch (error) {
+    handlers.onError?.(
+      error instanceof Error ? error : new Error(String(error))
+    )
+  }
+
+  return {
+    stop: () => {
+      if (stopped) return
+      stopped = true
+      void vad.destroy()
+    },
+  }
+}

--- a/packages/voice-agents/src/spoken-approval.test.ts
+++ b/packages/voice-agents/src/spoken-approval.test.ts
@@ -1,0 +1,103 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  interpretConsent,
+  spokenApproval,
+  spokenApprovals,
+} from './spoken-approval.js'
+
+const approval = (reason?: string) => ({
+  toolCallId: 'call-1',
+  toolName: 'todos__deleteTodo',
+  reason,
+})
+
+describe('spokenApproval', () => {
+  test('speaks the function’s wording verbatim', () => {
+    const reason = 'Delete the todo called "Buy milk"'
+    const spoken = spokenApproval(approval(reason))
+
+    // The whole point: the sanctioned sentence survives intact.
+    assert.ok(spoken.text.startsWith(reason))
+    assert.equal(spoken.text, `${reason}. Is that okay?`)
+    assert.equal(spoken.undescribed, false)
+  })
+
+  test('does not double up punctuation the description already has', () => {
+    const spoken = spokenApproval(approval('Delete every completed todo?'))
+    assert.equal(spoken.text, 'Delete every completed todo? Is that okay?')
+  })
+
+  test('admits it cannot describe a tool that gave no description', () => {
+    const spoken = spokenApproval(approval(undefined))
+
+    assert.equal(spoken.undescribed, true)
+    assert.match(spoken.text, /todos__deleteTodo/)
+    // It must not invent a description of the effect from the tool name.
+    assert.doesNotMatch(spoken.text, /delete the/i)
+  })
+
+  test('treats a whitespace-only description as no description at all', () => {
+    assert.equal(spokenApproval(approval('   ')).undescribed, true)
+  })
+
+  test('keeps one utterance per call rather than merging them', () => {
+    const spoken = spokenApprovals([
+      { toolCallId: 'a', toolName: 'add', reason: 'Add a todo called "Milk"' },
+      { toolCallId: 'b', toolName: 'del', reason: 'Delete the todo "Bread"' },
+    ])
+
+    assert.equal(spoken.length, 2)
+    assert.equal(spoken[0]!.toolCallId, 'a')
+    assert.equal(spoken[1]!.toolCallId, 'b')
+  })
+})
+
+describe('interpretConsent', () => {
+  for (const answer of [
+    'yes',
+    'Yeah, go ahead',
+    'sure',
+    'ok',
+    'okay do it',
+    'yep, please do',
+    'no problem',
+    'that works',
+  ]) {
+    test(`grants on "${answer}"`, () => {
+      assert.equal(interpretConsent(answer), 'granted')
+    })
+  }
+
+  for (const answer of [
+    'no',
+    'nope',
+    "don't",
+    'do not do that',
+    'stop',
+    'cancel that',
+    'never mind',
+    'wait',
+  ]) {
+    test(`denies on "${answer}"`, () => {
+      assert.equal(interpretConsent(answer), 'denied')
+    })
+  }
+
+  test('is unclear when the answer holds both', () => {
+    // Asking again costs a sentence. Guessing costs the delete.
+    assert.equal(interpretConsent('yes — no, wait'), 'unclear')
+  })
+
+  test('is unclear on silence or an unrelated answer', () => {
+    assert.equal(interpretConsent(''), 'unclear')
+    assert.equal(interpretConsent('   '), 'unclear')
+    assert.equal(interpretConsent('what was the second one again'), 'unclear')
+  })
+
+  test('does not read consent out of a word that merely contains one', () => {
+    assert.equal(interpretConsent('the note said yesterday'), 'unclear')
+    assert.equal(interpretConsent('add nostalgia to the list'), 'unclear')
+  })
+})

--- a/packages/voice-agents/src/spoken-approval.ts
+++ b/packages/voice-agents/src/spoken-approval.ts
@@ -1,0 +1,192 @@
+/**
+ * Asking permission out loud.
+ *
+ * On a screen, a badly worded confirmation is still checkable — the user can
+ * see the tool name, the arguments, and the button they are about to press. In
+ * a voice conversation the sentence *is* the entire interface, so the sentence
+ * they answer has to be the one the function sanctioned, not the model's
+ * summary of it. A paraphrase here is not a cosmetic problem: "delete the
+ * production database" and "tidy things up" get the same "yeah, go on".
+ *
+ * So the reason text from `approvalDescription` is never rewritten, never
+ * shortened, and never generated from the arguments. It is carried verbatim
+ * inside a fixed question, and if a function supplied no description we say so
+ * rather than inventing one.
+ */
+
+/** A pending approval as it arrives from the agent run. */
+export interface PendingApproval {
+  toolCallId: string
+  toolName: string
+  /** The verbatim text from the function's `approvalDescription`. */
+  reason?: string
+}
+
+export interface SpokenApproval {
+  toolCallId: string
+  toolName: string
+  /** Exactly what to synthesize — nothing else may be spoken in its place. */
+  text: string
+  /**
+   * True when the function supplied no `approvalDescription`, so `text` names
+   * the tool instead of describing what it will do. Worth surfacing: it means
+   * the user is being asked to consent to something nobody has described, and
+   * a stricter caller may prefer to refuse rather than ask.
+   */
+  undescribed: boolean
+}
+
+export interface SpokenApprovalOptions {
+  /**
+   * Appended after the verbatim reason to turn a statement into a question.
+   * Kept separate from the reason precisely so the reason stays untouched.
+   */
+  question?: string
+  /**
+   * Used when the function supplied no description. Receives the tool name.
+   * The default deliberately admits ignorance rather than guessing.
+   */
+  undescribed?: (toolName: string) => string
+}
+
+const DEFAULT_QUESTION = 'Is that okay?'
+
+const defaultUndescribed = (toolName: string) =>
+  `The assistant wants to run ${toolName}, and there is no description of what that does. Should I let it?`
+
+/**
+ * The utterance for a single approval. The reason is copied in as-is — only a
+ * trailing full stop is added, and only when it would otherwise run into the
+ * question.
+ */
+export const spokenApproval = (
+  approval: PendingApproval,
+  options: SpokenApprovalOptions = {}
+): SpokenApproval => {
+  const reason = approval.reason?.trim()
+
+  if (!reason) {
+    const undescribed = options.undescribed ?? defaultUndescribed
+    return {
+      toolCallId: approval.toolCallId,
+      toolName: approval.toolName,
+      text: undescribed(approval.toolName),
+      undescribed: true,
+    }
+  }
+
+  const question = options.question ?? DEFAULT_QUESTION
+  const separator = /[.!?]$/.test(reason) ? ' ' : '. '
+
+  return {
+    toolCallId: approval.toolCallId,
+    toolName: approval.toolName,
+    text: `${reason}${separator}${question}`,
+    undescribed: false,
+  }
+}
+
+/**
+ * One utterance per approval, in order.
+ *
+ * Deliberately not merged into a single sentence: each call gets its own answer,
+ * and "add a todo and delete the other one — okay?" cannot be answered with one
+ * word without guessing which half the user meant.
+ */
+export const spokenApprovals = (
+  approvals: PendingApproval[],
+  options: SpokenApprovalOptions = {}
+): SpokenApproval[] =>
+  approvals.map((approval) => spokenApproval(approval, options))
+
+export type Consent = 'granted' | 'denied' | 'unclear'
+
+// Longest first: "no problem" has to be recognised as agreement before its
+// "no" is read as refusal.
+const GRANTS = [
+  'no problem',
+  'no worries',
+  'go ahead',
+  'go for it',
+  'do it',
+  'please do',
+  'sounds good',
+  'that works',
+  'yes please',
+  'affirmative',
+  'confirm',
+  'confirmed',
+  'approved',
+  'approve',
+  'okay',
+  'ok',
+  'yes',
+  'yeah',
+  'yep',
+  'yup',
+  'sure',
+  'fine',
+]
+
+const DENIALS = [
+  'do not',
+  'dont',
+  'never mind',
+  'nevermind',
+  'hold on',
+  'wait',
+  'stop',
+  'cancel',
+  'forget it',
+  'negative',
+  'denied',
+  'deny',
+  'no',
+  'nope',
+  'nah',
+]
+
+const normalise = (transcript: string) =>
+  transcript
+    .toLowerCase()
+    .replace(/['’]/g, '')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+const takePhrases = (text: string, phrases: string[]) => {
+  let found = false
+  let remaining = text
+  for (const phrase of phrases) {
+    // Matched phrases are removed so a later pass cannot read the same words
+    // again — this is what keeps "no problem" from also counting as a refusal.
+    const next = remaining.replace(new RegExp(`\\b${phrase}\\b`, 'g'), ' ')
+    if (next !== remaining) {
+      found = true
+      remaining = next
+    }
+  }
+  return { found, remaining }
+}
+
+/**
+ * What a spoken answer to an approval means.
+ *
+ * Returns `'unclear'` for anything that is not plainly one or the other,
+ * including answers that contain both ("yes — no, wait"). Asking again costs a
+ * sentence; guessing costs whatever the tool was about to do, and the caller
+ * cannot tell the two apart afterwards. Silence, a cough and a change of
+ * subject all land here too, which is correct: none of them are consent.
+ */
+export const interpretConsent = (transcript: string): Consent => {
+  const text = normalise(transcript)
+  if (!text) return 'unclear'
+
+  const grants = takePhrases(text, GRANTS)
+  const denials = takePhrases(grants.remaining, DENIALS)
+
+  if (grants.found && denials.found) return 'unclear'
+  if (denials.found) return 'denied'
+  if (grants.found) return 'granted'
+  return 'unclear'
+}

--- a/packages/voice-agents/src/use-voice-conversation.ts
+++ b/packages/voice-agents/src/use-voice-conversation.ts
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  AudioPlaybackQueue,
+  type SpeechChunk,
+  type SpokenSoFar,
+} from './audio-playback-queue.js'
+import { VoiceSession, type VoiceTurn } from './voice-session.js'
+
+export interface VoiceConversationOptions {
+  /**
+   * A finished turn, ready to transcribe and send. `interrupted` is non-null
+   * when the user talked over the agent — it holds what they actually heard
+   * before being cut off, which the caller should send alongside the turn so
+   * the model can see where it got to.
+   */
+  onTurn: (
+    turn: VoiceTurn,
+    context: { interrupted: SpokenSoFar | null }
+  ) => void | Promise<void>
+  /**
+   * The user started talking while the agent was speaking. Fires within a frame
+   * of the first audible sample — before the turn is over and long before there
+   * is a transcript — so this is where an in-flight run is aborted.
+   *
+   * Playback is already paused by the time this runs. It is not yet discarded:
+   * a turn that turns out to be too short to be speech resumes it instead.
+   */
+  onBargeIn?: () => void | Promise<void>
+  deviceId?: string
+  silenceDelay?: number
+  minDecibels?: number
+  minTurnMs?: number
+  onError?: (error: Error) => void
+}
+
+export interface VoiceConversation {
+  listening: boolean
+  /** The agent is currently talking. */
+  speaking: boolean
+  /** 0–100 through the trailing pause, or `null` when not in one. */
+  silenceProgress: number | null
+  error: Error | null
+  start: () => Promise<void>
+  stop: () => void
+  setDevice: (deviceId: string | undefined) => Promise<void>
+  /** Queue a synthesized utterance for playback. */
+  speak: (chunk: SpeechChunk) => Promise<void>
+  /** Stop the agent talking now and report what was heard. */
+  interrupt: () => SpokenSoFar
+}
+
+/**
+ * The half-duplex voice loop: the user talks, the agent answers out loud, and
+ * either can cut the other off.
+ *
+ * Headless on purpose. It renders nothing, knows nothing about how a turn
+ * reaches a backend, and holds no chat state — so it composes with an existing
+ * chat surface (assistant-ui, or anything else) rather than replacing it. The
+ * caller owns transcription and transport; this owns the microphone, the
+ * playback queue, and the ordering between them.
+ *
+ * The ordering is the substance. Barge-in pauses playback on the first audible
+ * frame so the agent shuts up immediately, but only *commits* the interruption
+ * when the turn ends and proves to be speech — otherwise a cough would end
+ * every reply.
+ */
+export const useVoiceConversation = (
+  options: VoiceConversationOptions
+): VoiceConversation => {
+  const [listening, setListening] = useState(false)
+  const [speaking, setSpeaking] = useState(false)
+  const [silenceProgress, setSilenceProgress] = useState<number | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+
+  const sessionRef = useRef<VoiceSession | null>(null)
+  const playbackRef = useRef<AudioPlaybackQueue | null>(null)
+  // Whether the current turn began over the agent's voice. Read when the turn
+  // ends, which is why it is a ref and not state: a re-render in between would
+  // lose the race with `onTurn`.
+  const bargedInRef = useRef(false)
+  const optionsRef = useRef(options)
+  optionsRef.current = options
+
+  const fail = useCallback((err: unknown) => {
+    const e = err instanceof Error ? err : new Error(String(err))
+    setError(e)
+    optionsRef.current.onError?.(e)
+  }, [])
+
+  const getPlayback = useCallback(() => {
+    if (!playbackRef.current) {
+      const queue = new AudioPlaybackQueue()
+      queue.onIdle = () => setSpeaking(false)
+      playbackRef.current = queue
+    }
+    return playbackRef.current
+  }, [])
+
+  const interrupt = useCallback((): SpokenSoFar => {
+    const heard = playbackRef.current?.interrupt() ?? {
+      text: '',
+      complete: true,
+    }
+    setSpeaking(false)
+    return heard
+  }, [])
+
+  const start = useCallback(async () => {
+    if (sessionRef.current) {
+      await sessionRef.current.start()
+      setListening(true)
+      return
+    }
+    const session = new VoiceSession({
+      deviceId: optionsRef.current.deviceId,
+      silenceDelay: optionsRef.current.silenceDelay,
+      minDecibels: optionsRef.current.minDecibels,
+      minTurnMs: optionsRef.current.minTurnMs,
+      onSpeechStart: () => {
+        setSilenceProgress(null)
+        const playback = playbackRef.current
+        if (!playback?.playing) return
+        bargedInRef.current = true
+        void playback.pause()
+        void optionsRef.current.onBargeIn?.()
+      },
+      onSilenceProgress: (percentage) =>
+        setSilenceProgress(percentage === 0 ? null : percentage),
+      onTurn: (turn) => {
+        setSilenceProgress(null)
+        const interrupted = bargedInRef.current ? interrupt() : null
+        bargedInRef.current = false
+        void Promise.resolve(
+          optionsRef.current.onTurn(turn, { interrupted })
+        ).catch(fail)
+      },
+      onTurnDiscarded: () => {
+        setSilenceProgress(null)
+        if (!bargedInRef.current) return
+        bargedInRef.current = false
+        void playbackRef.current?.resume()
+      },
+      onError: fail,
+    })
+    sessionRef.current = session
+    try {
+      await session.start()
+      setListening(true)
+    } catch (err) {
+      fail(err)
+    }
+  }, [fail, interrupt])
+
+  const stop = useCallback(() => {
+    sessionRef.current?.stop()
+    setListening(false)
+    setSilenceProgress(null)
+  }, [])
+
+  const setDevice = useCallback(
+    async (deviceId: string | undefined) => {
+      try {
+        await sessionRef.current?.setDevice(deviceId)
+      } catch (err) {
+        fail(err)
+      }
+    },
+    [fail]
+  )
+
+  const speak = useCallback(
+    async (chunk: SpeechChunk) => {
+      try {
+        setSpeaking(true)
+        await getPlayback().enqueue(chunk)
+      } catch (err) {
+        setSpeaking(false)
+        fail(err)
+      }
+    },
+    [fail, getPlayback]
+  )
+
+  // The microphone is released on unmount and nowhere else — see VoiceSession.
+  useEffect(
+    () => () => {
+      void sessionRef.current?.destroy()
+      void playbackRef.current?.destroy()
+      sessionRef.current = null
+      playbackRef.current = null
+    },
+    []
+  )
+
+  return {
+    listening,
+    speaking,
+    silenceProgress,
+    error,
+    start,
+    stop,
+    setDevice,
+    speak,
+    interrupt,
+  }
+}

--- a/packages/voice-agents/src/voice-session.ts
+++ b/packages/voice-agents/src/voice-session.ts
@@ -1,0 +1,335 @@
+import { detectSilence } from './silence-detector.js'
+import { detectSpeech, type SpeechDetectorOptions } from './speech-detector.js'
+
+/** A completed turn: everything the user said between speaking up and pausing. */
+export interface VoiceTurn {
+  /**
+   * The clip, in whatever the detector in use produces: Opus in a WebM
+   * container from the energy detector's `MediaRecorder`, or 16kHz mono WAV
+   * from the speech model. Both are things every transcription API accepts,
+   * and the `Blob`'s own `type` says which — so a caller uploading it does not
+   * need to know, and one hardcoding a filename extension does.
+   */
+  audio: Blob
+  durationMs: number
+}
+
+export interface VoiceSessionOptions {
+  /** `MediaDeviceInfo.deviceId` of the input to use. Omitted means the browser
+   *  default. Change it with {@link VoiceSession.setDevice}. */
+  deviceId?: string
+  /** Milliseconds of silence that end a turn. Defaults to 1200. */
+  silenceDelay?: number
+  /** Analyser noise floor in dBFS. Defaults to -50. */
+  minDecibels?: number
+  /**
+   * Turns shorter than this are dropped instead of being emitted. Defaults to
+   * 400ms. A cough or a chair creak clears the energy threshold, and
+   * transcription models answer near-silence with confabulated stock phrases —
+   * "Thank you.", "Thanks for watching!" — which then get sent to the agent as
+   * though the user said them.
+   *
+   * Energy detector only. A duration floor is a proxy for "was that speech",
+   * and on the {@link VoiceSessionOptions.speech} path the model answers that
+   * question directly — its own `minSpeechMs` is the equivalent knob, applied
+   * to the speech rather than to the elapsed time around it. Applying both
+   * would mean whichever is stricter silently wins, and it would throw away
+   * exactly the turns that matter most: "yes" is under 400ms, and it is the
+   * whole answer to a spoken approval.
+   */
+  minTurnMs?: number
+  /**
+   * End turns with Silero VAD instead of the energy detector — "has the user
+   * stopped speaking" rather than "has the room gone quiet". Opt-in, and the
+   * `load` it requires is what pulls in the model, so a caller that omits this
+   * pays nothing for it.
+   *
+   * Falls back to the energy detector, silently apart from
+   * {@link VoiceSessionOptions.onError}, if the device cannot run it or the
+   * model fails to load — a conversation that works worse beats one that does
+   * not start. {@link VoiceSessionOptions.onSilenceProgress} does not fire on
+   * this path: the model decides a turn is over rather than counting down to
+   * it, so there is no progress to show.
+   *
+   * The clip changes too. On this path it comes from the model — 16kHz mono
+   * WAV, cut at both ends — instead of a `MediaRecorder` armed the moment the
+   * previous turn ended, which is Opus but carries every second of room
+   * between the turns at the front. See {@link VoiceTurn.audio}.
+   */
+  speech?: SpeechDetectorOptions
+  /** Fires on the first audible frame of a turn, while the agent may still be
+   *  talking. This is the barge-in trigger. */
+  onSpeechStart?: () => void
+  /** 0–100 through the trailing pause, for a countdown affordance. Energy
+   *  detector only — see {@link VoiceSessionOptions.speech}. */
+  onSilenceProgress?: (percentage: number) => void
+  /** Fires once a turn ends and passes the {@link VoiceSessionOptions.minTurnMs} floor. */
+  onTurn: (turn: VoiceTurn) => void
+  /** Fires when a turn ended but was too short to be speech. Distinguished from
+   *  {@link VoiceSessionOptions.onTurn} so a caller that paused the agent on
+   *  {@link VoiceSessionOptions.onSpeechStart} can resume it — a cough should
+   *  not end the agent's reply. */
+  onTurnDiscarded?: () => void
+  onError?: (error: Error) => void
+}
+
+const MIME_CANDIDATES = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4']
+
+const pickMimeType = (): string | undefined =>
+  MIME_CANDIDATES.find((type) => MediaRecorder.isTypeSupported(type))
+
+/**
+ * Whether Silero can run here at all.
+ *
+ * Deliberately shallow: the library resamples any rate to the 16kHz the model
+ * wants and falls back to a `ScriptProcessor` where there is no worklet, so the
+ * only hard requirement is a WASM runtime to execute the model in. Anything
+ * finer-grained than this — how fast the device actually is — is not knowable
+ * up front, which is what the detector's diagnostics are for.
+ */
+const speechDetectionSupported = (): boolean =>
+  typeof WebAssembly !== 'undefined' &&
+  (typeof AudioWorkletNode === 'function' ||
+    typeof ScriptProcessorNode === 'function')
+
+/**
+ * A microphone that stays open across turns.
+ *
+ * The whole design follows from one constraint: `getUserMedia` runs exactly
+ * once, in {@link start}, and the tracks are only stopped in {@link destroy}.
+ * Acquiring per turn is the obvious implementation and it is the one that makes
+ * Bluetooth unusable — every acquisition renegotiates the headset from A2DP to
+ * the mono HFP profile, which stops any music playing, drops output quality
+ * audibly, and takes long enough that the first word of the turn is missing.
+ * Holding the mic open means the profile switch happens once, at the start of
+ * the conversation, and the user hears one transition instead of one per turn.
+ *
+ * Only the `MediaRecorder` cycles per turn. It is cheap and holds no device.
+ */
+export class VoiceSession {
+  private stream: MediaStream | null = null
+  private ctx: AudioContext | null = null
+  private source: MediaStreamAudioSourceNode | null = null
+  private mono: MediaStreamAudioDestinationNode | null = null
+  private recorder: MediaRecorder | null = null
+  private stopDetector: (() => void) | null = null
+  /**
+   * The speech detector, when in use. Unlike the energy detector this one is
+   * armed once for the session rather than per turn — `MicVAD.new` loads a
+   * model and a WASM runtime, which is not something to do between sentences.
+   */
+  private stopSpeech: (() => void) | null = null
+  private listening = false
+  private deviceId: string | undefined
+
+  constructor(private readonly options: VoiceSessionOptions) {
+    this.deviceId = options.deviceId
+  }
+
+  get isListening(): boolean {
+    return this.listening
+  }
+
+  /** Acquire the microphone (once) and begin waiting for the first turn. */
+  async start(): Promise<void> {
+    if (this.listening) return
+    await this.acquire()
+    // Before `listening`, so the first turn is armed knowing which detector it
+    // has. Loading the model takes a second or two on a cold cache, and that
+    // wait belongs here rather than in the middle of the user's first sentence.
+    if (this.options.speech) await this.startSpeechDetector()
+    this.listening = true
+    this.captureNextTurn()
+  }
+
+  /** Stop waiting for turns but keep the microphone open, so resuming does not
+   *  renegotiate the device. Use this between conversations, not {@link destroy}. */
+  stop(): void {
+    this.listening = false
+    this.endTurn()
+  }
+
+  /**
+   * Switch input device. This is the one operation that must reacquire, so it
+   * is also the one that will make a Bluetooth headset click — hence a separate
+   * call the user triggers, rather than something reacted to automatically.
+   */
+  async setDevice(deviceId: string | undefined): Promise<void> {
+    const wasListening = this.listening
+    this.stop()
+    await this.release()
+    this.deviceId = deviceId
+    if (wasListening) await this.start()
+  }
+
+  /** Release the microphone. The session is unusable afterwards. */
+  async destroy(): Promise<void> {
+    this.stop()
+    await this.release()
+  }
+
+  private async acquire(): Promise<void> {
+    if (this.stream) return
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: this.deviceId ? { deviceId: { exact: this.deviceId } } : true,
+    })
+    const ctx = new AudioContext()
+    const source = ctx.createMediaStreamSource(stream)
+    // Recording the raw stream would capture whatever channel count the device
+    // reports; speech models take mono, and downmixing here is cheaper than
+    // uploading a stereo clip of one voice.
+    const mono = ctx.createMediaStreamDestination()
+    mono.channelCount = 1
+    source.connect(mono)
+
+    this.stream = stream
+    this.ctx = ctx
+    this.source = source
+    this.mono = mono
+  }
+
+  /**
+   * Bring up the speech detector, or decide we cannot and say so.
+   *
+   * Every failure here is non-fatal on purpose. The energy detector is already
+   * wired and works everywhere; a device without WebAssembly, a CDN that will
+   * not serve the model, a browser that refuses the worklet — none of those are
+   * reasons for the conversation not to happen, they are reasons for it to
+   * happen the other way.
+   */
+  private async startSpeechDetector(): Promise<void> {
+    const { ctx, stream, options } = this
+    if (!ctx || !stream || !options.speech) return
+    if (!speechDetectionSupported()) {
+      options.onError?.(
+        new Error('Speech detection unsupported on this device; using silence')
+      )
+      return
+    }
+    try {
+      const { stop } = await detectSpeech(
+        ctx,
+        stream,
+        {
+          onSpeechStart: () => options.onSpeechStart?.(),
+          // The clip comes from the detector, not from a recorder running
+          // alongside it. A recorder has to be armed before anyone speaks, so
+          // everything between the turns ends up in the clip and only the end
+          // is trimmed; the detector hands back the segment it actually
+          // decided was speech, cut at both ends.
+          // No duration floor here — see {@link VoiceSessionOptions.minTurnMs}.
+          // Audio present means the model called it speech and it cleared the
+          // model's own `minSpeechMs`; absent means it did not.
+          onSpeechEnd: ({ startedAt, endedAt, audio }) => {
+            if (!this.listening) return
+            if (audio) {
+              options.onTurn({ audio, durationMs: endedAt - startedAt })
+            } else {
+              options.onTurnDiscarded?.()
+            }
+          },
+          onError: options.onError,
+        },
+        options.speech
+      )
+      this.stopSpeech = stop
+    } catch (error) {
+      // Named as a fallback rather than re-raised as-is. The conversation still
+      // works after this, which is the point, and a bare error message reads as
+      // "nothing happened" when in fact the other detector took over.
+      const message = error instanceof Error ? error.message : String(error)
+      options.onError?.(
+        new Error(`Speech detection failed (${message}); using silence`)
+      )
+    }
+  }
+
+  private async release(): Promise<void> {
+    this.stopSpeech?.()
+    this.stopSpeech = null
+    this.stream?.getTracks().forEach((track) => track.stop())
+    this.source?.disconnect()
+    await this.ctx?.close()
+    this.stream = null
+    this.ctx = null
+    this.source = null
+    this.mono = null
+  }
+
+  private endTurn(): void {
+    this.stopDetector?.()
+    this.stopDetector = null
+    if (this.recorder && this.recorder.state !== 'inactive') {
+      this.recorder.stop()
+    }
+    this.recorder = null
+  }
+
+  /**
+   * Arm one turn. Self-perpetuating: the detector's end-of-speech callback
+   * emits the clip and immediately arms the next turn, so the session listens
+   * continuously without the caller driving a loop.
+   *
+   * Nothing to do on the speech path — that detector is armed once for the
+   * session and produces its own audio, so there is no per-turn recorder to
+   * cycle.
+   */
+  private captureNextTurn(): void {
+    const { ctx, source, mono } = this
+    if (!ctx || !source || !mono || !this.listening) return
+    if (this.stopSpeech) return
+
+    const mimeType = pickMimeType()
+    const recorder = new MediaRecorder(
+      mono.stream,
+      mimeType ? { mimeType } : undefined
+    )
+    const parts: Blob[] = []
+    recorder.ondataavailable = (event) => {
+      if (event.data.size > 0) parts.push(event.data)
+    }
+    this.recorder = recorder
+
+    let durationMs = 0
+    recorder.onstop = () => {
+      const audio = new Blob(parts, { type: mimeType ?? 'audio/webm' })
+      if (durationMs >= (this.options.minTurnMs ?? 400)) {
+        this.options.onTurn({ audio, durationMs })
+      } else if (durationMs > 0) {
+        this.options.onTurnDiscarded?.()
+      }
+      this.captureNextTurn()
+    }
+
+    this.stopDetector = detectSilence(
+      ctx,
+      source,
+      {
+        onSpeechStart: this.options.onSpeechStart,
+        onSilenceProgress: this.options.onSilenceProgress,
+        onSpeechEnd: ({ startedAt, endedAt }) => {
+          this.stopDetector = null
+          durationMs = endedAt - startedAt
+          if (recorder.state !== 'inactive') recorder.stop()
+        },
+      },
+      {
+        // Dead air the user sits through on every turn before any work starts
+        // at all — the one part of the round trip that is pure waiting rather
+        // than something being computed, and so the cheapest to give back.
+        // 700ms rides out the pause inside a sentence without being the thing
+        // people notice. Raise it if turns start getting cut in half.
+        silenceDelay: this.options.silenceDelay ?? 700,
+        minDecibels: this.options.minDecibels ?? -50,
+      }
+    )
+
+    try {
+      recorder.start()
+    } catch (error) {
+      this.options.onError?.(
+        error instanceof Error ? error : new Error(String(error))
+      )
+    }
+  }
+}

--- a/packages/voice-agents/tsconfig.cjs.json
+++ b/packages/voice-agents/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "ignoreDeprecations": "6.0",
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "es2015",
+    "moduleResolution": "node"
+  },
+  "exclude": ["**/*.test.ts", "node_modules", "dist"]
+}

--- a/packages/voice-agents/tsconfig.json
+++ b/packages/voice-agents/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "module": "Node18",
+    "outDir": "dist/esm",
+    "target": "esnext",
+    "declaration": true,
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"]
+  },
+  "include": ["src/*.ts"],
+  "exclude": ["**/*.test.ts", "node_modules"]
+}

--- a/verifiers/middleware-and-permissions/src/start.ts
+++ b/verifiers/middleware-and-permissions/src/start.ts
@@ -405,6 +405,15 @@ async function main(): Promise<void> {
     // modifyInput runs left→right, then per stream event: wire channel middleware
     // runs before modifyOutputStream (converted to channel middleware),
     // modifyOutput runs right→left after stream completes
+    //
+    // The trailing pair is the `done` event. It goes through the middleware
+    // like any other stream event rather than straight at the channel, because
+    // it is the only signal a stream hook gets that the reply is over, and the
+    // ones that buffer need it — `voiceOutput` speaks a trailing fragment that
+    // never reached a full stop, and waits on audio it has already paid to
+    // synthesize. Sent raw, that work is thrown away by the `close()` that
+    // follows. It lands after `modifyOutput` because `modifyOutput` is about
+    // the completed reply, and `done` is about the stream carrying it.
     const agentStreamPassed = await testAgentStreamWiring(
       [
         { name: 'modifyInput', type: 'ai-middleware', phase: 'before' },
@@ -416,6 +425,8 @@ async function main(): Promise<void> {
         { name: 'wire-cm', type: 'channel-middleware', phase: 'before' },
         { name: 'modifyOutputStream', type: 'ai-middleware', phase: 'before' },
         { name: 'modifyOutput', type: 'ai-middleware', phase: 'before' },
+        { name: 'wire-cm', type: 'channel-middleware', phase: 'before' },
+        { name: 'modifyOutputStream', type: 'ai-middleware', phase: 'before' },
       ],
       singletonServices
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,6 +116,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ai-sdk/openai-compatible@npm:^2.0.63":
+  version: 2.0.63
+  resolution: "@ai-sdk/openai-compatible@npm:2.0.63"
+  dependencies:
+    "@ai-sdk/provider": "npm:3.0.14"
+    "@ai-sdk/provider-utils": "npm:4.0.41"
+  peerDependencies:
+    zod: ^3.25.76 || ^4.1.8
+  checksum: 10/cffab8ec1c6c8bb42ba1e24b4610665082474e1fa934bb64bcfdeb6d22700bd4444250941d99fe6b0cadcfed3bf94334b2004232d0720543c57912891ac60f92
+  languageName: node
+  linkType: hard
+
 "@ai-sdk/openai@npm:^3.0.37":
   version: 3.0.37
   resolution: "@ai-sdk/openai@npm:3.0.37"
@@ -141,21 +153,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ai-sdk/provider-utils@npm:4.0.41":
+  version: 4.0.41
+  resolution: "@ai-sdk/provider-utils@npm:4.0.41"
+  dependencies:
+    "@ai-sdk/provider": "npm:3.0.14"
+    "@standard-schema/spec": "npm:^1.1.0"
+    eventsource-parser: "npm:^3.0.8"
+    undici: "npm:^5.29.0"
+  peerDependencies:
+    zod: ^3.25.76 || ^4.1.8
+  checksum: 10/a34e1fe72599756c22b90d8a32ee2a8af589b3523f649626abfe7091718cc7105679b9fd0192b7e635c952275c664838979bde8aaccca7823b4fe71cc1ffd375
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/provider@npm:3.0.14, @ai-sdk/provider@npm:^3.0.0, @ai-sdk/provider@npm:^3.0.14":
+  version: 3.0.14
+  resolution: "@ai-sdk/provider@npm:3.0.14"
+  dependencies:
+    json-schema: "npm:^0.4.0"
+  checksum: 10/f5992c94e10b8ee412657a62746cc485679fe6172cdfa7c26443203dfc79f41e1ec023dc72ffcdc0b182401087fc22fd35ff2df51343bd58cf5c338ba542af87
+  languageName: node
+  linkType: hard
+
 "@ai-sdk/provider@npm:3.0.8":
   version: 3.0.8
   resolution: "@ai-sdk/provider@npm:3.0.8"
   dependencies:
     json-schema: "npm:^0.4.0"
   checksum: 10/85fb7b9c7cd9ea1aa9840aa57a9517a7ecec8c25a33a31e4615f4eceede9fe61f072b2a2915e4713f2b78c8b94a8c25a79ddbcf998f0d537c02ba47442402542
-  languageName: node
-  linkType: hard
-
-"@ai-sdk/provider@npm:^3.0.0":
-  version: 3.0.14
-  resolution: "@ai-sdk/provider@npm:3.0.14"
-  dependencies:
-    json-schema: "npm:^0.4.0"
-  checksum: 10/f5992c94e10b8ee412657a62746cc485679fe6172cdfa7c26443203dfc79f41e1ec023dc72ffcdc0b182401087fc22fd35ff2df51343bd58cf5c338ba542af87
   languageName: node
   linkType: hard
 
@@ -3554,6 +3580,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fastify/busboy@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "@fastify/busboy@npm:2.1.1"
+  checksum: 10/2bb8a7eca8289ed14c9eb15239bc1019797454624e769b39a0b90ed204d032403adc0f8ed0d2aef8a18c772205fa7808cf5a1b91f21c7bfc7b6032150b1062c5
+  languageName: node
+  linkType: hard
+
 "@fastify/error@npm:^4.0.0":
   version: 4.2.0
   resolution: "@fastify/error@npm:4.2.0"
@@ -5661,6 +5694,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@pikku/ai-deepinfra@workspace:*, @pikku/ai-deepinfra@workspace:packages/services/ai-deepinfra":
+  version: 0.0.0-use.local
+  resolution: "@pikku/ai-deepinfra@workspace:packages/services/ai-deepinfra"
+  dependencies:
+    "@ai-sdk/provider": "npm:^3.0.14"
+    typescript: "npm:^6.0.3"
+  peerDependencies:
+    "@ai-sdk/provider": ^3.0.0
+  languageName: unknown
+  linkType: soft
+
 "@pikku/ai-vercel@npm:^0.12.8, @pikku/ai-vercel@workspace:*, @pikku/ai-vercel@workspace:packages/services/ai-vercel":
   version: 0.0.0-use.local
   resolution: "@pikku/ai-vercel@workspace:packages/services/ai-vercel"
@@ -6016,6 +6060,7 @@ __metadata:
     "@ai-sdk/provider": "npm:^3.0.0"
     "@pikku/better-auth": "workspace:*"
     "@pikku/core": "npm:*"
+    "@pikku/voice-agents": "workspace:*"
     "@types/node": "npm:^22"
     ai: "npm:^6.0.105"
     better-auth: "npm:^1.6.19"
@@ -6031,6 +6076,7 @@ __metadata:
   resolution: "@pikku/e2e@workspace:e2e"
   dependencies:
     "@ai-sdk/openai": "npm:^3.0.37"
+    "@ai-sdk/openai-compatible": "npm:^2.0.63"
     "@pikku/addon-console": "workspace:*"
     "@pikku/addon-email-send": "npm:0.1.2"
     "@pikku/addon-gmail": "npm:0.1.2"
@@ -6038,6 +6084,7 @@ __metadata:
     "@pikku/addon-hmac-signer": "workspace:*"
     "@pikku/addon-mailgun": "npm:0.1.2"
     "@pikku/addon-mandrill": "npm:0.1.2"
+    "@pikku/ai-deepinfra": "workspace:*"
     "@pikku/ai-vercel": "workspace:*"
     "@pikku/better-auth": "workspace:*"
     "@pikku/cli": "workspace:*"
@@ -7435,6 +7482,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@pikku/voice-agents@workspace:*, @pikku/voice-agents@workspace:packages/voice-agents":
+  version: 0.0.0-use.local
+  resolution: "@pikku/voice-agents@workspace:packages/voice-agents"
+  dependencies:
+    "@ricky0123/vad-web": "npm:^0.0.30"
+    "@types/react": "npm:^19"
+    react: "npm:^19"
+    typescript: "npm:^6.0.3"
+  peerDependencies:
+    react: ^18 || ^19
+  languageName: unknown
+  linkType: soft
+
 "@pikku/websocket@npm:^0.12.2, @pikku/websocket@npm:^0.12.3, @pikku/websocket@workspace:*, @pikku/websocket@workspace:packages/client-websocket":
   version: 0.0.0-use.local
   resolution: "@pikku/websocket@workspace:packages/client-websocket"
@@ -7529,6 +7589,71 @@ __metadata:
   bin:
     protoc: protoc.js
   checksum: 10/1a6ec0279ea76ae0b8bdeecc032e027bae233d2b1c643f0d9ea91045cd3c41d27b6f321b906bf49f2bae77ecdd346edaa45fbeb6bed6a85c9c07ec3e8778d9b7
+  languageName: node
+  linkType: hard
+
+"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
+  checksum: 10/8a938d84fe4889411296db66b29287bd61ea3c14c2d23e7a8325f46a2b8ce899857c5f038d65d7641805e6c1d06b495525c7faf00c44f85a7ee6476649034969
+  languageName: node
+  linkType: hard
+
+"@protobufjs/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/base64@npm:1.1.2"
+  checksum: 10/c71b100daeb3c9bdccab5cbc29495b906ba0ae22ceedc200e1ba49717d9c4ab15a6256839cebb6f9c6acae4ed7c25c67e0a95e734f612b258261d1a3098fe342
+  languageName: node
+  linkType: hard
+
+"@protobufjs/codegen@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@protobufjs/codegen@npm:2.0.5"
+  checksum: 10/290335fa114f26202abc0695f279d53e2fd516b01cfd8298923591e0bda011295ff40e3582a1cda0a0f27cbc5039a0292082d5ad08872bb5d6243a614ac15c88
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/eventemitter@npm:1.1.1"
+  checksum: 10/a54dc1aff4475ffad4fdf3235c71a553f5e40e3b4cf6a2e217151895a61cb4eb0be20d63791db22441ca25e594671f1021977133f9939540750231ff7d8e9dd6
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/fetch@npm:1.1.1"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.1"
+  checksum: 10/427cf2da8c69b494b0df3b2fb1f43c97f0f71ca2c8ef8232dac7e44f2527ad0cc9cecb243eda14a918e86018bfa6d54d92252240d2b37ed205b13adb5506fa1d
+  languageName: node
+  linkType: hard
+
+"@protobufjs/float@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@protobufjs/float@npm:1.0.2"
+  checksum: 10/634c2c989da0ef2f4f19373d64187e2a79f598c5fb7991afb689d29a2ea17c14b796b29725945fa34b9493c17fb799e08ac0a7ccaae460ee1757d3083ed35187
+  languageName: node
+  linkType: hard
+
+"@protobufjs/path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/path@npm:1.1.2"
+  checksum: 10/bb709567935fd385a86ad1f575aea98131bbd719c743fb9b6edd6b47ede429ff71a801cecbd64fc72deebf4e08b8f1bd8062793178cdaed3713b8d15771f9b83
+  languageName: node
+  linkType: hard
+
+"@protobufjs/pool@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/pool@npm:1.1.0"
+  checksum: 10/b9c7047647f6af28e92aac54f6f7c1f7ff31b201b4bfcc7a415b2861528854fce3ec666d7e7e10fd744da905f7d4aef2205bbcc8944ca0ca7a82e18134d00c46
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "@protobufjs/utf8@npm:1.1.2"
+  checksum: 10/ff759348d60e8f65137d3a7a16e00cf69abd9a6dede75e50ec377c6aebb4ac400a4a70af2e77eb2bf75e2accf30abbea81803e9403004b1922ea70776bfdc3aa
   languageName: node
   linkType: hard
 
@@ -8992,6 +9117,15 @@ __metadata:
     react: ">=17"
     react-dom: ">=17"
   checksum: 10/159566da042f29c15e506d4c49cd938b28644ad7710b266e35293c268286c48488b92d7c621f25700bfbabff84470c181ec2683a44c04d1749370c09d2e4a12b
+  languageName: node
+  linkType: hard
+
+"@ricky0123/vad-web@npm:^0.0.30":
+  version: 0.0.30
+  resolution: "@ricky0123/vad-web@npm:0.0.30"
+  dependencies:
+    onnxruntime-web: "npm:^1.17.0"
+  checksum: 10/9253d4e5d61db938a675ce3166ea92b2f6cd44fde7f0c92e3780d7beb51ac7044e56d70374e9218a6b15b52b2773e1ab71c3cd29c6bbf51a9e142027451bedb7
   languageName: node
   linkType: hard
 
@@ -12079,6 +12213,15 @@ __metadata:
   dependencies:
     undici-types: "npm:~7.16.0"
   checksum: 10/ad15db75cfaec9e6311a1db7f3a91799be4c2698e1cfb0f74cc4d6e4398361550d00a4070921e1de7d9a10db83e41fd29f3a640dfacdabbd1c74ae16d8ce943a
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=13.7.0":
+  version: 26.1.2
+  resolution: "@types/node@npm:26.1.2"
+  dependencies:
+    undici-types: "npm:~8.3.0"
+  checksum: 10/2dd6d75b80c006deab4e381acc8cb2e3d634f10141f05fd6cadaabddd80a95f04aef7b00a574bd8fd5e08e940b899c23b91dd09a70b11a34a2762203b5eea25e
   languageName: node
   linkType: hard
 
@@ -15904,6 +16047,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventsource-parser@npm:^3.0.8":
+  version: 3.1.0
+  resolution: "eventsource-parser@npm:3.1.0"
+  checksum: 10/6aa03b4d6e3450935690fd9cca6e47b9877287c9419dba9705b85a73e741c7dfbc22b4ebeca25adf05c9549e33c4491e3ca71f80ddfac585e469b7da91f76e20
+  languageName: node
+  linkType: hard
+
 "eventsource@npm:^3.0.2":
   version: 3.0.7
   resolution: "eventsource@npm:3.0.7"
@@ -16479,6 +16629,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"flatbuffers@npm:^25.1.24":
+  version: 25.9.23
+  resolution: "flatbuffers@npm:25.9.23"
+  checksum: 10/e2086e7f9b04f7932a93f6935347d8cdca0cbdcb582cd23b2b7c55aa1f831c6e33ba595c49bebe25767a945fc4698984840692baa470d61db4484e06aac4df15
+  languageName: node
+  linkType: hard
+
 "follow-redirects@npm:^1.15.11":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
@@ -16907,6 +17064,13 @@ __metadata:
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
+  languageName: node
+  linkType: hard
+
+"guid-typescript@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "guid-typescript@npm:1.0.9"
+  checksum: 10/829dd87866800a5138aafa0873994028bbc446eb20ff4cae6452d471a2a3d26f7025bed3eb980692c0f022fd22f95ea7396122b46b45a4b5084958505a4fc50c
   languageName: node
   linkType: hard
 
@@ -18582,7 +18746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:^5.3.2":
+"long@npm:^5.2.3, long@npm:^5.3.2":
   version: 5.3.2
   resolution: "long@npm:5.3.2"
   checksum: 10/b6b55ddae56fcce2864d37119d6b02fe28f6dd6d9e44fd22705f86a9254b9321bd69e9ffe35263b4846d54aba197c64882adcb8c543f2383c1e41284b321ea64
@@ -20470,6 +20634,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"onnxruntime-common@npm:1.27.0":
+  version: 1.27.0
+  resolution: "onnxruntime-common@npm:1.27.0"
+  checksum: 10/43ecc1a5b8e74e421d67241150ce1a438614fcb9e3b177cc51166e2642e05f1dab44d1b46916d3576e846248df4a7da002ec9de2f6434608bb73b41128947814
+  languageName: node
+  linkType: hard
+
+"onnxruntime-web@npm:^1.17.0":
+  version: 1.27.0
+  resolution: "onnxruntime-web@npm:1.27.0"
+  dependencies:
+    flatbuffers: "npm:^25.1.24"
+    guid-typescript: "npm:^1.0.9"
+    long: "npm:^5.2.3"
+    onnxruntime-common: "npm:1.27.0"
+    platform: "npm:^1.3.6"
+    protobufjs: "npm:^7.2.4"
+  checksum: 10/d43f01c8a1566f69e2701943a6ae4be54e9e10269d8431c3dc378cefd4f7a65abc2463facd53192f822b58b2ca53de8fb70bab58cff9225a6e0b7f7d0ee80673
+  languageName: node
+  linkType: hard
+
 "open@npm:^10.0.0, open@npm:^10.2.0":
   version: 10.2.0
   resolution: "open@npm:10.2.0"
@@ -21255,6 +21440,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"platform@npm:^1.3.6":
+  version: 1.3.6
+  resolution: "platform@npm:1.3.6"
+  checksum: 10/1f2d8333e23ea6a7620c828d2fc1ccbbd33e01928fb142323420506114d7325ebdeb1b38544efbf64e90ab73af0847f874d0f475b9327bcf53510fa827a4ef95
+  languageName: node
+  linkType: hard
+
 "playwright-core@npm:1.58.2":
   version: 1.58.2
   resolution: "playwright-core@npm:1.58.2"
@@ -21591,6 +21783,25 @@ __metadata:
   version: 7.1.0
   resolution: "property-information@npm:7.1.0"
   checksum: 10/896d38a52ad7170de73f832d277c69e76a9605d941ebb3f0d6e56271414a7fdf95ff6d2819e68036b8a0c7d2d4d88bf1d4a5765c032cb19c2343567ee3a14b15
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.2.4":
+  version: 7.6.5
+  resolution: "protobufjs@npm:7.6.5"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.5"
+    "@protobufjs/eventemitter": "npm:^1.1.1"
+    "@protobufjs/fetch": "npm:^1.1.1"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.1"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^5.3.2"
+  checksum: 10/58a5a635fbe0632a5c48a1ab659fabfc26d5b994915a20ad623a2cfb59a2ca7411d9f4f690ca79074967b632e2db58ecc184ab507927f5b7d0852fc16568d3da
   languageName: node
   linkType: hard
 
@@ -24533,6 +24744,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~8.3.0":
+  version: 8.3.0
+  resolution: "undici-types@npm:8.3.0"
+  checksum: 10/6681d2837ac75a75ac1cc46090aa2b8ddc7c6b8ecc295a6cdb06838752a730da3d8afeecf05e5ab7903160eafad3a8b6ffa1927e5ded260590f4d4fef18646d5
+  languageName: node
+  linkType: hard
+
 "undici@npm:7.24.4":
   version: 7.24.4
   resolution: "undici@npm:7.24.4"
@@ -24544,6 +24762,15 @@ __metadata:
   version: 7.28.0
   resolution: "undici@npm:7.28.0"
   checksum: 10/154423b280d623278a61decb437f8a7e581fb18b8c95556ef956b32a58cd668eadbb812d28e20678cb2dc545a566f35a3afc0962307ca801da30f4741117986d
+  languageName: node
+  linkType: hard
+
+"undici@npm:^5.29.0":
+  version: 5.29.0
+  resolution: "undici@npm:5.29.0"
+  dependencies:
+    "@fastify/busboy": "npm:^2.0.0"
+  checksum: 10/0ceca8924a32acdcc0cfb8dd2d368c217840970aa3f5e314fc169608474be6341c5b8e50cad7bd257dbe3b4e432bc5d0a0d000f83644b54fa11a48735ec52b93
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Spike: a Pikku agent you can hold a spoken conversation with, and a way to test that it actually did what it said.

Two halves, deliberately split so the OSS story stays clean: the API side lives in `core`, the browser side lives in a new `@pikku/voice-agents` package, and neither knows about the other's runtime.

## What's here

**`core` — cooperative interrupt.** A verbal agent needs something a text one never did: the ability to be stopped mid-turn without losing what already happened. `abortScope` carries a cancellation signal down through the function runner, and `beginChanges()` gives an agent a checkpoint it can be interrupted *at* rather than anywhere. `interrupted` joins the AI run status enum, kept distinct from `failed` — the run was stopped on purpose, usually because the user talked over it, so it shouldn't surface in error reporting.

**`@pikku/voice-agents` (new).** Mic capture, speech and silence detection, playback queueing, spoken approvals.

**`@pikku/ai-deepinfra` (new).** STT/TTS provider. The voice path moved off Whisper once its invented filler turned out not to be filterable by confidence — it will produce a confident "Thank you." from silence.

**`cli` — two fixes that meant `actor.converse` had never once worked under `pikku scenario run`.**

Scenario steps execute in the CLI process, which stubbed its singleton services to three entries, so every conversing scenario died on `AIProviderNotConfigured` before saying anything. It now builds a runner the same way `pikku dev` does, and only when the project declares agents, so agent-less projects still need no AI env.

The second is worse because it is silent. `supportsStructuredOutputs` defaults to `false`, which drops `outputSchema`, degrades the call to bare `json_object`, and returns well-formed JSON with whatever keys the model felt like. Nothing errors; the caller reads `undefined` off every field it asked for and behaves as though the model said nothing.

Also adds `scenarios.actorModel`, so the model the *actor* thinks with is configurable and explicitly not the model under test.

## The testing idea

A voice agent once replied "Okay — marking get lunch done." having called no tool at all, and on another run reached for `deleteTodo`. Both of those pass a test that only reads the actor's verdict, because the actor is judging the *conversation*, and the conversation was fine.

So the assertions go to the store instead: the todo exists, it is completed, exactly one of it exists, and the todo nobody mentioned is untouched.

Verified negatively — with `completeTodo` removed from the agent, the run produces:

```
Then the actor concludes the task succeeded                    ✓
Then the store holds the todo, completed                       ✗  No todo titled "get lunch" in the store
```

The actor's verdict passes while the store shows nothing happened. That's the case a verdict-only test ships green.

Note what is **not** asserted: which tools ran. The user asked for a todo to be done, not for `completeTodo` to be invoked. Whether the agent's sentence was honest about how it got there is a grade on the run rather than a check on the world, and belongs to the judge in #719.

## Actor model

`gpt-4.1-mini`, chosen against a bench of the actor's four real behaviours — return each schema, and end the conversation when the goal is met. Every cheaper candidate failed the last one: `Mistral-Small-3.2-24B` scored 0/4 on "say you're done", so it burned the full 12-turn budget and took **320s instead of 33s**. Per-token savings are an illusion there, because each wasted turn also bills the agent's model.

## Verification

- `@pikku/core` — 1591 pass, 0 fail
- `@pikku/ai-vercel` 33, `@pikku/ai-deepinfra` 22, `@pikku/voice-agents` 28 — all passing
- Both converse scenarios pass end-to-end against a live model
- Rebased onto latest `main`; three conflicts resolved by hand (`voice-output.ts` for the new `emit`/`signal` params, `scenario.ts` alongside the new `setRunSurface`, and the `func:` → `default:` step rename), then the full suite re-run

## One intentional behaviour change — please look at this

`done` now goes **through the stream middleware** rather than straight at the channel, and is awaited:

```diff
-    channel.send({ type: 'done' })
+    await outputChannel.send({ type: 'done' })
```

It is the only signal a stream hook gets that the reply is over, and hooks that buffer need it — `voiceOutput` speaks a trailing fragment that never reached a full stop, and waits on audio it has already paid to synthesize. Sent raw, that work is thrown away by the `close()` on the next line.

This changes observable middleware ordering, so `verifiers/middleware-and-permissions` is updated: `modifyOutputStream` now fires once more, after `modifyOutput`. That ordering is deliberate — `modifyOutput` is about the completed reply, `done` is about the stream carrying it — but it is a spec change and anyone with a `modifyOutputStream` hook will now see one extra event. Shout if that trade is wrong; the alternative is a separate flush hook that only buffering middleware implements.

The pre-push verifier suite is what caught this, not me.

## Reviewer notes

- `e2e/pikku.config.json` shows some unrelated array-formatting churn. That's `lint-staged`'s prettier reformatting a file whose committed copy on `main` was stale — not a hand edit.
- One pre-existing `tsc` error remains in `packages/cli/src/services.ts` (`strictMeta`), untouched by this branch and present on `main`.
- This is a spike. `packages/voice-agents` has no README beyond a stub and the browser side has had far less adversarial testing than the core side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice conversation support with microphone input, speech detection, silence handling, playback queues, barge-in, and spoken approvals.
  * Added AI agent interruption controls with interruption status, reasons, and delivery of pending tool results.
  * Added DeepInfra support for speech transcription and synthesis.
  * Added a complete voice assistant demonstration with todo-list interactions.
  * Added audio and interruption events for streamed agent responses.
* **Bug Fixes**
  * Improved binary HTTP response handling and silent-transcription behavior.
  * Read-only tools are now clearly identified and protected from unintended mutations.
* **Documentation**
  * Added setup and usage documentation for voice agents and DeepInfra integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->