### PR TITLE
fix(inspector,core): let scopes and roles be declared in more than one file again

### DIFF
--- a/.changeset/scope-role-single-declaration.md
+++ b/.changeset/scope-role-single-declaration.md
@@ -1,0 +1,12 @@
+---
+'@pikku/inspector': patch
+'@pikku/core': patch
+---
+
+`defineScope` and `defineSystemRole` accumulate across call sites again. Only `definePersonas` is one-per-codebase.
+
+The previous release made all three single-declaration constructs, which no project scaffolding user-admin could satisfy: the CLI generates a `defineScope` of its own in `user-admin.gen.ts` carrying the whole `admin` tree, and `@pikku/addon-console` spells the same tree out again, so a second hand-written declaration failed the build with PKU583 — and the losing file's scopes were dropped from the metadata rather than merged.
+
+Exempting generated files would have reinstated exactly the ambiguity the rule removes, only for the files nobody can read the rule from. The real fix is for `admin` to be a default scope nobody declares, at which point the rule can come back for scopes and roles.
+
+`definePersonas` is unaffected: nothing generates one, so its single call site stands.

--- a/packages/core/src/wirings/role/define-system-role.ts
+++ b/packages/core/src/wirings/role/define-system-role.ts
@@ -10,10 +10,6 @@ import type { CoreSystemRoles } from './role.types.js'
  * it, but cannot rename, re-scope or delete it. Roles an admin composes in the
  * console are unaffected and are not declared here.
  *
- * Exactly one `defineSystemRole(...)` is allowed per codebase, so there is one
- * place to read the declared roles from and one place to add to. A second call
- * — even in the same file — fails the build.
- *
  * Removal is deliberately not destructive. Deleting a declaration leaves the
  * row in the store, marked undeclared and inert, until `pikku roles prune` —
  * the same additive contract `defineScope` has, and for the same reason: a

--- a/packages/core/src/wirings/scope/define-scope.ts
+++ b/packages/core/src/wirings/scope/define-scope.ts
@@ -10,10 +10,6 @@ import type { CoreScopes } from './scope.types.js'
  * yields `admin`, `admin:invoices`, `admin:invoices:create`,
  * `admin:invoices:void` and `billing`.
  *
