### PR TITLE
feat(sqlite): make user-defined SQL functions an explicit, checked capability

### DIFF
--- a/.changeset/sqlite-udf-parity.md
+++ b/.changeset/sqlite-udf-parity.md
@@ -1,0 +1,20 @@
+---
+'@pikku/kysely-bun-sqlite': patch
+'@pikku/kysely-node-sqlite': patch
+'@pikku/kysely-sqlite': patch
+---
+
+Make user-defined SQL functions an explicit, checked capability of the SQLite drivers.
+
+`node:sqlite` can register scalar UDFs (`db.function()`); `bun:sqlite` cannot. Until now
+neither driver mentioned that, so an app that registered a UDF by reaching for the raw
+connection worked on Node and, on bun, failed as `no such function: …` from whichever
+query used it — typically one endpoint breaking in production while everything else
+looked healthy.
+
+Both drivers now export `registerSqliteFunctions(db, functions)` and accept a
+`functions` option on `createNodeSqliteKysely` / `createBunSqliteKysely`. The Node
+implementation registers them as deterministic; the bun implementation throws
+`SqliteFunctionsUnsupportedError` — exported from `@pikku/kysely-sqlite`, and naming
+every function requested — so the incompatibility surfaces at wiring time with a message
+saying what to do about it.

--- a/packages/services/kysely-bun-sqlite/README.md
+++ b/packages/services/kysely-bun-sqlite/README.md
@@ -28,6 +28,22 @@ const db = createBunSqliteKysely<KyselyPikkuDB>({
 `camelCase` (default `true`) applies Kysely's `CamelCasePlugin`; pass extra
 `plugins` to layer more on top. Use `':memory:'` for an in-memory database.
 
+## User-defined SQL functions are not supported
+
+`bun:sqlite` has no equivalent of `node:sqlite`'s `db.function()`, so scalar
+UDFs cannot be registered on this driver. Passing `functions` — or calling
+`registerSqliteFunctions` — throws `SqliteFunctionsUnsupportedError` immediately,
+naming every function requested.
+
+That is deliberate. The alternative is code that registers its functions on Node
+and silently does not on bun, where the difference only appears as
+`no such function: …` from whichever query calls one.
+
+If you hit this, either run on Node with `@pikku/kysely-node-sqlite`, or move the
+computation out of SQL: precompute what the function was matching on into an
+indexed table, use that index to narrow to a candidate set, and run the real
+logic over those rows in TypeScript.
+
 ## Docs
 
 https://pikku.dev/docs

--- a/packages/services/kysely-bun-sqlite/src/coercion-plugin.test.ts
+++ b/packages/services/kysely-bun-sqlite/src/coercion-plugin.test.ts
@@ -27,10 +27,9 @@ describe('createCoercionPlugin', () => {
   })
 
   test('coerces date columns from ISO strings to Date', async () => {
-    const [row] = await runTransform(
-      { users: { created_at: 'date' } },
-      [{ created_at: '2026-06-26T00:00:00.000Z' }]
-    )
+    const [row] = await runTransform({ users: { created_at: 'date' } }, [
+      { created_at: '2026-06-26T00:00:00.000Z' },
+    ])
     assert.ok(row.created_at instanceof Date)
     assert.equal(
       (row.created_at as Date).toISOString(),
@@ -39,10 +38,9 @@ describe('createCoercionPlugin', () => {
   })
 
   test('leaves unparseable date strings untouched', async () => {
-    const [row] = await runTransform(
-      { users: { created_at: 'date' } },
-      [{ created_at: 'not-a-date' }]
-    )
+    const [row] = await runTransform({ users: { created_at: 'date' } }, [
+      { created_at: 'not-a-date' },
+    ])
     assert.equal(row.created_at, 'not-a-date')
   })
 
@@ -65,19 +63,17 @@ describe('createCoercionPlugin', () => {
   })
 
   test('passes through null values and unmapped columns', async () => {
-    const rows = await runTransform(
-      { users: { created_at: 'date' } },
-      [{ created_at: null, name: 'leave me' }]
-    )
+    const rows = await runTransform({ users: { created_at: 'date' } }, [
+      { created_at: null, name: 'leave me' },
+    ])
     assert.equal(rows[0].created_at, null)
     assert.equal(rows[0].name, 'leave me')
   })
 
   test('matches both snake_case and camelCase column names', async () => {
-    const rows = await runTransform(
-      { users: { created_at: 'date' } },
-      [{ createdAt: '2026-06-26T00:00:00.000Z' }]
-    )
+    const rows = await runTransform({ users: { created_at: 'date' } }, [
+      { createdAt: '2026-06-26T00:00:00.000Z' },
+    ])
     assert.ok(rows[0].createdAt instanceof Date)
   })
 

--- a/packages/services/kysely-bun-sqlite/src/create-bun-sqlite-kysely.ts
+++ b/packages/services/kysely-bun-sqlite/src/create-bun-sqlite-kysely.ts
@@ -5,7 +5,9 @@ import {
   CamelCasePlugin,
   type KyselyPlugin,
 } from 'kysely'
+import type { SqliteFunctionMap } from '@pikku/kysely-sqlite'
 import { BunSqliteDatabase } from './bun-sqlite-adapter.js'
+import { registerSqliteFunctions } from './register-functions.js'
 
 export interface CreateBunSqliteKyselyOptions {
   /** Path to the SQLite file. Use ':memory:' for an in-memory DB. */
@@ -14,12 +16,24 @@ export interface CreateBunSqliteKyselyOptions {
   camelCase?: boolean
   /** Extra plugins to layer on top. */
   plugins?: KyselyPlugin[]
+  /**
+   * Accepted only so that setting it fails loudly. bun:sqlite cannot register
+   * user-defined SQL functions, so passing any throws
+   * SqliteFunctionsUnsupportedError here rather than leaving the queries that
+   * call them to fail with "no such function" later.
+   *
+   * The option is declared — instead of simply absent — so that code shared
+   * with `createNodeSqliteKysely` still type-checks and the incompatibility
+   * shows up as an error that explains itself.
+   */
+  functions?: SqliteFunctionMap
 }
 
 export function createBunSqliteKysely<DB>(
   options: CreateBunSqliteKyselyOptions
 ): Kysely<DB> {
   const db = new Database(options.filename)
+  if (options.functions) registerSqliteFunctions(db, options.functions)
   const plugins: KyselyPlugin[] = []
   if (options.camelCase ?? true) plugins.push(new CamelCasePlugin())
   if (options.plugins) plugins.push(...options.plugins)

--- a/packages/services/kysely-bun-sqlite/src/index.ts
+++ b/packages/services/kysely-bun-sqlite/src/index.ts
@@ -3,6 +3,12 @@ export {
   createBunSqliteKysely,
   type CreateBunSqliteKyselyOptions,
 } from './create-bun-sqlite-kysely.js'
+export { registerSqliteFunctions } from './register-functions.js'
+export {
+  SqliteFunctionsUnsupportedError,
+  type SqliteFunction,
+  type SqliteFunctionMap,
+} from '@pikku/kysely-sqlite'
 export {
   createCoercionPlugin,
   type CoercionMap,

--- a/packages/services/kysely-bun-sqlite/src/register-functions.test.ts
+++ b/packages/services/kysely-bun-sqlite/src/register-functions.test.ts
@@ -1,0 +1,54 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { Database } from 'bun:sqlite'
+import { SqliteFunctionsUnsupportedError } from '@pikku/kysely-sqlite'
+import { registerSqliteFunctions } from './register-functions.js'
+import { createBunSqliteKysely } from './create-bun-sqlite-kysely.js'
+
+describe('registerSqliteFunctions', () => {
+  test('throws rather than silently skipping registration', () => {
+    const db = new Database(':memory:')
+    assert.throws(
+      () => registerSqliteFunctions(db, { similarity: () => 0 }),
+      SqliteFunctionsUnsupportedError
+    )
+    db.close()
+  })
+
+  test('names every requested function, so the error says what to port', () => {
+    const db = new Database(':memory:')
+    try {
+      registerSqliteFunctions(db, {
+        similarity: () => 0,
+        levenshtein: () => 0,
+      })
+      assert.fail('expected a throw')
+    } catch (error) {
+      assert.ok(error instanceof SqliteFunctionsUnsupportedError)
+      assert.deepEqual(error.functionNames, ['similarity', 'levenshtein'])
+      assert.match(error.message, /similarity, levenshtein/)
+      assert.match(error.message, /kysely-node-sqlite/)
+    }
+    db.close()
+  })
+
+  // The point of the whole change: the failure has to happen while the app is
+  // wiring itself up, not on the first request that reaches a query using one.
+  test('createBunSqliteKysely rejects `functions` at construction', () => {
+    assert.throws(
+      () =>
+        createBunSqliteKysely({
+          filename: ':memory:',
+          functions: { similarity: () => 0 },
+        }),
+      SqliteFunctionsUnsupportedError
+    )
+  })
+
+  test('omitting `functions` is unaffected', async () => {
+    const db = createBunSqliteKysely<{ t: { id: number } }>({
+      filename: ':memory:',
+    })
+    await db.destroy()
+  })
+})

--- a/packages/services/kysely-bun-sqlite/src/register-functions.ts
+++ b/packages/services/kysely-bun-sqlite/src/register-functions.ts
@@ -1,0 +1,30 @@
+import type { Database } from 'bun:sqlite'
+import {
+  SqliteFunctionsUnsupportedError,
+  type SqliteFunctionMap,
+} from '@pikku/kysely-sqlite'
+
+/**
+ * The bun counterpart to `@pikku/kysely-node-sqlite`'s function of the same
+ * name. It always throws: bun:sqlite exposes `loadExtension` but nothing
+ * equivalent to node:sqlite's `db.function()`, so scalar UDFs cannot be
+ * registered at all.
+ *
+ * It exists precisely so that the failure happens here. Without it the two
+ * drivers differ silently — code written against node registers its functions,
+ * the same code on bun does not, and the difference only surfaces as
+ * `no such function: …` from whichever query calls one, which in practice means
+ * one endpoint failing in production while the rest of the app looks healthy.
+ *
+ * Throwing at wiring time turns that into a startup error naming every function
+ * involved.
+ */
+export function registerSqliteFunctions(
+  _db: Database,
+  functions: SqliteFunctionMap
+): never {
+  throw new SqliteFunctionsUnsupportedError(
+    'bun:sqlite',
+    Object.keys(functions)
+  )
+}

--- a/packages/services/kysely-node-sqlite/README.md
+++ b/packages/services/kysely-node-sqlite/README.md
@@ -28,6 +28,32 @@ const db = createNodeSqliteKysely<KyselyPikkuDB>({
 `camelCase` (default `true`) applies Kysely's `CamelCasePlugin`; pass extra
 `plugins` to layer more on top. Use `':memory:'` for an in-memory database.
 
+## User-defined SQL functions
+
+`node:sqlite` can register scalar functions, so SQL can call your own code:
+
+```typescript
+const db = createNodeSqliteKysely<KyselyPikkuDB>({
+  filename: 'app.db',
+  functions: {
+    similarity: (a, b) => trigramSimilarity(String(a), String(b)),
+  },
+})
+```
+
+They are registered as **deterministic**, which is what allows SQLite to use
+them in an index and to cache repeated calls. Do not register a function whose
+result depends on the clock, a random source, or anything mutable.
+
+If you build the connection yourself — as you must when you need pragmas like
+WAL or `busy_timeout` — call `registerSqliteFunctions(db, { … })` on it directly.
+
+**This option has no bun equivalent.** `bun:sqlite` cannot register functions at
+all, so `@pikku/kysely-bun-sqlite` throws `SqliteFunctionsUnsupportedError`
+rather than accepting them. Using this is a decision to stay on Node; if you may
+want to move, do the computation outside SQL over an indexed candidate set
+instead.
+
 ## Docs
 
 https://pikku.dev/docs

--- a/packages/services/kysely-node-sqlite/package.json
+++ b/packages/services/kysely-node-sqlite/package.json
@@ -11,6 +11,9 @@
     "tsc": "tsc",
     "ncu": "npx npm-check-updates",
     "build": "tsc -b",
+    "test": "bash run-tests.sh",
+    "test:watch": "bash run-tests.sh --watch",
+    "test:coverage": "bash run-tests.sh --coverage",
     "prepublishOnly": "yarn build"
   },
   "engines": {
@@ -27,6 +30,7 @@
   "devDependencies": {
     "@pikku/core": "^0.12.44",
     "@types/node": "^22",
+    "tsx": "^4.19.2",
     "typescript": "^6.0.3"
   },
   "exports": {

--- a/packages/services/kysely-node-sqlite/run-tests.sh
+++ b/packages/services/kysely-node-sqlite/run-tests.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Parse command line arguments
+WATCH_MODE=false
+COVERAGE_MODE=false
+
+for arg in "$@"
+do
+    case $arg in
+        --watch)
+        WATCH_MODE=true
+        shift
+        ;;
+        --coverage)
+        COVERAGE_MODE=true
+        shift
+        ;;
+    esac
+done
+
+# Build the command
+CMD="node --import tsx --test --test-force-exit src/**/*.test.ts"
+
+if [ "$WATCH_MODE" = true ]; then
+    CMD="$CMD --watch"
+fi
+
+if [ "$COVERAGE_MODE" = true ]; then
+    CMD="$CMD --experimental-test-coverage"
+fi
+
+# Execute the command
+eval $CMD

--- a/packages/services/kysely-node-sqlite/src/create-node-sqlite-kysely.ts
+++ b/packages/services/kysely-node-sqlite/src/create-node-sqlite-kysely.ts
@@ -5,7 +5,9 @@ import {
   CamelCasePlugin,
   type KyselyPlugin,
 } from 'kysely'
+import type { SqliteFunctionMap } from '@pikku/kysely-sqlite'
 import { NodeSqliteDatabase } from './node-sqlite-adapter.js'
+import { registerSqliteFunctions } from './register-functions.js'
 
 export interface CreateNodeSqliteKyselyOptions {
   /** Path to the SQLite file. Use ':memory:' for an in-memory DB. */
@@ -14,12 +16,22 @@ export interface CreateNodeSqliteKyselyOptions {
   camelCase?: boolean
   /** Extra plugins to layer on top. */
   plugins?: KyselyPlugin[]
+  /**
+   * Scalar user-defined SQL functions to register, keyed by the name SQL calls
+   * them by. Registered as deterministic.
+   *
+   * Note that this is the one option with no bun equivalent:
+   * `createBunSqliteKysely` throws if it is set, because bun:sqlite cannot
+   * register functions. Using it is a decision to stay on Node.
+   */
+  functions?: SqliteFunctionMap
 }
 
 export function createNodeSqliteKysely<DB>(
   options: CreateNodeSqliteKyselyOptions
 ): Kysely<DB> {
   const db = new DatabaseSync(options.filename)
+  if (options.functions) registerSqliteFunctions(db, options.functions)
   const plugins: KyselyPlugin[] = []
   if (options.camelCase ?? true) plugins.push(new CamelCasePlugin())
   if (options.plugins) plugins.push(...options.plugins)

--- a/packages/services/kysely-node-sqlite/src/index.ts
+++ b/packages/services/kysely-node-sqlite/src/index.ts
@@ -3,6 +3,12 @@ export {
   createNodeSqliteKysely,
   type CreateNodeSqliteKyselyOptions,
 } from './create-node-sqlite-kysely.js'
+export { registerSqliteFunctions } from './register-functions.js'
+export {
+  SqliteFunctionsUnsupportedError,
+  type SqliteFunction,
+  type SqliteFunctionMap,
+} from '@pikku/kysely-sqlite'
 export {
   createCoercionPlugin,
   type CoercionMap,

--- a/packages/services/kysely-node-sqlite/src/register-functions.test.ts
+++ b/packages/services/kysely-node-sqlite/src/register-functions.test.ts
@@ -1,0 +1,52 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { DatabaseSync } from 'node:sqlite'
+import { sql } from 'kysely'
+import { registerSqliteFunctions } from './register-functions.js'
+import { createNodeSqliteKysely } from './create-node-sqlite-kysely.js'
+
+describe('registerSqliteFunctions', () => {
+  test('makes the function callable from SQL', () => {
+    const db = new DatabaseSync(':memory:')
+    registerSqliteFunctions(db, {
+      shout: (value) => `${String(value).toUpperCase()}!`,
+    })
+
+    const row = db.prepare(`SELECT shout('hello') AS v`).get() as { v: string }
+    assert.equal(row.v, 'HELLO!')
+    db.close()
+  })
+
+  test('registers as deterministic, so it is usable in an index', () => {
+    const db = new DatabaseSync(':memory:')
+    registerSqliteFunctions(db, { half: (n) => Number(n) / 2 })
+
+    db.exec('CREATE TABLE t (n INTEGER)')
+    // SQLite rejects non-deterministic functions in an index outright, so this
+    // statement succeeding IS the assertion about how they were registered.
+    db.exec('CREATE INDEX t_half ON t (half(n))')
+    db.close()
+  })
+
+  test('registers every entry in the map', () => {
+    const db = new DatabaseSync(':memory:')
+    registerSqliteFunctions(db, { a: () => 1, b: () => 2 })
+
+    const row = db.prepare('SELECT a() + b() AS v').get() as { v: number }
+    assert.equal(row.v, 3)
+    db.close()
+  })
+
+  test('createNodeSqliteKysely registers them on the connection it builds', async () => {
+    const db = createNodeSqliteKysely<{ t: { id: number } }>({
+      filename: ':memory:',
+      functions: { double: (n) => Number(n) * 2 },
+    })
+
+    const result = await sql<{
+      v: number
+    }>`SELECT double(21) AS v`.execute(db)
+    assert.equal(result.rows[0]!.v, 42)
+    await db.destroy()
+  })
+})

--- a/packages/services/kysely-node-sqlite/src/register-functions.ts
+++ b/packages/services/kysely-node-sqlite/src/register-functions.ts
@@ -1,0 +1,27 @@
+import type { DatabaseSync } from 'node:sqlite'
+import type { SqliteFunctionMap } from '@pikku/kysely-sqlite'
+
+/**
+ * Registers scalar user-defined SQL functions on a node:sqlite connection.
+ *
+ * Exported separately from `createNodeSqliteKysely` because an app that needs
+ * pragmas — WAL, `foreign_keys`, `busy_timeout` — has to build the connection
+ * itself, and would otherwise have no supported way to add UDFs to it.
+ *
+ * Registered as `deterministic`, which is what makes them usable in indexes and
+ * lets SQLite cache repeated calls with the same arguments. That is a promise
+ * about the function, not a hint: one whose output depends on the clock, a
+ * random source or anything mutable must not go through here.
+ *
+ * There is no bun counterpart. `@pikku/kysely-bun-sqlite` exports the same name
+ * so the import resolves either way, but it throws — see
+ * SqliteFunctionsUnsupportedError.
+ */
+export function registerSqliteFunctions(
+  db: DatabaseSync,
+  functions: SqliteFunctionMap
+): void {
+  for (const [name, fn] of Object.entries(functions)) {
+    db.function(name, { deterministic: true }, fn as never)
+  }
+}

--- a/packages/services/kysely-sqlite/src/index.ts
+++ b/packages/services/kysely-sqlite/src/index.ts
@@ -7,6 +7,11 @@ export { SQLiteKyselyWorkflowRunService } from './sqlite-kysely-workflow-run-ser
 export { SQLiteKyselyChannelStore } from './sqlite-kysely-channel-store.js'
 export { SQLiteKyselyEventHubStore } from './sqlite-kysely-eventhub-store.js'
 export { SQLiteKyselySecretService } from './sqlite-kysely-secret-service.js'
+export {
+  SqliteFunctionsUnsupportedError,
+  type SqliteFunction,
+  type SqliteFunctionMap,
+} from './sqlite-functions.js'
 export { LibsqlWebDialect } from './libsql-web-dialect.js'
 export type { LibsqlWebDialectConfig } from './libsql-web-dialect.js'
 

--- a/packages/services/kysely-sqlite/src/sqlite-functions.ts
+++ b/packages/services/kysely-sqlite/src/sqlite-functions.ts
@@ -1,0 +1,47 @@
+/**
+ * User-defined SQL functions, shared between the runtime-specific SQLite
+ * drivers so that `functions: { … }` means the same thing whichever one an app
+ * is wired to.
+ *
+ * Only `@pikku/kysely-node-sqlite` can actually register them. bun:sqlite has
+ * no equivalent of `db.function()`, so `@pikku/kysely-bun-sqlite` rejects this
+ * option outright rather than accepting it and letting the queries fail. That
+ * asymmetry is the whole reason this type is declared once, in a package both
+ * depend on: an app that names its UDFs against this type finds out at wiring
+ * time — or at the type level — that it cannot move to bun, instead of finding
+ * out as `no such function: …` from whichever endpoint happens to use it.
+ */
+
+/**
+ * A scalar SQL function. Arguments arrive as the values SQLite stores — string,
+ * number, bigint, Uint8Array or null — and the return value must be one SQLite
+ * can store, so no Date, boolean or object.
+ */
+export type SqliteFunction = (
+  ...args: Array<string | number | bigint | Uint8Array | null>
+) => string | number | bigint | Uint8Array | null
+
+/** Scalar SQL functions to register, keyed by the name SQL will call them by. */
+export type SqliteFunctionMap = Record<string, SqliteFunction>
+
+/**
+ * Thrown when UDFs are requested on a runtime that cannot provide them.
+ *
+ * Its own class rather than a plain Error because the one sensible reaction —
+ * fall back to doing the work outside SQL — is worth being able to catch for.
+ */
+export class SqliteFunctionsUnsupportedError extends Error {
+  constructor(
+    readonly runtime: string,
+    readonly functionNames: string[]
+  ) {
+    super(
+      `${runtime} cannot register user-defined SQL functions, but ${functionNames.length} were requested: ${functionNames.join(', ')}.\n\n` +
+        `Every query calling them would fail with "no such function". Options:\n` +
+        `  - run on Node with @pikku/kysely-node-sqlite, which supports them; or\n` +
+        `  - do the work outside SQL, narrowing rows with an index first so the\n` +
+        `    computation runs over a candidate set rather than the whole table.`
+    )
+    this.name = 'SqliteFunctionsUnsupportedError'
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6297,6 +6297,7 @@ __metadata:
     "@pikku/kysely-sqlite": "npm:^0.12.7"
     "@types/node": "npm:^22"
     kysely: "npm:^0.29.0"
+    tsx: "npm:^4.19.2"
     typescript: "npm:^6.0.3"
   peerDependencies:
     "@pikku/core": ^0.12.44


### PR DESCRIPTION
Closes #1093

## The problem

`@pikku/kysely-node-sqlite` runs on `node:sqlite`, which can register scalar UDFs through `db.function()`. `@pikku/kysely-bun-sqlite` runs on `bun:sqlite`, which has no equivalent — it offers `loadExtension` and nothing else.

Neither driver said so. An app that registered a UDF by reaching for the raw connection worked on Node and, on bun, failed as `no such function: …` from whichever query called it. The failure lands as far from its cause as it can get: typically one endpoint breaking in production while every other part of the app looks healthy.

## The change

**Types declared once, in the package both drivers depend on.** `@pikku/kysely-sqlite` now exports `SqliteFunction`, `SqliteFunctionMap` and `SqliteFunctionsUnsupportedError`, so a function map means the same thing whichever driver an app is wired to, and an app that names its UDFs against this type learns at the type level that it cannot move to bun.

**Both drivers export `registerSqliteFunctions(db, functions)`** and accept a `functions` option on `createNodeSqliteKysely` / `createBunSqliteKysely`. The standalone export matters because an app that needs pragmas (WAL, `foreign_keys`, `busy_timeout`) builds the connection itself and would otherwise have no supported way to add UDFs to it.

- **Node** registers them as `deterministic`, which is what makes them usable in indexes and lets SQLite cache repeated calls. That is a promise about the function, not a hint — one depending on the clock or a random source must not go through here, and the JSDoc says so.
- **Bun** throws `SqliteFunctionsUnsupportedError`, naming every function requested and pointing at the two real options (move to Node, or do the work outside SQL over an index-narrowed candidate set).

The bun `functions` option is *declared* rather than simply absent, deliberately: code shared between the two drivers still type-checks, and the incompatibility surfaces as an error that explains itself instead of an unknown-property error that doesn't.

## Testing

Both suites pass, and the node tests assert the deterministic registration rather than just callability:

- `kysely-node-sqlite` — 4 tests: callable from SQL, registered as deterministic (proven by using one in an index), every entry in the map registered, and `createNodeSqliteKysely` registering on the connection it builds.
- `kysely-bun-sqlite` — 21 tests across 4 files, covering the throw path and naming.

`tsc --noEmit` is clean on all three packages. Adds a `run-tests.sh` plus test scripts to `kysely-node-sqlite`, which had no test runner wired up.

Changeset is `patch` for all three packages, per the pre-0.13 convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering deterministic SQLite user-defined functions when creating Node-based database connections.
  * Added shared types and exports for defining SQLite functions.
  * Added function configuration support to Bun-based connections.

* **Bug Fixes**
  * Bun-based connections now provide a clear error when unsupported SQL functions are requested, including affected function names and alternatives.

* **Documentation**
  * Added guidance and examples for SQLite function registration, compatibility limitations, and available alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->