### PR TITLE
fix(core,inspector): carry secret allowedHosts through codegen and widen the SSRF guard

### DIFF
--- a/.changeset/secret-allowed-hosts-and-ssrf-ranges.md
+++ b/.changeset/secret-allowed-hosts-and-ssrf-ranges.md
@@ -1,0 +1,39 @@
+---
+'@pikku/core': patch
+'@pikku/inspector': patch
+'@pikku/addon-graph': patch
+'@pikku/express': patch
+'@pikku/fastify': patch
+'@pikku/uws': patch
+'@pikku/node-http-server': patch
+---
+
+Carry a secret's `allowedHosts` through code generation, and close three gaps in
+the SSRF guard.
+
+`allowedHosts` was declared and enforced but never survived codegen: the
+inspector did not read the property off the `defineSecret` literal, and the meta
+builder rebuilt its objects without it. Enforcement in `assertSecretAllowedForHost`
+then always saw `undefined`, so the egress restriction was a no-op by default —
+and, with `secrets.requireAllowedHosts` set, threw for every secret including the
+ones that correctly declared hosts. Both stages now carry the field, and the
+secrets verifier asserts it against the generated JSON rather than a hand-written
+meta literal, which is why the existing tests stayed green.
+
+`isPrivateHost` now checks an explicit CIDR table instead of ad-hoc octet
+comparisons. It previously missed `100.64.0.0/10` — which contains Alibaba
+Cloud's `100.100.100.200` metadata endpoint — along with `192.0.0.0/24`,
+`198.18.0.0/15`, `192.88.99.0/24`, the TEST-NETs, multicast and reserved space.
+IPv6 gains a real parser, so `fec0::/10`, `ff00::/8`, and NAT64 (`64:ff9b::/96`)
+and 6to4 (`2002::/16`) forms wrapping an internal IPv4 address are caught.
+
+`safeFetch` takes an optional `resolveHost`, checked on the initial URL and every
+redirect hop, so a *public* hostname pointing at a private address is refused —
+the `169-254-169-254.nip.io` shape a literal-only check cannot see. Core cannot
+resolve DNS itself (Workers has no DNS API), so the Node resolver ships as
+`@pikku/core/node-host-resolver` and the Node server runtimes install it during
+`init()`. The connection is not pinned to the address that was checked, so a
+rebind between check and connect is still possible.
+
+The graph addon's `httpRequest` node called bare `fetch`, bypassing the guard
+entirely; it now goes through `safeFetch`.

--- a/packages/addon/pikku-graph/src/http-requester.service.ts
+++ b/packages/addon/pikku-graph/src/http-requester.service.ts
@@ -1,4 +1,5 @@
 import { assertSecretAllowedForHost, type SecretService } from '@pikku/core'
+import { safeFetch } from '@pikku/core/safe-fetch'
 import type { CredentialService, MetaService } from '@pikku/core/services'
 
 /** How a credential is applied to a request. Carries names only, never values. */
@@ -78,7 +79,11 @@ export class PikkuHttpRequesterService implements HttpRequesterService {
       }
     }
 
-    return await fetch(url, { method, headers: requestHeaders, body })
+    return await safeFetch(url.toString(), {
+      method,
+      headers: requestHeaders,
+      body,
+    })
   }
 
   private async resolveCredential(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "./trigger": "./dist/wirings/trigger/index.js",
     "./rpc": "./dist/wirings/rpc/index.js",
     "./safe-fetch": "./dist/utils/safe-fetch.js",
+    "./node-host-resolver": "./dist/utils/node-host-resolver.js",
     "./mcp": "./dist/wirings/mcp/index.js",
     "./ai-agent": "./dist/wirings/ai-agent/index.js",
     "./gateway": "./dist/wirings/gateway/index.js",

--- a/packages/core/src/utils/node-host-resolver.ts
+++ b/packages/core/src/utils/node-host-resolver.ts
@@ -1,0 +1,20 @@
+import { lookup } from 'node:dns/promises'
+
+import { setDefaultHostResolver, type HostResolver } from './safe-fetch.js'
+
+/**
+ * Resolves a hostname through the platform resolver, returning every address it
+ * points at so `safeFetch` can reject a public name aimed at an internal one.
+ *
+ * This module is Node-only and is never imported by core itself — Workers has no
+ * DNS API, and a static `node:dns` import in the shared path would break that
+ * build.
+ */
+export const nodeHostResolver: HostResolver = async (hostname) => {
+  const results = await lookup(hostname, { all: true, verbatim: true })
+  return results.map(({ address }) => address)
+}
+
+/** Installs {@link nodeHostResolver} as the default for every `safeFetch`. */
+export const installNodeHostResolver = () =>
+  setDefaultHostResolver(nodeHostResolver)

--- a/packages/core/src/utils/safe-fetch.test.ts
+++ b/packages/core/src/utils/safe-fetch.test.ts
@@ -41,15 +41,54 @@ describe('isPrivateHost', () => {
     }
   })
 
