### PR TITLE
fix(core): let gateway handlers inherit their real meta instead of a fabricated one

### DIFF
--- a/.changeset/gateway-handlers-inherit-real-meta.md
+++ b/.changeset/gateway-handlers-inherit-real-meta.md
@@ -1,0 +1,24 @@
+---
+'@pikku/core': patch
+---
+
+Gateway handlers now run under the metadata their author actually wrote, instead
+of a fabricated meta object.
+
+`registerGatewayHandler` used to synthesize `{ sessionless: true,
+inputSchemaName: null, outputSchemaName: null }` for every gateway handler, so a
+function declared with `pikkuFunc` — which records "session required" in meta
+rather than through an `auth` property — was silently made sessionless, and its
+input schema was never validated. It now inherits `sessionless`, the schema
+names, `scopes` and tag middleware from the function the gateway was wired with,
+falling back to the old sessionless default only when nothing was declared (a
+gateway wired by hand rather than through codegen).
+
+Tag middleware also reaches gateways for the first time. `addTagMiddleware('x',
+…)` combined with `wireGateway({ tags: ['x'] })` previously resolved to nothing
+at all — the inspector computed the middleware and no runtime path read it — so
+a tag that read like a gate applied none.
+
+**Both are tightening changes.** A gateway whose handler declared a session
+requirement, or whose tags name registered middleware, now enforces what it
+already said it enforced.

--- a/packages/core/knowledge/decisions/security/gateway-handlers-run-through-the-function-runner-gate.md
+++ b/packages/core/knowledge/decisions/security/gateway-handlers-run-through-the-function-runner-gate.md
@@ -17,7 +17,16 @@ runner's gate is the only thing that evaluates a function's declared `auth`,
 `scopes` and `permissions`; a direct call runs the handler with none of them
 checked.
 
-The handler is registered with `sessionless: true`. Gateway inbound traffic is
+The synthetic registration **inherits the wired function's own metadata** —
+`sessionless`, input and output schema names, `scopes`, tag middleware — read
+back from `pikkuState(null, 'gateway', 'meta')[name].pikkuFuncId`, which the
+inspector already records. The synthetic id exists so the gate runs; it is not a
+licence to run the handler under metadata its author never wrote. A handler
+declared with `pikkuFunc` says session-required in meta rather than through an
+`auth` property, and that declaration is honoured.
+
+When nothing was declared — no inspector entry, as when a gateway is wired by
+hand — the handler falls back to `sessionless: true`. Gateway inbound traffic is
 authenticated by the platform adapter (webhook signature verification, platform
 tokens), not by a user session, so defaulting to session-required would reject
 every legitimate webhook. `CoreGateway.auth` and the handler's own `auth: true`
@@ -26,6 +35,7 @@ whenever declared, session or not.
 
 **What this rules out:** invoking `config.func` directly from any gateway
 transport as an optimisation, and "simplifying" the synthetic function
-registration away. It also rules out flipping the sessionless default to
-session-required as a hardening measure — that breaks every webhook rather than
+registration away. It also rules out fabricating the handler's metadata rather
+than inheriting it, and flipping the _fallback_ to session-required as a
+hardening measure — that breaks every webhook that declared nothing, rather than
 securing it; require auth per gateway via `CoreGateway.auth` instead.

--- a/packages/core/src/wirings/gateway/gateway-authorization.test.ts
+++ b/packages/core/src/wirings/gateway/gateway-authorization.test.ts
@@ -8,6 +8,7 @@ import {
   addGlobalPermission,
   clearPermissionsCache,
 } from '../../permissions.js'
+import { addTagMiddleware } from '../../middleware-runner.js'
 import type {
   GatewayAdapter,
   GatewayInboundMessage,
@@ -81,6 +82,31 @@ const seedCompiledMeta = () => {
         sessionless: true,
       }
     }
