### PR TITLE
feat(cli): flag a hand-rolled server bootstrap that skips the lifecycle hooks

### DIFF
--- a/.changeset/skills-server-lifecycle.md
+++ b/.changeset/skills-server-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'@pikku/skills': patch
+---
+
+Document `pikkuServerLifecycle` in the skills corpus. `pikku-concepts` now presents both bootstrap paths (letting `pikku dev`/`pikku serve` own the server vs. embedding in your own runtime) instead of only the hand-rolled entrypoint, `pikku-services` gains a `pikkuServerLifecycle` reference covering hook ordering, discovery rules and the `afterStop`-runs-after-services-stop caveat, and `pikku-config` documents the `lint` severity map including `customServerBootstrap`.

--- a/.changeset/verify-server-lifecycle-hooks.md
+++ b/.changeset/verify-server-lifecycle-hooks.md
@@ -1,0 +1,9 @@
+---
+'@pikku/cli': patch
+---
+
+`pikku workspace validate` now warns when a project boots its own server instead of using the `pikkuServerLifecycle` hooks.
+
+It fires only when the root `start`/`dev` script starts a server without `pikku dev` / `pikku serve` **and** no Pikku runtime adapter (`@pikku/express`, `@pikku/fastify`, `@pikku/uws`, `@pikku/lambda`, `@pikku/cloudflare`, `@pikku/next`, …) is installed — depending on an adapter means the hand-rolled entrypoint is deliberate, since `pikku serve` cannot host those runtimes. Scripts that delegate (turbo, nx, `yarn workspace`, npm-run-all, …) are not flagged either.
+
+Opt out — or escalate to an error — with `"lint": { "customServerBootstrap": "off" }` in `pikku.config.json`.

