### PR TITLE
fix(node-http-server,templates): fail closed on the dispatch routes and stop shipping a fallback remote secret

### DIFF
--- a/.changeset/dispatch-routes-fail-closed.md
+++ b/.changeset/dispatch-routes-fail-closed.md
@@ -1,0 +1,22 @@
+---
+'@pikku/node-http-server': patch
+---
+
+The `/__pikku/queue-job` and `/__pikku/scheduler-job` dispatch routes now reject
+every caller when `dispatchSecret` is unset, instead of accepting anyone. This
+matches `@pikku/cloudflare`, which already fails closed on the same header and
+the same `PIKKU_DISPATCH_SECRET` value.
+
+**Breaking for anyone relying on the old behaviour:** if you mount
+`dispatchJobs: true` without a `dispatchSecret`, dispatch requests that used to
+run now return 401. Set `dispatchSecret` to the value your dispatcher sends in
+`x-pikku-dispatch`.
+
+The secret comparison also no longer compares lengths first, which leaked the
+secret's length through timing.
+
+The remote-rpc templates no longer fall back to a hardcoded
+`PIKKU_REMOTE_SECRET`. `start.ts` is the production start script, so that literal
+was a published key that could mint a session token as any user. An unset
+variable now gets a random per-run secret, and both READMEs document that you
+must set it yourself before deploying.

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.test.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.test.ts
@@ -667,3 +667,125 @@ describe('PikkuNodeHTTPServer MCP mounting', { concurrency: false }, () => {
     )
   })
 })
+
+describe('PikkuNodeHTTPServer dispatch routes', { concurrency: false }, () => {
+  let server: PikkuNodeHTTPServer | undefined
+
+  beforeEach(() => {
+    resetPikkuState()
+    pikkuState(null, 'package', 'singletonServices', {
+      schema: {
+        compileSchema: async () => {},
+        getSchemaNames: () => new Set<string>(),
+      },
+    } as any)
+  })
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop()
+      server = undefined
+    }
+  })
+
+  const startServer = async (
+    options?: ConstructorParameters<typeof PikkuNodeHTTPServer>[2],
+    logger = createMockLogger()
+  ) => {
+    server = new PikkuNodeHTTPServer(
+      { hostname: '127.0.0.1', port: 0 } as any,
+      logger as any,
+      options
+    )
+    await server.init()
+    await server.start()
+    const address = server.server.address()
+    assert.ok(address && typeof address === 'object')
+    return `http://127.0.0.1:${address.port}`
+  }
+
+  const dispatch = (
+    origin: string,
+    path: string,
+    headers: Record<string, string> = {}
+  ) =>
+    fetch(`${origin}${path}`, {
+      method: 'POST',
+      headers: { connection: 'close', ...headers },
+      body: JSON.stringify({ taskName: 'anything', queueName: 'anything' }),
+    })
+
+  test('rejects a dispatch request when no dispatchSecret is configured', async () => {
+    const origin = await startServer({ dispatchJobs: true })
+
+    for (const path of ['/__pikku/scheduler-job', '/__pikku/queue-job']) {
+      const response = await dispatch(origin, path)
+      assert.equal(
+        response.status,
+        401,
+        `${path} must fail closed when dispatchSecret is unset`
+      )
+    }
+  })
+
+  test('warns at startup that the dispatch routes will reject every caller', async () => {
+    const { logger, warnings } = createCapturingLogger()
+    await startServer({ dispatchJobs: true }, logger as any)
+
+    assert.ok(
+      warnings.some((msg) => msg.includes('dispatchSecret')),
+      'expected a startup warning naming dispatchSecret'
+    )
+  })
+
+  test('rejects a wrong dispatch secret, and one of the wrong length alike', async () => {
+    const origin = await startServer({
+      dispatchJobs: true,
+      dispatchSecret: 'the-expected-dispatch-secret',
+    })
+
+    const wrong = await dispatch(origin, '/__pikku/scheduler-job', {
+      'x-pikku-dispatch': 'the-provided-dispatch-secret',
+    })
+    assert.equal(wrong.status, 401)
+
+    const short = await dispatch(origin, '/__pikku/scheduler-job', {
+      'x-pikku-dispatch': 'short',
+    })
+    assert.equal(short.status, 401)
+
+    const missing = await dispatch(origin, '/__pikku/scheduler-job')
+    assert.equal(missing.status, 401)
+  })
+
+  test('lets the correct dispatch secret through to the job handler', async () => {
+    const secret = 'the-expected-dispatch-secret'
+    const origin = await startServer({
+      dispatchJobs: true,
+      dispatchSecret: secret,
+    })
+
+    const response = await dispatch(origin, '/__pikku/scheduler-job', {
+      'x-pikku-dispatch': secret,
+    })
+    // No scheduled task is registered, so the handler answers 422
+    // (ack-no-retry) — reaching it at all is what proves auth passed.
+    assert.notEqual(
+      response.status,
+      401,
+      'a matching secret must not be rejected'
+    )
+  })
+
+  test('does not mount the dispatch routes when dispatchJobs is off', async () => {
+    const origin = await startServer({ dispatchSecret: 'a-secret' })
+
+    const response = await dispatch(origin, '/__pikku/scheduler-job')
+    assert.notEqual(
+      response.status,
+      401,
+      'an unmounted dispatch path must fall through to the normal pipeline'
+    )
+    assert.notEqual(response.status, 204)
+  })
+})

