### PR TITLE
fix(console): stop leaking react-router, and keep the page title over the count

### DIFF
--- a/.changeset/console-router-shim-not-react-router.md
+++ b/.changeset/console-router-shim-not-react-router.md
@@ -1,0 +1,11 @@
+---
+'@pikku/console': patch
+---
+
+`FunctionsPage` and `VirtualUserDocument` imported `useSearchParams` and `Link`
+straight from `react-router` instead of the console's own router shim. The
+console is router-agnostic — every other page goes through `../router`, which
+the host fills via an adapter — so in a host running anything else (TanStack
+Router, for one) those two components threw `useLocation() may be used only in
+the context of a <Router>` and took the whole shell down with them, since the
+host's error boundary catches the render, not just the route.

--- a/.changeset/shell-header-title-outlives-count.md
+++ b/.changeset/shell-header-title-outlives-count.md
@@ -1,0 +1,10 @@
+---
+'@pikku/console': patch
+---
+
+`ShellHeader` dropped the title before the count when the text stack did not
+fit. The count slot carries a description on some pages, so a header with a
+52px page name and a 657px description would shed the name and keep the
+sentence, leaving the page anonymous. The text stack still collapses ahead of
+any control, but within it the title now outlives the count: full stack →
+title only → count only → neither.

--- a/packages/console/src/components/ui/ShellHeader.tsx
+++ b/packages/console/src/components/ui/ShellHeader.tsx
@@ -96,11 +96,16 @@ export const ShellHeader = <T extends string = string>({
     actMode: 'label',
     ...over,
   })
-  // The whole text stack collapses first, as a unit: title goes, then the
-  // count/description, leaving no text at all before any control degrades.
+  // The whole text stack still collapses before any control degrades, but
+  // WITHIN that stack the title is the last thing to go, not the first. The
+  // count slot carries a description on some pages — the secrets page's is a
+  // 657px sentence — so dropping the title first spent a 52px page name to keep
+  // it, and the page rendered anonymous. Title-only sits between the full stack
+  // and the empty one.
   const candidates: Candidate[] = []
   if (title != null)
     candidates.push(base({ showTitle: true, showCount: count != null }))
+  if (title != null && count != null) candidates.push(base({ showTitle: true }))
   if (count != null) candidates.push(base({ showCount: true }))
   candidates.push(base({ actMode: 'label' }))
   candidates.push(base({ actMode: 'icon' }))

--- a/packages/console/src/components/virtual-users/VirtualUserDocument.tsx
+++ b/packages/console/src/components/virtual-users/VirtualUserDocument.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link } from 'react-router'
+import { useLink } from '../../router'
 import {
   Anchor,
   Badge,
@@ -102,25 +102,28 @@ const Figure: React.FC<{
  * The functions list filters on text, so the link carries the name as its
  * search — the same thing you would have typed, without having to remember it.
  */
-const EndpointNames: React.FC<{ names: string[] }> = ({ names }) => (
-  <Box className={styles.nameList} data-testid="reach-names">
-    <Group gap={6}>
-      {names.map((name) => (
-        <Anchor
-          key={name}
-          component={Link}
-          to={`/functions?search=${encodeURIComponent(name)}`}
-          size="xs"
-          ff="monospace"
-          underline="hover"
-          c="dimmed"
-        >
-          {asI18n(name)}
-        </Anchor>
-      ))}
-    </Group>
-  </Box>
-)
+const EndpointNames: React.FC<{ names: string[] }> = ({ names }) => {
+  const Link = useLink()
+  return (
+    <Box className={styles.nameList} data-testid="reach-names">
+      <Group gap={6}>
+        {names.map((name) => (
+          <Anchor
+            key={name}
+            component={Link}
+            to={`/functions?search=${encodeURIComponent(name)}`}
+            size="xs"
+            ff="monospace"
+            underline="hover"
+            c="dimmed"
+          >
+            {asI18n(name)}
+          </Anchor>
+        ))}
+      </Group>
+    </Box>
+  )
+}
 
 /**
  * A feature is named by a sentence often enough that a legend of six of them

--- a/packages/console/src/pages/FunctionsPage.tsx
+++ b/packages/console/src/pages/FunctionsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSearchParams } from 'react-router'
+import { useSearchParams } from '../router'
 import { Group, TextInput } from '@pikku/mantine/core'
 import { Search } from 'lucide-react'
 import { m } from '@/i18n/messages'


### PR DESCRIPTION
Two independent faults, both of which only show up in a host that is not the standalone console app. Both carry patch changesets.

### `react-router` imported past the router shim

`FunctionsPage` and `VirtualUserDocument` imported `useSearchParams` and `Link` straight from `react-router`. The console is router-agnostic — every other page goes through `../router`, which the host fills via an adapter — so under any other router these two threw:

```
useLocation() may be used only in the context of a <Router> component
```

That is a render-time throw, so the host's error boundary swallows the entire shell, not just the route. Confirmed live: every stage `functions` route in Fabric's console renders a bare "Something went wrong!" page.

`VirtualUserDocument` takes the `useLink()` hook rather than a `Link` import, since the shim exports the hook, not a component binding.

### `ShellHeader` shed the title before the count

The collapse ladder dropped the title first and kept the count. The count slot carries a *description* on some pages — the secrets page's is a 657px sentence next to a 52px page name — so the header spent the page's name to keep the sentence and rendered anonymous.

The documented principle is unchanged: the text stack still collapses before any control degrades. Only the order *within* the stack changes, adding a title-only rung:

full stack → **title only** → count only → neither

### Verification

- `tsc --noEmit` clean on `packages/console`
- The react-router crash and the missing title were both reproduced live against a deployed console, and the header diagnosis came from dumping the measurement row's slot widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation-related rendering issues in some host environments by improving router compatibility.
  * Updated the console header so the title stays visible longer when space is tight, with a better collapse order for title and count/details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->