- * Exactly one `defineScope(...)` is allowed per codebase, so there is one place
- * to read the declared scopes from and one place to add to. A second call —
- * even in the same file — fails the build.
- *
  * @example
  * ```typescript
  * defineScope({

--- a/packages/inspector/src/add/add-scope.test.ts
+++ b/packages/inspector/src/add/add-scope.test.ts
@@ -166,10 +166,8 @@ describe('addScope inspector', () => {
     assert.deepEqual(state.scopes.definitions[1]!.scopes, { read: {} })
   })
 
-  // One call site per codebase, so there is one place to read the scopes from
-  // and one place to add to. The keyed form above is how you declare more.
-  test('a second defineScope in the same file is refused', async () => {
-    const { state, criticals } = await inspectSource(
+  test('extracts several declarations', async () => {
+    const { state } = await inspectSource(
       [
         "import { defineScope } from '@pikku/core/scope'",
         'defineScope({ admin: {} })',
@@ -177,42 +175,36 @@ describe('addScope inspector', () => {
       ].join('\n')
     )
 
-    const hit = criticals.find(
-      (c) => c.code === ErrorCode.DUPLICATE_SCOPE_DEFINITION
-    )
-    assert.ok(
-      hit,
-      `expected DUPLICATE_SCOPE_DEFINITION, got ${JSON.stringify(criticals)}`
-    )
     assert.deepEqual(
       state.scopes.definitions.map((d) => d.name),
-      ['admin']
+      ['admin', 'billing']
     )
   })
 
-  test('a second defineScope in another file is refused', async () => {
-    const { criticals, files } = await inspectSources({
-      'scopes.ts': [
+  // The CLI generates a `defineScope` of its own — `user-admin.gen.ts` ships
+  // the whole `admin` tree, and `@pikku/addon-console` spells it out again — so
+  // a project that scaffolds user-admin declares scopes in more than one file
+  // and every one of them has to survive.
+  test('declarations in separate files all survive', async () => {
+    const { state, criticals } = await inspectSources({
+      'user-admin.gen.ts': [
         "import { defineScope } from '@pikku/core/scope'",
         'defineScope({ admin: {} })',
       ].join('\n'),
-      'more-scopes.ts': [
+      'scopes.ts': [
         "import { defineScope } from '@pikku/core/scope'",
         'defineScope({ billing: {} })',
       ].join('\n'),
     })
 
-    const hit = criticals.find(
-      (c) => c.code === ErrorCode.DUPLICATE_SCOPE_DEFINITION
+    assert.deepEqual(
+      criticals.filter((c) => /Only one defineScope/.test(c.message)),
+      [],
+      `expected no duplicate critical, got ${JSON.stringify(criticals)}`
     )
-    assert.ok(
-      hit,
-      `expected DUPLICATE_SCOPE_DEFINITION, got ${JSON.stringify(criticals)}`
-    )
-    assert.ok(
-      hit!.message.includes(files['scopes.ts']!) &&
-        hit!.message.includes(files['more-scopes.ts']!),
-      `expected both files named, got ${hit!.message}`
+    assert.deepEqual(
+      state.scopes.definitions.map((d) => d.name).sort(),
+      ['admin', 'billing']
     )
   })
 

--- a/packages/inspector/src/add/add-scope.ts
+++ b/packages/inspector/src/add/add-scope.ts
@@ -2,7 +2,6 @@ import * as ts from 'typescript'
 import { getPropertyValue } from '../utils/get-property-value.js'
 import type { AddWiring, InspectorLogger } from '../types.js'
 import { ErrorCode } from '../error-codes.js'
-import { claimSingleDeclaration } from '../utils/single-declaration.js'
 import type { ScopeNodeMeta } from '@pikku/core/scope'
 
 const SEPARATOR = ':'
@@ -159,18 +158,6 @@ export const addScope: AddWiring = (logger, node, checker, state, _options) => {
 
   const sourceFile = node.getSourceFile().fileName
 
-  if (
-    !claimSingleDeclaration(
-      logger,
-      state.scopes.files,
-      ErrorCode.DUPLICATE_SCOPE_DEFINITION,
-      'defineScope',
-      sourceFile
-    )
-  ) {
-    return
-  }
-
   // Roots are keyed exactly like the nodes beneath them, so each property of
   // the call's single argument is one tree.
   for (const prop of unwrapped.properties) {
@@ -226,6 +213,7 @@ export const addScope: AddWiring = (logger, node, checker, state, _options) => {
       scopes = extractScopeNodes(scopesProp.initializer, name, logger)
     }
 
+    state.scopes.files.add(sourceFile)
     state.scopes.definitions.push({
       name,
       displayName: displayNameValue || undefined,

--- a/packages/inspector/src/add/add-system-role.test.ts
+++ b/packages/inspector/src/add/add-system-role.test.ts
@@ -110,31 +110,24 @@ describe('addSystemRole inspector', () => {
     )
   })
 
-  // One call site per codebase, so there is one place to read the roles from
-  // and one place to add to. The keyed form above is how you declare more.
-  test('a second defineSystemRole in the same file is refused', async () => {
-    const { state, criticals } = await inspectSource(
+  test('extracts roles from several calls in one file', async () => {
+    const { state } = await inspectSource(
       withScopes(
         "defineSystemRole({ buyer: { scopes: ['catalogue:read'] } })",
         "defineSystemRole({ admin: { scopes: ['admin'] } })"
       )
     )
 
-    const hit = criticals.find(
-      (c) => c.code === ErrorCode.DUPLICATE_SYSTEM_ROLE_DEFINITION
-    )
-    assert.ok(
-      hit,
-      `expected DUPLICATE_SYSTEM_ROLE_DEFINITION, got ${JSON.stringify(criticals)}`
-    )
     assert.deepEqual(
-      state.systemRoles.definitions.map((r) => r.name),
-      ['buyer']
+      state.systemRoles.definitions.map((r) => r.name).sort(),
+      ['admin', 'buyer']
     )
   })
 
-  test('a second defineSystemRole in another file is refused', async () => {
-    const { criticals, files } = await inspectSources({
+  // Roles follow scopes: a project scaffolding user-admin has a generated
+  // declaration beside its own, so every file's roles have to survive.
+  test('declarations in separate files all survive', async () => {
+    const { state, criticals } = await inspectSources({
       'roles.ts': withScopes(
         "defineSystemRole({ buyer: { scopes: ['catalogue:read'] } })"
       ),
@@ -144,17 +137,14 @@ describe('addSystemRole inspector', () => {
       ].join('\n'),
     })
 
-    const hit = criticals.find(
-      (c) => c.code === ErrorCode.DUPLICATE_SYSTEM_ROLE_DEFINITION
+    assert.deepEqual(
+      criticals.filter((c) => /Only one defineSystemRole/.test(c.message)),
+      [],
+      `expected no duplicate critical, got ${JSON.stringify(criticals)}`
     )
-    assert.ok(
-      hit,
-      `expected DUPLICATE_SYSTEM_ROLE_DEFINITION, got ${JSON.stringify(criticals)}`
-    )
-    assert.ok(
-      hit!.message.includes(files['roles.ts']!) &&
-        hit!.message.includes(files['more-roles.ts']!),
-      `expected both files named, got ${hit!.message}`
+    assert.deepEqual(
+      state.systemRoles.definitions.map((r) => r.name).sort(),
+      ['admin', 'buyer']
     )
   })
 

--- a/packages/inspector/src/add/add-system-role.test.ts
+++ b/packages/inspector/src/add/add-system-role.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { inspect } from '../inspector.js'
-import { ErrorCode } from '../error-codes.js'
+import type { ErrorCode } from '../error-codes.js'
 import type { InspectorLogger } from '../types.js'
 
 const makeLogger = (criticals: Array<{ code: ErrorCode; message: string }>) =>

--- a/packages/inspector/src/add/add-system-role.ts
+++ b/packages/inspector/src/add/add-system-role.ts
@@ -2,7 +2,6 @@ import * as ts from 'typescript'
 import { getPropertyValue } from '../utils/get-property-value.js'
 import type { AddWiring } from '../types.js'
 import { ErrorCode } from '../error-codes.js'
-import { claimSingleDeclaration } from '../utils/single-declaration.js'
 
 const SEPARATOR = ':'
 
@@ -98,18 +97,6 @@ export const addSystemRole: AddWiring = (
 
   const sourceFile = node.getSourceFile().fileName
 
-  if (
-    !claimSingleDeclaration(
-      logger,
-      state.systemRoles.files,
-      ErrorCode.DUPLICATE_SYSTEM_ROLE_DEFINITION,
-      'defineSystemRole',
-      sourceFile
-    )
-  ) {
-    return
-  }
-
   for (const prop of unwrapped.properties) {
     if (!ts.isPropertyAssignment(prop)) {
       continue
@@ -165,6 +152,7 @@ export const addSystemRole: AddWiring = (
       | string
       | null
 
+    state.systemRoles.files.add(sourceFile)
     state.systemRoles.definitions.push({
       name,
       displayName: displayName || undefined,

--- a/packages/inspector/src/error-codes.ts
+++ b/packages/inspector/src/error-codes.ts
@@ -51,9 +51,11 @@ export enum ErrorCode {
   DUPLICATE_AUTH_DEFINITION = 'PKU581',
   AUTH_NOT_EXPORTED = 'PKU582',
 
-  // Single-declaration constructs — one call site per codebase
-  DUPLICATE_SCOPE_DEFINITION = 'PKU583',
-  DUPLICATE_SYSTEM_ROLE_DEFINITION = 'PKU584',
+  // Single-declaration constructs — one call site per codebase.
+  // PKU583 (defineScope) and PKU584 (defineSystemRole) are retired, not free:
+  // scopes and roles held this rule until the generated `admin` tree made it
+  // unsatisfiable, and get it back once `admin` is a default scope nobody
+  // declares. Do not reuse those two numbers for anything else.
   DUPLICATE_PERSONAS_DEFINITION = 'PKU585',
 
   // HTTP Route errors

--- a/packages/inspector/src/utils/single-declaration.ts
+++ b/packages/inspector/src/utils/single-declaration.ts
@@ -4,11 +4,10 @@ import type { InspectorLogger } from '../types.js'
 /**
  * Claims the one call site a single-declaration construct is allowed.
  *
- * `defineScope`, `defineSystemRole` and `definePersonas` each take a keyed
- * object, so one call already declares as many entries as you like. Letting the
- * call itself repeat buys nothing and costs the thing that matters: a single
- * place to read the declared set from, and a single place to add to it. The
- * same rule `pikkuBetterAuth` has had all along.
+ * `definePersonas` takes a keyed object, so one call already declares as many
+ * entries as you like. Letting the call itself repeat buys nothing and costs
+ * the thing that matters: a single place to read the declared set from, and a
+ * single place to add to it. The same rule `pikkuBetterAuth` has had all along.
  *
  * A second call in the SAME file is refused too — "the file" is not an answer
  * to "where do I add a persona?" when the file holds two calls, so allowing it
@@ -16,10 +15,17 @@ import type { InspectorLogger } from '../types.js'
  *
  * A generated file is exempt, and never claims the slot either. The rule exists
  * to name the one place a person adds to, and nobody adds to a file the CLI
- * rewrites on the next run — the scaffolds that ship a scope tree of their own
- * (`user-admin.gen.ts`, and the addon scaffolds beside it) would otherwise make
- * every project that generates one unbuildable, and take the app's own
- * declaration down with them.
+ * rewrites on the next run — `pikku-personas.gen.ts` would otherwise make every
+ * project that scaffolds one unbuildable, and take the app's own declaration
+ * down with it.
+ *
+ * `defineScope` and `defineSystemRole` held this rule too, briefly, and do not
+ * until the `admin` tree stops being app-declared. The exemption above is not
+ * enough for them: the CLI generates a `defineScope` in `user-admin.gen.ts` and
+ * `@pikku/addon-console` spells the same tree out again in a hand-written file,
+ * so two non-generated declarations remain and the build still fails. The fix
+ * is for `admin` to be a default scope nobody declares, and the rule comes back
+ * for scopes and roles once that lands.
  *
  * @param files - The construct's `files` set, which doubles as the claim.
  * @returns true when the caller holds the claim and should carry on.


### PR DESCRIPTION
Fixes #1120. Alternative to #1121 — same bug, opposite direction.

#1119 (mine) made `defineScope`, `defineSystemRole` and `definePersonas` one call per codebase. **No project that scaffolds user-admin can satisfy that**: the CLI generates a `defineScope` of its own in `user-admin.gen.ts` carrying the whole `admin` tree, and `@pikku/addon-console` spells the same tree out again in `src/scopes.ts`. A second hand-written call fails with PKU583, and the losing file's scopes are dropped rather than merged.

`definePersonas` keeps its single call site — nothing generates one.

## Why not #1121

#1121 exempts `.gen.ts` from the claim. That doesn't add an exception to the rule, it changes the rule to "one hand-written declaration plus arbitrarily many generated ones", and restores the silent-merge semantics #1119 removed for exactly the files nobody can read the rule from. It also leaves the real defect untouched: the `admin` tree is spelled out **three times** — `serialize-user-admin-functions.ts:116`, `packages/addon/pikku-console/src/scopes.ts:19`, and `ADMIN_SCOPE_TREE` in `better-auth/src/auth-scopes.ts:63` — each with a comment saying it must stay byte-identical to the others or codegen fails. #1119 didn't cause that; it made a latent hazard visible.

The fix is for `admin` to be a **default scope nobody declares**, dropping the generated `defineScope` and the addon's inline copy. Then there is no second call, the rule can come back for scopes and roles unchanged, and three copies become one. That is a larger change than a red `main` should wait for, so this reverts my overreach in the meantime.

## Verification — A/B against `main`

Same command sequence, same machine, `main`-based worktree vs this branch (`pikku all`, addons then e2e, two passes):

| | `main` | this branch |
|---|---|---|
| PKU583 duplicate `defineScope` | **fires** | gone |
| `reports`, `reports:read` in available scopes | **dropped** | present |
| `getReport` requires undeclared `reports:read` | **fires** | gone |
| `report-viewer` grants undeclared `reports:read` | **fires** | gone |

The dropped-`reports` cascade is the data loss in action: e2e declares `reports` in `scopes.ts`, loses the claim to the generated file, and every gate referencing it then fails too.

**Honest scope of the claim:** four other diagnostics (`pikku:scopes:manage`/`:read` undeclared, PKU574, PKU952) are byte-identical on both sides — pre-existing, untouched by this change, and I believe artifacts of my local run skipping CI's addon-rebuild-between-passes step rather than real failures. I have not proven the E2E jobs go green end to end; I have proven this specific regression is gone and nothing else moved.

Unit: `@pikku/inspector` 640/640, `@pikku/core` 1945/1945 (0 fail), `yarn build:packages` clean.

## Registry hygiene

PKU583/PKU584 are deleted rather than left dead — `error-codes-emitted.test.ts` enforces that every code has an emission site — with a comment marking the numbers not-for-reuse so they are still there when the rule returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scope and system-role declarations can now be defined multiple times across files and call sites.
  * All valid declarations and associated metadata are retained instead of being rejected or overwritten.
  * Duplicate-definition errors for scopes and system roles are no longer reported.

* **Documentation**
  * Clarified declaration rules and retired obsolete duplicate-definition error codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->