+  test('flags reserved IPv4 blocks that are not routable public space', () => {
+    for (const host of [
+      '100.64.0.1', // carrier-grade NAT
+      '100.100.100.200', // Alibaba Cloud metadata endpoint
+      '100.127.255.255', // top of 100.64.0.0/10
+      '192.0.0.192', // IETF protocol assignments
+      '198.18.0.1', // benchmarking
+      '198.19.255.255', // top of 198.18.0.0/15
+      '192.88.99.1', // 6to4 anycast
+      '192.0.2.1', // TEST-NET-1
+      '198.51.100.1', // TEST-NET-2
+      '203.0.113.1', // TEST-NET-3
+      '224.0.0.1', // multicast
+      '240.0.0.1', // reserved
+      '255.255.255.255', // broadcast
+    ]) {
+      assert.equal(isPrivateHost(host), true, `${host} should be private`)
+    }
+  })
+
+  test('flags IPv6 forms that tunnel to an internal IPv4 address', () => {
+    for (const host of [
+      '64:ff9b::a9fe:a9fe', // NAT64 wrapping 169.254.169.254
+      '[64:ff9b::169.254.169.254]', // same, dotted-quad tail
+      '2002:a9fe:a9fe::', // 6to4 wrapping 169.254.169.254
+      '2002:6464:64c8::', // 6to4 wrapping 100.100.100.200
+      'fec0::1', // deprecated site-local
+      'ff02::1', // multicast
+      '100::1', // discard-only
+    ]) {
+      assert.equal(isPrivateHost(host), true, `${host} should be private`)
+    }
+  })
+
   test('allows public hosts', () => {
     for (const host of [
       'example.com',
       '8.8.8.8',
       '172.32.0.1',
       '11.0.0.1',
+      '100.63.255.255', // just below the CGNAT block
+      '100.128.0.0', // just above the CGNAT block
+      '198.17.255.255', // just below the benchmarking block
+      '198.20.0.0', // just above the benchmarking block
       '134744072', // decimal-encoded 8.8.8.8 — public
       '2001:db8::1', // documentation range — public
-      'fec0::1', // deprecated site-local, outside fe80::/10 — treated public
+      '2002:808:808::', // 6to4 wrapping public 8.8.8.8
+      '64:ff9b::808:808', // NAT64 wrapping public 8.8.8.8
     ]) {
       assert.equal(isPrivateHost(host), false, `${host} should be public`)
     }
@@ -134,6 +173,109 @@ describe('safeFetch', () => {
         )
         assert.equal(calls.length, 1)
         assert.ok(calls[0]!.includes('example.com'))
+      }
+    )
+  })
+
+  test('refuses a public hostname that resolves to a private address', async () => {
+    await withStubbedFetch(
+      () => new Response('ok', { status: 200 }),
+      async (calls) => {
+        // The shape the literal-only check misses: a name that parses as public
+        // but whose A record points at the cloud metadata endpoint.
+        await assert.rejects(
+          safeFetch(
+            'https://169-254-169-254.nip.io/latest/meta-data/',
+            {},
+            {
+              resolveHost: async () => ['169.254.169.254'],
+            }
+          ),
+          /resolves to 169\.254\.169\.254/
+        )
+        assert.equal(calls.length, 0)
+      }
+    )
+  })
+
+  test('refuses when any one resolved address is private', async () => {
+    await withStubbedFetch(
+      () => new Response('ok', { status: 200 }),
+      async (calls) => {
+        await assert.rejects(
+          safeFetch(
+            'https://split-horizon.example.com/',
+            {},
+            {
+              resolveHost: async () => ['93.184.216.34', '10.0.0.5'],
+            }
+          ),
+          /resolves to 10\.0\.0\.5/
+        )
+        assert.equal(calls.length, 0)
+      }
+    )
+  })
+
+  test('re-resolves the host of a redirect hop', async () => {
+    await withStubbedFetch(
+      (url) =>
+        url.includes('start.com')
+          ? new Response(null, {
+              status: 302,
+              headers: { location: 'https://rebound.example.com/next' },
+            })
+          : new Response('ok', { status: 200 }),
+      async (calls) => {
+        await assert.rejects(
+          safeFetch(
+            'https://start.com',
+            {},
+            {
+              resolveHost: async (hostname) =>
+                hostname === 'start.com' ? ['93.184.216.34'] : ['127.0.0.1'],
+            }
+          ),
+          /resolves to 127\.0\.0\.1/
+        )
+        assert.equal(calls.length, 1)
+      }
+    )
+  })
+
+  test('allows a public hostname that resolves to public addresses', async () => {
+    await withStubbedFetch(
+      () => new Response('ok', { status: 200 }),
+      async (calls) => {
+        const res = await safeFetch(
+          'https://example.com/',
+          {},
+          {
+            resolveHost: async () => ['93.184.216.34'],
+          }
+        )
+        assert.equal(res.status, 200)
+        assert.equal(calls.length, 1)
+      }
+    )
+  })
+
+  test('does not resolve an IP literal or an allowlisted host', async () => {
+    await withStubbedFetch(
+      () => new Response('ok', { status: 200 }),
+      async () => {
+        let resolverCalls = 0
+        const resolveHost = async () => {
+          resolverCalls++
+          return ['10.0.0.1']
+        }
+        await safeFetch('https://93.184.216.34/', {}, { resolveHost })
+        await safeFetch(
+          'https://internal.example.com/',
+          {},
+          { resolveHost, allowedHosts: ['internal.example.com'] }
+        )
+        assert.equal(resolverCalls, 0)
       }
     )
   })

