### PR TITLE
fix(console): let ShellHeader read the chrome's body gutter

### DIFF
--- a/packages/console/src/components/ui/ShellHeader.tsx
+++ b/packages/console/src/components/ui/ShellHeader.tsx
@@ -253,11 +253,11 @@ export const ShellHeader = <T extends string = string>({
       <Paper
         radius={0}
         py={0}
-        px="xl"
         h={50}
         style={{
           display: 'flex',
           alignItems: 'center',
+          paddingInline: 'var(--console-body-gutter, var(--mantine-spacing-xl))',
         }}
       >
         <Group
@@ -359,10 +359,10 @@ export const ShellHeader = <T extends string = string>({
           second toolbar row, pushing the page content below it. */}
       <Collapse expanded={panelOpen && showFunnel}>
         <Box
-          px="xl"
           py="xs"
           style={{
             borderBottom: '1px solid var(--mantine-color-default-border)',
+            paddingInline: 'var(--console-body-gutter, var(--mantine-spacing-xl))',
           }}
         >
           <Group wrap="wrap" gap="sm" align="center">


### PR DESCRIPTION
`ShellHeader` hardcoded `px="xl"` on its bar and on its collapsed-filters overflow row, while every layout below it pads with `--console-body-gutter`. That token is retuned per chrome mode (`xl` standalone, `md` under `HostConsoleChrome`), so in an embedding host the header ended up inset twice as far as the content underneath it — the title and the page body on two different left edges.

Both now read the same token, with `var(--mantine-spacing-xl)` as the fallback so the standalone console renders exactly as before.

Spotted on Fabric's addons screen, which embeds `PackagesPage` under host chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)