--- a/packages/cli/src/functions/commands/workspace-validate.test.ts
+++ b/packages/cli/src/functions/commands/workspace-validate.test.ts
@@ -6,6 +6,7 @@ import { describe, test } from 'node:test'
 import {
   readJsonSafe,
   runWorkspaceValidate,
+  type Finding,
 } from '../validate/workspace-validate.js'
 
 async function makeTmp() {
@@ -14,6 +15,40 @@ async function makeTmp() {
 
 async function writeJson(path: string, data: unknown) {
   await writeFile(path, JSON.stringify(data, null, 2), 'utf8')
+}
+
+async function setRootScripts(
+  root: string,
+  scripts: Record<string, string>,
+  extraDeps: Record<string, string> = {}
+) {
+  await writeJson(join(root, 'package.json'), {
+    workspaces: ['packages/*', 'apps/*'],
+    dependencies: { '@pikku/core': '^1.0.0', ...extraDeps },
+    scripts,
+  })
+}
+
+async function setFunctionsDeps(root: string, deps: Record<string, string>) {
+  await writeJson(join(root, 'packages', 'functions', 'package.json'), {
+    type: 'module',
+    dependencies: { zod: '^4', ...deps },
+  })
+}
+
+async function setLintRule(root: string, severity: string) {
+  await writeJson(join(root, 'pikku.config.json'), {
+    srcDirectories: ['packages/functions/src'],
+    outDir: 'packages/functions/.pikku',
+    dev: { db: { file: '.pikku-runtime/dev.db' } },
+    clientFiles: {
+      rpcMapDeclarationFile:
+        'packages/functions-sdk/src/pikku/rpc-map.gen.d.ts',
+      reactQueryFile: 'packages/functions-sdk/src/pikku/api.gen.ts',
+    },
+    scaffold: { console: true },
+    lint: { customServerBootstrap: severity },
+  })
 }
 
 async function makeValidWorkspace(root: string) {
@@ -444,6 +479,205 @@ describe('pikku workspace validate', () => {
 
       assert.ok(!ids.includes('auth-dev-db-missing'))
       assert.ok(!ids.includes('auth-schema-missing-tables'))
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('custom-server-bootstrap', () => {
+  const findBootstrap = (findings: Finding[]) =>
+    findings.find((f) => f.id === 'custom-server-bootstrap')
+
+  test('no start or dev script → no finding', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidWorkspace(tmp)
+      await setRootScripts(tmp, { build: 'tsc' })
+      const result = await runWorkspaceValidate(tmp)
+      assert.strictEqual(findBootstrap(result.findings), undefined)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('start script booting its own server → warn finding', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidWorkspace(tmp)
+      await setRootScripts(tmp, { start: 'node dist/start.js' })
+      const result = await runWorkspaceValidate(tmp)
+      const finding = findBootstrap(result.findings)
+      assert.ok(finding, 'expected custom-server-bootstrap finding')
+      assert.strictEqual(finding!.severity, 'warn')
+      assert.match(finding!.message, /"start"/)
+      assert.match(finding!.fixHint, /pikkuServerLifecycle/)
+      assert.strictEqual(result.ok, true)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('dev script booting its own server → warn finding', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidWorkspace(tmp)
+      await setRootScripts(tmp, { dev: 'tsx watch src/server.ts' })
+      const result = await runWorkspaceValidate(tmp)
+      const finding = findBootstrap(result.findings)
+      assert.ok(finding, 'expected custom-server-bootstrap finding')
+      assert.match(finding!.message, /"dev"/)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('both scripts custom → one finding naming both', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidWorkspace(tmp)
+      await setRootScripts(tmp, {
+        start: 'node dist/start.js',
+        dev: 'tsx watch src/server.ts',
+      })
+      const result = await runWorkspaceValidate(tmp)
+      const matches = result.findings.filter(
+        (f) => f.id === 'custom-server-bootstrap'
+      )
+      assert.strictEqual(matches.length, 1)
+      assert.match(matches[0]!.message, /"start", "dev"/)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  for (const script of [
+    'pikku serve',
+    'pikku serve --port 4077',
+    'npx pikku dev',
+    'yarn pikku serve --console',
+    'pnpm exec pikku dev',
+    'bunx pikku serve',
+    'NODE_ENV=production pikku serve -p 3000',
+    'pikku prebuild && pikku serve',
+  ]) {
+    test(`"${script}" is recognised as a pikku-owned server`, async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidWorkspace(tmp)
+        await setRootScripts(tmp, { start: script })
+        const result = await runWorkspaceValidate(tmp)
+        assert.strictEqual(findBootstrap(result.findings), undefined)
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+  }
+
+  for (const script of [
+    'turbo run start',
+    'yarn workspace @app/functions start',
+    'npm run start --workspace=functions',
+    'npm-run-all build serve',
+  ]) {
+    test(`"${script}" delegates, so it is not flagged`, async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidWorkspace(tmp)
+        await setRootScripts(tmp, { start: script })
+        const result = await runWorkspaceValidate(tmp)
+        assert.strictEqual(findBootstrap(result.findings), undefined)
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+  }
+
+  for (const pkg of [
+    '@pikku/express',
+    '@pikku/express-middleware',
+    '@pikku/fastify',
+    '@pikku/uws',
+    '@pikku/lambda',
+    '@pikku/cloudflare',
+    '@pikku/next',
+    '@pikku/node-http-server',
+    '@pikku/bun-server',
+    '@pikku/modelcontextprotocol',
+  ]) {
+    test(`${pkg} in root deps means the custom entrypoint is intentional`, async () => {
+      const tmp = await makeTmp()
+      try {
+        await makeValidWorkspace(tmp)
+        await setRootScripts(
+          tmp,
+          { start: 'node dist/start.js' },
+          { [pkg]: '^1.0.0' }
+        )
+        const result = await runWorkspaceValidate(tmp)
+        assert.strictEqual(findBootstrap(result.findings), undefined)
+      } finally {
+        await rm(tmp, { recursive: true, force: true })
+      }
+    })
+  }
+
+  test('a runtime adapter in the functions package also silences it', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidWorkspace(tmp)
+      await setRootScripts(tmp, { start: 'node dist/start.js' })
+      await setFunctionsDeps(tmp, { '@pikku/fastify-plugin': '^1.0.0' })
+      const result = await runWorkspaceValidate(tmp)
+      assert.strictEqual(findBootstrap(result.findings), undefined)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('a non-runtime @pikku package does not silence it', async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidWorkspace(tmp)
+      await setRootScripts(
+        tmp,
+        { start: 'node dist/start.js' },
+        { '@pikku/jose': '^1.0.0', '@pikku/kysely': '^1.0.0' }
+      )
+      const result = await runWorkspaceValidate(tmp)
+      assert.ok(
+        findBootstrap(result.findings),
+        'expected custom-server-bootstrap finding'
+      )
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test("lint.customServerBootstrap 'off' opts out", async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidWorkspace(tmp)
+      await setRootScripts(tmp, { start: 'node dist/start.js' })
+      await setLintRule(tmp, 'off')
+      const result = await runWorkspaceValidate(tmp)
+      assert.strictEqual(findBootstrap(result.findings), undefined)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test("lint.customServerBootstrap 'error' fails the run", async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeValidWorkspace(tmp)
+      await setRootScripts(tmp, { start: 'node dist/start.js' })
+      await setLintRule(tmp, 'error')
+      const result = await runWorkspaceValidate(tmp)
+      const finding = findBootstrap(result.findings)
+      assert.ok(finding, 'expected custom-server-bootstrap finding')
+      assert.strictEqual(finding!.severity, 'error')
+      assert.strictEqual(result.ok, false)
     } finally {
       await rm(tmp, { recursive: true, force: true })
     }

--- a/packages/cli/src/functions/validate/bootstrap-checks.ts
+++ b/packages/cli/src/functions/validate/bootstrap-checks.ts
@@ -1,0 +1,119 @@
+import { join } from 'node:path'
+import { readJsonSafe } from './shared-checks.js'
+import type { ValidateFinding } from './persona-checks.js'
+
+type PackageManifest = {
+  scripts?: Record<string, string>
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+/**
+ * `pikku dev` / `pikku serve` own the server lifecycle, so a project that boots
+ * through them can hang setup off `pikkuServerLifecycle` instead of constructing
+ * its own services. These patterns cover the runner prefixes people put in front
+ * of the binary (npx/yarn/pnpm/bun), leading env assignments, and `&&` chains.
+ */
+const PIKKU_SERVER_SCRIPT =
+  /(?:^|[\s;&|])pikku(?:\.js)?\s+(?:-[^\s]*\s+)*(?:dev|serve)(?:\s|$)/
+
+/**
+ * Scripts that hand off to another script rather than starting a process
+ * themselves. We cannot follow the indirection, so they are treated as unknown
+ * rather than reported.
+ */
+const DELEGATING_SCRIPT =
+  /(?:^|[\s;&|])(?:turbo|nx|lerna|npm-run-all|run-p|run-s)(?:\s|$)|(?:^|[\s;&|])(?:npm|yarn|pnpm|bun)\s+(?:run|workspace|workspaces|--filter)(?:\s|$)/
+
+/**
+ * Runtime adapters that embed Pikku in a server the project owns. Depending on
+ * one is a deliberate choice to bootstrap by hand — `pikku dev` / `pikku serve`
+ * cannot host these, so their entrypoints are not reported.
+ */
+const RUNTIME_ADAPTER_PACKAGES = new Set([
+  '@pikku/azure-functions',
+  '@pikku/bun-server',
+  '@pikku/cloudflare',
+  '@pikku/express',
+  '@pikku/express-middleware',
+  '@pikku/fastify',
+  '@pikku/fastify-plugin',
+  '@pikku/lambda',
+  '@pikku/modelcontextprotocol',
+  '@pikku/next',
+  '@pikku/node-http-server',
+  '@pikku/tanstack-start',
+  '@pikku/uws',
+  '@pikku/uws-handler',
+  '@pikku/ws',
+])
+
+async function hasRuntimeAdapter(
+  root: string,
+  rootPkg: PackageManifest
+): Promise<boolean> {
+  const fnPkg = await readJsonSafe<PackageManifest>(
+    join(root, 'packages', 'functions', 'package.json')
+  )
+  const names = [
+    ...Object.keys(rootPkg.dependencies ?? {}),
+    ...Object.keys(rootPkg.devDependencies ?? {}),
+    ...Object.keys(fnPkg?.dependencies ?? {}),
+    ...Object.keys(fnPkg?.devDependencies ?? {}),
+  ]
+  return names.some((name) => RUNTIME_ADAPTER_PACKAGES.has(name))
+}
+
+type LintSeverity = 'off' | 'warn' | 'error'
+
+function bootstrapLintSeverity(
+  pikkuConfig: { lint?: unknown } | null
+): LintSeverity {
+  const lint = pikkuConfig?.lint as
+    | { customServerBootstrap?: unknown }
+    | undefined
+  const configured = lint?.customServerBootstrap
+  return configured === 'off' || configured === 'error' || configured === 'warn'
+    ? configured
+    : 'warn'
+}
+
+/**
+ * Reports a root `start`/`dev` script that boots a server Pikku does not own.
+ *
+ * Services built in a hand-rolled entrypoint never reach the
+ * `pikkuServerLifecycle` hooks, so startup and shutdown work silently does not
+ * run. A project depending on a runtime adapter has opted into owning its own
+ * server, and a script that delegates to another runner cannot be followed, so
+ * neither is reported.
+ */
+export async function runBootstrapChecks(
+  root: string,
+  rootPkg: PackageManifest | null,
+  pikkuConfig: { lint?: unknown } | null
+): Promise<ValidateFinding[]> {
+  if (!rootPkg) return []
+
+  const severity = bootstrapLintSeverity(pikkuConfig)
+  if (severity === 'off') return []
+  if (await hasRuntimeAdapter(root, rootPkg)) return []
+
+  const customScripts = (['start', 'dev'] as const).filter((name) => {
+    const script = rootPkg.scripts?.[name]
+    if (!script) return false
+    return !PIKKU_SERVER_SCRIPT.test(script) && !DELEGATING_SCRIPT.test(script)
+  })
+  if (customScripts.length === 0) return []
+
+  const named = customScripts.map((n) => `"${n}"`).join(', ')
+  return [
+    {
+      id: 'custom-server-bootstrap',
+      severity,
+      message: `package.json ${named} ${customScripts.length > 1 ? 'scripts start a server' : 'script starts a server'} without \`pikku dev\` or \`pikku serve\`, and no Pikku runtime adapter is installed — services created in a hand-rolled entrypoint bypass the server lifecycle hooks`,
+      path: join(root, 'package.json'),
+      fixHint:
+        'Start the server with `pikku serve` (or `pikku dev` locally) and move startup and shutdown work into a `pikkuServerLifecycle({ beforeStart, afterStart, beforeStop, afterStop })` export, which receives the already-created singleton services. To keep a custom entrypoint, set "lint": { "customServerBootstrap": "off" } in pikku.config.json',
+    },
+  ]
+}

--- a/packages/cli/src/functions/validate/shared-checks.ts
+++ b/packages/cli/src/functions/validate/shared-checks.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs'
 import { readFile, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { runKnowledgeValidate } from '@pikku/knowledge'
+import { runBootstrapChecks } from './bootstrap-checks.js'
 import { runPersonaChecks, type ValidateFinding } from './persona-checks.js'
 import { runScenarioFileChecks } from './scenario-file-checks.js'
 
@@ -244,6 +245,7 @@ export async function runSharedProjectChecks(
   // ── root package.json ──────────────────────────────────────────────────
   type RootPkg = {
     workspaces?: unknown
+    scripts?: Record<string, string>
     dependencies?: Record<string, string>
     devDependencies?: Record<string, string>
   }
@@ -535,6 +537,9 @@ export async function runSharedProjectChecks(
       'Create packages/functions-sdk/ as a workspace with src/pikku/ as the generated output root; point clientFiles.rpcMapDeclarationFile and clientFiles.reactQueryFile there'
     )
   }
+
+  // ── server bootstrap ───────────────────────────────────────────────────
+  findings.push(...(await runBootstrapChecks(root, rootPkg, pikkuConfig)))
 
   // ── personas, scenario files and the knowledge base ────────────────────
   findings.push(...(await runPersonaChecks(root, pikkuConfig)))

--- a/packages/cli/src/functions/validate/shared-checks.ts
+++ b/packages/cli/src/functions/validate/shared-checks.ts
@@ -24,6 +24,9 @@ export type SharedPikkuConfig = {
   db?: {
     engine?: 'sqlite' | 'postgres'
   }
+  lint?: {
+    customServerBootstrap?: 'off' | 'warn' | 'error'
+  }
 }
 
 export type SharedFnPkg = {

--- a/packages/cli/types/config.d.ts
+++ b/packages/cli/types/config.d.ts
@@ -540,6 +540,14 @@ export type PikkuCLIInput = {
     servicesNotDestructured?: 'off' | 'warn' | 'error'
     wiresNotDestructured?: 'off' | 'warn' | 'error'
     functionDynamicImport?: 'off' | 'warn' | 'error'
+    /**
+     * Flag a root `start`/`dev` script that boots a server without `pikku dev`
+     * or `pikku serve`, since a hand-rolled entrypoint constructs its own
+     * services and never runs the `pikkuServerLifecycle` hooks. Defaults to
+     * 'warn'; set 'off' to keep a custom entrypoint. Unlike the rules above
+     * this one is evaluated by `pikku workspace validate`, not by codegen.
+     */
+    customServerBootstrap?: 'off' | 'warn' | 'error'
   }
 
   /**

--- a/packages/skills/skills/pikku-concepts/SKILL.md
+++ b/packages/skills/skills/pikku-concepts/SKILL.md
@@ -145,7 +145,35 @@ Schemas serve triple duty: runtime validation, TypeScript types, and OpenAPI doc
 
 ## Server Bootstrap
 
-Every Pikku app follows the same bootstrap pattern regardless of runtime:
+There are two ways to start a Pikku app. Pick based on whether you need to own the HTTP server.
+
+**1. Let Pikku own the server (preferred when you don't need a specific runtime)**
+
+`pikku dev` and `pikku serve` create the config and singleton services, start the server, and shut it down cleanly. You write no bootstrap code at all — startup and shutdown work goes in lifecycle hooks:
+
+```typescript
+// src/lifecycle.ts
+import { pikkuServerLifecycle } from '@pikku/core'
+import type { SingletonServices } from '../types/application-types.js'
+
+export const lifecycle = pikkuServerLifecycle<SingletonServices>({
+  beforeStart: async ({ kysely }) => {
+    await runMigrations(kysely)
+  },
+  afterStart: async ({ logger }) => {
+    logger.info('accepting traffic')
+  },
+  beforeStop: async ({ queueService }) => {
+    await queueService.drain()
+  },
+})
+```
+
+Export exactly one `pikkuServerLifecycle` from anywhere in `srcDirectories` — the inspector finds it by the wrapper call. Every hook is optional and receives the already-created singleton services. See pikku-services for the ordering and the `afterStop` caveat.
+
+**2. Bootstrap it yourself (required for a specific runtime)**
+
+Express, Fastify, uWS, Lambda, Cloudflare and Next.js need their own entrypoint, because Pikku is embedded in a server you own:
 
 ```typescript
 import '../../functions/.pikku/pikku-bootstrap.gen.js' // Generated — registers all wirings
@@ -167,6 +195,10 @@ const server = new PikkuFastifyServer(
 await server.init()
 await server.start()
 ```
+
+**Lifecycle hooks do not run on this path** — only `pikku dev` and `pikku serve` invoke them. Do your startup work directly in the entrypoint instead.
+
+`pikku workspace validate` warns when a project starts a server by hand *and* depends on no runtime adapter, since that combination means path 1 was available and unused. Silence it with `"lint": { "customServerBootstrap": "off" }` in `pikku.config.json`.
 
 ## Code Generation
 
@@ -203,6 +235,7 @@ src/
 │   └── queue.wiring.ts
 ├── schemas.ts           # Zod/Valibot schemas
 ├── services.ts          # Service factories (see pikku-services)
+├── lifecycle.ts         # Server lifecycle hooks (pikku dev/serve only)
 ├── middleware.ts         # Middleware definitions (see pikku-security)
 ├── permissions.ts       # Permission definitions (see pikku-security)
 └── .pikku/              # Generated (gitignored)

--- a/packages/skills/skills/pikku-config/SKILL.md
+++ b/packages/skills/skills/pikku-config/SKILL.md
@@ -201,7 +201,24 @@ const apiKey = process.env.API_KEY
 const apiKey = services.variables.get('API_KEY')
 ```
 
-`process.env` belongs only in server bootstrap code (`start.ts`).
+`process.env` belongs only in server bootstrap code (`start.ts`). Under `pikku dev` / `pikku serve` there is no `start.ts` — startup work goes in a `pikkuServerLifecycle` export, and the hooks receive the singleton services, so read configuration through `variables` there too (see pikku-services).
+
+### Lint rules
+
+`pikku.config.json` can set the severity of individual checks:
+
+```json
+{
+  "lint": {
+    "servicesNotDestructured": "error",
+    "wiresNotDestructured": "error",
+    "functionDynamicImport": "warn",
+    "customServerBootstrap": "warn"
+  }
+}
+```
+
+`customServerBootstrap` is the one evaluated by `pikku workspace validate` rather than codegen: it warns when the root `start`/`dev` script boots a server without `pikku dev` / `pikku serve` and no runtime adapter is installed. Set it to `"off"` to keep a hand-rolled entrypoint, or `"error"` to enforce the hooks.
 
 ## Complete Example
 

--- a/packages/skills/skills/pikku-services/SKILL.md
+++ b/packages/skills/skills/pikku-services/SKILL.md
@@ -2,10 +2,11 @@
 name: pikku-services
 description: >-
   Use when setting up dependency injection, creating custom services, or configuring the service
-  layer in a Pikku app. Covers pikkuServices (singleton), pikkuWireServices (per-request), service
-  typing, built-in services, and tree-shaking. TRIGGER when: code uses
-  pikkuServices/pikkuWireServices, user asks about services.ts, dependency injection, service
-  factories, or built-in services (ConsoleLogger, JoseJWTService). DO NOT TRIGGER when: user asks
+  layer in a Pikku app. Covers pikkuServices (singleton), pikkuWireServices (per-request),
+  pikkuServerLifecycle (startup/shutdown hooks), service typing, built-in services, and
+  tree-shaking. TRIGGER when: code uses pikkuServices/pikkuWireServices/pikkuServerLifecycle, user
+  asks about services.ts, lifecycle.ts, dependency injection, service factories, startup or
+  shutdown work, or built-in services (ConsoleLogger, JoseJWTService). DO NOT TRIGGER when: user asks
   about auth middleware (use pikku-security) or secrets/variables (use pikku-config).
 installGroups: [core]
 ---
@@ -73,6 +74,39 @@ export const createWireServices = pikkuWireServices(
   }
 )
 ```
+
+### `pikkuServerLifecycle(hooks)` — startup and shutdown work
+
+A service factory should **construct** services, not run startup side effects. Seeding a database, warming a cache, starting a background consumer or draining a queue belongs in lifecycle hooks, which receive the singleton services after they are built:
+
+```typescript
+// src/lifecycle.ts
+import { pikkuServerLifecycle } from '@pikku/core'
+import type { SingletonServices } from '../types/application-types.js'
+
+export const lifecycle = pikkuServerLifecycle<SingletonServices>({
+  beforeStart: async ({ kysely }) => {
+    await runMigrations(kysely) // before the port opens
+  },
+  afterStart: async (services) => {
+    await seedDevData(services) // server is accepting traffic
+  },
+  beforeStop: async ({ queueService }) => {
+    await queueService.drain() // services are still alive here
+  },
+  afterStop: async () => {
+    await releaseExternalLock() // services are ALREADY stopped
+  },
+})
+```
+
+Every hook is optional. Order is `beforeStart` → server starts → `afterStart`, then on SIGINT `beforeStop` → services stopped → server stopped → `afterStop`.
+
+**`afterStop` runs after the singleton services have been stopped.** It still receives the services object, but the services inside it are shut down — using one there is a use-after-close bug. Anything that needs a live service goes in `beforeStop`.
+
+Export **exactly one** `pikkuServerLifecycle` from anywhere in `srcDirectories`; the inspector finds it by the wrapper call, so the filename is free (`src/lifecycle.ts` by convention). It must be an exported `const` initialized with a direct call to `pikkuServerLifecycle` — a re-export or a conditional wrapper is invisible to the inspector.
+
+**Only `pikku dev` and `pikku serve` run these hooks.** If you bootstrap your own server (Express, Fastify, uWS, Lambda, Cloudflare, Next.js), no runtime adapter invokes them — put the work in your entrypoint instead.
 
 ### Auto-Generated Service Manifest
 

--- a/templates/functions/src/lifecycle.ts
+++ b/templates/functions/src/lifecycle.ts
@@ -1,0 +1,24 @@
+import { pikkuServerLifecycle } from '@pikku/core'
+import type { SingletonServices } from '../types/application-types.js'
+
+/**
+ * Server lifecycle hooks, run by `pikku dev` and `pikku serve`.
+ *
+ * Every hook is optional and receives the singleton services after they have
+ * been created, so startup work that needs a service — migrations, seeding,
+ * warming a cache, starting a consumer — belongs here rather than in the
+ * service factory.
+ *
+ * Order is beforeStart -> server starts -> afterStart, then on shutdown
+ * beforeStop -> services stopped -> server stopped -> afterStop. Note that
+ * afterStop runs once the services are already stopped, so anything needing a
+ * live service goes in beforeStop.
+ *
+ * Runtimes that own their own entrypoint (Express, Fastify, uWS, Lambda,
+ * Cloudflare, Next.js) do not run these hooks — do that work in start.ts.
+ */
+export const lifecycle = pikkuServerLifecycle<SingletonServices>({
+  afterStart: async ({ logger }) => {
+    logger.info('Todo server ready')
+  },
+})


### PR DESCRIPTION
`pikku dev` and `pikku serve` create the singleton services themselves, so a project booting through them hangs startup and shutdown work off `pikkuServerLifecycle`. A hand-rolled entrypoint builds its own services and never reaches those hooks — the work silently does not run, and nothing says so.

`pikku workspace validate` now warns when **both** hold:

- the root `start`/`dev` script starts a server without `pikku dev` / `pikku serve`, and
- the project depends on no Pikku runtime adapter.

Depending on an adapter (Express, Fastify, uWS, Lambda, Cloudflare, Next, …) is a deliberate choice to own the server, and a script that delegates to turbo/nx/lerna/`yarn workspace` cannot be followed — neither is reported. `"lint": { "customServerBootstrap": "off" | "warn" | "error" }` sets the severity; default `warn`.

Also: `templates/functions/src/lifecycle.ts` shows the hooks in the template, and the skills corpus documented only the hand-rolled bootstrap — `pikku-concepts` now presents both paths, `pikku-services` gains a `pikkuServerLifecycle` reference with hook ordering and the `afterStop`-runs-after-services-stop caveat, and `pikku-config` documents the `lint` severity map.

## Provenance and the one non-mechanical change

Written in a worktree that was never opened as a PR — found while pruning dead worktrees. It did not rebase: #1105 had since moved these checks out of `workspace-validate.ts` into `shared-checks.ts`, so a mechanical rebase would have reverted that refactor.

The check is therefore **ported, not cherry-picked** — it lives in a new `validate/bootstrap-checks.ts` exporting `runBootstrapChecks`, matching the `persona-checks.ts` / `scenario-file-checks.ts` sibling-module pattern `shared-checks.ts` already composes. Logic, regexes, adapter list, message and fix hint are byte-identical to the original; only the surrounding structure changed. Worth a closer look than the diff size suggests.

## Verification

`@pikku/cli`: **822/822 pass, 0 fail** against a fresh `yarn build:packages` on this branch — 29 more than main's 793, which is the ported suite. The `custom-server-bootstrap` block passes unchanged in its new home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for custom server startup scripts in `pikku workspace validate`.
  * Configurable findings support `off`, `warn`, or `error` severity levels.
  * Added lifecycle configuration to the functions template, including startup hooks.
* **Documentation**
  * Expanded guidance for managed and custom server startup paths.
  * Documented lifecycle hook ordering, service availability, runtime limitations, and lint configuration.
* **Tests**
  * Added comprehensive coverage for startup detection, exclusions, adapters, and severity settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->