### PR TITLE
fix(inspector): let a generated file declare without taking the single slot

### DIFF
--- a/.changeset/generated-single-declaration.md
+++ b/.changeset/generated-single-declaration.md
@@ -1,0 +1,17 @@
+---
+'@pikku/inspector': patch
+---
+
+Let a generated file declare scopes, roles and personas without taking the
+single-declaration slot.
+
+`defineScope`, `defineSystemRole` and `definePersonas` are one-per-codebase, and
+the CLI generates declarations of its own — `user-admin.gen.ts` ships the whole
+`admin` scope tree. Any project that scaffolded one therefore had two
+declarations and failed codegen with PKU583, and the losing file's scopes were
+dropped from the metadata rather than merged.
+
+The rule exists to name the one place a person reads from and adds to, and
+nobody adds to a file the next codegen run overwrites. A generated declaration
+is still extracted; it just neither claims the slot nor collides with the app's
+own.

--- a/packages/inspector/src/add/add-personas.test.ts
+++ b/packages/inspector/src/add/add-personas.test.ts
@@ -281,6 +281,31 @@ describe('addPersonas inspector', () => {
     )
   })
 
+  // The CLI scaffolds personas of its own, and nobody adds a persona to a file
+  // the next codegen run overwrites — so a generated declaration neither takes
+  // the single slot nor collides with the app's own.
+  test('a generated declaration neither claims the slot nor conflicts', async () => {
+    const { state, criticals } = await inspectSources({
+      'pikku-personas.gen.ts': [
+        "import { definePersonas } from '@pikku/core/persona'",
+        "definePersonas({ dave: { name: 'Dave' } })",
+      ].join('\n'),
+      'personas.ts': withRoles("definePersonas({ susan: { name: 'Susan' } })"),
+    })
+
+    assert.deepEqual(
+      criticals.filter(
+        (c) => c.code === ErrorCode.DUPLICATE_PERSONAS_DEFINITION
+      ),
+      [],
+      `expected no duplicate critical, got ${JSON.stringify(criticals)}`
+    )
+    assert.deepEqual(state.personas.definitions.map((d) => d.id).sort(), [
+      'dave',
+      'susan',
+    ])
+  })
+
   // A half-read roles array typechecks, runs, and grants less than the source
   // says — so an unreadable one reads as absent.
   test('a computed roles array is not half-extracted', async () => {

--- a/packages/inspector/src/add/add-scope.test.ts
+++ b/packages/inspector/src/add/add-scope.test.ts
@@ -216,6 +216,33 @@ describe('addScope inspector', () => {
     )
   })
 
+  // The CLI scaffolds a scope tree of its own — `user-admin.gen.ts` declares the
+  // whole `admin` tree — so a generated declaration cannot be made to compete
+  // with the app's own for the single slot.
+  test('a generated declaration neither claims the slot nor conflicts', async () => {
+    const { state, criticals } = await inspectSources({
+      'user-admin.gen.ts': [
+        "import { defineScope } from '@pikku/core/scope'",
+        'defineScope({ admin: {} })',
+      ].join('\n'),
+      'scopes.ts': [
+        "import { defineScope } from '@pikku/core/scope'",
+        'defineScope({ billing: {} })',
+      ].join('\n'),
+    })
+
+    assert.deepEqual(
+      criticals.filter((c) => c.code === ErrorCode.DUPLICATE_SCOPE_DEFINITION),
+      [],
+      `expected no duplicate critical, got ${JSON.stringify(criticals)}`
+    )
+    assert.deepEqual(
+      state.scopes.definitions.map((d) => d.name).sort(),
+      ['admin', 'billing'],
+      "both the generated tree and the app's own must survive"
+    )
+  })
+
   test('is critical when a root embeds the separator', async () => {
     const { criticals } = await inspectSource(
       [

--- a/packages/inspector/src/add/add-system-role.test.ts
+++ b/packages/inspector/src/add/add-system-role.test.ts
@@ -158,6 +158,32 @@ describe('addSystemRole inspector', () => {
     )
   })
 
+  // A generated file is not the one place a person adds a role to, so it neither
+  // takes the single slot nor collides with the app's own declaration.
+  test('a generated declaration neither claims the slot nor conflicts', async () => {
+    const { state, criticals } = await inspectSources({
+      'roles.gen.ts': [
+        "import { defineSystemRole } from '@pikku/core/role'",
+        'defineSystemRole({ admin: { scopes: [] } })',
+      ].join('\n'),
+      'roles.ts': withScopes(
+        "defineSystemRole({ buyer: { scopes: ['catalogue:read'] } })"
+      ),
+    })
+
+    assert.deepEqual(
+      criticals.filter(
+        (c) => c.code === ErrorCode.DUPLICATE_SYSTEM_ROLE_DEFINITION
+      ),
+      [],
+      `expected no duplicate critical, got ${JSON.stringify(criticals)}`
+    )
+    assert.deepEqual(state.systemRoles.definitions.map((r) => r.name).sort(), [
+      'admin',
+      'buyer',
+    ])
+  })
+
   test('a role granting nothing is legitimate, said explicitly', async () => {
     const { state, criticals } = await inspectSource(
       withScopes('defineSystemRole({', '  guest: { scopes: [] },', '})')

--- a/packages/inspector/src/utils/single-declaration.ts
+++ b/packages/inspector/src/utils/single-declaration.ts
@@ -14,6 +14,13 @@ import type { InspectorLogger } from '../types.js'
  * to "where do I add a persona?" when the file holds two calls, so allowing it
  * would keep the ambiguity the rule exists to remove.
  *
+ * A generated file is exempt, and never claims the slot either. The rule exists
+ * to name the one place a person adds to, and nobody adds to a file the CLI
+ * rewrites on the next run — the scaffolds that ship a scope tree of their own
+ * (`user-admin.gen.ts`, and the addon scaffolds beside it) would otherwise make
+ * every project that generates one unbuildable, and take the app's own
+ * declaration down with them.
+ *
  * @param files - The construct's `files` set, which doubles as the claim.
  * @returns true when the caller holds the claim and should carry on.
  */
@@ -24,6 +31,10 @@ export const claimSingleDeclaration = (
   helper: string,
   sourceFile: string
 ): boolean => {
+  if (sourceFile.endsWith('.gen.ts')) {
+    return true
+  }
+
   const [first] = files
   if (first === undefined) {
     files.add(sourceFile)


### PR DESCRIPTION
Fixes #1120. Unblocks the four E2E jobs that are red on `main`.

#1119 made `defineScope`, `defineSystemRole` and `definePersonas` one per codebase. The CLI generates declarations of its own — `user-admin.gen.ts` ships the whole `admin` scope tree — so any project that scaffolds user-admin has two, and codegen fails:

```
[PKU583] Only one defineScope(...) is allowed per codebase … Found a second in
e2e/packages/functions/src/scopes.ts (first: …/pikku/admin/user-admin.gen.ts).
```

That is the current state of `main`: **E2E Standard, E2E CLI, E2E Console and E2E Agent all fail** in the shared `e2e-codegen` step, and every branch cut from main inherits it. It also loses data quietly — `claimSingleDeclaration` returns `false` and the caller returns, so the losing file's scopes never reach the metadata.

## The fix

A generated file is exempt from the claim, and never takes the slot either.

The rule's own rationale is "one place to read the declared set from, and a single place to add to it". A file the CLI rewrites on the next run is not that place, so it has nothing to claim and nothing to lose to a claim. Its declarations are still extracted — both the generated tree and the app's own survive, which is what the app needed all along.

This is the reasoning the inspector already applies to `.gen.ts` in `post-process.ts` and `add-auth.ts`.

## Verification

- Three new tests, one per construct, each red before the change and green after: a generated declaration alongside a hand-written one produces no critical, and **both** sets of declarations land in the state.
- The existing single-declaration tests are untouched and still pass — a second hand-written call is still refused, in the same file or another.
- `packages/inspector`: 643/643, `tsc --noEmit` clean.