### PR TITLE
fix(ci): move the bootstrap pin past signedContentPath

### DIFF
--- a/packages/cli/build.sh
+++ b/packages/cli/build.sh
@@ -16,21 +16,25 @@ rm -rf -- .pikku dist
 # `routePermissions.size`, and every bootstrap build broke at once — including
 # on main, which had been green minutes earlier.
 #
-# 0.12.83 is the CLI from that same release wave, so it matches 0.12.43. It
-# imports @pikku/better-auth rather than @pikku/auth-js, which is why the
-# bootstrap installs better-auth directly instead of overriding it.
+# The whole set moves together or none of it does. The 2026-08-03 wave went out
+# inside 62 seconds — inspector 00:16:45, core 00:16:47, better-auth 00:16:54,
+# cli 00:17:47 — so these four are members of one release.
+#
+# The previous pin (cli 0.12.83 / core 0.12.64) had to move: the workspace now
+# calls `signedContentPath` from @pikku/node-http-server, and core 0.12.64
+# predates that export, so the bootstrap CLI died loading the tree it was meant
+# to inspect. A pin is only as good as the exports that tree depends on.
 #
 # Historical note, still relevant when choosing a version: 0.12.36 shipped a
 # `@pikku/better-auth: workspace:*` dependency that leaked verbatim to npm and
 # is uninstallable, so bootstrapping off `latest` can self-deadlock.
 echo "Bootstrapping with published @pikku/cli..."
-: "${PIKKU_CLI_VERSION:=0.12.83}"
-: "${PIKKU_INSPECTOR_VERSION:=0.12.43}"
-: "${PIKKU_BETTER_AUTH_VERSION:=0.12.12}"
-# core 0.12.64 went out 40 seconds before cli 0.12.83, so it is the third member
-# of that same wave. It is a *peer* of both the CLI and the inspector, which is
-# why it has to be named here to exist at all once peer resolution is off.
-: "${PIKKU_CORE_VERSION:=0.12.64}"
+: "${PIKKU_CLI_VERSION:=0.12.96}"
+: "${PIKKU_INSPECTOR_VERSION:=0.12.52}"
+: "${PIKKU_BETTER_AUTH_VERSION:=0.12.20}"
+# core is a *peer* of both the CLI and the inspector, which is why it has to be
+# named here to exist at all once peer resolution is off.
+: "${PIKKU_CORE_VERSION:=0.12.74}"
 # The other peer that has to be named: @pikku/better-auth peers on the upstream
 # `better-auth` library and imports it at module load, so without it the
 # bootstrap CLI dies on "Cannot find package 'better-auth'".


### PR DESCRIPTION
Build has been red on `main` since Aug 2 with:

```
Failed to run Pikku CLI: The requested module '@pikku/core/services/local-content'
does not provide an export named 'signedContentPath'
```

`packages/cli/build.sh` bootstraps codegen with a published CLI, and `main` pins `PIKKU_CORE_VERSION:=0.12.64`. The workspace now calls `signedContentPath` from `@pikku/node-http-server`, and 0.12.64 predates that export — so the bootstrap CLI dies loading the tree it was meant to inspect. Verified against the registry:

| published core | exports `signedContentPath` |
| --- | --- |
| 0.12.64 (pinned on main) | no |
| 0.12.74 | yes |

Reproduced locally on `origin/main` (`bash -x packages/cli/build.sh` fails at `$_bootstrap_dir/node_modules/.bin/pikku bootstrap`), and the same command against a 0.12.96 / 0.12.74 bootstrap tree completes.

The whole wave moves together — cli 0.12.96, inspector 0.12.52, better-auth 0.12.20, core 0.12.74 — for the reason already documented in the script: the CLI and the inspector share the inspector state shape.

**Note:** this same diff is currently sitting uncommitted in @yasserf's working tree. If it is going out on `feat/1093-sqlite-udf-parity` instead, close this — it exists so `main` is not red while that lands.

No changeset: CI-only, nothing published changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)