+  }
+}
+
+/**
+ * What the inspector records for a gateway and the function it was wired with.
+ * These tests wire gateways by hand, so nothing populates it otherwise — and it
+ * has to be in place before `wireGateway`, exactly as the generated bootstrap
+ * loads every meta file before any wiring file.
+ */
+const seedDeclaredHandler = (
+  gatewayName: string,
+  funcId: string,
+  funcMeta: Record<string, any>,
+  gatewayMeta: Record<string, any> = {}
+) => {
+  ;(pikkuState(null, 'function', 'meta') as any)[funcId] = {
+    pikkuFuncId: funcId,
+    inputSchemaName: null,
+    outputSchemaName: null,
+    ...funcMeta,
+  }
+  ;(pikkuState(null, 'gateway', 'meta') as any)[gatewayName] = {
+    pikkuFuncId: funcId,
+    name: gatewayName,
+    ...gatewayMeta,
   }
 }
 
@@ -229,6 +255,68 @@ describe('gateway handler authorization', () => {
       assert.deepEqual(calls, ['ran'])
     })
 
+    test('a handler declared with pikkuFunc keeps its session requirement', async () => {
+      const calls: string[] = []
+
+      seedDeclaredHandler('declared-session', 'myHandler', {
+        sessionless: false,
+      })
+
+      wireGateway({
+        name: 'declared-session',
+        type: 'webhook',
+        route: '/webhooks/declared-session',
+        adapter: createMockAdapter(),
+        func: {
+          func: async () => {
+            calls.push('ran')
+            return { text: 'reply' }
+          },
+        } as any,
+      })
+
+      seedCompiledMeta()
+      httpRouter.initialize()
+
+      const response = await postMessage('/webhooks/declared-session')
+
+      assert.equal(response.status, 403)
+      assert.deepEqual(
+        calls,
+        [],
+        'a session-required pikkuFunc must not be silently made sessionless'
+      )
+    })
+
+    test('a handler declared sessionless keeps running without a session', async () => {
+      const calls: string[] = []
+
+      seedDeclaredHandler('declared-sessionless', 'mySessionlessHandler', {
+        sessionless: true,
+      })
+
+      wireGateway({
+        name: 'declared-sessionless',
+        type: 'webhook',
+        route: '/webhooks/declared-sessionless',
+        adapter: createMockAdapter(),
+        func: {
+          func: async () => {
+            calls.push('ran')
+            return { text: 'reply' }
+          },
+        } as any,
+      })
+
+      seedCompiledMeta()
+      httpRouter.initialize()
+
+      const response = await postMessage('/webhooks/declared-sessionless')
+
+      assert.equal(response.status, 200)
+      assert.deepEqual(calls, ['ran'])
+    })
+
     test('gateway-level auth: true requires a session', async () => {
       const calls: string[] = []
 
@@ -279,6 +367,49 @@ describe('gateway handler authorization', () => {
 
       assert.equal(response.status, 403)
       assert.deepEqual(calls, [], 'auth: true must require a session')
+    })
+
+    test('tag middleware declared for the gateway actually runs', async () => {
+      const order: string[] = []
+
+      addTagMiddleware('audited', [
+        async (_s: any, _wire: any, next: any) => {
+          order.push('middleware')
+          await next()
+        },
+      ] as any)
+
+      seedDeclaredHandler(
+        'tagged',
+        'myTaggedHandler',
+        { sessionless: true },
+        { tags: ['audited'], middleware: [{ type: 'tag', tag: 'audited' }] }
+      )
+
+      wireGateway({
+        name: 'tagged',
+        type: 'webhook',
+        route: '/webhooks/tagged',
+        adapter: createMockAdapter(),
+        func: {
+          func: async () => {
+            order.push('handler')
+            return { text: 'reply' }
+          },
+        } as any,
+      })
+
+      seedCompiledMeta()
+      httpRouter.initialize()
+
+      const response = await postMessage('/webhooks/tagged')
+
+      assert.equal(response.status, 200)
+      assert.deepEqual(
+        order,
+        ['middleware', 'handler'],
+        'addTagMiddleware must gate a gateway carrying the tag'
+      )
     })
 
     test('the adapter still auto-sends the handler reply', async () => {

--- a/packages/core/src/wirings/gateway/gateway-runner.ts
+++ b/packages/core/src/wirings/gateway/gateway-runner.ts
@@ -23,19 +23,45 @@ const bridgeMiddlewareSession = async (wire: PikkuRawWire): Promise<void> => {
   }
 }
 
+/**
+ * Metadata the inspector recorded for the function the gateway was wired with.
+ * The bootstrap loads every meta file before any wiring file, so this is
+ * already populated by the time a gateway wires itself. A gateway wired by
+ * hand rather than through codegen has no entry, and falls back to the
+ * sessionless default below.
+ */
+const declaredHandlerMeta = (config: CoreGateway) => {
+  const declaredFuncId = pikkuState(null, 'gateway', 'meta')[config.name]
+    ?.pikkuFuncId
+  return declaredFuncId
+    ? pikkuState(null, 'function', 'meta')[declaredFuncId]
+    : undefined
+}
+
 // knowledge: decisions/security/gateway-handlers-run-through-the-function-runner-gate.md
 const registerGatewayHandler = (config: CoreGateway): string => {
   const funcId = gatewayHandlerFuncId(config.name)
   const funcMeta = pikkuState(null, 'function', 'meta')
+  const declared = declaredHandlerMeta(config)
   funcMeta[funcId] = {
+    ...declared,
     pikkuFuncId: funcId,
-    inputSchemaName: null,
-    outputSchemaName: null,
-    sessionless: true,
+    inputSchemaName: declared?.inputSchemaName ?? null,
+    outputSchemaName: declared?.outputSchemaName ?? null,
+    sessionless: declared?.sessionless ?? true,
   }
   addFunction(funcId, config.func as any)
   return funcId
 }
+
+/**
+ * Tag middleware the inspector resolved for this gateway. It is keyed by
+ * gateway name rather than reachable from `config`, because `tags` is a
+ * compile-time input everywhere — nothing at runtime maps a tag to its
+ * middleware group.
+ */
+const gatewayInheritedMiddleware = (config: CoreGateway) =>
+  pikkuState(null, 'gateway', 'meta')[config.name]?.middleware
 
 export const resolveGatewayAdapter = (
   config: CoreGateway,
@@ -134,6 +160,7 @@ const wireWebhookGateway = (config: CoreGateway): void => {
 const createWebhookPostHandler = (config: CoreGateway) => {
   const { name, middleware: userMiddleware } = config
   const handlerFuncId = registerGatewayHandler(config)
+  const inheritedMiddleware = gatewayInheritedMiddleware(config)
 
   return async (
     services: CoreSingletonServices,
@@ -169,6 +196,7 @@ const createWebhookPostHandler = (config: CoreGateway) => {
         singletonServices: services,
         data: () => parsed,
         auth: config.auth,
+        inheritedMiddleware,
         wire: wire as any,
       })
     }
@@ -253,6 +281,7 @@ const wireWebsocketGateway = (config: CoreGateway): void => {
 
   const userMiddleware = config.middleware as CorePikkuMiddleware[] | undefined
   const handlerFuncId = registerGatewayHandler(config)
+  const inheritedMiddleware = gatewayInheritedMiddleware(config)
 
   addFunction(connectFuncId, {
     auth: false,
@@ -292,6 +321,7 @@ const wireWebsocketGateway = (config: CoreGateway): void => {
           singletonServices: services,
           data: () => parsed,
           auth: config.auth,
+          inheritedMiddleware,
           wire: wire as any,
         })
       }
@@ -333,6 +363,7 @@ export const createListenerMessageHandler = (
 ): ((rawData: unknown) => Promise<void>) => {
   const userMiddleware = config.middleware as CorePikkuMiddleware[] | undefined
   const handlerFuncId = registerGatewayHandler(config)
+  const inheritedMiddleware = gatewayInheritedMiddleware(config)
 
   return async (rawData: unknown): Promise<void> => {
     const adapter = await resolveGatewayAdapter(config, singletonServices)
@@ -354,6 +385,7 @@ export const createListenerMessageHandler = (
         singletonServices,
         data: () => parsed,
         auth: config.auth,
+        inheritedMiddleware,
         wire,
       })
     }


### PR DESCRIPTION
Closes #1156.

Both findings had the same root cause: **the gateway handler executed under fabricated metadata instead of the function's real metadata.**

```ts
// before — registerGatewayHandler
funcMeta[funcId] = {
  pikkuFuncId: funcId,
  inputSchemaName: null,
  outputSchemaName: null,
  sessionless: true,
}
```

## F12 — a session-required `pikkuFunc` was silently made sessionless

Session-requirement lives **only** in meta. `pikkuFunc` is identity at runtime,
and the inspector derives `sessionless` from the helper name:

```ts
meta.sessionless = funcInitializer.expression.text !== 'pikkuFunc'
```

The function runner's gate reads meta by the id it is handed, and all three
transports hand it the synthetic id — so `wireGateway({ func: someSessionRequiredPikkuFunc })`
ran sessionless. The author's declaration was overwritten. Only an explicit
`auth: true` property (which `pikkuFunc` does not add) restored it.

Collateral from the same fabricated meta: `inputSchemaName: null` meant input
validation, coercion and schema defaults were skipped, and `scopes` from meta
were absent.

The handler now inherits `sessionless`, both schema names, `scopes` and
function-level tag middleware, resolved through the `pikkuFuncId` the inspector
**already writes** into gateway meta — nothing new is emitted. Ordering is safe:
the generated bootstrap sorts every meta import ahead of every wiring import, so
gateway meta is populated before a gateway wires itself. A gateway wired by hand
(no inspector entry) keeps the sessionless fallback.

## F13 — `addTagMiddleware` was inert for gateways

Tag middleware resolves only from `MiddlewareMetadata[]` passed into the runner.
The three gateway call sites passed none, and the fabricated meta had no
`middleware` key, so `wireGateway({ tags: ['audited'] })` plus
`addTagMiddleware('audited', …)` applied **nothing** — a tag that reads like a
gate was a no-op. The inspector had computed it into gateway meta all along
(`resolveMiddleware(state, obj, tags, checker)`); no runtime path read it.

All three transports now pass it as `inheritedMiddleware`.

## Decision doc

`gateway-handlers-run-through-the-function-runner-gate.md` documented the
sessionless default and ruled out "flipping the sessionless default to
session-required as a hardening measure". That rationale assumed the only session
signal is an explicit `auth` field, and it is preserved here — the *fallback* is
unchanged, only a declaration that already existed is now honoured. The doc is
amended to say the synthetic id exists so the gate runs, not so the handler can
run under metadata its author never wrote.

## Verification

- The two new tests were confirmed red against the unfixed runner
  (`a handler declared with pikkuFunc keeps its session requirement`,
  `tag middleware declared for the gateway actually runs`) and green after —
  the other 13 in the file passed throughout, so nothing existing was reversed.
- `@pikku/core` full suite: 2006 tests, 0 failures.
- `verifiers/gateway`: 11/11 passed.

## Deliberately not included

The issue offered extending `validate-tags-resolve-to-middleware.ts` to warn on
inert `wireGateway` tags. Gateway tags now actually resolve, so the warning is no
longer the safety net it was for `wireAddon`; leaving it out keeps this PR to the
two findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway handlers now preserve the wired function’s session requirements, schema names, scopes, and tag middleware.
  * Tag middleware runs before gateway handlers across supported gateway types.
  * Gateways without available metadata continue using a sessionless fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->