--- a/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
+++ b/packages/runtimes/node-http-server/src/pikku-node-http-server.ts
@@ -7,7 +7,12 @@ import {
 import { createReadStream } from 'node:fs'
 import { mkdir, stat, writeFile } from 'node:fs/promises'
 import { normalize, resolve } from 'node:path'
-import { randomUUID, timingSafeEqual } from 'node:crypto'
+import {
+  createHmac,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from 'node:crypto'
 
 import type { CoreConfig } from '@pikku/core'
 import { stopSingletonServices } from '@pikku/core'
@@ -103,16 +108,16 @@ export type PikkuNodeHTTPServerOptions = {
    * `httpQueueJobs`. Off by default.
    *
    * Unlike a CF WfP namespace script, a container usually HAS a public
-   * hostname — so set `dispatchSecret` to require the shared secret on these
-   * routes. Without it they are unauthenticated and anyone who can reach the
-   * server could trigger queue/scheduled work.
+   * hostname — so `dispatchSecret` is required for these routes to serve
+   * anyone at all. Without it every dispatch request is rejected.
    */
   dispatchJobs?: boolean
   /**
    * Shared secret required in the `x-pikku-dispatch` header on the dispatch
    * routes (when `dispatchJobs` is on). The dispatcher attaches it; public
-   * callers don't have it. When unset, the routes accept any caller and a
-   * warning is logged at startup.
+   * callers don't have it. When unset, the routes reject every caller and a
+   * warning is logged at startup — the same fail-closed contract the
+   * cloudflare runtime's `PIKKU_DISPATCH_SECRET` already has.
    */
   dispatchSecret?: string
   /**
@@ -203,7 +208,7 @@ export class PikkuNodeHTTPServer {
     logRegisterRoutes(this.logger)
     if (this.options.dispatchJobs && !this.options.dispatchSecret) {
       this.logger.warn(
-        'pikku-node-http-server: dispatch routes (/__pikku/queue-job, /__pikku/scheduler-job) are mounted WITHOUT a dispatchSecret — any caller that can reach this server can trigger queue/scheduled work.'
+        'pikku-node-http-server: dispatch routes (/__pikku/queue-job, /__pikku/scheduler-job) are mounted WITHOUT a dispatchSecret — every dispatch request will be rejected. Set dispatchSecret to the value the dispatcher sends in the x-pikku-dispatch header.'
       )
     }
     await this.initMCP()
@@ -256,6 +261,30 @@ export class PikkuNodeHTTPServer {
   }
 
   /**
+   * Fails closed: an unset `dispatchSecret` rejects every caller, matching
+   * `@pikku/cloudflare`'s `isDispatchAuthorized`. The comparison runs over
+   * HMACs taken under a key generated freshly per call, so the digests that
+   * actually get compared are fixed-width and unpredictable — that leaks
+   * neither the secret's bytes nor its length, which a length check before
+   * `timingSafeEqual` would.
+   */
+  private isDispatchAuthorized(req: IncomingMessage): boolean {
+    const expected = this.options.dispatchSecret
+    if (!expected) {
+      return false
+    }
+    const provided = req.headers['x-pikku-dispatch']
+    if (typeof provided !== 'string') {
+      return false
+    }
+    const key = randomBytes(32)
+    return timingSafeEqual(
+      createHmac('sha256', key).update(provided).digest(),
+      createHmac('sha256', key).update(expected).digest()
+    )
+  }
+
+  /**
    * Handle the in-stack dispatch routes. Mirrors the CF handler's
    * `/__pikku/queue-job` + `/__pikku/scheduler-job` contract so the same
    * fabric dispatcher path reaches a container target. Status codes match the
@@ -266,18 +295,10 @@ export class PikkuNodeHTTPServer {
     req: IncomingMessage,
     res: ServerResponse
   ): Promise<void> {
-    const expected = this.options.dispatchSecret
-    if (expected) {
-      const provided = req.headers['x-pikku-dispatch']
-      const ok =
-        typeof provided === 'string' &&
-        provided.length === expected.length &&
-        timingSafeEqual(Buffer.from(provided), Buffer.from(expected))
-      if (!ok) {
-        res.writeHead(401, { 'content-type': 'application/json' })
-        res.end('{"ok":false,"error":"bad dispatch secret"}')
-        return
-      }
+    if (!this.isDispatchAuthorized(req)) {
+      res.writeHead(401, { 'content-type': 'application/json' })
+      res.end('{"ok":false,"error":"unauthorized"}')
+      return
     }
 
     let body: any

--- a/templates/remote-rpc-pg/README.md
+++ b/templates/remote-rpc-pg/README.md
@@ -37,6 +37,18 @@ Default connection string:
 postgres://postgres:password@localhost:5432/pikku_remote_rpc
 ```
 
+## Environment
+
+| Variable              | Required              | Purpose                                                                                             |
+| --------------------- | --------------------- | --------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`        | no                    | PostgreSQL connection string. Defaults to the one above.                                            |
+| `PIKKU_REMOTE_SECRET` | **yes in production** | Encrypts the session claim in the remote-RPC token. Anyone holding it can mint a token as any user. |
+
+`yarn start` generates an ephemeral `PIKKU_REMOTE_SECRET` when the variable is
+unset, so the template runs with no setup. That value is different on every run
+and is not shared with servers you start separately — set the variable yourself
+whenever tokens need to outlive a restart, and always before deploying.
+
 ## Setup
 
 ```bash
@@ -86,16 +98,19 @@ yarn test
 
 You can run multiple servers to see true distributed RPC:
 
+Both terminals need the _same_ `PIKKU_REMOTE_SECRET`, or each run generates its
+own and the servers cannot verify each other's tokens.
+
 Terminal 1:
 
 ```bash
-PORT=3001 DEPLOYMENT_ID=server-a yarn start
+PIKKU_REMOTE_SECRET=<shared-secret> PORT=3001 DEPLOYMENT_ID=server-a yarn start
 ```
 
 Terminal 2:
 
 ```bash
-PORT=3002 DEPLOYMENT_ID=server-b yarn start
+PIKKU_REMOTE_SECRET=<shared-secret> PORT=3002 DEPLOYMENT_ID=server-b yarn start
 ```
 
 Both servers register with DeploymentService. Calling `/remote-greet` on either server will discover and call `greet` on one of the registered servers.

--- a/templates/remote-rpc-pg/src/start.ts
+++ b/templates/remote-rpc-pg/src/start.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from 'child_process'
+import { randomBytes } from 'crypto'
 import { fileURLToPath } from 'url'
 import { dirname, resolve } from 'path'
 
@@ -6,8 +7,17 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const serverScript = resolve(__dirname, 'server.ts')
 const PORTS = [3001, 3002]
 
+// This secret encrypts the session claim in the remote-RPC token, so anyone
+// holding it can mint a token as any user. A fixed literal here would ship that
+// power to every deployment of this template, so an unset variable gets a fresh
+// random secret instead — shared with the servers spawned below, and gone on
+// restart. Set PIKKU_REMOTE_SECRET to a value of your own to keep tokens valid
+// across restarts and across separately-started servers.
 if (!process.env.PIKKU_REMOTE_SECRET) {
-  process.env.PIKKU_REMOTE_SECRET = 'dev-remote-secret-not-for-production-use'
+  process.env.PIKKU_REMOTE_SECRET = randomBytes(32).toString('hex')
+  console.warn(
+    'PIKKU_REMOTE_SECRET is not set — generated an ephemeral one for this run. Set it explicitly before deploying.'
+  )
 }
 
 function spawnServer(port: number): ChildProcess {

--- a/templates/remote-rpc-redis/README.md
+++ b/templates/remote-rpc-redis/README.md
@@ -37,6 +37,18 @@ Default connection string:
 redis://localhost:6379
 ```
 
+## Environment
+
+| Variable              | Required              | Purpose                                                                                             |
+| --------------------- | --------------------- | --------------------------------------------------------------------------------------------------- |
+| `REDIS_URL`           | no                    | Redis connection string. Defaults to `redis://localhost:6379`.                                      |
+| `PIKKU_REMOTE_SECRET` | **yes in production** | Encrypts the session claim in the remote-RPC token. Anyone holding it can mint a token as any user. |
+
+`yarn start` generates an ephemeral `PIKKU_REMOTE_SECRET` when the variable is
+unset, so the template runs with no setup. That value is different on every run
+and is not shared with servers you start separately — set the variable yourself
+whenever tokens need to outlive a restart, and always before deploying.
+
 ## Setup
 
 ```bash
@@ -83,16 +95,19 @@ yarn test
 
 You can run multiple servers to see true distributed RPC:
 
+Both terminals need the _same_ `PIKKU_REMOTE_SECRET`, or each run generates its
+own and the servers cannot verify each other's tokens.
+
 Terminal 1:
 
 ```bash
-PORT=3001 DEPLOYMENT_ID=server-a yarn start
+PIKKU_REMOTE_SECRET=<shared-secret> PORT=3001 DEPLOYMENT_ID=server-a yarn start
 ```
 
 Terminal 2:
 
 ```bash
-PORT=3002 DEPLOYMENT_ID=server-b yarn start
+PIKKU_REMOTE_SECRET=<shared-secret> PORT=3002 DEPLOYMENT_ID=server-b yarn start
 ```
 
 Both servers register with DeploymentService. Calling `/remote-greet` on either server will discover and call `greet` on one of the registered servers.

--- a/templates/remote-rpc-redis/src/start.ts
+++ b/templates/remote-rpc-redis/src/start.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from 'child_process'
+import { randomBytes } from 'crypto'
 import { fileURLToPath } from 'url'
 import { dirname, resolve } from 'path'
 
@@ -6,8 +7,17 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const serverScript = resolve(__dirname, 'server.ts')
 const PORTS = [3001, 3002]
 
+// This secret encrypts the session claim in the remote-RPC token, so anyone
+// holding it can mint a token as any user. A fixed literal here would ship that
+// power to every deployment of this template, so an unset variable gets a fresh
+// random secret instead — shared with the servers spawned below, and gone on
+// restart. Set PIKKU_REMOTE_SECRET to a value of your own to keep tokens valid
+// across restarts and across separately-started servers.
 if (!process.env.PIKKU_REMOTE_SECRET) {
-  process.env.PIKKU_REMOTE_SECRET = 'dev-remote-secret-not-for-production-use'
+  process.env.PIKKU_REMOTE_SECRET = randomBytes(32).toString('hex')
+  console.warn(
+    'PIKKU_REMOTE_SECRET is not set — generated an ephemeral one for this run. Set it explicitly before deploying.'
+  )
 }
 
 function spawnServer(port: number): ChildProcess {


### PR DESCRIPTION
Closes #1152.

## F7 — the node dispatch routes failed open

`handleDispatchJob` wrapped its entire auth check in `if (expected) { … }` with
no `else`. With `dispatchJobs: true` and no `dispatchSecret`, every caller fell
straight through to the job handler.

That matters more than a normal unauthenticated route, because dispatch routing
happens **before** `fetchData` — no Pikku middleware, session, auth or permission
layer runs on these requests at all. An anonymous caller could:

- `POST /__pikku/scheduler-job` → run any registered cron task, at any rate
- `POST /__pikku/queue-job` → run any registered queue processor with
  attacker-controlled `data` (and `queueName` resolves by longest-suffix match,
  so exact names weren't even needed)

Reachable in practice: `deploy-cloudflare`'s generated container entrypoint
hardcodes `dispatchJobs: true` with `dispatchSecret:
process.env.PIKKU_DISPATCH_SECRET`.

The sibling runtime already gets this right — `@pikku/cloudflare`'s
`isDispatchAuthorized` rejects when the secret is unset, over the same header and
the same `PIKKU_DISPATCH_SECRET` value. Node is now the same shape.

Also fixed: the comparison checked `provided.length === expected.length` before
`timingSafeEqual`, leaking the secret's length. It now compares HMACs taken under
a key generated freshly per call, which is what cloudflare's `constantTimeEqual`
does and why it doesn't have the same leak.

**This is a deliberate breaking change** — the old behaviour was documented in
the JSDoc ("When unset, the routes accept any caller"). Both the JSDoc and the
startup warning now describe fail-closed, and the changeset spells out the
migration: set `dispatchSecret`.

The routes had zero tests. There are now five, covering unset secret, wrong
secret, wrong-length secret, missing header, matching secret, and the
`dispatchJobs: false` case. The unset-secret one was confirmed red (503 — it
reached the handler) before the fix.

## F10 — the remote-rpc templates shipped a working secret

`templates/remote-rpc-{redis,pg}/src/start.ts` assigned
`PIKKU_REMOTE_SECRET = 'dev-remote-secret-not-for-production-use'` when the
variable was unset. `start.ts` **is** the production start script
(`"start": "tsx src/start.ts"`), and it propagates the value to both spawned
servers. `assertStrongKeyMaterial` is a length check and the literal is 40 chars,
so nothing complained.

The secret encrypts the session claim in the remote-RPC token
(`middleware/remote-auth.ts`), so anyone reading the template repo could mint a
token as any user against a deployment that never set the variable. Neither
README documented it.

An unset variable now gets a random 32-byte per-run secret plus a warning, so the
template still runs with zero setup, and both READMEs gained an Environment
section marking it required in production — including a note that the
"multiple servers" flow needs the *same* value in both terminals.

## Verification

- `@pikku/node-http-server` tests: 24/26 pass. The 2 failures are the MCP mount
  tests, confirmed failing on this same base before my changes (unbuilt
  `@pikku/modelcontextprotocol` in the local worktree).
- `changeset status` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
