### PR TITLE
fix(db): keep db.schema honest about which schema a table is in

### DIFF
--- a/.changeset/db-schema-honest.md
+++ b/.changeset/db-schema-honest.md
@@ -1,0 +1,7 @@
+---
+'@pikku/cli': patch
+---
+
+`db generate` and `db check` now agree with PostgreSQL about which schema a runtime table lives in, when `db.schema` names one.
+
+Coverage matching let a copy of a runtime table in another schema satisfy a source whose tables belong in the configured one, so `db generate` could call the source up to date having created nothing there. The generated `ALTER TABLE` delta inserted the schema raw, and PostgreSQL folds an unquoted identifier, so a mixed-case `db.schema` altered a table the runtime never reads. `db check` reported the configured schema's tables as living in `public`.

--- a/packages/cli/src/functions/commands/db-check.ts
+++ b/packages/cli/src/functions/commands/db-check.ts
@@ -40,12 +40,13 @@ export const dbCheck = pikkuSessionlessFunc<{}, void>({
       logger
     )
 
-    // Table names elide the `public` schema, which reads as ambiguous in a
-    // report whose whole point can be a second copy of `app.orders` sitting in
-    // `public`. Put the schema back for display only.
+    // Table names elide the schema they landed in, which reads as ambiguous in
+    // a report whose whole point can be a second copy of `app.orders` sitting
+    // in `public`. Put the schema back for display only — the configured one
+    // when there is one, since that is where these tables belong.
     const qualify = (table: string) =>
       resolved.dialect === 'postgres' && !table.includes('.')
-        ? `public.${table}`
+        ? `${resolved.schema ?? 'public'}.${table}`
         : table
 
     if (drift.runtimeTables.length) {

--- a/packages/cli/src/functions/db/local-db.test.ts
+++ b/packages/cli/src/functions/db/local-db.test.ts
@@ -1291,6 +1291,47 @@ describe('db.schema', () => {
     assert.doesNotMatch(runtime.sql, /"app"\./)
     assert.match(runtime.sql, /create table "workflow_step"/i)
   })
+
+  /**
+   * A table of the same name in another schema is a different table.
+   *
+   * The bare desired names match a qualified covered one so that migrations
+   * written before the option existed still count. Letting that match ignore
+   * which schema the copy is in makes `public.workflow_step` — the very table
+   * the option exists to move away from — read as coverage, and generation
+   * would call the source up to date having created nothing in `app`.
+   */
+  test('a table covered in another schema is not coverage for this one', async () => {
+    usePostgresProject({
+      migrationSql: `CREATE TABLE public.workflow_step (
+  run_id TEXT NOT NULL,
+  step_name TEXT NOT NULL
+);
+`,
+    })
+    const resolved = resolveDb({}, root, root, undefined, 'app')!
+
+    const { written, upToDate } = await generateMigrations(
+      resolved,
+      root,
+      ['src'],
+      { error: (msg: string) => assert.fail(`unexpected error log: ${msg}`) }
+    )
+
+    assert.ok(
+      !upToDate.includes('pikku-runtime'),
+      'the runtime source still needs its tables in app'
+    )
+    const migration = written.find((w) => w.source === 'pikku-runtime')
+    assert.ok(migration, 'the runtime source got a migration')
+    const body = readFileSync(migration.file, 'utf8')
+
+    // Created, not altered. Counting the `public` copy as coverage turns the
+    // table into a column-level delta, and every one of those ALTERs then runs
+    // against an `app.workflow_step` that was never created.
+    assert.match(body, /create table ("app"\.)?"?workflow_step"?/i)
+    assert.doesNotMatch(body, /ALTER TABLE "app"\.workflow_step/)
+  })
 })
 
 /**
@@ -1325,7 +1366,7 @@ CREATE TABLE app.workflow_step (
 
   // The column the covered table is missing, as an alteration of the table in
   // `app` — not of whatever `workflow_step` resolves to.
-  assert.match(body, /ALTER TABLE app\.workflow_step ADD COLUMN/)
+  assert.match(body, /ALTER TABLE "app"\.workflow_step ADD COLUMN/)
   assert.doesNotMatch(
     body,
     /ALTER TABLE workflow_step /,

--- a/packages/cli/src/functions/db/local-db.ts
+++ b/packages/cli/src/functions/db/local-db.ts
@@ -704,8 +704,9 @@ export async function reset(
     `)
 
     for (const { schema_name: schemaName } of result.rows) {
-      const quoted = `"${schemaName.replace(/"/g, '""')}"`
-      await client.query(`DROP SCHEMA IF EXISTS ${quoted} CASCADE`)
+      await client.query(
+        `DROP SCHEMA IF EXISTS ${quoteIdentifier(schemaName)} CASCADE`
+      )
     }
 
     await client.query('CREATE SCHEMA IF NOT EXISTS public')
@@ -879,9 +880,19 @@ async function introspectorToMap(intro: DbIntrospector): Promise<SchemaMap> {
   return map
 }
 
+/**
+ * The tables and columns `desired` has that `actual` does not.
+ *
+ * `schema` is the one the desired bare names belong in, when the caller knows.
+ * Given it, only that schema's copy of a table counts: a `workflow_step` in
+ * `public` is a different table from the `app.workflow_step` a source with
+ * `db.schema: "app"` wants, and letting it match would report the source
+ * satisfied by a table its SQL never creates.
+ */
 function diffSchemas(
   desired: SchemaMap,
-  actual: SchemaMap
+  actual: SchemaMap,
+  schema?: string
 ): {
   missingTables: string[]
   missingColumns: { table: string; columns: string[] }[]
@@ -890,7 +901,9 @@ function diffSchemas(
   const missingColumns: { table: string; columns: string[] }[] = []
 
   for (const [table, cols] of desired) {
-    const actualCols = actual.get(table) ?? schemaQualifiedMatch(actual, table)
+    const actualCols = schema
+      ? actual.get(qualifiedTableKey(schema, table))
+      : (actual.get(table) ?? schemaQualifiedMatch(actual, table))
     if (!actualCols) {
       missingTables.push(table)
       continue
@@ -899,6 +912,21 @@ function diffSchemas(
     if (missing.length) missingColumns.push({ table, columns: missing })
   }
   return { missingTables, missingColumns }
+}
+
+/**
+ * How an introspected schema map keys a table in a given schema.
+ *
+ * Introspection elides `public`, so the key for a table there is the bare name.
+ * Anything else carries its qualifier.
+ */
+function qualifiedTableKey(schema: string, table: string): string {
+  return schema === 'public' ? table : `${schema}.${table}`
+}
+
+/** A PostgreSQL identifier, quoted so its casing survives the parser. */
+function quoteIdentifier(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`
 }
 
 /**
@@ -1766,7 +1794,8 @@ export async function generateMigrations(
 
     const { missingTables, missingColumns } = diffSchemas(
       source.desired.tables,
-      covered
+      covered,
+      source.schema
     )
     if (missingTables.length === 0 && missingColumns.length === 0) {
       result.upToDate.push(source.name)
@@ -1777,9 +1806,12 @@ export async function generateMigrations(
     // that keeps its tables in a schema has them covered as `app.workflow_step`
     // while the declaration names them bare, so a strict `covered.has(t)` reads
     // "nothing is covered" and re-emits the whole schema over tables that are
-    // already there.
-    const partial = [...source.desired.tables.keys()].some(
-      (t) => covered.has(t) || schemaQualifiedMatch(covered, t) !== undefined
+    // already there — and a copy in some other schema is not that table, so it
+    // must not count either.
+    const partial = [...source.desired.tables.keys()].some((t) =>
+      source.schema
+        ? covered.has(qualifiedTableKey(source.schema, t))
+        : covered.has(t) || schemaQualifiedMatch(covered, t) !== undefined
     )
 
     let body: string
@@ -1788,8 +1820,12 @@ export async function generateMigrations(
     // The source's own SQL is already qualified when it can be; the delta below
     // is written here from bare introspected names, so it has to be qualified
     // to match, or it alters a table in whichever schema `search_path` finds.
+    // Quoted, because the compiled SQL this delta has to line up with goes
+    // through the schema builder and is quoted there. `db.schema: "App"` left
+    // raw folds to `app`, so the delta would alter a table in a schema the
+    // runtime never uses.
     const qualify = (table: string) =>
-      source.schema ? `${source.schema}.${table}` : table
+      source.schema ? `${quoteIdentifier(source.schema)}.${table}` : table
 
     if (!partial) {
       body = source.desired.sql


### PR DESCRIPTION
Follow-up to #1095, which added `db.schema`. Three ways the option told the truth in config and lied in the database.

**Coverage matching ignored the schema.** A copy of a runtime table sitting in another schema satisfied a source whose tables belong in the configured one, so `db generate` could report the source up to date having created nothing there.

**The generated `ALTER TABLE` delta inserted the schema raw.** PostgreSQL folds an unquoted identifier, so a mixed-case `db.schema` altered a table the runtime never reads.

**`db check` reported the configured schema's tables as living in `public`.**

## Provenance

The commit was written in a worktree off #1095 and never opened as a PR — found while pruning dead worktrees. Cherry-picked cleanly onto current `main`; the changeset is new, since the original commit had none.

## Verification

`@pikku/cli`: 793/793 pass, 0 fail, against a fresh `yarn build:packages` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)