--- a/packages/core/src/utils/safe-fetch.ts
+++ b/packages/core/src/utils/safe-fetch.ts
@@ -33,6 +33,134 @@ function parseIPv4Octets(
 }
 
 /**
+ * IPv4 blocks that must never be reachable from user-supplied URLs: private,
+ * loopback, link-local (cloud metadata), carrier-grade NAT (Alibaba's
+ * `100.100.100.200` metadata endpoint), IETF protocol assignments, benchmarking,
+ * 6to4 anycast, the documentation TEST-NETs, multicast and reserved space.
+ */
+const PRIVATE_IPV4_BLOCKS: ReadonlyArray<readonly [string, number]> = [
+  ['0.0.0.0', 8],
+  ['10.0.0.0', 8],
+  ['100.64.0.0', 10],
+  ['127.0.0.0', 8],
+  ['169.254.0.0', 16],
+  ['172.16.0.0', 12],
+  ['192.0.0.0', 24],
+  ['192.0.2.0', 24],
+  ['192.88.99.0', 24],
+  ['192.168.0.0', 16],
+  ['198.18.0.0', 15],
+  ['198.51.100.0', 24],
+  ['203.0.113.0', 24],
+  ['224.0.0.0', 4],
+  ['240.0.0.0', 4],
+]
+
+const toUint32 = (octets: [number, number, number, number]): number =>
+  ((octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3]) >>> 0
+
+const PRIVATE_IPV4_RANGES = PRIVATE_IPV4_BLOCKS.map(([base, prefix]) => {
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0
+  return [(toUint32(parseIPv4Octets(base)!) & mask) >>> 0, mask] as const
+})
+
+const isPrivateIPv4 = (octets: [number, number, number, number]): boolean => {
+  const addr = toUint32(octets)
+  return PRIVATE_IPV4_RANGES.some(
+    ([base, mask]) => (addr & mask) >>> 0 === base
+  )
+}
+
+/**
+ * Expands an IPv6 literal into its eight 16-bit groups, handling `::` elision
+ * and a trailing dotted-quad. `null` when not a well-formed IPv6 literal.
+ */
+function parseIPv6Groups(host: string): number[] | null {
+  const zoneless = host.split('%')[0]!
+  const halves = zoneless.split('::')
+  if (halves.length > 2) return null
+
+  const parseSide = (side: string): number[] | null => {
+    if (side === '') return []
+    const parts = side.split(':')
+    const groups: number[] = []
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i]!
+      if (i === parts.length - 1 && part.includes('.')) {
+        const v4 = parseIPv4Octets(part)
+        if (!v4) return null
+        groups.push((v4[0] << 8) | v4[1], (v4[2] << 8) | v4[3])
+        continue
+      }
+      if (!/^[0-9a-f]{1,4}$/.test(part)) return null
+      groups.push(parseInt(part, 16))
+    }
+    return groups
+  }
+
+  const head = parseSide(halves[0]!)
+  if (head === null) return null
+
+  if (halves.length === 1) {
+    return head.length === 8 ? head : null
+  }
+
+  const tail = parseSide(halves[1]!)
+  if (tail === null) return null
+  if (head.length + tail.length > 7) return null
+  return [...head, ...new Array(8 - head.length - tail.length).fill(0), ...tail]
+}
+
+const embeddedIPv4 = (
+  hi: number,
+  lo: number
+): [number, number, number, number] => [
+  (hi >> 8) & 0xff,
+  hi & 0xff,
+  (lo >> 8) & 0xff,
+  lo & 0xff,
+]
+
+function isPrivateIPv6(groups: number[]): boolean {
+  const [g0, g1, g2, g3, g4, g5, g6, g7] = groups as [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+  ]
+
+  if (groups.every((g) => g === 0)) return true // :: unspecified
+  if (groups.slice(0, 7).every((g) => g === 0) && g7 === 1) return true // ::1
+
+  // IPv4-mapped ::ffff:0:0/96 and IPv4-compatible ::/96
+  if (g0 === 0 && g1 === 0 && g2 === 0 && g3 === 0 && g4 === 0) {
+    if (g5 === 0xffff || g5 === 0) return isPrivateIPv4(embeddedIPv4(g6, g7))
+  }
+  // NAT64 well-known prefix 64:ff9b::/96
+  if (
+    g0 === 0x64 &&
+    g1 === 0xff9b &&
+    g2 === 0 &&
+    g3 === 0 &&
+    g4 === 0 &&
+    g5 === 0
+  )
+    return isPrivateIPv4(embeddedIPv4(g6, g7))
+  // 6to4 2002::/16 carries the IPv4 address in the next 32 bits
+  if (g0 === 0x2002) return isPrivateIPv4(embeddedIPv4(g1, g2))
+  if (g0 === 0x100 && g1 === 0 && g2 === 0 && g3 === 0) return true // discard-only 100::/64
+  if ((g0 & 0xffc0) === 0xfe80) return true // link-local fe80::/10
+  if ((g0 & 0xfe00) === 0xfc00) return true // unique-local fc00::/7
+  if ((g0 & 0xffc0) === 0xfec0) return true // deprecated site-local fec0::/10
+  if ((g0 & 0xff00) === 0xff00) return true // multicast ff00::/8
+  return false
+}
+
+/**
  * Whether a hostname is an obvious internal target. Best-effort literal
  * matching only: it cannot catch a public hostname that *resolves* to a
  * private IP.
@@ -46,31 +174,30 @@ export function isPrivateHost(hostname: string): boolean {
     return true
 
   if (host.includes(':')) {
-    if (host === '::' || host === '::1') return true
-    const mappedV4 = host.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)
-    if (mappedV4) return isPrivateHost(mappedV4[1]!)
-    const mappedHex = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
-    if (mappedHex) {
-      const hi = parseInt(mappedHex[1]!, 16)
-      const lo = parseInt(mappedHex[2]!, 16)
-      return isPrivateHost(
-        `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`
-      )
-    }
-    if (/^fe[89ab]/.test(host)) return true // link-local fe80::/10
-    if (host.startsWith('fc') || host.startsWith('fd')) return true // unique-local fc00::/7
-    return false
+    const groups = parseIPv6Groups(host)
+    return groups ? isPrivateIPv6(groups) : false
   }
 
   const v4 = parseIPv4Octets(host)
-  if (v4) {
-    const [a, b] = v4
-    if (a === 127 || a === 10 || a === 0) return true
-    if (a === 169 && b === 254) return true // link-local incl. cloud metadata
-    if (a === 172 && b >= 16 && b <= 31) return true
-    if (a === 192 && b === 168) return true
-  }
-  return false
+  return v4 ? isPrivateIPv4(v4) : false
+}
+
+/** Resolves a hostname to the IP addresses it points at. */
+export type HostResolver = (hostname: string) => Promise<string[]>
+
+let defaultHostResolver: HostResolver | undefined
+
+/**
+ * Installs the resolver {@link safeFetch} uses when a call passes no
+ * `resolveHost` of its own.
+ *
+ * Core cannot resolve DNS itself — Workers has no DNS API — so without a
+ * resolver the guard is literal-only and a public name pointing at
+ * `169.254.169.254` passes. Node runtimes install
+ * `nodeHostResolver` from `@pikku/core/node-host-resolver` at startup.
+ */
+export function setDefaultHostResolver(resolver: HostResolver | undefined) {
+  defaultHostResolver = resolver
 }
 
 export interface SafeFetchOptions {
@@ -81,6 +208,50 @@ export interface SafeFetchOptions {
   allowedHosts?: string[]
   /** Maximum redirect hops to follow (each re-validated). Defaults to 3. */
   maxRedirects?: number
+  /**
+   * Resolves a hostname so a *public* name pointing at a private address is
+   * refused. Defaults to whatever {@link setDefaultHostResolver} installed;
+   * pass `null` to opt a call out of resolution entirely.
+   */
+  resolveHost?: HostResolver | null
+}
+
+/** Whether a hostname is already an IP literal, which the sync check covers. */
+function isIpLiteral(hostname: string): boolean {
+  const host = hostname.replace(/^\[|\]$/g, '').replace(/\.$/, '')
+  if (host.includes(':')) return parseIPv6Groups(host.toLowerCase()) !== null
+  return parseIPv4Octets(host) !== null
+}
+
+/**
+ * Rejects a hostname that resolves to an internal address.
+ *
+ * Resolution happens once per hop and the connection is not pinned to the
+ * address checked, so a rebind between this check and the socket connecting is
+ * still possible; catching that needs a runtime-level connect hook.
+ */
+async function assertResolvedHostAllowed(
+  hostname: string,
+  options: SafeFetchOptions
+): Promise<void> {
+  if (options.allowedHosts) return
+  const resolver =
+    options.resolveHost === null
+      ? undefined
+      : (options.resolveHost ?? defaultHostResolver)
+  if (!resolver || isIpLiteral(hostname)) return
+
+  const addresses = await resolver(hostname)
+  if (addresses.length === 0) {
+    throw new Error(`Refusing to fetch: '${hostname}' resolved to no addresses`)
+  }
+  for (const address of addresses) {
+    if (isPrivateHost(address)) {
+      throw new Error(
+        `Refusing to fetch from a private/internal host: '${hostname}' resolves to ${address}`
+      )
+    }
+  }
 }
 
 export function assertFetchableUrl(
@@ -142,7 +313,9 @@ export async function safeFetch(
   options: SafeFetchOptions = {}
 ): Promise<Response> {
   const maxRedirects = options.maxRedirects ?? 3
-  let currentUrl = assertFetchableUrl(url, options).toString()
+  const initial = assertFetchableUrl(url, options)
+  await assertResolvedHostAllowed(initial.hostname, options)
+  let currentUrl = initial.toString()
   let currentInit = init
 
   for (let hop = 0; ; hop++) {
@@ -157,10 +330,12 @@ export async function safeFetch(
     if (!location || hop >= maxRedirects) {
       return response
     }
-    const nextUrl = assertFetchableUrl(
+    const next = assertFetchableUrl(
       new URL(location, currentUrl).toString(),
       options
-    ).toString()
+    )
+    await assertResolvedHostAllowed(next.hostname, options)
+    const nextUrl = next.toString()
     await response.body?.cancel()
     let nextInit = redirectInit(response.status, currentInit)
     if (new URL(nextUrl).origin !== new URL(currentUrl).origin) {

--- a/packages/core/src/wirings/secret/validate-secret-definitions.test.ts
+++ b/packages/core/src/wirings/secret/validate-secret-definitions.test.ts
@@ -108,6 +108,53 @@ describe('validateAndBuildSecretDefinitionsMeta', () => {
     )
   })
 
+  test('should carry allowedHosts into the meta', () => {
+    const definitions = [
+      {
+        name: 'example-api',
+        displayName: 'Example API',
+        secretId: 'EXAMPLE_API_CREDENTIALS',
+        allowedHosts: ['api.example.com', '*.example.com'],
+        sourceFile: 'a.ts',
+      },
+    ]
+    const result = validateAndBuildSecretDefinitionsMeta(
+      definitions as any,
+      new Map()
+    )
+    assert.deepStrictEqual(result['example-api']!.allowedHosts, [
+      'api.example.com',
+      '*.example.com',
+    ])
+  })
+
+  test('should carry allowedHosts into the meta for a shared secretId', () => {
+    const definitions = [
+      {
+        name: 'cred1',
+        displayName: 'Cred 1',
+        secretId: 'SHARED',
+        allowedHosts: ['first.example.com'],
+        sourceFile: 'a.ts',
+      },
+      {
+        name: 'cred2',
+        displayName: 'Cred 2',
+        secretId: 'SHARED',
+        allowedHosts: ['second.example.com'],
+        sourceFile: 'b.ts',
+      },
+    ]
+    const result = validateAndBuildSecretDefinitionsMeta(
+      definitions as any,
+      new Map()
+    )
+    assert.deepStrictEqual(result['cred1']!.allowedHosts, ['first.example.com'])
+    assert.deepStrictEqual(result['cred2']!.allowedHosts, [
+      'second.example.com',
+    ])
+  })
+
   test('should handle empty definitions', () => {
     const result = validateAndBuildSecretDefinitionsMeta([], new Map())
     assert.deepStrictEqual(result, {})

--- a/packages/core/src/wirings/secret/validate-secret-definitions.ts
+++ b/packages/core/src/wirings/secret/validate-secret-definitions.ts
@@ -57,6 +57,7 @@ export function validateAndBuildSecretDefinitionsMeta(
           oauth2: def.oauth2,
           rotationPeriod: def.rotationPeriod,
           docsUrl: def.docsUrl,
+          allowedHosts: def.allowedHosts,
           sourceFile: def.sourceFile,
         }
       }
@@ -75,6 +76,7 @@ export function validateAndBuildSecretDefinitionsMeta(
         oauth2: def.oauth2,
         rotationPeriod: def.rotationPeriod,
         docsUrl: def.docsUrl,
+        allowedHosts: def.allowedHosts,
         sourceFile: def.sourceFile,
       }
     }

--- a/packages/inspector/src/add/add-keyed-wiring.ts
+++ b/packages/inspector/src/add/add-keyed-wiring.ts
@@ -1,6 +1,7 @@
 import * as ts from 'typescript'
 import {
   getPropertyValue,
+  getArrayPropertyValue,
   assertStringLiteralProperty,
 } from '../utils/get-property-value.js'
 import type { AddWiring, InspectorState } from '../types.js'
@@ -57,6 +58,7 @@ export const createAddKeyedWiring = (config: KeyedWiringConfig): AddWiring => {
         | string
         | null
       const docsUrlValue = getPropertyValue(obj, 'docsUrl') as string | null
+      const allowedHostsValue = getArrayPropertyValue(obj, 'allowedHosts')
       const idValue = getPropertyValue(obj, config.idField) as string | null
 
       let schemaVariableName: string | null = null
@@ -167,6 +169,7 @@ export const createAddKeyedWiring = (config: KeyedWiringConfig): AddWiring => {
         description: descriptionValue || undefined,
         rotationPeriod: rotationPeriodValue || undefined,
         docsUrl: docsUrlValue || undefined,
+        allowedHosts: allowedHostsValue || undefined,
         [config.idField]: idValue,
         schema: schemaLookupName,
         sourceFile,

--- a/packages/runtimes/express-server/src/pikku-express-server.ts
+++ b/packages/runtimes/express-server/src/pikku-express-server.ts
@@ -11,6 +11,7 @@ import { resolve, normalize } from 'path'
 
 import type { CoreConfig } from '@pikku/core'
 import { stopSingletonServices } from '@pikku/core'
+import { installNodeHostResolver } from '@pikku/core/node-host-resolver'
 import type { Logger } from '@pikku/core/services'
 import type { RunHTTPWiringOptions } from '@pikku/core/http'
 import { pikkuExpressMiddleware } from '@pikku/express-middleware'
@@ -97,6 +98,8 @@ export class PikkuExpressServer {
   }
 
   public async init(httpOptions: RunHTTPWiringOptions = {}) {
+    installNodeHostResolver()
+
     // Express buffers the body before Pikku ever sees it, so the parser limit
     // is the only place an oversized request can be stopped. Pikku's
     // `maxBodySize` therefore feeds express's own limit, with an explicit

--- a/packages/runtimes/fastify-server/src/pikku-fastify-server.ts
+++ b/packages/runtimes/fastify-server/src/pikku-fastify-server.ts
@@ -2,6 +2,7 @@ import Fastify from 'fastify'
 
 import type { CoreConfig } from '@pikku/core'
 import { stopSingletonServices } from '@pikku/core'
+import { installNodeHostResolver } from '@pikku/core/node-host-resolver'
 import type { Logger } from '@pikku/core/services'
 import type { RunHTTPWiringOptions } from '@pikku/core/http'
 import pikkuFastifyPlugin from '@pikku/fastify-plugin'
@@ -49,6 +50,8 @@ export class PikkuFastifyServer {
    * Initializes the server by setting up health check and registering the Pikku Fastify plugin.
    */
   public async init(httpOptions: RunHTTPWiringOptions = {}) {
+    installNodeHostResolver()
+
     this.app.get(this.config.healthCheckPath || '/health-check', async () => {
       return { status: 'ok' }
     })

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
@@ -11,6 +11,7 @@ import { randomUUID, timingSafeEqual } from 'node:crypto'
 
 import type { CoreConfig } from '@pikku/core'
 import { stopSingletonServices } from '@pikku/core'
+import { installNodeHostResolver } from '@pikku/core/node-host-resolver'
 import { pikkuState } from '@pikku/core/internal'
 import {
   signedContentPath,
@@ -194,6 +195,7 @@ export class PikkuNodeHTTPServer {
   }
 
   public async init(): Promise<void> {
+    installNodeHostResolver()
     compileAllSchemas(this.logger)
     if (this.options.configureServer) {
       await this.options.configureServer(this.server)

--- a/packages/runtimes/uws-server/src/pikku-uws-server.ts
+++ b/packages/runtimes/uws-server/src/pikku-uws-server.ts
@@ -2,6 +2,7 @@ import * as uWS from 'uWebSockets.js'
 
 import type { CoreConfig } from '@pikku/core'
 import { stopSingletonServices } from '@pikku/core'
+import { installNodeHostResolver } from '@pikku/core/node-host-resolver'
 import type { Logger } from '@pikku/core/services'
 import type { RunHTTPWiringOptions } from '@pikku/core/http'
 
@@ -42,6 +43,8 @@ export class PikkuUWSServer {
    * Initializes the server by setting up health check and request handling routes.
    */
   public async init(httpOptions: RunHTTPWiringOptions = {}) {
+    installNodeHostResolver()
+
     this.app.get(
       this.config.healthCheckPath || '/health-check',
       async (res) => {

--- a/verifiers/secrets/src/test-secret-allowed-hosts.ts
+++ b/verifiers/secrets/src/test-secret-allowed-hosts.ts
@@ -1,0 +1,41 @@
+/**
+ * Verifies `allowedHosts` survives the inspector → meta → generated JSON
+ * pipeline.
+ *
+ * `test-secretless.ts` covers the enforcement half, but it hand-authors a
+ * `SecretDefinitionsMeta` literal, so it stays green even when codegen drops the
+ * field and leaves the egress control a permanent no-op at runtime. This reads
+ * the real generated artifact instead.
+ */
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { assertSecretAllowedForHost } from '@pikku/core'
+import type { SecretDefinitionsMeta } from '@pikku/core/secret'
+
+const metaPath = join(
+  fileURLToPath(new URL('../.pikku/secrets/', import.meta.url)),
+  'pikku-secrets-meta.gen.json'
+)
+
+const meta = JSON.parse(
+  readFileSync(metaPath, 'utf-8')
+) as SecretDefinitionsMeta
+
+const exampleApi = meta['example-api']
+assert.ok(exampleApi, `'example-api' missing from ${metaPath}`)
+assert.deepEqual(
+  exampleApi.allowedHosts,
+  ['api.example.com', '*.example.com'],
+  'allowedHosts declared in credentials.ts did not survive code generation'
+)
+console.log('✓ allowedHosts survives inspector → meta → generated JSON')
+
+const secretId = exampleApi.secretId
+assertSecretAllowedForHost(secretId, 'https://api.example.com/v1', meta)
+assertSecretAllowedForHost(secretId, 'https://cdn.example.com/v1', meta)
+assert.throws(() =>
+  assertSecretAllowedForHost(secretId, 'https://evil.example.net/v1', meta)
+)
+console.log('✓ the generated allowedHosts actually gates an outbound host')

--- a/verifiers/secrets/test.sh
+++ b/verifiers/secrets/test.sh
@@ -23,5 +23,10 @@ echo ""
 echo "=== Testing SecretValue at the sinks ==="
 npx tsx src/test-secret-value.ts
 
+# Test 5: allowedHosts survives code generation
+echo ""
+echo "=== Testing allowedHosts reaches the generated meta ==="
+npx tsx src/test-secret-allowed-hosts.ts
+
 echo ""
 echo "=== All tests passed ==="


### PR DESCRIPTION
Closes #1151.

## `allowedHosts` never reached runtime (F5, F6)

`defineSecret({ allowedHosts })` is documented as an egress control and
`assertSecretAllowedForHost` enforces it, but the value was dropped twice on the
way to runtime:

- `packages/inspector/src/add/add-keyed-wiring.ts` never read the property off
  the object literal, so it was absent from the inspector state.
- `packages/core/src/wirings/secret/validate-secret-definitions.ts` rebuilds the
  meta object field-by-field in **two** branches (shared `secretId`, and fresh
  definition) and neither copied it.

Net effect: enforcement always saw `undefined`. With the default
(`requireAllowedHosts` off) that is a silent no-op — a secret declared for
`api.example.com` could be sent anywhere. Turn `requireAllowedHosts` on and every
secret throws instead.

The existing tests stayed green because they hand-author a `SecretDefinitionsMeta`
literal rather than reading a generated one. The new verifier test
(`verifiers/secrets/src/test-secret-allowed-hosts.ts`) reads the real
`.pikku/secrets/pikku-secrets-meta.gen.json`, so it fails when codegen drops the
field. Confirmed red before the inspector fix, green after.

## SSRF guard widened (F9)

`isPrivateHost` did ad-hoc octet comparisons and missed a lot of non-public
space. It now checks an explicit CIDR table:

`0.0.0.0/8`, `10/8`, `100.64/10`, `127/8`, `169.254/16`, `172.16/12`,
`192.0.0/24`, `192.0.2/24`, `192.88.99/24`, `192.168/16`, `198.18/15`,
`198.51.100/24`, `203.0.113/24`, `224/4`, `240/4`.

`100.64.0.0/10` is the notable one — it contains Alibaba Cloud's
`100.100.100.200` metadata endpoint, which the old guard treated as public.

IPv6 gets a real parser (`::` elision plus trailing dotted-quad) instead of
prefix string matching, so `fec0::/10`, `ff00::/8`, `100::/64` and the NAT64
(`64:ff9b::/96`) / 6to4 (`2002::/16`) forms that wrap an internal IPv4 address
are all caught.

## DNS rebinding-ish bypass (F8)

The guard matched on hostname strings only, so `169-254-169-254.nip.io` — a
public name resolving to the AWS metadata address — went straight through.

`safeFetch` now takes an optional `resolveHost` and applies it to the initial URL
and to every redirect hop, refusing when any resolved address is private. It is
skipped for IP literals (already checked) and when an explicit `allowedHosts` is
supplied.

Core cannot resolve DNS itself — Cloudflare Workers' `nodejs_compat` has no
`node:dns` — so the resolver is injected rather than imported. The Node
implementation ships as the `@pikku/core/node-host-resolver` subpath, and the four
Node server runtimes (express, fastify, uws, node-http) call
`installNodeHostResolver()` at the top of `init()`.

This checks the resolved address rather than pinning the connection to it, so a
rebind between check and connect is still theoretically possible. Fixing that
needs a custom agent/dispatcher per runtime and is out of scope here.

The redirect half of F8 was a false positive — `safeFetch` already forces
`redirect: 'manual'` and re-validates each hop. That behaviour is preserved and
now also re-resolves.

## Bonus: the graph addon bypassed the guard entirely

`packages/addon/pikku-graph/src/http-requester.service.ts` called bare `fetch`,
so the `httpRequest` graph node — user-controlled URL — skipped every check
above. It now goes through `safeFetch`.

## Verification

- `packages/core` unit tests: full suite green (1992 pass)
- `yarn build`: clean
- secrets verifier: green, including the two new assertions; proven red with the
  inspector fix reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened protection against server-side request forgery (SSRF) across IPv4 and IPv6 address ranges.
  * Added DNS-based checks for hostnames, including every redirect destination.
  * Graph HTTP requests now use the safer request handling.
* **Configuration**
  * Allowed-host settings are now preserved during secret generation, including exact and wildcard host rules.
  * Server runtimes automatically enable hostname safety checks.
* **Bug Fixes**
  * Improved handling of private, reserved, tunneled, and mapped IP addresses while allowing valid public destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->